### PR TITLE
fix(jazz-react): mark the auth as loading when authState is not ready

### DIFF
--- a/.changeset/forty-garlics-punch.md
+++ b/.changeset/forty-garlics-punch.md
@@ -1,0 +1,5 @@
+---
+"jazz-react": patch
+---
+
+mark the auth as loading when authState is not ready

--- a/packages/jazz-react/src/auth/DemoAuth.tsx
+++ b/packages/jazz-react/src/auth/DemoAuth.tsx
@@ -77,7 +77,7 @@ export function DemoAuth<Acc extends Account = Account>({
                   })
                 : Component({
                       appName,
-                      loading: false,
+                      loading: true,
                       existingUsers: [],
                       logInAs: () => {},
                       signUp: (_) => {},


### PR DESCRIPTION
Wanted to implement an "auto-login" but got some issues because `loading` is passed always as `false`.

I guess this can be considered a bug, so I've changed the logic to pass `true`