### PR TITLE
fix(BinaryCoStream): resolve the loadAsBlob call only when the stream id ended

### DIFF
--- a/.changeset/dry-crews-press.md
+++ b/.changeset/dry-crews-press.md
@@ -1,0 +1,5 @@
+---
+"cojson": patch
+---
+
+Clean up binary stream ending logic

--- a/.changeset/fluffy-deers-learn.md
+++ b/.changeset/fluffy-deers-learn.md
@@ -1,0 +1,5 @@
+---
+"jazz-tools": patch
+---
+
+Fix loadAsBlob resolving too early


### PR DESCRIPTION
Currently BinaryStream.loadAsBlob resolves into undefined if the BinaryStream isn't complete.

With this PR we change the behavoir to wait for the BinaryStream to be completed before resolving the promise.

NOTE: This is the second iteration for the bugfix. I've the first one I've also changed the behavoir of `load` but later found out that wasn't the best choice: https://github.com/gardencmp/jazz/pull/335#discussion_r1723661794
