### PR TITLE
fix(musicPlayer): fix the playlist check on invitation

### DIFF
--- a/examples/musicPlayer/src/7_InvitePage.tsx
+++ b/examples/musicPlayer/src/7_InvitePage.tsx
@@ -23,7 +23,7 @@ export function InvitePage() {
 
                 if (
                     playlist &&
-                    !me.root.playlists.some((item) => playlist.id !== item?.id)
+                    !me.root.playlists.some((item) => playlist.id === item?.id)
                 ) {
                     me.root.playlists.push(playlist);
                 }


### PR DESCRIPTION
Noticed that the playlists werent added correctly when sharing.

Digging found that the problem was the deduping check done on the playlists array.