### PR TITLE
Fix DemoAuth for Next.js

### DIFF
--- a/packages/jazz-react/src/auth/DemoAuth.tsx
+++ b/packages/jazz-react/src/auth/DemoAuth.tsx
@@ -104,7 +104,7 @@ const DemoAuthBasicUI = ({
     signUp: (username: string) => void;
 }) => {
     const [username, setUsername] = useState<string>("");
-    const darkMode = window.matchMedia("(prefers-color-scheme: dark)").matches;
+    const darkMode = typeof window !== 'undefined' ? window.matchMedia("(prefers-color-scheme: dark)").matches : false;
 
     return (
         <div


### PR DESCRIPTION
Because `window` is not defined during SSR we need to check first