### PR TITLE
cojson-transport-ws: reuse runtime and use fibers instead of setTimeout

### DIFF
--- a/packages/cojson-transport-ws/src/index.ts
+++ b/packages/cojson-transport-ws/src/index.ts
@@ -8,6 +8,7 @@ import {
     Runtime,
     Console,
     Fiber,
+    GlobalValue,
 } from "effect";
 
 interface WebsocketEvents {
@@ -24,6 +25,14 @@ interface AnyWebSocket {
     close(): void;
     send(data: string): void;
 }
+
+const jazzPings = GlobalValue.globalValue<
+    Array<{
+        received: number;
+        sent: number;
+        dc: string;
+    }>
+>("jazzPings", () => []);
 
 export function createWebSocketPeer(options: {
     id: string;
@@ -90,16 +99,7 @@ export function createWebSocketPeer(options: {
                         return;
                     }
 
-                    const g: typeof globalThis & {
-                        jazzPings?: Array<{
-                            received: number;
-                            sent: number;
-                            dc: string;
-                        }>;
-                    } = globalThis;
-
-                    g.jazzPings ||= [];
-                    g.jazzPings.push({
+                    jazzPings.push({
                         received: Date.now(),
                         sent: msg.time,
                         dc: msg.dc,

--- a/packages/cojson-transport-ws/src/index.ts
+++ b/packages/cojson-transport-ws/src/index.ts
@@ -8,7 +8,6 @@ import {
     Runtime,
     Console,
     Fiber,
-    GlobalValue,
 } from "effect";
 
 interface WebsocketEvents {
@@ -26,13 +25,13 @@ interface AnyWebSocket {
     send(data: string): void;
 }
 
-const jazzPings = GlobalValue.globalValue<
-    Array<{
+const g: typeof globalThis & {
+    jazzPings?: {
         received: number;
         sent: number;
         dc: string;
-    }>
->("jazzPings", () => []);
+    }[];
+} = globalThis;
 
 export function createWebSocketPeer(options: {
     id: string;
@@ -100,7 +99,8 @@ export function createWebSocketPeer(options: {
                     return;
                 }
 
-                jazzPings.push({
+                g.jazzPings ||= [];
+                g.jazzPings.push({
                     received: Date.now(),
                     sent: msg.time,
                     dc: msg.dc,


### PR DESCRIPTION
when calling Effect.runFork we don't propagate layers and using fibers can allow us to interrupt ongoing requests when the pings fail
