### PR TITLE
fix(pets): set the ownership of reactions to the write group

### DIFF
--- a/examples/pets/src/3_NewPetPostForm.tsx
+++ b/examples/pets/src/3_NewPetPostForm.tsx
@@ -36,7 +36,9 @@ export function NewPetPostForm() {
                 const petPost = PartialPetPost.create(
                     {
                         name,
-                        reactions: PetReactions.create([], { owner: me }),
+                        reactions: PetReactions.create([], {
+                            owner: petPostGroup,
+                        }),
                     },
                     { owner: petPostGroup },
                 );


### PR DESCRIPTION
While debugging the problem I've noticed that the key was missing only for the `reactions` list and found that the ownership assigned during the creation wasn't correct.

So this ended up to be a quick fix but it also highlights how it's easy to do mistakes when setting up permissions.

Let's say that this was a production app, is there a way to fix the permissions on the already created coValues?

If yes this should be probably part of the docs or the FAQ.