### PR TITLE
fix(inspector): subscribe to latent covalues instead of loading them immediately

### DIFF
--- a/.changeset/thin-olives-fold.md
+++ b/.changeset/thin-olives-fold.md
@@ -1,0 +1,5 @@
+---
+"jazz-inspector": patch
+---
+
+fix(inspector): subscribe to latent covalues instead of loading them immediately

--- a/examples/inspector/src/viewer/use-resolve-covalue.ts
+++ b/examples/inspector/src/viewer/use-resolve-covalue.ts
@@ -8,209 +8,215 @@ type JSON = string | number | boolean | null | JSON[] | { [key: string]: JSON };
 type JSONObject = { [key: string]: JSON };
 
 type ResolvedImageDefinition = {
-  originalSize: [number, number];
-  placeholderDataURL?: string;
-  [res: `${number}x${number}`]: RawBinaryCoStream["id"];
+    originalSize: [number, number];
+    placeholderDataURL?: string;
+    [res: `${number}x${number}`]: RawBinaryCoStream["id"];
 };
 
 // Type guard for browser image
 export const isBrowserImage = (
-  coValue: JSONObject
+    coValue: JSONObject,
 ): coValue is ResolvedImageDefinition => {
-  return "originalSize" in coValue && "placeholderDataURL" in coValue;
+    return "originalSize" in coValue && "placeholderDataURL" in coValue;
 };
 
 export type ResolvedGroup = {
-  readKey: string;
-  [key: string]: JSON;
+    readKey: string;
+    [key: string]: JSON;
 };
 
 export const isGroup = (coValue: JSONObject): coValue is ResolvedGroup => {
-  return "readKey" in coValue;
+    return "readKey" in coValue;
 };
 
 export type ResolvedAccount = {
-  profile: {
-    name: string;
-  };
-  [key: string]: JSON;
+    profile: {
+        name: string;
+    };
+    [key: string]: JSON;
 };
 
 export const isAccount = (coValue: JSONObject): coValue is ResolvedAccount => {
-  return isGroup(coValue) && "profile" in coValue;
+    return isGroup(coValue) && "profile" in coValue;
 };
 
 export async function resolveCoValue(
-  coValueId: CoID<RawCoValue>,
-  node: LocalNode
+    coValueId: CoID<RawCoValue>,
+    node: LocalNode,
 ): Promise<
