### PR TITLE
feat(jazz-run): add a command to spin a local sync server

### DIFF
--- a/.changeset/forty-plants-kiss.md
+++ b/.changeset/forty-plants-kiss.md
@@ -1,5 +1,5 @@
 ---
-"jazz-run": minor
+"jazz-run": patch
 ---
 
 Added sync command to start a local sync server

--- a/.changeset/forty-plants-kiss.md
+++ b/.changeset/forty-plants-kiss.md
@@ -1,0 +1,5 @@
+---
+"jazz-run": minor
+---
+
+Added sync command to start a local sync server

--- a/examples/chat/.gitignore
+++ b/examples/chat/.gitignore
@@ -22,3 +22,5 @@ dist-ssr
 *.njsproj
 *.sln
 *.sw?
+
+sync-db/

--- a/examples/chat/README.md
+++ b/examples/chat/README.md
@@ -39,4 +39,4 @@ If you have feedback, let us know on [Discord](https://discord.gg/utDMjHYg42) or
 
 By default, the example app uses [Jazz Global Mesh](https://jazz.tools/mesh) (`wss://sync.jazz.tools`) - so cross-device use, invites and collaboration should just work.
 
-You can also run a local sync server by running `npx jazz-run cojson-simple-sync` and adding the query param `?sync=ws://localhost:4200` to the URL of the example app (for example: `http://localhost:5173/?sync=ws://localhost:4200`), or by setting the `sync` parameter of the `<Jazz.Provider>` provider component in [./src/2_main.tsx](./src/2_main.tsx).
+You can also run a local sync server by running `npx jazz-run sync` and adding the query param `?sync=ws://localhost:4200` to the URL of the example app (for example: `http://localhost:5173/?sync=ws://localhost:4200`), or by setting the `sync` parameter of the `<Jazz.Provider>` provider component in [./src/2_main.tsx](./src/2_main.tsx).

--- a/examples/chat/README.md
+++ b/examples/chat/README.md
@@ -39,4 +39,4 @@ If you have feedback, let us know on [Discord](https://discord.gg/utDMjHYg42) or
 
 By default, the example app uses [Jazz Global Mesh](https://jazz.tools/mesh) (`wss://sync.jazz.tools`) - so cross-device use, invites and collaboration should just work.
 
-You can also run a local sync server by running `npx cojson-simple-sync` and adding the query param `?sync=ws://localhost:4200` to the URL of the example app (for example: `http://localhost:5173/?sync=ws://localhost:4200`), or by setting the `sync` parameter of the `<Jazz.Provider>` provider component in [./src/2_main.tsx](./src/2_main.tsx).
+You can also run a local sync server by running `npx jazz-run cojson-simple-sync` and adding the query param `?sync=ws://localhost:4200` to the URL of the example app (for example: `http://localhost:5173/?sync=ws://localhost:4200`), or by setting the `sync` parameter of the `<Jazz.Provider>` provider component in [./src/2_main.tsx](./src/2_main.tsx).

--- a/examples/inspector/.gitignore
+++ b/examples/inspector/.gitignore
@@ -22,3 +22,5 @@ dist-ssr
 *.njsproj
 *.sln
 *.sw?
+
+sync-db/

--- a/examples/pets/.gitignore
+++ b/examples/pets/.gitignore
@@ -26,3 +26,5 @@ dist-ssr
 /playwright-report/
 /blob-report/
 /playwright/.cache/
+
+sync-db/

--- a/examples/pets/README.md
+++ b/examples/pets/README.md
@@ -7,6 +7,7 @@ Live version: https://example-pets.jazz.tools
 (this requires `pnpm` to be installed, see [https://pnpm.io/installation](https://pnpm.io/installation))
 
 Start by checking out `jazz`
+
 ```bash
 git clone https://github.com/gardencmp/jazz.git
 cd jazz/examples/pets
@@ -34,9 +35,8 @@ pnpm dev
 
 If you have feedback, let us know on [Discord](https://discord.gg/utDMjHYg42) or open an issue or PR to fix something that seems wrong.
 
-
 ## Configuration: sync server
 
 By default, the example app uses [Jazz Global Mesh](https://jazz.tools/mesh) (`wss://sync.jazz.tools`) - so cross-device use, invites and collaboration should just work.
 
-You can also run a local sync server by running `npx cojson-simple-sync` and adding the query param `?sync=ws://localhost:4200` to the URL of the example app (for example: `http://localhost:5173/?sync=ws://localhost:4200`), or by setting the `sync` parameter of the `<Jazz.Provider>` provider component in [./src/2_main.tsx](./src/2_main.tsx).
+You can also run a local sync server by running `npx jazz-run cojson-simple-sync` and adding the query param `?sync=ws://localhost:4200` to the URL of the example app (for example: `http://localhost:5173/?sync=ws://localhost:4200`), or by setting the `sync` parameter of the `<Jazz.Provider>` provider component in [./src/2_main.tsx](./src/2_main.tsx).

--- a/examples/pets/README.md
+++ b/examples/pets/README.md
@@ -39,4 +39,4 @@ If you have feedback, let us know on [Discord](https://discord.gg/utDMjHYg42) or
 
 By default, the example app uses [Jazz Global Mesh](https://jazz.tools/mesh) (`wss://sync.jazz.tools`) - so cross-device use, invites and collaboration should just work.
 
-You can also run a local sync server by running `npx jazz-run cojson-simple-sync` and adding the query param `?sync=ws://localhost:4200` to the URL of the example app (for example: `http://localhost:5173/?sync=ws://localhost:4200`), or by setting the `sync` parameter of the `<Jazz.Provider>` provider component in [./src/2_main.tsx](./src/2_main.tsx).
+You can also run a local sync server by running `npx jazz-run sync` and adding the query param `?sync=ws://localhost:4200` to the URL of the example app (for example: `http://localhost:5173/?sync=ws://localhost:4200`), or by setting the `sync` parameter of the `<Jazz.Provider>` provider component in [./src/2_main.tsx](./src/2_main.tsx).

--- a/examples/todo/.gitignore
+++ b/examples/todo/.gitignore
@@ -22,3 +22,5 @@ dist-ssr
 *.njsproj
 *.sln
 *.sw?
+
+sync-db/

--- a/examples/todo/README.md
+++ b/examples/todo/README.md
@@ -7,6 +7,7 @@ Live version: https://example-todo.jazz.tools
 (this requires `pnpm` to be installed, see [https://pnpm.io/installation](https://pnpm.io/installation))
 
 Start by checking out `jazz`
+
 ```bash
 git clone https://github.com/gardencmp/jazz.git
 cd jazz/examples/todo
@@ -32,12 +33,12 @@ pnpm dev
 
 ## Structure
 
-- [`src/basicComponents`](./src/basicComponents): simple components to build the UI, unrelated to Jazz (uses [shadcn/ui](https://ui.shadcn.com))
-- [`src/components`](./src/components/): helper components that do contain Jazz-specific logic, but aren't very relevant to understand the basics of Jazz and CoJSON
-- [`src/1_schema.ts`](./src/1_schema.ts),
-[`src/2_main.tsx`](./src/2_main.tsx),
-[`src/3_NewProjectForm.tsx`](./src/3_NewProjectForm.tsx),
-[`src/4_ProjectTodoTable.tsx`](./src/4_ProjectTodoTable.tsx): the main files for this example, see the walkthrough below
+-   [`src/basicComponents`](./src/basicComponents): simple components to build the UI, unrelated to Jazz (uses [shadcn/ui](https://ui.shadcn.com))
+-   [`src/components`](./src/components/): helper components that do contain Jazz-specific logic, but aren't very relevant to understand the basics of Jazz and CoJSON
+-   [`src/1_schema.ts`](./src/1_schema.ts),
+    [`src/2_main.tsx`](./src/2_main.tsx),
+    [`src/3_NewProjectForm.tsx`](./src/3_NewProjectForm.tsx),
+    [`src/4_ProjectTodoTable.tsx`](./src/4_ProjectTodoTable.tsx): the main files for this example, see the walkthrough below
 
 ## Walkthrough
 
@@ -53,7 +54,7 @@ pnpm dev
 
 ### Helpers
 
-- (not yet explained) Creating Invite Links/QR codes with `<InviteButton/>`: [`src/components/InviteButton.tsx`](./src/components/InviteButton.tsx)
+-   (not yet explained) Creating Invite Links/QR codes with `<InviteButton/>`: [`src/components/InviteButton.tsx`](./src/components/InviteButton.tsx)
 
 This is the whole Todo List app!
 
@@ -61,9 +62,8 @@ This is the whole Todo List app!
 
 If you have feedback, let us know on [Discord](https://discord.gg/utDMjHYg42) or open an issue or PR to fix something that seems wrong.
 
-
 ## Configuration: sync server
 
 By default, the example app uses [Jazz Global Mesh](https://jazz.tools/mesh) (`wss://sync.jazz.tools`) - so cross-device use, invites and collaboration should just work.
 
-You can also run a local sync server by running `npx cojson-simple-sync` and adding the query param `?sync=ws://localhost:4200` to the URL of the example app (for example: `http://localhost:5173/?sync=ws://localhost:4200`), or by setting the `sync` parameter of the `<Jazz.Provider>` provider component in [./src/2_main.tsx](./src/2_main.tsx).
+You can also run a local sync server by running `npx jazz-run cojson-simple-sync` and adding the query param `?sync=ws://localhost:4200` to the URL of the example app (for example: `http://localhost:5173/?sync=ws://localhost:4200`), or by setting the `sync` parameter of the `<Jazz.Provider>` provider component in [./src/2_main.tsx](./src/2_main.tsx).

--- a/examples/todo/README.md
+++ b/examples/todo/README.md
@@ -66,4 +66,4 @@ If you have feedback, let us know on [Discord](https://discord.gg/utDMjHYg42) or
 
 By default, the example app uses [Jazz Global Mesh](https://jazz.tools/mesh) (`wss://sync.jazz.tools`) - so cross-device use, invites and collaboration should just work.
 
-You can also run a local sync server by running `npx jazz-run cojson-simple-sync` and adding the query param `?sync=ws://localhost:4200` to the URL of the example app (for example: `http://localhost:5173/?sync=ws://localhost:4200`), or by setting the `sync` parameter of the `<Jazz.Provider>` provider component in [./src/2_main.tsx](./src/2_main.tsx).
+You can also run a local sync server by running `npx jazz-run sync` and adding the query param `?sync=ws://localhost:4200` to the URL of the example app (for example: `http://localhost:5173/?sync=ws://localhost:4200`), or by setting the `sync` parameter of the `<Jazz.Provider>` provider component in [./src/2_main.tsx](./src/2_main.tsx).

--- a/packages/jazz-run/.gitignore
+++ b/packages/jazz-run/.gitignore
@@ -169,3 +169,5 @@ dist
 .pnp.\*
 
 .DS_Store
+
+sync-db/

--- a/packages/jazz-run/package.json
+++ b/packages/jazz-run/package.json
@@ -20,6 +20,7 @@
         "@effect/typeclass": "^0.25.5",
         "cojson": "workspace:*",
         "cojson-transport-ws": "workspace:*",
+        "cojson-storage-sqlite": "workspace:*",
         "jazz-tools": "workspace:*",
         "ws": "^8.14.2"
     },

--- a/packages/jazz-run/src/index.ts
+++ b/packages/jazz-run/src/index.ts
@@ -11,6 +11,7 @@ import {
     isControlledAccount,
 } from "jazz-tools";
 import type { AccountID } from "cojson";
+import { startCoJsonSimpleSync } from "./startCoJsonSimpleSync.js";
 
 const jazzTools = Command.make("jazz-tools");
 
@@ -86,7 +87,9 @@ const accountBase = Command.make("account");
 
 const account = accountBase.pipe(Command.withSubcommands([accountCreate]));
 
-const command = jazzTools.pipe(Command.withSubcommands([account]));
+const command = jazzTools.pipe(
+    Command.withSubcommands([account, startCoJsonSimpleSync]),
+);
 
 const cli = Command.run(command, {
     name: "Jazz CLI Tools",

--- a/packages/jazz-run/src/index.ts
+++ b/packages/jazz-run/src/index.ts
@@ -11,7 +11,7 @@ import {
     isControlledAccount,
 } from "jazz-tools";
 import type { AccountID } from "cojson";
-import { startCoJsonSimpleSync } from "./startCoJsonSimpleSync.js";
+import { startSync } from "./startSync.js";
 
 const jazzTools = Command.make("jazz-tools");
 
@@ -87,9 +87,7 @@ const accountBase = Command.make("account");
 
 const account = accountBase.pipe(Command.withSubcommands([accountCreate]));
 
-const command = jazzTools.pipe(
-    Command.withSubcommands([account, startCoJsonSimpleSync]),
-);
+const command = jazzTools.pipe(Command.withSubcommands([account, startSync]));
 
 const cli = Command.run(command, {
     name: "Jazz CLI Tools",

--- a/packages/jazz-run/src/startCoJsonSimpleSync.ts
+++ b/packages/jazz-run/src/startCoJsonSimpleSync.ts
@@ -1,0 +1,80 @@
+import { Command, Options } from "@effect/cli";
+import {
+    ControlledAgent,
+    LocalNode,
+    WasmCrypto,
+    cojsonInternals,
+} from "cojson";
+import { WebSocketServer } from "ws";
+
+import { createWebSocketPeer } from "cojson-transport-ws";
+import { Effect } from "effect";
+
+const port = Options.text("port")
+    .pipe(Options.withAlias("p"))
+    .pipe(Options.withDefault("4200"));
+
+export const startCoJsonSimpleSync = Command.make(
+    "cojson-simple-sync",
+    { port },
+    ({ port }) => {
+        return Effect.gen(function* () {
+            const crypto = yield* Effect.promise(() => WasmCrypto.create());
+
+            const wss = new WebSocketServer({ port: parseInt(port) });
+
+            console.log(
+                "COJSON sync server listening on port " + wss.options.port,
+            );
+
+            const agentSecret = crypto.newRandomAgentSecret();
+            const agentID = crypto.getAgentID(agentSecret);
+
+            const localNode = new LocalNode(
+                new ControlledAgent(agentSecret, crypto),
+                cojsonInternals.newRandomSessionID(agentID),
+                crypto,
+            );
+
+            wss.on("connection", function connection(ws, req) {
+                const pinging = setInterval(() => {
+                    ws.send(
+                        JSON.stringify({
+                            type: "ping",
+                            time: Date.now(),
+                            dc: "unknown",
+                        }),
+                    );
+                }, 1500);
+
+                ws.on("close", () => {
+                    clearInterval(pinging);
+                });
+
+                const clientAddress =
+                    (req.headers["x-forwarded-for"] as string | undefined)
+                        ?.split(",")[0]
+                        ?.trim() || req.socket.remoteAddress;
+
+                const clientId = clientAddress + "@" + new Date().toISOString();
+
+                localNode.syncManager.addPeer(
+                    createWebSocketPeer({
+                        id: clientId,
+                        role: "client",
+                        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                        websocket: ws as any, // TODO: fix types
+                        expectPings: false,
+                    }),
+                );
+
+                ws.on("error", (e) =>
+                    console.error(`Error on connection ${clientId}:`, e),
+                );
+            });
+
+            // Indefintely pending promise to keep the server up
+            yield* Effect.promise(() => new Promise(() => {}));
+        });
+    },
+);

--- a/packages/jazz-run/src/startSync.ts
+++ b/packages/jazz-run/src/startSync.ts
@@ -47,14 +47,6 @@ export const startSync = Command.make(
                 "COJSON sync server listening on port " + wss.options.port,
             );
 
-            /**
-             * In Jazz the communication is decentralized
-             * so the sync server is implemented as "just another peer" in the network
-             *
-             * LocalNode is the class we use to manage the connected peers that could be:
-             * - the storage layer
-             * - the WebSocket connections
-             */
             const agentSecret = crypto.newRandomAgentSecret();
             const agentID = crypto.getAgentID(agentSecret);
 
@@ -77,7 +69,7 @@ export const startSync = Command.make(
             }
 
             wss.on("connection", function connection(ws, req) {
-                // ping/pong for the connection livenerss
+                // ping/pong for the connection liveness
                 const pinging = setInterval(() => {
                     ws.send(
                         JSON.stringify({
@@ -114,8 +106,8 @@ export const startSync = Command.make(
                 );
             });
 
-            // Indefintely pending promise to keep the server up
-            yield* Effect.promise(() => new Promise(() => {}));
+            // Keep the server up
+            yield* Effect.never;
         });
     },
 );

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -670,6 +670,9 @@ importers:
       cojson:
         specifier: workspace:*
         version: link:../cojson
+      cojson-storage-sqlite:
+        specifier: workspace:*
+        version: link:../cojson-storage-sqlite
       cojson-transport-ws:
         specifier: workspace:*
         version: link:../cojson-transport-ws


### PR DESCRIPTION
In order to fix #180 and make the `cojson-simple-sync` easier to maintain we are integrating it inside `jazz-run`

