### PR TITLE
Add example apps to docs

### DIFF
--- a/homepage/homepage/app/docs/resources/examples/page.tsx
+++ b/homepage/homepage/app/docs/resources/examples/page.tsx
@@ -23,7 +23,7 @@ export default function Page() {
     ];
     return (
         <>
-            <h1>Examples</h1>
+            <h1>Example Apps</h1>
             <ul>
                 {examples.map(({ name, slug }) => (
                     <li key={name}>

--- a/homepage/homepage/app/docs/resources/examples/page.tsx
+++ b/homepage/homepage/app/docs/resources/examples/page.tsx
@@ -1,0 +1,40 @@
+export default function Page() {
+    const examples = [
+        {
+            name: "Chat",
+            slug: "chat",
+        },
+        {
+            name: "Music player",
+            slug: "music-player",
+        },
+        {
+            name: "Pets",
+            slug: "pets",
+        },
+        {
+            name: "Todo",
+            slug: "todo",
+        },
+        {
+            name: "Password manager",
+            slug: "password-manager",
+        },
+    ];
+    return (
+        <>
+            <h1>Examples</h1>
+            <ul>
+                {examples.map(({ name, slug }) => (
+                    <li key={name}>
+                        <a
+                            href={`https://github.com/gardencmp/jazz/tree/main/examples/${slug}`}
+                        >
+                            {name}
+                        </a>
+                    </li>
+                ))}
+            </ul>
+        </>
+    );
+}

--- a/homepage/homepage/components/docs/nav.tsx
+++ b/homepage/homepage/components/docs/nav.tsx
@@ -141,6 +141,17 @@ export function DocNav({ className }: { className?: string }) {
             </div>
 
             <div>
+                <DocNavHeader>Resources</DocNavHeader>
+                <ul>
+                    <li>
+                        <DocNavLink href="/docs/resources/examples">
+                            Examples
+                        </DocNavLink>
+                    </li>
+                </ul>
+            </div>
+
+            <div>
                 <DocNavHeader href="/docs/api-reference">
                     API Reference
                 </DocNavHeader>

--- a/homepage/homepage/components/docs/nav.tsx
+++ b/homepage/homepage/components/docs/nav.tsx
@@ -145,7 +145,7 @@ export function DocNav({ className }: { className?: string }) {
                 <ul>
                     <li>
                         <DocNavLink href="/docs/resources/examples">
-                            Examples
+                            Example Apps
                         </DocNavLink>
                     </li>
                 </ul>


### PR DESCRIPTION
Looks very boring for now. Will add screenshots when the example apps are looking better. For now, at least people will know these exist.

<img width="1269" alt="image" src="https://github.com/user-attachments/assets/f70c2824-9388-4e3a-b8c4-f4575064f044">
