### PR TITLE
ignore error on ws close, fixing "Invalid state: Controller is already closed"

### DIFF
--- a/packages/cojson-transport-nodejs-ws/src/index.ts
+++ b/packages/cojson-transport-nodejs-ws/src/index.ts
@@ -25,7 +25,13 @@ export function websocketReadableStream<T>(ws: WebSocket) {
                 }
                 controller.enqueue(msg);
             });
-            ws.addEventListener("close", () => controller.close());
+            ws.addEventListener("close", () => {
+                try {
+                    controller.close()
+                } catch(ignore) {
+                    // will throw if already closed, with no way to check before-hand
+                }
+            });
             ws.addEventListener("error", () =>
                 controller.error(new Error("The WebSocket errored!"))
             );


### PR DESCRIPTION
When a connection to the sync server cannot be made when `startWorker`, an error is thrown here that doesn't bubble up to be caught by that promise, and the node process exits. By catching the error here, the process will continue to run. I need it to continue to run to be able to determine why it can't connect.