### PR TITLE
fix(BinaryCoStream): resolve the load request only when the stream is ended

### DIFF
--- a/packages/jazz-tools/src/coValues/coStream.ts
+++ b/packages/jazz-tools/src/coValues/coStream.ts
@@ -509,6 +509,10 @@ export class BinaryCoStream extends CoValueBase implements CoValue {
         return this._raw.getBinaryChunks(options?.allowUnfinished);
     }
 
+    isBinaryStreamEnded(): boolean {
+        return this._raw.isBinaryStreamEnded();
+    }
+
     start(options: BinaryStreamInfo): void {
         this._raw.startBinaryStream(options);
     }

--- a/packages/jazz-tools/src/coValues/deepLoading.ts
+++ b/packages/jazz-tools/src/coValues/deepLoading.ts
@@ -1,6 +1,7 @@
 import { SessionID } from "cojson";
 import {
     Account,
+    BinaryCoStream,
     CoList,
     CoStream,
     CoStreamEntry,
@@ -11,6 +12,10 @@ import {
 } from "../internal.js";
 import { CoKeys, CoMap } from "./coMap.js";
 import { CoValue, ID } from "./interfaces.js";
+
+function isBinaryCoStream(value: CoValue): value is BinaryCoStream {
+    return value._type === "BinaryCoStream";
+}
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export function fulfillsDepth(depth: any, value: CoValue): boolean {
@@ -81,8 +86,8 @@ export function fulfillsDepth(depth: any, value: CoValue): boolean {
                           ).optional,
             );
         }
-    } else if (value._type === "BinaryCoStream") {
-        return true;
+    } else if (isBinaryCoStream(value)) {
+        return value.isBinaryStreamEnded();
     } else {
         console.error(value);
         throw new Error("Unexpected value type: " + value._type);


### PR DESCRIPTION
Currently  `BinaryStream.loadAsBlob` resolves into undefined if the BinaryStream isn't complete.

With this PR we change the behavoir to wait for the BinaryStream to be completed before resolving the promise.