-  | {
-      value: RawCoValue;
-      snapshot: JSONObject;
-      type: CoJsonType | null;
-      extendedType: ExtendedCoJsonType | undefined;
-    }
-  | {
-      value: undefined;
-      snapshot: "unavailable";
-      type: null;
-      extendedType: undefined;
-    }
+    | {
+          value: RawCoValue;
+          snapshot: JSONObject;
+          type: CoJsonType | null;
+          extendedType: ExtendedCoJsonType | undefined;
+      }
+    | {
+          value: undefined;
+          snapshot: "unavailable";
+          type: null;
+          extendedType: undefined;
+      }
 > {
-  const value = await node.load(coValueId);
+    const value = await node.load(coValueId);
 
-  if (value === "unavailable") {
-    return {
-      value: undefined,
-      snapshot: "unavailable",
-      type: null,
-      extendedType: undefined,
-    };
-  }
-
-  const snapshot = value.toJSON() as JSONObject;
-  const type = value.type as CoJsonType;
-
-  // Determine extended type
-  let extendedType: ExtendedCoJsonType | undefined;
-
-  if (type === "comap") {
-    if (isBrowserImage(snapshot)) {
-      extendedType = "image";
-    } else if (isAccount(snapshot)) {
-      extendedType = "account";
-    } else if (isGroup(snapshot)) {
-      extendedType = "group";
-    } else {
-      // This check is a bit of a hack
-      // There might be a better way to do this
-      const children = Object.values(snapshot).slice(0, 10);
-      if (
-        children.every((c) => typeof c === "string" && c.startsWith("co_")) &&
-        children.length > 3
-      ) {
-        extendedType = "record";
-      }
-    }
-  }
-
-  return {
-    value,
-    snapshot,
-    type,
-    extendedType,
-  };
-}
-
-function subscribeToCoValue(
-  coValueId: CoID<RawCoValue>,
-  node: LocalNode,
-  callback: (result: Awaited<ReturnType<typeof resolveCoValue>>) => void
-) {
-  return node.subscribe(coValueId, (value) => {
     if (value === "unavailable") {
-      callback({
-        value: undefined,
-        snapshot: "unavailable",
-        type: null,
-        extendedType: undefined,
-      });
-    } else {
-      const snapshot = value.toJSON() as JSONObject;
-      const type = value.type as CoJsonType;
-      let extendedType: ExtendedCoJsonType | undefined;
+        return {
+            value: undefined,
+            snapshot: "unavailable",
+            type: null,
+            extendedType: undefined,
+        };
+    }
 
-      if (type === "comap") {
+    const snapshot = value.toJSON() as JSONObject;
+    const type = value.type as CoJsonType;
+
+    // Determine extended type
+    let extendedType: ExtendedCoJsonType | undefined;
+
+    if (type === "comap") {
         if (isBrowserImage(snapshot)) {
-          extendedType = "image";
+            extendedType = "image";
         } else if (isAccount(snapshot)) {
-          extendedType = "account";
+            extendedType = "account";
         } else if (isGroup(snapshot)) {
-          extendedType = "group";
+            extendedType = "group";
         } else {
-          const children = Object.values(snapshot).slice(0, 10);
-          if (
-            children.every(
-              (c) => typeof c === "string" && c.startsWith("co_")
-            ) &&
-            children.length > 3
-          ) {
-            extendedType = "record";
-          }
+            // This check is a bit of a hack
+            // There might be a better way to do this
+            const children = Object.values(snapshot).slice(0, 10);
+            if (
+                children.every(
+                    (c) => typeof c === "string" && c.startsWith("co_"),
+                ) &&
+                children.length > 3
+            ) {
+                extendedType = "record";
+            }
         }
-      }
+    }
 
-      callback({
+    return {
         value,
         snapshot,
         type,
         extendedType,
-      });
-    }
-  });
+    };
+}
+
+function subscribeToCoValue(
+    coValueId: CoID<RawCoValue>,
+    node: LocalNode,
+    callback: (result: Awaited<ReturnType<typeof resolveCoValue>>) => void,
+) {
+    return node.subscribe(coValueId, (value) => {
+        if (value === "unavailable") {
+            callback({
+                value: undefined,
+                snapshot: "unavailable",
+                type: null,
+                extendedType: undefined,
+            });
+        } else {
+            const snapshot = value.toJSON() as JSONObject;
+            const type = value.type as CoJsonType;
+            let extendedType: ExtendedCoJsonType | undefined;
+
+            if (type === "comap") {
+                if (isBrowserImage(snapshot)) {
+                    extendedType = "image";
+                } else if (isAccount(snapshot)) {
+                    extendedType = "account";
+                } else if (isGroup(snapshot)) {
+                    extendedType = "group";
+                } else {
+                    const children = Object.values(snapshot).slice(0, 10);
+                    if (
+                        children.every(
+                            (c) => typeof c === "string" && c.startsWith("co_"),
+                        ) &&
+                        children.length > 3
+                    ) {
+                        extendedType = "record";
+                    }
+                }
+            }
+
+            callback({
+                value,
+                snapshot,
+                type,
+                extendedType,
+            });
+        }
+    });
 }
 
 export function useResolvedCoValue(
-  coValueId: CoID<RawCoValue>,
-  node: LocalNode
+    coValueId: CoID<RawCoValue>,
+    node: LocalNode,
 ) {
-  const [result, setResult] =
-    useState<Awaited<ReturnType<typeof resolveCoValue>>>();
+    const [result, setResult] =
+        useState<Awaited<ReturnType<typeof resolveCoValue>>>();
 
-  useEffect(() => {
-    let isMounted = true;
-    const unsubscribe = subscribeToCoValue(coValueId, node, (newResult) => {
-      if (isMounted) {
-        setResult(newResult);
-      }
-    });
+    useEffect(() => {
+        let isMounted = true;
+        const unsubscribe = subscribeToCoValue(coValueId, node, (newResult) => {
+            if (isMounted) {
+                setResult(newResult);
+            }
+        });
 
-    return () => {
-      isMounted = false;
-      unsubscribe();
-    };
-  }, [coValueId, node]);
+        return () => {
+            isMounted = false;
+            unsubscribe();
+        };
+    }, [coValueId, node]);
 
-  return (
-    result || {
-      value: undefined,
-      snapshot: undefined,
-      type: undefined,
-      extendedType: undefined,
-    }
-  );
+    return (
+        result || {
+            value: undefined,
+            snapshot: undefined,
+            type: undefined,
+            extendedType: undefined,
+        }
+    );
 }
 
 export function useResolvedCoValues(
-  coValueIds: CoID<RawCoValue>[],
-  node: LocalNode
+    coValueIds: CoID<RawCoValue>[],
+    node: LocalNode,
 ) {
-  const [results, setResults] = useState<
-    Awaited<ReturnType<typeof resolveCoValue>>[]
-  >([]);
+    const [results, setResults] = useState<
+        Awaited<ReturnType<typeof resolveCoValue>>[]
+    >([]);
 
-  useEffect(() => {
-    let isMounted = true;
-    const unsubscribes: (() => void)[] = [];
+    useEffect(() => {
+        let isMounted = true;
+        const unsubscribes: (() => void)[] = [];
 
-    coValueIds.forEach((coValueId, index) => {
-      const unsubscribe = subscribeToCoValue(coValueId, node, (newResult) => {
-        if (isMounted) {
-          setResults((prevResults) => {
-            const newResults = [...prevResults];
-            newResults[index] = newResult;
-            return newResults;
-          });
-        }
-      });
-      unsubscribes.push(unsubscribe);
-    });
+        coValueIds.forEach((coValueId, index) => {
+            const unsubscribe = subscribeToCoValue(
+                coValueId,
+                node,
+                (newResult) => {
+                    if (isMounted) {
+                        setResults((prevResults) => {
+                            const newResults = [...prevResults];
+                            newResults[index] = newResult;
+                            return newResults;
+                        });
+                    }
+                },
+            );
+            unsubscribes.push(unsubscribe);
+        });
 
-    return () => {
-      isMounted = false;
-      unsubscribes.forEach((unsubscribe) => unsubscribe());
-    };
-  }, [coValueIds, node]);
+        return () => {
+            isMounted = false;
+            unsubscribes.forEach((unsubscribe) => unsubscribe());
+        };
+    }, [coValueIds, node]);
 
-  return results;
+    return results;
 }

