### PR TITLE
fix(musicPlayer): move the upload of example data outside of the initial migration

### DIFF
--- a/examples/chat/README.md
+++ b/examples/chat/README.md
@@ -39,4 +39,4 @@ If you have feedback, let us know on [Discord](https://discord.gg/utDMjHYg42) or
 
 By default, the example app uses [Jazz Global Mesh](https://jazz.tools/mesh) (`wss://sync.jazz.tools`) - so cross-device use, invites and collaboration should just work.
 
-You can also run a local sync server by running `npx jazz-run sync` and adding the query param `?sync=ws://localhost:4200` to the URL of the example app (for example: `http://localhost:5173/?sync=ws://localhost:4200`), or by setting the `sync` parameter of the `<Jazz.Provider>` provider component in [./src/2_main.tsx](./src/2_main.tsx).
+You can also run a local sync server by running `npx jazz-run sync` and adding the query param `?sync=ws://localhost:4200` to the URL of the example app (for example: `http://localhost:5173/?peer=ws://localhost:4200`), or by setting the `sync` parameter of the `<Jazz.Provider>` provider component in [./src/2_main.tsx](./src/2_main.tsx).

--- a/examples/musicPlayer/README.md
+++ b/examples/musicPlayer/README.md
@@ -39,4 +39,4 @@ If you have feedback, let us know on [Discord](https://discord.gg/utDMjHYg42) or
 
 By default, the example app uses [Jazz Global Mesh](https://jazz.tools/mesh) (`wss://sync.jazz.tools`) - so cross-device use, invites and collaboration should just work.
 
-You can also run a local sync server by running `npx cojson-simple-sync` and adding the query param `?sync=ws://localhost:4200` to the URL of the example app (for example: `http://localhost:5173/?sync=ws://localhost:4200`), or by setting the `sync` parameter of the `<Jazz.Provider>` provider component in [./src/2_main.tsx](./src/2_main.tsx).
+You can also run a local sync server by running `npx cojson-simple-sync` and adding the query param `?sync=ws://localhost:4200` to the URL of the example app (for example: `http://localhost:5173/?peer=ws://localhost:4200`), or by setting the `sync` parameter of the `<Jazz.Provider>` provider component in [./src/2_main.tsx](./src/2_main.tsx).

--- a/examples/musicPlayer/src/1_schema.ts
+++ b/examples/musicPlayer/src/1_schema.ts
@@ -6,7 +6,6 @@ import {
     Profile,
     Account,
 } from "jazz-tools";
-import { getAudioFileData } from "./lib/audio/getAudioFileData";
 
 /** Walkthrough: Defining the data model with CoJSON
  *
@@ -81,17 +80,17 @@ export class MusicaAccountRoot extends CoMap {
     // to resume the song
     activeTrack = co.optional.ref(MusicTrack);
     activePlaylist = co.ref(Playlist);
+
+    exampleDataLoaded = co.optional.boolean;
 }
 
 export class MusicaAccount extends Account {
     profile = co.ref(Profile);
     root = co.ref(MusicaAccountRoot);
 
-    /** The account migration is run on account creation and on every log-in.
+    /** 
+     *  The account migration is run on account creation and on every log-in.
      *  You can use it to set up the account root and any other initial CoValues you need.
-     *
-     * It's a nice way to shape the inital structure of the account data
-     * and add "onboarding" info.
      */
     async migrate(creationProps?: { name: string }) {
         super.migrate(creationProps);
@@ -99,26 +98,7 @@ export class MusicaAccount extends Account {
         if (!this._refs.root) {
             const ownership = { owner: this };
 
-            const trackFile = await (await fetch("/example.mp3")).blob();
-            const data = await getAudioFileData(trackFile);
-
-            const initialMusicTrack = MusicTrack.create(
-                {
-                    file: await BinaryCoStream.createFromBlob(
-                        trackFile,
-                        ownership,
-                    ),
-                    duration: data.duration,
-                    waveform: MusicTrackWaveform.create(
-                        { data: data.waveform },
-                        ownership,
-                    ),
-                    title: "Example audio",
-                },
-                ownership,
-            );
-
-            const tracks = ListOfTracks.create([initialMusicTrack], ownership);
+            const tracks = ListOfTracks.create([], ownership);
             const rootPlaylist = Playlist.create(
                 {
                     tracks,
@@ -131,8 +111,9 @@ export class MusicaAccount extends Account {
                 {
                     rootPlaylist,
                     playlists: ListOfPlaylists.create([], ownership),
-                    activeTrack: initialMusicTrack,
+                    activeTrack: null,
                     activePlaylist: rootPlaylist,
+                    exampleDataLoaded: false,
                 },
                 ownership,
             );

--- a/examples/musicPlayer/src/2_main.tsx
+++ b/examples/musicPlayer/src/2_main.tsx
@@ -13,6 +13,7 @@ import "./index.css";
 
 import { MusicaAccount } from "@/1_schema";
 import { createJazzReactContext, DemoAuth } from "jazz-react";
+import { useUploadExampleData } from "./lib/useUploadExampleData";
 
 /**
  * Walkthrough: The top-level provider `<Jazz.Provider/>`
@@ -33,6 +34,8 @@ export const { useAccount, useCoState, useAcceptInvite } = Jazz;
 
 function Main() {
     const mediaPlayer = useMediaPlayer();
+
+    useUploadExampleData();
 
     /**
      * `me` represents the current user account, which will determine

--- a/examples/musicPlayer/src/3_actions.ts
+++ b/examples/musicPlayer/src/3_actions.ts
@@ -24,7 +24,7 @@ import {
 
 export async function uploadMusicTracks(
     account: MusicaAccount,
-    files: FileList,
+    files: Iterable<File>,
 ) {
     // The ownership object defines the user that owns the created coValues
     // by setting the ownership with "account" we configure the coValues to be private

--- a/examples/musicPlayer/src/lib/useUploadExampleData.ts
+++ b/examples/musicPlayer/src/lib/useUploadExampleData.ts
@@ -1,0 +1,28 @@
+import { useEffect } from "react";
+import { useAccount } from "../2_main";
+import { uploadMusicTracks } from "@/3_actions";
+import { MusicaAccount } from "@/1_schema";
+
+export function useUploadExampleData() {
+    const { me } = useAccount({
+        root: {}
+    });
+
+    const shouldUploadOnboardingData = me?.root?.exampleDataLoaded === false;
+
+    useEffect(() => {
+        if (me?.root && shouldUploadOnboardingData) {
+            me.root.exampleDataLoaded = true;
+
+            uploadOnboardingData(me).then(() => {
+                me.root.exampleDataLoaded = true;
+            });
+        }
+    }, [shouldUploadOnboardingData])
+}
+
+async function uploadOnboardingData(me: MusicaAccount) {
+    const trackFile = await (await fetch("/example.mp3")).blob();
+
+    return uploadMusicTracks(me, [new File([trackFile], "Example song")]);
+}

--- a/examples/password-manager/README.md
+++ b/examples/password-manager/README.md
@@ -64,4 +64,4 @@ If you have feedback, let us know on [Discord](https://discord.gg/utDMjHYg42) or
 
 By default, the example app uses [Jazz Global Mesh](https://jazz.tools/mesh) (`wss://sync.jazz.tools`) - so cross-device use, invites and collaboration should just work.
 
-You can also run a local sync server by running `npx cojson-simple-sync` and adding the query param `?sync=ws://localhost:4200` to the URL of the example app (for example: `http://localhost:5173/?sync=ws://localhost:4200`), or by setting the `sync` parameter of the `<Jazz.Provider>` provider component in [./src/2_main.tsx](./src/2_main.tsx).
+You can also run a local sync server by running `npx cojson-simple-sync` and adding the query param `?sync=ws://localhost:4200` to the URL of the example app (for example: `http://localhost:5173/?peer=ws://localhost:4200`), or by setting the `sync` parameter of the `<Jazz.Provider>` provider component in [./src/2_main.tsx](./src/2_main.tsx).

--- a/examples/pets/README.md
+++ b/examples/pets/README.md
@@ -39,4 +39,4 @@ If you have feedback, let us know on [Discord](https://discord.gg/utDMjHYg42) or
 
 By default, the example app uses [Jazz Global Mesh](https://jazz.tools/mesh) (`wss://sync.jazz.tools`) - so cross-device use, invites and collaboration should just work.
 
-You can also run a local sync server by running `npx jazz-run sync` and adding the query param `?sync=ws://localhost:4200` to the URL of the example app (for example: `http://localhost:5173/?sync=ws://localhost:4200`), or by setting the `sync` parameter of the `<Jazz.Provider>` provider component in [./src/2_main.tsx](./src/2_main.tsx).
+You can also run a local sync server by running `npx jazz-run sync` and adding the query param `?sync=ws://localhost:4200` to the URL of the example app (for example: `http://localhost:5173/?peer=ws://localhost:4200`), or by setting the `sync` parameter of the `<Jazz.Provider>` provider component in [./src/2_main.tsx](./src/2_main.tsx).

--- a/examples/todo/README.md
+++ b/examples/todo/README.md
@@ -66,4 +66,4 @@ If you have feedback, let us know on [Discord](https://discord.gg/utDMjHYg42) or
 
 By default, the example app uses [Jazz Global Mesh](https://jazz.tools/mesh) (`wss://sync.jazz.tools`) - so cross-device use, invites and collaboration should just work.
 
-You can also run a local sync server by running `npx jazz-run sync` and adding the query param `?sync=ws://localhost:4200` to the URL of the example app (for example: `http://localhost:5173/?sync=ws://localhost:4200`), or by setting the `sync` parameter of the `<Jazz.Provider>` provider component in [./src/2_main.tsx](./src/2_main.tsx).
+You can also run a local sync server by running `npx jazz-run sync` and adding the query param `?sync=ws://localhost:4200` to the URL of the example app (for example: `http://localhost:5173/?peer=ws://localhost:4200`), or by setting the `sync` parameter of the `<Jazz.Provider>` provider component in [./src/2_main.tsx](./src/2_main.tsx).


### PR DESCRIPTION
Moved the example upload outside the initial migration because:
- The upload becomes blocking for the account creation flow, making the signup process slower
- By uploading the example data in the intial migration we make it an hard dependency for the account creation, which isn't great since file uploads may fail or take a long amount of time in unstable connections.