### PR TITLE
Spacing improvements on landing pages (home and mesh)

### DIFF
--- a/homepage/design-system/src/app/components/atoms/CodeRef.tsx
+++ b/homepage/design-system/src/app/components/atoms/CodeRef.tsx
@@ -11,7 +11,7 @@ export function CodeRef({ children }: { children: React.ReactNode }) {
                 "border",
                 "text-stone-800 dark:text-stone-200",
                 "bg-stone-100 dark:bg-stone-800",
-                "border-stone-200 dark:border-stone-800"
+                "border-stone-200 dark:border-stone-900"
             )}
         >
             {children}

--- a/homepage/design-system/src/app/components/atoms/GridCard.tsx
+++ b/homepage/design-system/src/app/components/atoms/GridCard.tsx
@@ -6,7 +6,7 @@ export function GridCard(props: { children: ReactNode; className?: string }) {
         <div
             className={clsx(
                 "col-span-2 p-4 [&>h4]:mt-0 [&>h3]:mt-0 [&>:last-child]:mb-0",
-                "border border-stone-200 dark:border-stone-800 rounded-xl shadow-sm",
+                "border border-stone-200 dark:border-stone-900 rounded-xl shadow-sm",
                 props.className
             )}
         >

--- a/homepage/design-system/src/app/components/molecules/HairlineGrid.tsx
+++ b/homepage/design-system/src/app/components/molecules/HairlineGrid.tsx
@@ -8,7 +8,6 @@ export function HairlineBleedGrid({ children }: { children: React.ReactNode }) {
                 "mb-10",
                 "items-stretch",
                 "gap-[1px]",
-                "-mx-4 md:-mx-6",
                 "rounded-xl",
                 "overflow-hidden",
                 "bg-stone-50 dark:bg-stone-950",

--- a/homepage/design-system/src/app/components/molecules/HeroHeader.tsx
+++ b/homepage/design-system/src/app/components/molecules/HeroHeader.tsx
@@ -29,7 +29,7 @@ export function HeroHeader({
     pt?: boolean;
 }) {
     return (
-        <hgroup className={clsx(pt && "md:pt-20", "mb-10")}>
+        <hgroup className={clsx(pt && "pt-12 md:pt-20", "mb-10")}>
             <H1>{title}</H1>
             <H1Sub>{slogan}</H1Sub>
         </hgroup>

--- a/homepage/design-system/src/app/components/molecules/LabelledFeatureIcon.tsx
+++ b/homepage/design-system/src/app/components/molecules/LabelledFeatureIcon.tsx
@@ -13,7 +13,7 @@ export function LabelledFeatureIcon({
             className={clsx(
                 "p-4 flex flex-col items-center justify-center gap-2",
                 "not-prose text-base",
-                "border border-stone-200 dark:border-stone-800 rounded-xl"
+                "border border-stone-200 dark:border-stone-900 rounded-xl"
             )}
         >
             <div className="text-stone-500 mr-2">

--- a/homepage/design-system/src/app/components/molecules/LabelledFeatureIcon.tsx
+++ b/homepage/design-system/src/app/components/molecules/LabelledFeatureIcon.tsx
@@ -19,7 +19,9 @@ export function LabelledFeatureIcon({
             <div className="text-stone-500 mr-2">
                 <Icon strokeWidth={1} strokeLinecap="butt" size={40} />
             </div>
-            <div className="text-stone-700 dark:text-stone-300">{label}</div>
+            <div className="text-sm text-stone-700 md:text-base dark:text-stone-300">
+                {label}
+            </div>
         </div>
     );
 }

--- a/homepage/design-system/src/app/components/molecules/Prose.tsx
+++ b/homepage/design-system/src/app/components/molecules/Prose.tsx
@@ -13,7 +13,7 @@ export function Prose(props: { children: ReactNode; className?: string }) {
                 "prose-p:max-w-3xl prose-p:leading-snug",
                 "prose-strong:font-medium",
                 "prose-code:font-normal prose-code:leading-tight prose-code:before:content-none prose-code:after:content-none prose-code:bg-stone-100 prose-code:dark:bg-stone-900 prose-code:p-1 prose-code:rounded",
-                "prose-pre:text-black dark:prose-pre:text-white prose-pre:max-w-3xl prose-pre:text-[0.8em] prose-pre:leading-[1.3] prose-pre:-mt-2 prose-pre:my-4 prose-pre:px-10 prose-pre:py-2 prose-pre:-mx-10 prose-pre:bg-transparent",
+                "prose-pre:text-black dark:prose-pre:text-white prose-pre:max-w-3xl prose-pre:text-[0.8em] prose-pre:leading-[1.3] prose-pre:-mt-2 prose-pre:my-4 prose-pre:px-10 prose-pre:py-2 prose-pre:bg-transparent",
                 "[&_pre_.line]:relative [&_pre_.line]:min-h-[1.3em] [&_pre_.lineNo]:text-[0.75em] [&_pre_.lineNo]:text-stone-300 [&_pre_.lineNo]:dark:text-stone-700 [&_pre_.lineNo]:absolute [&_pre_.lineNo]:text-right [&_pre_.lineNo]:w-8 [&_pre_.lineNo]:-left-10 [&_pre_.lineNo]:top-[0.3em] [&_pre_.lineNo]:select-none",
                 props.className || "prose lg:prose-lg"
             )}

--- a/homepage/homepage/app/(home)/intro.mdx
+++ b/homepage/homepage/app/(home)/intro.mdx
@@ -1,4 +1,4 @@
-<h2 className="not-prose text-2xl font-medium tracking-tight mt-3 md:mt-5 mb-6">Hard things are easy now.</h2>
+<h2 className="not-prose text-2xl font-medium tracking-tight mt-3 md:mt-5 mb-6 dark:text-white">Hard things are easy now.</h2>
 
 Jazz is an **open-source toolkit** that replaces APIs, databases and message queues with **a&nbsp;single new abstraction:**
 

--- a/homepage/homepage/app/(home)/page.tsx
+++ b/homepage/homepage/app/(home)/page.tsx
@@ -57,7 +57,7 @@ import { H3 } from "gcmp-design-system/src/app/components/atoms/Headings";
 
 export default function Home() {
     return (
-        <>
+        <div className="space-y-16">
             <HeroHeader
                 title="Instant sync."
                 slogan="A new way to build apps with distributed state."
@@ -104,13 +104,13 @@ export default function Home() {
                 </div>
             </HairlineBleedGrid>
 
-            <div className="-mx-[calc(min(0,(100vw-95rem)/2))]">
+            <div>
                 <SectionHeader
                     title="First impressions..."
                     slogan="A chat app in 174 lines of code."
                 />
 
-                <GappedGrid className="mt-0 -mx-4 md:-mx-6">
+                <GappedGrid className="mt-0">
                     <CodeExampleTabs
                         tabs={[
                             {
@@ -139,18 +139,21 @@ export default function Home() {
                     <ResponsiveIframe
                         src="https://chat.jazz.tools"
                         localSrc="http://localhost:5173"
-                        className="col-span-full lg:col-span-2 rounded-xl overflow-hidden min-h-[50vh]"
+                        className="order-first col-span-full lg:col-span-2 rounded-sm overflow-hidden min-h-[50vh] lg:order-last"
                     />
                 </GappedGrid>
             </div>
 
-            <SectionHeader
-                title="Collaborative Values"
-                slogan="Your new building blocks."
-            />
-            <Prose>
-                <CoValuesIntro />
-            </Prose>
+            <div>
+                <SectionHeader
+                    title="Collaborative Values"
+                    slogan="Your new building blocks."
+                />
+
+                <Prose>
+                    <CoValuesIntro />
+                </Prose>
+            </div>
 
             <GappedGrid
                 title="Bread-and-butter datastructures"
@@ -239,15 +242,17 @@ export default function Home() {
                 </GridCard>
             </GappedGrid>
 
-            <SectionHeader
-                title="The Jazz Toolkit"
-                slogan="A high-level toolkit for building apps around CoValues."
-            />
+            <div>
+                <SectionHeader
+                    title="The Jazz Toolkit"
+                    slogan="A high-level toolkit for building apps around CoValues."
+                />
 
-            <Prose>Supported environments:</Prose>
-            <SmallProse>
-                <SupportedEnvironments />
-            </SmallProse>
+                <Prose>Supported environments:</Prose>
+                <SmallProse>
+                    <SupportedEnvironments />
+                </SmallProse>
+            </div>
 
             <GappedGrid>
                 <GridCard>
@@ -316,38 +321,42 @@ export default function Home() {
                 </GridCard>
             </GappedGrid>
 
-            <SectionHeader
-                title="Jazz Mesh"
-                slogan="Serverless sync & storage for Jazz apps"
-            />
+            <div>
+                <SectionHeader
+                    title="Jazz Mesh"
+                    slogan="Serverless sync & storage for Jazz apps"
+                />
 
-            <Prose>
-                <MeshIntro />
-            </Prose>
+                <Prose>
+                    <MeshIntro />
+                </Prose>
 
-            <P>
-                {"->"}{" "}
-                <TextLink href="/mesh" target="_blank">
-                    Learn more about Jazz Mesh
-                </TextLink>
-            </P>
-
-            <H3>Get Started</H3>
-            <UL>
-                <LI>
-                    <TextLink href="/docs" target="_blank">
-                        Read the docs
+                <P>
+                    {"->"}{" "}
+                    <TextLink href="/mesh" target="_blank">
+                        Learn more about Jazz Mesh
                     </TextLink>
-                </LI>
-                <LI>
-                    <TextLink
-                        href="https://discord.gg/utDMjHYg42"
-                        target="_blank"
-                    >
-                        Join our Discord
-                    </TextLink>
-                </LI>
-            </UL>
-        </>
+                </P>
+            </div>
+
+            <div>
+                <H3>Get Started</H3>
+                <UL>
+                    <LI>
+                        <TextLink href="/docs" target="_blank">
+                            Read the docs
+                        </TextLink>
+                    </LI>
+                    <LI>
+                        <TextLink
+                            href="https://discord.gg/utDMjHYg42"
+                            target="_blank"
+                        >
+                            Join our Discord
+                        </TextLink>
+                    </LI>
+                </UL>
+            </div>
+        </div>
     );
 }

--- a/homepage/homepage/app/(home)/supportedEnvironments.mdx
+++ b/homepage/homepage/app/(home)/supportedEnvironments.mdx
@@ -1,8 +1,5 @@
 import { ComingSoonBadge } from "gcmp-design-system/src/app/components/atoms/ComingSoonBadge";
 
-
-Supported environments:
-
 - Browser (sync via WebSockets, IndexedDB persistence)
     - React
     - Vanilla JS / framework agnostic base

--- a/homepage/homepage/app/docs/guide.mdx
+++ b/homepage/homepage/app/docs/guide.mdx
@@ -354,7 +354,7 @@ This works because CoValues
 -   notify subscribers of the change (who will receive a fresh, updated view of the CoValue)
 
 <aside className="text-sm border border-stone-300 dark:border-stone-700 rounded px-4 my-4 max-w-3xl [&_pre]:mx-0">
-    <h4 className="not-prose text-base py-2 mb-3 -mx-4 px-4 border-b border-stone-300 dark:border-stone-700">💡 A Quick Overview of Subscribing to CoValues</h4>
+    <h4 className="not-prose text-base py-2 mb-3 px-4 border-b border-stone-300 dark:border-stone-700">💡 A Quick Overview of Subscribing to CoValues</h4>
 
     There are three main ways to subscribe to a CoValue:
 

--- a/homepage/homepage/app/globals.css
+++ b/homepage/homepage/app/globals.css
@@ -132,7 +132,7 @@ pre.twoslash data-lsp::before {
     position: absolute;
     transform: translate(0, 1.2rem);
     max-width: 30rem;
-    @apply text-xs px-1.5 py-1 rounded border border-stone-200 dark:border-stone-800 shadow-lg overflow-hidden whitespace-pre-wrap text-stone-700 bg-stone-50 dark:text-stone-200 dark:bg-stone-950;
+    @apply text-xs px-1.5 py-1 rounded border border-stone-200 dark:border-stone-900 shadow-lg overflow-hidden whitespace-pre-wrap text-stone-700 bg-stone-50 dark:text-stone-200 dark:bg-stone-950;
     text-align: left;
     z-index: 100;
     opacity: 0;

--- a/homepage/homepage/app/mesh/page.tsx
+++ b/homepage/homepage/app/mesh/page.tsx
@@ -24,194 +24,208 @@ export const metadata = {
 
 export default function Mesh() {
     return (
-        <>
+        <div className="space-y-16">
             <HeroHeader
                 title="Sync & Storage Mesh"
                 slogan="The first Collaboration Delivery Network."
             />
-            <P>
-                Real-time sync and storage infrastructure that scales up to
-                millions of users.
-                <br />
-                Pricing that scales down to zero.
-            </P>
-            <GappedGrid>
-                <GridCard>
-                    <H3>Optimal mesh routing.</H3>
 
-                    <P>
-                        Get ultra-low latency between any group of users with
-                        our decentralized mesh interconnect.
-                    </P>
-                </GridCard>
-                <GridCard>
-                    <H3>Smart caching.</H3>
+            <div>
+                <P>
+                    Real-time sync and storage infrastructure that scales up to
+                    millions of users.
+                    <br />
+                    Pricing that scales down to zero.
+                </P>
+                <GappedGrid>
+                    <GridCard>
+                        <H3>Optimal mesh routing.</H3>
 
-                    <P>
-                        Give users instant load times, with their latest data
-                        state always cached close to them.
-                    </P>
-                </GridCard>
-                <GridCard>
-                    <H3>Blob storage & media streaming.</H3>
+                        <P>
+                            Get ultra-low latency between any group of users
+                            with our decentralized mesh interconnect.
+                        </P>
+                    </GridCard>
+                    <GridCard>
+                        <H3>Smart caching.</H3>
 
-                    <P>
-                        Store files and media streams as idiomatic `CoValues`
-                        without S3.
-                    </P>
-                </GridCard>
-            </GappedGrid>
-            <SectionHeader title="Pricing" slogan="" />
-            <GappedGrid>
-                <GridCard>
-                    <H3>
-                        Mesh Free <div className="text-2xl float-right">$0</div>
-                    </H3>
+                        <P>
+                            Give users instant load times, with their latest
+                            data state always cached close to them.
+                        </P>
+                    </GridCard>
+                    <GridCard>
+                        <H3>Blob storage & media streaming.</H3>
 
-                    <UL>
-                        <LI>Best-effort sync</LI>
-                        <LI>3,000 sync-minutes/mo</LI>
-                        <LI>1 GB storage</LI>
-                    </UL>
-                </GridCard>
-                <GridCard>
-                    <H3>
-                        Mesh Starter <ComingSoonBadge />
-                        <div className="float-right">
-                            <span className="text-2xl">$9</span>/mo
-                        </div>
-                    </H3>
-                    <UL>
-                        <LI>Base-priority sync</LI>
-                        <LI>6,000 sync-minutes/mo</LI>
-                        <LI>100 GB storage</LI>
-                    </UL>
-                    <div className="text-xs">
-                        <P>Extra usage:</P>
-                        <LI>$9 per additional 6,000 sync-minutes</LI>
-                        <LI>$9 per additional 1TB storage/mo</LI>
-                    </div>
-                </GridCard>
-                <GridCard>
-                    <H3>
-                        Mesh Pro <ComingSoonBadge />
-                        <div className="float-right">
-                            <span className="text-2xl">$79</span>/mo
-                        </div>
-                    </H3>
-                    <UL>
-                        <LI>High-priority sync</LI>
-                        <LI>30,000 sync-minutes/mo</LI>
-                        <LI>1 TB storage</LI>
-                        <LI>Offer sync.yourdomain.com</LI>
-                    </UL>
-                    <div className="text-xs">
-                        <P>Extra usage:</P>
+                        <P>
+                            Store files and media streams as idiomatic
+                            `CoValues` without S3.
+                        </P>
+                    </GridCard>
+                </GappedGrid>
+            </div>
+
+            <div>
+                <SectionHeader title="Pricing" slogan="" />
+                <GappedGrid>
+                    <GridCard>
+                        <H3>
+                            Mesh Free{" "}
+                            <div className="text-2xl float-right">$0</div>
+                        </H3>
+
                         <UL>
-                            <LI>$15 per additional 6,000 sync-minutes</LI>
-                            <LI>$15 per additional 1TB storage/mo</LI>
+                            <LI>Best-effort sync</LI>
+                            <LI>3,000 sync-minutes/mo</LI>
+                            <LI>1 GB storage</LI>
+                        </UL>
+                    </GridCard>
+                    <GridCard>
+                        <H3>
+                            Mesh Starter <ComingSoonBadge />
+                            <div className="float-right">
+                                <span className="text-2xl">$9</span>/mo
+                            </div>
+                        </H3>
+                        <UL>
+                            <LI>Base-priority sync</LI>
+                            <LI>6,000 sync-minutes/mo</LI>
+                            <LI>100 GB storage</LI>
+                        </UL>
+                        <div className="text-xs">
+                            <P>Extra usage:</P>
+                            <LI>$9 per additional 6,000 sync-minutes</LI>
+                            <LI>$9 per additional 1TB storage/mo</LI>
+                        </div>
+                    </GridCard>
+                    <GridCard>
+                        <H3>
+                            Mesh Pro <ComingSoonBadge />
+                            <div className="float-right">
+                                <span className="text-2xl">$79</span>/mo
+                            </div>
+                        </H3>
+                        <UL>
+                            <LI>High-priority sync</LI>
+                            <LI>30,000 sync-minutes/mo</LI>
+                            <LI>1 TB storage</LI>
+                            <LI>Offer sync.yourdomain.com</LI>
+                        </UL>
+                        <div className="text-xs">
+                            <P>Extra usage:</P>
+                            <UL>
+                                <LI>$15 per additional 6,000 sync-minutes</LI>
+                                <LI>$15 per additional 1TB storage/mo</LI>
+                            </UL>
+                        </div>
+                    </GridCard>
+                </GappedGrid>
+                <H3>FAQ</H3>
+                <SmallProse>
+                    <PricingFAQ />
+                </SmallProse>
+            </div>
+
+            <div>
+                <SectionHeader
+                    title="Global Footprint"
+                    slogan="We're rapidly expanding our network of sync & storage nodes. This is our current best-effort coverage."
+                />
+                <GappedGrid>
+                    <div className="text-sm">
+                        <H4>Under 50ms RTT</H4>
+                        <UL>
+                            <LI>Frankfurt</LI>
+                            <LI>New York</LI>
+                            <LI>Newark</LI>
+                            <LI>North California</LI>
+                            <LI>North Virginia</LI>
+                            <LI>San Francisco</LI>
+                            <LI>Singapore</LI>
+                            <LI>Toronto</LI>
                         </UL>
                     </div>
-                </GridCard>
-            </GappedGrid>
-            <H3>FAQ:</H3>
-            <SmallProse>
-                <PricingFAQ />
-            </SmallProse>
-            <SectionHeader
-                title="Global Footprint"
-                slogan="We're rapidly expanding our network of sync & storage nodes. This is our current best-effort coverage."
-            />
-            <GappedGrid>
-                <div className="text-sm">
-                    <H4>Under 50ms RTT</H4>
-                    <UL>
-                        <LI>Frankfurt</LI>
-                        <LI>New York</LI>
-                        <LI>Newark</LI>
-                        <LI>North California</LI>
-                        <LI>North Virginia</LI>
-                        <LI>San Francisco</LI>
-                        <LI>Singapore</LI>
-                        <LI>Toronto</LI>
-                    </UL>
-                </div>
 
-                <div className="text-sm">
-                    <H4>Under 100ms RTT</H4>
-                    <UL>
-                        <LI>Amsterdam</LI>
-                        <LI>Atlanta</LI>
-                        <LI>London</LI>
-                        <LI>Ohio</LI>
-                        <LI>Paris</LI>
-                    </UL>
-                </div>
+                    <div className="text-sm">
+                        <H4>Under 100ms RTT</H4>
+                        <UL>
+                            <LI>Amsterdam</LI>
+                            <LI>Atlanta</LI>
+                            <LI>London</LI>
+                            <LI>Ohio</LI>
+                            <LI>Paris</LI>
+                        </UL>
+                    </div>
 
-                <div className="text-sm">
-                    <H4>Under 200ms RTT</H4>
-                    <UL>
-                        <LI>Bangalore</LI>
-                        <LI>Dallas</LI>
-                        <LI>Mumbai</LI>
-                        <LI>Oregon</LI>
-                    </UL>
+                    <div className="text-sm">
+                        <H4>Under 200ms RTT</H4>
+                        <UL>
+                            <LI>Bangalore</LI>
+                            <LI>Dallas</LI>
+                            <LI>Mumbai</LI>
+                            <LI>Oregon</LI>
+                        </UL>
 
-                    <H4>Under 300ms RTT</H4>
-                    <UL>
-                        <LI> Seoul</LI>
-                        <LI> Tokyo</LI>
-                    </UL>
-                </div>
+                        <H4>Under 300ms RTT</H4>
+                        <UL>
+                            <LI> Seoul</LI>
+                            <LI> Tokyo</LI>
+                        </UL>
+                    </div>
 
-                <div className="text-sm">
-                    <H4>Under 400ms RTT</H4>
-                    <UL>
-                        <LI>Sao Paulo</LI>
-                        <LI>Sydney</LI>
-                    </UL>
+                    <div className="text-sm">
+                        <H4>Under 400ms RTT</H4>
+                        <UL>
+                            <LI>Sao Paulo</LI>
+                            <LI>Sydney</LI>
+                        </UL>
 
-                    <H4>Under 500ms RTT</H4>
+                        <H4>Under 500ms RTT</H4>
 
-                    <UL>
-                        <LI>Cape Town</LI>
-                    </UL>
-                </div>
-            </GappedGrid>
-            <H3>Enterprise</H3>
-            <P>
-                Custom deployment in the cloud, your private cloud, on-premises
-                or hybrids?
-                <br />
-                SLAs and dedicated support? White-glove integration services?
-                Let&apos;s talk:{" "}
-                <a href="mailto:hello@gcmp.io">hello@gcmp.io</a>
-            </P>
-            <SectionHeader
-                title="Custom Deployment Scenarios"
-                slogan="You can rely on Jazz Mesh. But you don't have to."
-            />
-            <P>
-                Because Jazz is open-source, you can optionally run your own
-                sync nodes &mdash; in a variety of setups.
-            </P>
-            <GappedGrid>
-                <GridCard>
-                    <Prose>
-                        <MeshPlusBackup />
-                    </Prose>
-                </GridCard>
-                <GridCard>
-                    <Prose>
-                        <MeshPlusDIY />
-                    </Prose>
-                </GridCard>
-                <GridCard>
-                    <Prose>
-                        <CompletelyDIY />
-                    </Prose>
-                </GridCard>
-            </GappedGrid>
-        </>
+                        <UL>
+                            <LI>Cape Town</LI>
+                        </UL>
+                    </div>
+                </GappedGrid>
+
+                <H3>Enterprise</H3>
+                <P>
+                    Custom deployment in the cloud, your private cloud,
+                    on-premises or hybrids?
+                    <br />
+                    SLAs and dedicated support? White-glove integration
+                    services? Let&apos;s talk:{" "}
+                    <a href="mailto:hello@gcmp.io">hello@gcmp.io</a>
+                </P>
+            </div>
+
+            <div>
+                <SectionHeader
+                    title="Custom Deployment Scenarios"
+                    slogan="You can rely on Jazz Mesh. But you don't have to."
+                />
+                <P>
+                    Because Jazz is open-source, you can optionally run your own
+                    sync nodes &mdash; in a variety of setups.
+                </P>
+                <GappedGrid>
+                    <GridCard>
+                        <Prose>
+                            <MeshPlusBackup />
+                        </Prose>
+                    </GridCard>
+                    <GridCard>
+                        <Prose>
+                            <MeshPlusDIY />
+                        </Prose>
+                    </GridCard>
+                    <GridCard>
+                        <Prose>
+                            <CompletelyDIY />
+                        </Prose>
+                    </GridCard>
+                </GappedGrid>
+            </div>
+        </div>
     );
 }

--- a/homepage/homepage/components/CodeExampleTabs.tsx
+++ b/homepage/homepage/components/CodeExampleTabs.tsx
@@ -27,7 +27,7 @@ export function CodeExampleTabs({
                 className,
             )}
         >
-            <div className="flex border-b dark:border-stone-800 dark:bg-stone-900">
+            <div className="flex border-b overflow-x-auto dark:border-stone-800 dark:bg-stone-900">
                 {tabs.map((tab, index) => (
                     <div key={index}>
                         <button

--- a/homepage/homepage/components/docs/nav.tsx
+++ b/homepage/homepage/components/docs/nav.tsx
@@ -95,7 +95,7 @@ export async function NavPackage({
         <>
             <Link
                 href={`/docs/api-reference/${packageName}`}
-                className="text-sm mt-4 font-mono flex gap-1 items-center -mx-4 px-4 pt-4 border-t border-stone-200 dark:border-stone-800 "
+                className="text-sm mt-4 font-mono flex gap-1 items-center -mx-4 px-4 pt-4 border-t border-stone-200 dark:border-stone-900 "
             >
                 {packageName}
                 <PackageIcon size={15} strokeWidth={1.5} />

--- a/homepage/homepage/components/docs/tags.tsx
+++ b/homepage/homepage/components/docs/tags.tsx
@@ -106,7 +106,7 @@ export function PropDecl({
     example?: ReactNode;
 }) {
     return (
-        <div className="py-2 border-t border-stone-200 dark:border-stone-800 mt-4 text-sm">
+        <div className="py-2 border-t border-stone-200 dark:border-stone-900 mt-4 text-sm">
             <div>
                 {name && <Highlight>{name + ":"}</Highlight>}
                 {"  "}
@@ -149,7 +149,7 @@ export function FnDecl({
     example: ReactNode;
 }) {
     return (
-        <div className="py-2 border-t border-stone-200 dark:border-stone-800 mt-4 text-sm">
+        <div className="py-2 border-t border-stone-200 dark:border-stone-900 mt-4 text-sm">
             <div>
                 {<Highlight>{signature + ":"}</Highlight>}{" "}
                 <span className="opacity-75 text-xs pl-1">


### PR DESCRIPTION
Quick improvements to get Home and Mesh looking decent
- consistent spacing between sections in the Home and Mesh
- allow horizontal scroll on tabs (needed in mobile)
- center align text in features section in hero in home
- remove all usage of negative margins