--- a/examples/inspector/src/viewer/use-resolve-covalue.ts
+++ b/examples/inspector/src/viewer/use-resolve-covalue.ts
@@ -58,7 +58,6 @@ export async function resolveCoValue(
     }
 > {
   const value = await node.load(coValueId);
-  console.log("[resolveCoValue] value", value);
 
   if (value === "unavailable") {
     return {

--- a/examples/inspector/src/viewer/use-resolve-covalue.ts
+++ b/examples/inspector/src/viewer/use-resolve-covalue.ts
@@ -8,145 +8,210 @@ type JSON = string | number | boolean | null | JSON[] | { [key: string]: JSON };
 type JSONObject = { [key: string]: JSON };
 
 type ResolvedImageDefinition = {
-    originalSize: [number, number];
-    placeholderDataURL?: string;
-    [res: `${number}x${number}`]: RawBinaryCoStream["id"];
+  originalSize: [number, number];
+  placeholderDataURL?: string;
+  [res: `${number}x${number}`]: RawBinaryCoStream["id"];
 };
 
 // Type guard for browser image
 export const isBrowserImage = (
-    coValue: JSONObject,
+  coValue: JSONObject
 ): coValue is ResolvedImageDefinition => {
-    return "originalSize" in coValue && "placeholderDataURL" in coValue;
+  return "originalSize" in coValue && "placeholderDataURL" in coValue;
 };
 
 export type ResolvedGroup = {
-    readKey: string;
-    [key: string]: JSON;
+  readKey: string;
+  [key: string]: JSON;
 };
 
 export const isGroup = (coValue: JSONObject): coValue is ResolvedGroup => {
-    return "readKey" in coValue;
+  return "readKey" in coValue;
 };
 
 export type ResolvedAccount = {
-    profile: {
-        name: string;
-    };
-    [key: string]: JSON;
+  profile: {
+    name: string;
+  };
+  [key: string]: JSON;
 };
 
 export const isAccount = (coValue: JSONObject): coValue is ResolvedAccount => {
-    return isGroup(coValue) && "profile" in coValue;
+  return isGroup(coValue) && "profile" in coValue;
 };
 
 export async function resolveCoValue(
-    coValueId: CoID<RawCoValue>,
-    node: LocalNode,
+  coValueId: CoID<RawCoValue>,
+  node: LocalNode
 ): Promise<
-    | {
-          value: RawCoValue;
-          snapshot: JSONObject;
-          type: CoJsonType | null;
-          extendedType: ExtendedCoJsonType | undefined;
-      }
-    | {
-          value: undefined;
-          snapshot: "unavailable";
-          type: null;
-          extendedType: undefined;
-      }
+  | {
+      value: RawCoValue;
+      snapshot: JSONObject;
+      type: CoJsonType | null;
+      extendedType: ExtendedCoJsonType | undefined;
+    }
+  | {
+      value: undefined;
+      snapshot: "unavailable";
+      type: null;
+      extendedType: undefined;
+    }
 > {
-    const value = await node.load(coValueId);
+  const value = await node.load(coValueId);
+  console.log("[resolveCoValue] value", value);
 
-    if (value === "unavailable") {
-        return {
-            value: undefined,
-            snapshot: "unavailable",
-            type: null,
-            extendedType: undefined,
-        };
-    }
-
-    const snapshot = value.toJSON() as JSONObject;
-    const type = value.type as CoJsonType;
-
-    // Determine extended type
-    let extendedType: ExtendedCoJsonType | undefined;
-
-    if (type === "comap") {
-        if (isBrowserImage(snapshot)) {
-            extendedType = "image";
-        } else if (isAccount(snapshot)) {
-            extendedType = "account";
-        } else if (isGroup(snapshot)) {
-            extendedType = "group";
-        } else {
-            // This check is a bit of a hack
-            // There might be a better way to do this
-            const children = Object.values(snapshot).slice(0, 10);
-            if (
-                children.every(
-                    (c) => typeof c === "string" && c.startsWith("co_"),
-                ) &&
-                children.length > 3
-            ) {
-                extendedType = "record";
-            }
-        }
-    }
-
+  if (value === "unavailable") {
     return {
+      value: undefined,
+      snapshot: "unavailable",
+      type: null,
+      extendedType: undefined,
+    };
+  }
+
+  const snapshot = value.toJSON() as JSONObject;
+  const type = value.type as CoJsonType;
+
+  // Determine extended type
+  let extendedType: ExtendedCoJsonType | undefined;
+
+  if (type === "comap") {
+    if (isBrowserImage(snapshot)) {
+      extendedType = "image";
+    } else if (isAccount(snapshot)) {
+      extendedType = "account";
+    } else if (isGroup(snapshot)) {
+      extendedType = "group";
+    } else {
+      // This check is a bit of a hack
+      // There might be a better way to do this
+      const children = Object.values(snapshot).slice(0, 10);
+      if (
+        children.every((c) => typeof c === "string" && c.startsWith("co_")) &&
+        children.length > 3
+      ) {
+        extendedType = "record";
+      }
+    }
+  }
+
+  return {
+    value,
+    snapshot,
+    type,
+    extendedType,
+  };
+}
+
+function subscribeToCoValue(
+  coValueId: CoID<RawCoValue>,
+  node: LocalNode,
+  callback: (result: Awaited<ReturnType<typeof resolveCoValue>>) => void
+) {
+  return node.subscribe(coValueId, (value) => {
+    if (value === "unavailable") {
+      callback({
+        value: undefined,
+        snapshot: "unavailable",
+        type: null,
+        extendedType: undefined,
+      });
+    } else {
+      const snapshot = value.toJSON() as JSONObject;
+      const type = value.type as CoJsonType;
+      let extendedType: ExtendedCoJsonType | undefined;
+
+      if (type === "comap") {
+        if (isBrowserImage(snapshot)) {
+          extendedType = "image";
+        } else if (isAccount(snapshot)) {
+          extendedType = "account";
+        } else if (isGroup(snapshot)) {
+          extendedType = "group";
+        } else {
+          const children = Object.values(snapshot).slice(0, 10);
+          if (
+            children.every(
+              (c) => typeof c === "string" && c.startsWith("co_")
+            ) &&
+            children.length > 3
+          ) {
+            extendedType = "record";
+          }
+        }
+      }
+
+      callback({
         value,
         snapshot,
         type,
         extendedType,
-    };
+      });
+    }
+  });
 }
 
 export function useResolvedCoValue(
-    coValueId: CoID<RawCoValue>,
-    node: LocalNode,
+  coValueId: CoID<RawCoValue>,
+  node: LocalNode
 ) {
-    const [result, setResult] =
-        useState<Awaited<ReturnType<typeof resolveCoValue>>>();
+  const [result, setResult] =
+    useState<Awaited<ReturnType<typeof resolveCoValue>>>();
 
-    useEffect(() => {
-        resolveCoValue(coValueId, node).then(setResult);
-    }, [coValueId, node]);
+  useEffect(() => {
+    let isMounted = true;
+    const unsubscribe = subscribeToCoValue(coValueId, node, (newResult) => {
+      if (isMounted) {
+        setResult(newResult);
+      }
+    });
 
-    return (
-        result || {
-            value: undefined,
-            snapshot: undefined,
-            type: undefined,
-            extendedType: undefined,
-        }
-    );
+    return () => {
+      isMounted = false;
+      unsubscribe();
+    };
+  }, [coValueId, node]);
+
+  return (
+    result || {
+      value: undefined,
+      snapshot: undefined,
+      type: undefined,
+      extendedType: undefined,
+    }
+  );
 }
 
 export function useResolvedCoValues(
-    coValueIds: CoID<RawCoValue>[],
-    node: LocalNode,
+  coValueIds: CoID<RawCoValue>[],
+  node: LocalNode
 ) {
-    const [results, setResults] = useState<
-        Awaited<ReturnType<typeof resolveCoValue>>[]
-    >([]);
+  const [results, setResults] = useState<
+    Awaited<ReturnType<typeof resolveCoValue>>[]
+  >([]);
 
-    useEffect(() => {
-        console.log("RETECHING", coValueIds);
-        const fetchResults = async () => {
-            if (coValueIds.length === 0) return;
-            const resolvedValues = await Promise.all(
-                coValueIds.map((coValueId) => resolveCoValue(coValueId, node)),
-            );
+  useEffect(() => {
+    let isMounted = true;
+    const unsubscribes: (() => void)[] = [];
 
-            console.log({ resolvedValues });
-            setResults(resolvedValues);
-        };
+    coValueIds.forEach((coValueId, index) => {
+      const unsubscribe = subscribeToCoValue(coValueId, node, (newResult) => {
+        if (isMounted) {
+          setResults((prevResults) => {
+            const newResults = [...prevResults];
+            newResults[index] = newResult;
+            return newResults;
+          });
+        }
+      });
+      unsubscribes.push(unsubscribe);
+    });
 
-        fetchResults();
-    }, [coValueIds, node]);
+    return () => {
+      isMounted = false;
+      unsubscribes.forEach((unsubscribe) => unsubscribe());
+    };
+  }, [coValueIds, node]);
 
-    return results;
+  return results;
 }


### PR DESCRIPTION
- added a new function `subscribeToCoValue()` to [examples/inspector/src/viewer/use-resolve-covalue.ts](https://github.com/gardencmp/jazz/pull/378/files#diff-256a17e2292c8d8014e5055607bc05d67e37ac9dc3fd1e3c4fe4841ee6ee2f50)
- `useResolvedCoValue()` and `useResolvedCoValues()` now use `subscribeToCoValue()` instead of `resolveCoValue()`
- basically using `node.subscribe()` over `node.load()`