### PR TITLE
Move `effect` to `peerDependencies` to avoid conflicts

### DIFF
--- a/packages/cojson/package.json
+++ b/packages/cojson/package.json
@@ -20,9 +20,11 @@
         "@hazae41/berith": "^1.2.6",
         "@noble/ciphers": "^0.1.3",
         "@scure/base": "^1.1.1",
-        "effect": "^3.1.3",
         "hash-wasm": "^4.9.0",
         "isomorphic-streams": "https://github.com/sgwilym/isomorphic-streams.git#aa9394781bfc92f8d7c981be7daf8af4b4cd4fae"
+    },
+    "peerDependencies": {
+        "effect": "^3.1.4"
     },
     "scripts": {
         "dev": "tsc --watch --sourceMap --outDir dist",

--- a/packages/jazz-browser/package.json
+++ b/packages/jazz-browser/package.json
@@ -8,10 +8,12 @@
     "@scure/bip39": "^1.3.0",
     "cojson": "workspace:*",
     "cojson-storage-indexeddb": "workspace:*",
-    "effect": "^3.1.4",
     "isomorphic-streams": "https://github.com/sgwilym/isomorphic-streams.git#aa9394781bfc92f8d7c981be7daf8af4b4cd4fae",
     "jazz-tools": "workspace:*",
     "typescript": "^5.1.6"
+  },
+  "peerDependencies": {
+    "effect": "^3.1.4"
   },
   "scripts": {
     "lint": "eslint src/**/*.ts",

--- a/packages/jazz-run/package.json
+++ b/packages/jazz-run/package.json
@@ -16,7 +16,6 @@
         "@effect/schema": "^0.66.16",
         "cojson": "workspace:*",
         "cojson-transport-nodejs-ws": "workspace:*",
-        "effect": "^3.1.3",
         "fast-check": "^3.17.2",
         "jazz-tools": "workspace:*",
         "ws": "^8.14.2"
@@ -25,5 +24,8 @@
         "@types/ws": "^8.5.5",
         "typescript": "^5.3.3",
         "vitest": "^0.34.6"
+    },
+    "peerDependencies": {
+        "effect": "^3.1.4"
     }
 }

--- a/packages/jazz-tools/package.json
+++ b/packages/jazz-tools/package.json
@@ -10,8 +10,10 @@
         "@effect/schema": "^0.66.16",
         "cojson": "workspace:*",
         "cojson-transport-nodejs-ws": "workspace:*",
-        "effect": "^3.1.3",
         "fast-check": "^3.17.2"
