### PR TITLE
Add support for property existence

### DIFF
--- a/packages/jazz-tools/src/coValues/coMap.ts
+++ b/packages/jazz-tools/src/coValues/coMap.ts
@@ -611,10 +611,6 @@ const CoMapProxyHandler: ProxyHandler<CoMap> = {
         }
     },
     has(target, key) {
-        if (key in target) {
-            return true;
-        }
-
         const descriptor = (target._schema[key as keyof CoMap["_schema"]] ||
             target._schema[ItemsSym]) as Schema;
 

--- a/packages/jazz-tools/src/coValues/coMap.ts
+++ b/packages/jazz-tools/src/coValues/coMap.ts
@@ -615,16 +615,14 @@ const CoMapProxyHandler: ProxyHandler<CoMap> = {
             return true;
         }
 
-        if (typeof key === "string") {
-            const descriptor = (target._schema[key as keyof CoMap["_schema"]] ||
-                target._schema[ItemsSym]) as Schema;
+        const descriptor = (target._schema[key as keyof CoMap["_schema"]] ||
+            target._schema[ItemsSym]) as Schema;
 
-            if (descriptor) {
-                return target._raw.get(key) !== undefined;
-            }
+        if (typeof key === "string" && descriptor) {
+            return target._raw.get(key) !== undefined;
+        } else {
+            return Reflect.has(target, key);
         }
-
-        return false;
     },
     deleteProperty(target, key) {
         const descriptor = (target._schema[key as keyof CoMap["_schema"]] ||

--- a/packages/jazz-tools/src/coValues/coMap.ts
+++ b/packages/jazz-tools/src/coValues/coMap.ts
@@ -610,6 +610,22 @@ const CoMapProxyHandler: ProxyHandler<CoMap> = {
             }
         }
     },
+    has(target, key) {
+        if (key in target) {
+            return true;
+        }
+
+        if (typeof key === "string") {
+            const descriptor = (target._schema[key as keyof CoMap["_schema"]] ||
+                target._schema[ItemsSym]) as Schema;
+
+            if (descriptor) {
+                return target._raw.get(key) !== undefined;
+            }
+        }
+
+        return false;
+    },
     deleteProperty(target, key) {
         const descriptor = (target._schema[key as keyof CoMap["_schema"]] ||
             target._schema[ItemsSym]) as Schema;

--- a/packages/jazz-tools/src/tests/coMap.test.ts
+++ b/packages/jazz-tools/src/tests/coMap.test.ts
@@ -106,6 +106,21 @@ describe("Simple CoMap operations", async () => {
         });
     });
 
+    describe("property existence", () => {
+        class TestMap extends CoMap.Record(co.string) {}
+        test("CoMap", () => {
+            const map = TestMap.create(
+                { name: "test" },
+                {
+                    owner: me,
+                },
+            );
+
+            expect("name" in map).toBe(true);
+            expect("something" in map).toBe(false);
+        });
+    });
+
     class RecursiveMap extends CoMap {
         name = co.string;
         next?: co<RecursiveMap | null> = co.ref(RecursiveMap);


### PR DESCRIPTION
Allow to do `'someproperty' in someCoMap` to check for optional properties. 

resolves #194