### PR TITLE
Allow to set add members after creating a group

### DIFF
--- a/packages/jazz-tools/src/coValues/group.ts
+++ b/packages/jazz-tools/src/coValues/group.ts
@@ -149,6 +149,7 @@ export class Group<
 
     addMember(member: Everyone | Account, role: Role) {
         this._raw.addMember(member === "everyone" ? member : member._raw, role);
+        return this;
     }
 
     get members() {


### PR DESCRIPTION
Make it possible to give permissions when creating a group  
```ts 
const group = new Group({ owner: me }).addMember('everyone', 'reader') 
```