+    },
+    "peerDependencies": {
+        "effect": "^3.1.4"
     },
     "scripts": {
         "test": "vitest",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -333,7 +333,7 @@ importers:
         specifier: ^1.1.1
         version: 1.1.5
       effect:
-        specifier: ^3.1.3
+        specifier: ^3.1.4
         version: 3.1.4
       hash-wasm:
         specifier: ^4.9.0
@@ -542,13 +542,13 @@ importers:
     dependencies:
       '@effect/cli':
         specifier: ^0.36.21
-        version: 0.36.21(@effect/platform@0.53.2)(@effect/printer-ansi@0.33.12)(@effect/printer@0.33.12)(@effect/schema@0.66.16)(effect@3.1.3)
+        version: 0.36.21(@effect/platform@0.53.2)(@effect/printer-ansi@0.33.12)(@effect/printer@0.33.12)(@effect/schema@0.66.16)(effect@3.1.4)
       '@effect/platform-node':
         specifier: ^0.49.2
-        version: 0.49.2(@effect/platform@0.53.2)(effect@3.1.3)
+        version: 0.49.2(@effect/platform@0.53.2)(effect@3.1.4)
       '@effect/schema':
         specifier: ^0.66.16
-        version: 0.66.16(effect@3.1.3)(fast-check@3.17.2)
+        version: 0.66.16(effect@3.1.4)(fast-check@3.17.2)
       cojson:
         specifier: workspace:*
         version: link:../cojson
@@ -556,8 +556,8 @@ importers:
         specifier: workspace:*
         version: link:../cojson-transport-nodejs-ws
       effect:
-        specifier: ^3.1.3
-        version: 3.1.3
+        specifier: ^3.1.4
+        version: 3.1.4
       fast-check:
         specifier: ^3.17.2
         version: 3.17.2
@@ -582,7 +582,7 @@ importers:
     dependencies:
       '@effect/schema':
         specifier: ^0.66.16
-        version: 0.66.16(effect@3.1.3)(fast-check@3.17.2)
+        version: 0.66.16(effect@3.1.4)(fast-check@3.17.2)
       cojson:
         specifier: workspace:*
         version: link:../cojson
@@ -590,8 +590,8 @@ importers:
         specifier: workspace:*
         version: link:../cojson-transport-nodejs-ws
       effect:
-        specifier: ^3.1.3
-        version: 3.1.3
+        specifier: ^3.1.4
+        version: 3.1.4
       fast-check:
         specifier: ^3.17.2
         version: 3.17.2
@@ -831,7 +831,7 @@ packages:
     dependencies:
       '@jridgewell/trace-mapping': 0.3.9
 
-  /@effect/cli@0.36.21(@effect/platform@0.53.2)(@effect/printer-ansi@0.33.12)(@effect/printer@0.33.12)(@effect/schema@0.66.16)(effect@3.1.3):
+  /@effect/cli@0.36.21(@effect/platform@0.53.2)(@effect/printer-ansi@0.33.12)(@effect/printer@0.33.12)(@effect/schema@0.66.16)(effect@3.1.4):
     resolution: {integrity: sha512-39ya5HjJxeFE84pv6D1JvZHHLwalB+yQWbNOWvu65Lf8FdngLptwDCNgOnrzvHvgOEguaPUaN7YHlHReUAOddA==}
     peerDependencies:
       '@effect/platform': ^0.53.2
@@ -840,37 +840,37 @@ packages:
       '@effect/schema': ^0.66.16
       effect: ^3.1.3
     dependencies:
-      '@effect/platform': 0.53.2(@effect/schema@0.66.16)(effect@3.1.3)
-      '@effect/printer': 0.33.12(@effect/typeclass@0.24.12)(effect@3.1.3)
-      '@effect/printer-ansi': 0.33.12(@effect/typeclass@0.24.12)(effect@3.1.3)
-      '@effect/schema': 0.66.16(effect@3.1.3)(fast-check@3.17.2)
-      effect: 3.1.3
+      '@effect/platform': 0.53.2(@effect/schema@0.66.16)(effect@3.1.4)
+      '@effect/printer': 0.33.12(@effect/typeclass@0.24.12)(effect@3.1.4)
+      '@effect/printer-ansi': 0.33.12(@effect/typeclass@0.24.12)(effect@3.1.4)
+      '@effect/schema': 0.66.16(effect@3.1.4)(fast-check@3.17.2)
+      effect: 3.1.4
       ini: 4.1.2
       toml: 3.0.0
       yaml: 2.4.2
     dev: false
 
-  /@effect/platform-node-shared@0.4.21(@effect/platform@0.53.2)(effect@3.1.3):
+  /@effect/platform-node-shared@0.4.21(@effect/platform@0.53.2)(effect@3.1.4):
     resolution: {integrity: sha512-F0cEeLQ9Qi5hr/KYxgjL2+bJT1Ti4Sd24czyCE1ETEMxUid7zca3NCBbhjDKNMkHYroGhP2bG2lVzRx048cfzg==}
     peerDependencies:
       '@effect/platform': ^0.53.2
       effect: ^3.1.3
     dependencies:
-      '@effect/platform': 0.53.2(@effect/schema@0.66.16)(effect@3.1.3)
+      '@effect/platform': 0.53.2(@effect/schema@0.66.16)(effect@3.1.4)
       '@parcel/watcher': 2.4.1
-      effect: 3.1.3
+      effect: 3.1.4
       multipasta: 0.2.1
     dev: false
 
-  /@effect/platform-node@0.49.2(@effect/platform@0.53.2)(effect@3.1.3):
+  /@effect/platform-node@0.49.2(@effect/platform@0.53.2)(effect@3.1.4):
     resolution: {integrity: sha512-OvixXYcQrRZAt0T/7GJ9Li2RRr6+3HDQ8kUiiBNo+OWyg25QVfQTsTU4OjT7MHnuR0mcNzbsu5VlDskci7/T/g==}
     peerDependencies:
       '@effect/platform': ^0.53.2
       effect: ^3.1.3
     dependencies:
-      '@effect/platform': 0.53.2(@effect/schema@0.66.16)(effect@3.1.3)
-      '@effect/platform-node-shared': 0.4.21(@effect/platform@0.53.2)(effect@3.1.3)
-      effect: 3.1.3
+      '@effect/platform': 0.53.2(@effect/schema@0.66.16)(effect@3.1.4)
+      '@effect/platform-node-shared': 0.4.21(@effect/platform@0.53.2)(effect@3.1.4)
+      effect: 3.1.4
       mime: 3.0.0
       undici: 6.16.1
       ws: 8.17.0
@@ -879,56 +879,56 @@ packages:
       - utf-8-validate
     dev: false
 
-  /@effect/platform@0.53.2(@effect/schema@0.66.16)(effect@3.1.3):
+  /@effect/platform@0.53.2(@effect/schema@0.66.16)(effect@3.1.4):
     resolution: {integrity: sha512-+OeR9o7UOdWsl8xQow7FUIgoJaPjqZ5dPz2xxGv0VeNDkAJMxu7+FWDtB7tK+r4PzhA3X/x5YaGbH09mcOD+mg==}
     peerDependencies:
       '@effect/schema': ^0.66.16
       effect: ^3.1.3
     dependencies:
-      '@effect/schema': 0.66.16(effect@3.1.3)(fast-check@3.17.2)
-      effect: 3.1.3
+      '@effect/schema': 0.66.16(effect@3.1.4)(fast-check@3.17.2)
+      effect: 3.1.4
       find-my-way-ts: 0.1.2
       multipasta: 0.2.1
       path-browserify: 1.0.1
     dev: false
 
-  /@effect/printer-ansi@0.33.12(@effect/typeclass@0.24.12)(effect@3.1.3):
+  /@effect/printer-ansi@0.33.12(@effect/typeclass@0.24.12)(effect@3.1.4):
     resolution: {integrity: sha512-MEGolsEBQlZNsgEoqq02erGgMmLH/6QAU3Bq9pQp2fkOR907LMvXTD++HiMRmEnV1mqDMxgQvICF6RA/voLnCA==}
     peerDependencies:
       '@effect/typeclass': ^0.24.12
       effect: ^3.1.3
     dependencies:
-      '@effect/printer': 0.33.12(@effect/typeclass@0.24.12)(effect@3.1.3)
-      '@effect/typeclass': 0.24.12(effect@3.1.3)
-      effect: 3.1.3
+      '@effect/printer': 0.33.12(@effect/typeclass@0.24.12)(effect@3.1.4)
+      '@effect/typeclass': 0.24.12(effect@3.1.4)
+      effect: 3.1.4
     dev: false
 
-  /@effect/printer@0.33.12(@effect/typeclass@0.24.12)(effect@3.1.3):
+  /@effect/printer@0.33.12(@effect/typeclass@0.24.12)(effect@3.1.4):
     resolution: {integrity: sha512-AY5uupL6yWm/fQsD+j9UHBKZcd6Ai4I6Z2PHec48KwgFQUiKCpn6sN69Scp8CINwKHrYsCtwwqyO+xt8yZOXDw==}
     peerDependencies:
       '@effect/typeclass': ^0.24.12
       effect: ^3.1.3
     dependencies:
-      '@effect/typeclass': 0.24.12(effect@3.1.3)
-      effect: 3.1.3
+      '@effect/typeclass': 0.24.12(effect@3.1.4)
+      effect: 3.1.4
     dev: false
 
-  /@effect/schema@0.66.16(effect@3.1.3)(fast-check@3.17.2):
+  /@effect/schema@0.66.16(effect@3.1.4)(fast-check@3.17.2):
     resolution: {integrity: sha512-sT/k5NOgKslGPzs3DUaCFuM6g2JQoIIT8jpwEorAZooplPIMK2xIspr7ECz6pp6Dc7Wz/ppXGk7HVyGZQsIYEQ==}
     peerDependencies:
       effect: ^3.1.3
       fast-check: ^3.13.2
     dependencies:
-      effect: 3.1.3
+      effect: 3.1.4
       fast-check: 3.17.2
     dev: false
 
-  /@effect/typeclass@0.24.12(effect@3.1.3):
+  /@effect/typeclass@0.24.12(effect@3.1.4):
     resolution: {integrity: sha512-s18bZwNKgVkp9kEK2ZkwnxOHRvn1UdpAnhVVHyUyYiUYJWGwlHUXTZWf0Y+kCaai+fLcLUGF63qu97JdNzdDyQ==}
     peerDependencies:
       effect: ^3.1.3
     dependencies:
-      effect: 3.1.3
+      effect: 3.1.4
     dev: false
 
   /@esbuild/aix-ppc64@0.19.10:
@@ -3841,10 +3841,6 @@ packages:
       unzipper: 0.10.14
       which: 4.0.0
     dev: true
-
-  /effect@3.1.3:
-    resolution: {integrity: sha512-afL9sbn4m9fCERYMLgUgtJC8+JvHb62zh0Q3v0O56z4aMAEdrrd+DKvLtlTbonQjgdOB37frE9LJuwUO7DV0ww==}
-    dev: false
 
   /effect@3.1.4:
     resolution: {integrity: sha512-eAKVwRyDF+8wCRKWY6yK7inCwsTGjLIyZTggbQjlVp/ziHBmfVsOCn/JOyW5iFjRoeZv7+TsLMUPjoMwkt1QQA==}


### PR DESCRIPTION
- Make sure that we don't have 2 effect versions installed in case the user also has effect installed

![image](https://github.com/gardencmp/jazz/assets/2978876/8d042801-e215-4666-923b-f3e7c912b455)
