### PR TITLE
chore: run e2e/BinaryCoStream tests on CI

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        project: ["examples/pets"]
+        project: ["e2e/BinaryCoStream", "examples/pets"]
 
     steps:
       - uses: actions/checkout@v3

--- a/e2e/BinaryCoStream/src/lib/waitForCoValue.ts
+++ b/e2e/BinaryCoStream/src/lib/waitForCoValue.ts
@@ -15,17 +15,25 @@ export function waitForCoValue<T extends CoValue>(
   depth: DepthsIn<T>
 ) {
   return new Promise<T>((resolve) => {
-    const unsubscribe = subscribeToCoValue(
-      coMap,
-      valueId,
-      account,
-      depth,
-      (value) => {
-        if (predicate(value)) {
-          resolve(value);
+    function subscribe() {
+      const unsubscribe = subscribeToCoValue(
+        coMap,
+        valueId,
+        account,
+        depth,
+        (value) => {
+          if (predicate(value)) {
+            resolve(value);
+            unsubscribe();
+          }
+        },
+        () => {
           unsubscribe();
+          setTimeout(subscribe, 100);
         }
-      }
-    );
+      );
+    }
+
+    subscribe();
   });
 }


### PR DESCRIPTION
Found that the sync was failing because `subscribeToCoValue` provides an `onUnavailable` callback to manage when a value is not found that I wasn't handling.

Solved by adding a retry system on top of it.

This highlights some issues on the sync process:
1. This kind of situation should be handled by the framework at a lower level
2. The problem arises because the upload of a big BinaryCoStream creates congestion in the outcoming channel, delaying the transmission of the message related to the CoMap creation.

The point 1. will be very likely addressed when doing the refactoring of the sync protocol.
The point 2. could be fixed by implementing a priority system that would flag the BinaryCoStream items as low priority.
