### PR TITLE
`addMember` should return account

### DIFF
--- a/packages/cojson/src/coValues/group.ts
+++ b/packages/cojson/src/coValues/group.ts
@@ -96,12 +96,12 @@ export class RawGroup<
      *
      * @category 2. Role changing
      */
-    addMember<T extends RawAccount | ControlledAccountOrAgent | Everyone>(
-        account:  T,
+    addMember(
+        account:  RawAccount | ControlledAccountOrAgent | Everyone,
         role: Role
-    ): T {
+    ) {
         this.addMemberInternal(account, role);
-        return account;
+        return this;
     }
 
     /** @internal */

--- a/packages/cojson/src/coValues/group.ts
+++ b/packages/cojson/src/coValues/group.ts
@@ -97,7 +97,7 @@ export class RawGroup<
      * @category 2. Role changing
      */
     addMember(
-        account:  RawAccount | ControlledAccountOrAgent | Everyone,
+        account: RawAccount | ControlledAccountOrAgent | Everyone,
         role: Role
     ) {
         this.addMemberInternal(account, role);

--- a/packages/cojson/src/coValues/group.ts
+++ b/packages/cojson/src/coValues/group.ts
@@ -96,11 +96,12 @@ export class RawGroup<
      *
      * @category 2. Role changing
      */
-    addMember(
-        account: RawAccount | ControlledAccountOrAgent | Everyone,
+    addMember<T extends RawAccount | ControlledAccountOrAgent | Everyone>(
+        account:  T,
         role: Role
-    ) {
+    ): T {
         this.addMemberInternal(account, role);
+        return account;
     }
 
     /** @internal */


### PR DESCRIPTION
Make it possible to give permissions when creating a group

```ts
const group = new Group({ owner: me }).addMember('everyone', 'reader')
```