### PR TITLE
Move to auth to use `localStorage` instead of `sessionStorage`

### DIFF
--- a/packages/jazz-browser-auth-local/src/index.ts
+++ b/packages/jazz-browser-auth-local/src/index.ts
@@ -9,12 +9,12 @@ import {
 import { agentSecretFromSecretSeed } from "cojson/src/crypto";
 import { AuthProvider, SessionProvider } from "jazz-browser";
 
-type SessionStorageData = {
+type LocalStorageData = {
     accountID: AccountID;
     accountSecret: AgentSecret;
 };
 
-const sessionStorageKey = "jazz-logged-in-secret";
+const localStorageKey = "jazz-logged-in-secret";
 
 export interface BrowserLocalAuthDriver {
     onReady: (next: {
@@ -45,16 +45,16 @@ export class BrowserLocalAuth implements AuthProvider {
         initialPeers: Peer[],
         migration?: AccountMigration
     ): Promise<LocalNode> {
-        if (sessionStorage[sessionStorageKey]) {
-            const sessionStorageData = JSON.parse(
-                sessionStorage[sessionStorageKey]
-            ) as SessionStorageData;
+        if (localStorage[localStorageKey]) {
+            const localStorageData = JSON.parse(
+                localStorage[localStorageKey]
+            ) as LocalStorageData;
 
-            const sessionID = await getSessionFor(sessionStorageData.accountID);
+            const sessionID = await getSessionFor(localStorageData.accountID);
 
             const node = await LocalNode.withLoadedAccount({
-                accountID: sessionStorageData.accountID,
-                accountSecret: sessionStorageData.accountSecret,
+                accountID: localStorageData.accountID,
+                accountSecret: localStorageData.accountSecret,
                 sessionID,
                 peersToLoadFrom: initialPeers,
                 migration,
@@ -149,10 +149,10 @@ async function signUp(
 
     console.log(webAuthNCredential, accountID);
 
-    sessionStorage[sessionStorageKey] = JSON.stringify({
+    localStorage[localStorageKey] = JSON.stringify({
         accountID,
         accountSecret,
-    } satisfies SessionStorageData);
+    } satisfies LocalStorageData);
 
     node.currentSessionID = await getSessionFor(accountID);
 
@@ -200,10 +200,10 @@ async function logIn(
         throw new Error("Invalid credential");
     }
 
-    sessionStorage[sessionStorageKey] = JSON.stringify({
+    localStorage[localStorageKey] = JSON.stringify({
         accountID,
         accountSecret,
-    } satisfies SessionStorageData);
+    } satisfies LocalStorageData);
 
     const node = await LocalNode.withLoadedAccount({
         accountID,
@@ -217,5 +217,5 @@ async function logIn(
 }
 
 function logOut() {
-    delete sessionStorage[sessionStorageKey];
+    delete localStorage[localStorageKey];
 }

--- a/packages/jazz-browser-auth-passphrase/src/index.ts
+++ b/packages/jazz-browser-auth-passphrase/src/index.ts
@@ -9,12 +9,12 @@ import {
 import { agentSecretFromSecretSeed } from "cojson/src/crypto";
 import { AuthProvider, SessionProvider } from "jazz-browser";
 
-type SessionStorageData = {
+type LocalStorageData = {
     accountID: AccountID;
     accountSecret: AgentSecret;
 };
 
-const sessionStorageKey = "jazz-logged-in-secret";
+const localStorageKey = "jazz-logged-in-secret";
 
 export interface BrowserPassphraseAuthDriver {
     onReady: (next: {
@@ -48,16 +48,16 @@ export class BrowserPassphraseAuth implements AuthProvider {
         initialPeers: Peer[],
         migration?: AccountMigration
     ): Promise<LocalNode> {
-        if (sessionStorage[sessionStorageKey]) {
-            const sessionStorageData = JSON.parse(
-                sessionStorage[sessionStorageKey]
-            ) as SessionStorageData;
+        if (localStorage[localStorageKey]) {
+            const localStorageData = JSON.parse(
+                localStorage[localStorageKey]
+            ) as LocalStorageData;
 
-            const sessionID = await getSessionFor(sessionStorageData.accountID);
+            const sessionID = await getSessionFor(localStorageData.accountID);
 
             const node = await LocalNode.withLoadedAccount({
-                accountID: sessionStorageData.accountID,
-                accountSecret: sessionStorageData.accountSecret,
+                accountID: localStorageData.accountID,
+                accountSecret: localStorageData.accountSecret,
                 sessionID,
                 peersToLoadFrom: initialPeers,
                 migration,
@@ -127,10 +127,10 @@ async function signUp(
             migration,
         });
 
-    sessionStorage[sessionStorageKey] = JSON.stringify({
+    localStorage[localStorageKey] = JSON.stringify({
         accountID,
         accountSecret,
-    } satisfies SessionStorageData);
+    } satisfies LocalStorageData);
 
     node.currentSessionID = await getSessionFor(accountID);
 
@@ -156,10 +156,10 @@ async function logIn(
 
     const accountID = cojsonInternals.idforHeader(cojsonInternals.accountHeaderForInitialAgentSecret(accountSecret)) as AccountID;
 
-    sessionStorage[sessionStorageKey] = JSON.stringify({
+    localStorage[localStorageKey] = JSON.stringify({
         accountID,
         accountSecret,
-    } satisfies SessionStorageData);
+    } satisfies LocalStorageData);
 
     const node = await LocalNode.withLoadedAccount({
         accountID,
@@ -173,5 +173,5 @@ async function logIn(
 }
 
 function logOut() {
-    delete sessionStorage[sessionStorageKey];
+    delete localStorage[localStorageKey];
 }

--- a/packages/jazz-browser/src/DemoAuth.ts
+++ b/packages/jazz-browser/src/DemoAuth.ts
@@ -12,7 +12,7 @@ type StorageData = {
     accountSecret: AgentSecret;
 };
 
-const sessionStorageKey = "demo-auth-logged-in-secret";
+const localStorageKey = "demo-auth-logged-in-secret";
 
 export interface BrowserDemoAuthDriver {
     onReady: (next: {
@@ -37,16 +37,16 @@ export class BrowserDemoAuth implements AuthProvider {
         initialPeers: Peer[],
         migration?: AccountMigration
     ): Promise<LocalNode> {
-        if (sessionStorage["demo-auth-logged-in-secret"]) {
-            const sessionStorageData = JSON.parse(
-                sessionStorage[sessionStorageKey]
+        if (localStorage["demo-auth-logged-in-secret"]) {
+            const localStorageData = JSON.parse(
+                localStorage[localStorageKey]
             ) as StorageData;
 
-            const sessionID = await getSessionFor(sessionStorageData.accountID);
+            const sessionID = await getSessionFor(localStorageData.accountID);
 
             const node = await LocalNode.withLoadedAccount({
-                accountID: sessionStorageData.accountID,
-                accountSecret: sessionStorageData.accountSecret,
+                accountID: localStorageData.accountID,
+                accountSecret: localStorageData.accountSecret,
                 sessionID,
                 peersToLoadFrom: initialPeers,
                 migration,
@@ -69,7 +69,7 @@ export class BrowserDemoAuth implements AuthProvider {
                                 accountID,
                                 accountSecret,
                             } satisfies StorageData);
-                            sessionStorage["demo-auth-logged-in-secret"] =
+                            localStorage["demo-auth-logged-in-secret"] =
                                 storageData;
                             localStorage[
                                 "demo-auth-existing-users-" + username
@@ -97,7 +97,7 @@ export class BrowserDemoAuth implements AuthProvider {
                                 ]
                             ) as StorageData;
 
-                            sessionStorage["demo-auth-logged-in-secret"] =
+                            localStorage["demo-auth-logged-in-secret"] =
                                 JSON.stringify(storageData);
 
                             const sessionID = await getSessionFor(
@@ -125,5 +125,5 @@ export class BrowserDemoAuth implements AuthProvider {
 }
 
 function logOut() {
-    delete sessionStorage[sessionStorageKey];
+    delete localStorage[localStorageKey];
 }


### PR DESCRIPTION
As discussed, I think it's better to have more persistent sessions per default.
After your API changes merge, I'm happy to change this into a more pluggable system?