### PR TITLE
docs: fix the get started links position

### DIFF
--- a/homepage/homepage/app/page.mdx
+++ b/homepage/homepage/app/page.mdx
@@ -268,11 +268,7 @@ Jazz Mesh is currently free &mdash; and it's set up as the default sync & storag
 
 ## Get Started
 
--   <Link href="/docs" target="_blank">
-        Read the docs
-    </Link>
--   <Link href="https://discord.gg/utDMjHYg42" target="_blank">
-        Join our Discord
-    </Link>
+-   <Link href="/docs" target="_blank">Read the docs</Link>
+-   <Link href="https://discord.gg/utDMjHYg42" target="_blank">Join our Discord</Link>
 
 </Prose>


### PR DESCRIPTION
A small style fix regarding the links on the "Get started" section.

|||
|--|--|
|Before|After|
|<img width="642" alt="Screenshot 2024-08-10 at 16 18 34" src="https://github.com/user-attachments/assets/c2abe422-93bb-4e28-a55f-72c443e3243f">|<img width="697" alt="Screenshot 2024-08-10 at 16 18 40" src="https://github.com/user-attachments/assets/b57711db-0c22-4579-bfe3-24b06c1ad015">|

