### PR TITLE
feat(react): migrate to useSyncExternalStore

### DIFF
--- a/examples/music-player/.eslintrc.cjs
+++ b/examples/music-player/.eslintrc.cjs
@@ -9,11 +9,12 @@ module.exports = {
   ],
   ignorePatterns: ['dist', '.eslintrc.cjs'],
   parser: '@typescript-eslint/parser',
-  plugins: ['react-refresh'],
+  plugins: ['react-refresh', "eslint-plugin-react-compiler"],
   rules: {
     'react-refresh/only-export-components': [
       'warn',
       { allowConstantExport: true },
     ],
+       "react-compiler/react-compiler": "error"
   },
 }

--- a/examples/music-player/package.json
+++ b/examples/music-player/package.json
@@ -38,6 +38,7 @@
         "@vitejs/plugin-react-swc": "^3.3.2",
         "autoprefixer": "^10.4.14",
         "eslint": "^8.46.0",
+        "eslint-plugin-react-compiler": "0.0.0-experimental-fa06e2c-20241014",
         "eslint-plugin-react-hooks": "^4.6.0",
         "eslint-plugin-react-refresh": "^0.4.3",
         "postcss": "^8.4.27",

--- a/examples/music-player/src/3_HomePage.tsx
+++ b/examples/music-player/src/3_HomePage.tsx
@@ -5,7 +5,7 @@ import { usePlayState } from "./lib/audio/usePlayState";
 import { SidePanel } from "./components/SidePanel";
 import { FileUploadButton } from "./components/FileUploadButton";
 import { Button } from "./components/ui/button";
-import { createNewPlaylist, uploadMusicTracks } from "./4_actions";
+import { createNewPlaylist, updatePlaylistTitle, uploadMusicTracks } from "./4_actions";
 import { useNavigate, useParams } from "react-router";
 import { ID } from "jazz-tools";
 import { Playlist } from "./1_schema";
@@ -62,7 +62,7 @@ export function HomePage({ mediaPlayer }: { mediaPlayer: MediaPlayer }) {
     ) => {
         if (!playlist) return;
 
-        playlist.title = evt.target.value;
+        updatePlaylistTitle(playlist, evt.target.value);
     };
 
     const handlePlaylistShareClick = async () => {

--- a/examples/music-player/src/4_actions.ts
+++ b/examples/music-player/src/4_actions.ts
@@ -128,3 +128,19 @@ export async function addTrackToPlaylist(
 
     playlist.tracks?.push(trackClone);
 }
+
+export async function updatePlaylistTitle(playlist: Playlist, title: string) {
+    playlist.title = title;
+}
+
+export async function updateMusicTrackTitle(track: MusicTrack, title: string) {
+    track.title = title;
+}
+
+export async function updateActivePlaylist(playlist: Playlist, me: MusicaAccount) {
+    me.root!.activePlaylist = playlist ?? me.root!.rootPlaylist;
+}
+
+export async function updateActiveTrack(track: MusicTrack, me: MusicaAccount) {
+    me.root!.activeTrack = track;
+}

--- a/examples/music-player/src/5_useMediaPlayer.ts
+++ b/examples/music-player/src/5_useMediaPlayer.ts
@@ -5,6 +5,7 @@ import { MusicTrack, Playlist } from "@/1_schema";
 import { useRef, useState } from "react";
 import { getNextTrack, getPrevTrack } from "./lib/getters";
 import { BinaryCoStream, ID } from "jazz-tools";
+import { updateActivePlaylist, updateActiveTrack } from "./4_actions";
 
 export function useMediaPlayer() {
     const { me } = useAccount();
@@ -39,7 +40,7 @@ export function useMediaPlayer() {
             return;
         }
 
-        me.root.activeTrack = track;
+        updateActiveTrack(track, me);
 
         await playMedia(file);
 
@@ -52,7 +53,7 @@ export function useMediaPlayer() {
         const track = await getNextTrack(me);
 
         if (track) {
-            me.root.activeTrack = track;
+            updateActiveTrack(track, me);
             await loadTrack(track);
         }
     }
@@ -78,7 +79,7 @@ export function useMediaPlayer() {
             return;
         }
 
-        me.root.activePlaylist = playlist ?? me.root.rootPlaylist;
+        updateActivePlaylist(playlist!, me);
 
         await loadTrack(track);
 

--- a/examples/music-player/src/components/MusicTrackRow.tsx
+++ b/examples/music-player/src/components/MusicTrackRow.tsx
@@ -10,7 +10,7 @@ import { MoreHorizontal } from "lucide-react";
 import { ChangeEvent } from "react";
 import { Button } from "./ui/button";
 import { useAccount, useCoState } from "@/2_main";
-import { addTrackToPlaylist } from "@/4_actions";
+import { addTrackToPlaylist, updateMusicTrackTitle } from "@/4_actions";
 import { ID } from "jazz-tools";
 
 export function MusicTrackRow({
@@ -30,7 +30,8 @@ export function MusicTrackRow({
 
     function handleTrackTitleChange(evt: ChangeEvent<HTMLInputElement>) {
         if (!track) return;
-        track.title = evt.target.value;
+    
+        updateMusicTrackTitle(track, evt.target.value);
     }
 
     const { me } = useAccount({

--- a/examples/password-manager/src/3_vault.tsx
+++ b/examples/password-manager/src/3_vault.tsx
@@ -5,9 +5,13 @@ import Table from "./components/table";
 import NewItemModal from "./components/new-item-modal";
 import InviteModal from "./components/invite-modal";
 
-import { saveItem, deleteItem, createFolder, updateItem } from "./4_actions";
+import { saveItem, deleteItem, createFolder, updateItem, addSharedFolder } from "./4_actions";
 import { Alert, AlertDescription } from "./components/alert";
-import { Folder, FolderList, PasswordItem } from "./1_schema";
+import {
+  Folder,
+  FolderList,
+  PasswordItem,
+} from "./1_schema";
 import { useAccount, useCoState } from "./2_main";
 import { CoMapInit, Group, ID } from "jazz-tools";
 import { useNavigate, useParams } from "react-router-dom";
@@ -17,20 +21,19 @@ const VaultPage: React.FC = () => {
   const { me, logOut } = useAccount();
   const sharedFolderId = useParams<{ sharedFolderId: ID<Folder> }>()
     .sharedFolderId;
-  const sharedFolder = useCoState(Folder, sharedFolderId);
+
   const navigate = useNavigate();
 
   useEffect(() => {
-    if (!sharedFolderId || !sharedFolder || !me.root?.folders) return;
-    const existsIndex = me.root?.folders.findIndex(
-      (f) => f?.id === sharedFolder.id
-    );
-    if (existsIndex > -1) {
-      me.root?.folders?.splice(existsIndex, 1);
-    }
-    me.root?.folders?.push(sharedFolder);
-    navigate("/vault");
-  }, [sharedFolder, me.root?.folders, sharedFolderId, navigate]);
+    if (!sharedFolderId) return;
+
+    addSharedFolder(sharedFolderId, me).then(() => {
+      navigate("/vault");
+    });
+
+    // We want to trigger this only on mount
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   const items = me.root?.folders?.flatMap(
     (folder) =>

--- a/examples/password-manager/src/lib/waitForCoValue.ts
+++ b/examples/password-manager/src/lib/waitForCoValue.ts
@@ -1,0 +1,39 @@
+import {
+  Account,
+  CoValue,
+  CoValueClass,
+  DepthsIn,
+  ID,
+  subscribeToCoValue,
+} from "jazz-tools";
+
+export function waitForCoValue<T extends CoValue>(
+  coMap: CoValueClass<T>,
+  valueId: ID<T>,
+  account: Account,
+  predicate: (value: T) => boolean,
+  depth: DepthsIn<T>
+) {
+  return new Promise<T>((resolve) => {
+    function subscribe() {
+      const unsubscribe = subscribeToCoValue(
+        coMap,
+        valueId,
+        account,
+        depth,
+        (value) => {
+          if (predicate(value)) {
+            resolve(value);
+            unsubscribe();
+          }
+        },
+        () => {
+          unsubscribe();
+          setTimeout(subscribe, 100);
+        }
+      );
+    }
+
+    subscribe();
+  });
+}

--- a/packages/jazz-react/src/index.tsx
+++ b/packages/jazz-react/src/index.tsx
@@ -16,7 +16,7 @@ import {
     DeeplyLoaded,
     DepthsIn,
     ID,
-    subscribeToCoValue,
+    createCoValueObservable,
 } from "jazz-tools";
 
 /** @category Context & Hooks */
@@ -152,30 +152,38 @@ export function createJazzReactApp<Acc extends Account>({
         id: ID<V> | undefined,
         depth: D & DepthsIn<V> = [] as D & DepthsIn<V>,
     ): DeeplyLoaded<V, D> | undefined {
-        const [state, setState] = useState<{
-            value: DeeplyLoaded<V, D> | undefined;
-        }>({ value: undefined });
         const context = React.useContext(JazzContext);
 
         if (!context) {
             throw new Error("useCoState must be used within a JazzProvider");
         }
 
-        useEffect(() => {
-            if (!id) return;
+        const [observable] = React.useState(() => createCoValueObservable());
 
-            return subscribeToCoValue(
-                Schema,
-                id,
-                "me" in context ? context.me : context.guest,
-                depth,
-                (value) => {
-                    setState({ value });
+        const value = React.useSyncExternalStore<
+            DeeplyLoaded<V, D> | undefined
+        >(
+            React.useCallback(
+                (callback) => {
+                    if (!id) return () => {};
+
+                    const agent = "me" in context ? context.me : context.guest;
+
+                    return observable.subscribe(
+                        Schema,
+                        id,
+                        agent,
+                        depth,
+                        callback,
+                    );
                 },
-            );
-        }, [Schema, id, context]);
+                [Schema, id, context],
+            ),
+            () => observable.getCurrentValue(),
+            () => observable.getCurrentValue(),
+        );
 
-        return state.value;
+        return value;
     }
 
     function useAcceptInvite<V extends CoValue>({

--- a/packages/jazz-tools/src/coValues/interfaces.ts
+++ b/packages/jazz-tools/src/coValues/interfaces.ts
@@ -213,6 +213,40 @@ export function subscribeToCoValue<V extends CoValue, Depth>(
     };
 }
 
+export function createCoValueObservable<V extends CoValue, Depth>() {
+    let currentValue: DeeplyLoaded<V, Depth> | undefined = undefined;
+
+    function subscribe(
+        cls: CoValueClass<V>,
+        id: ID<V>,
+        as: Account | AnonymousJazzAgent,
+        depth: Depth & DepthsIn<V>,
+        listener: () => void,
+        onUnavailable?: () => void,
+    ) {
+        const unsubscribe = subscribeToCoValue(
+            cls,
+            id,
+            as,
+            depth,
+            (value) => {
+                currentValue = value;
+                listener();
+            },
+            onUnavailable,
+        );
+
+        return unsubscribe
+    }
+
+    const observable = {
+        getCurrentValue: () => currentValue,
+        subscribe,
+    };
+
+    return observable;
+}
+
 export function subscribeToExistingCoValue<V extends CoValue, Depth>(
     existing: V,
     depth: Depth & DepthsIn<V>,

--- a/packages/jazz-tools/src/exports.ts
+++ b/packages/jazz-tools/src/exports.ts
@@ -21,7 +21,7 @@ export { ImageDefinition } from "./internal.js";
 export { CoValueBase, type CoValueClass } from "./internal.js";
 export type { DepthsIn, DeeplyLoaded } from "./internal.js";
 
-export { loadCoValue, subscribeToCoValue } from "./internal.js";
+export { loadCoValue, subscribeToCoValue, createCoValueObservable } from "./internal.js";
 
 export {
     type AuthMethod,

--- a/packages/jazz-tools/src/tests/subscribe.test.ts
+++ b/packages/jazz-tools/src/tests/subscribe.test.ts
@@ -1,0 +1,348 @@
+const Crypto = await WasmCrypto.create();
+import { expect, describe, it, vi, onTestFinished } from "vitest";
+import { connectedPeers } from "cojson/src/streamUtils.js";
+import {
+    Account,
+    CoList,
+    CoMap,
+    CoStream,
+    WasmCrypto,
+    co,
+    isControlledAccount,
+    createJazzContext,
+    fixedCredentialsAuth,
+} from "../index.js";
+import {
+    BinaryCoStream,
+    Group,
+    randomSessionProvider,
+    subscribeToCoValue,
+} from "../internal.js";
+
+class ChatRoom extends CoMap {
+    messages = co.ref(MessagesList);
+    name = co.string;
+}
+
+class Message extends CoMap {
+    text = co.string;
+    reactions = co.ref(ReactionsStream);
+    attachment = co.optional.ref(BinaryCoStream);
+}
+
+class MessagesList extends CoList.Of(co.ref(Message)) {}
+class ReactionsStream extends CoStream.Of(co.string) {}
+
+async function setupAccount() {
+    const me = await Account.create({
+        creationProps: { name: "Hermes Puggington" },
+        crypto: Crypto,
+    });
+
+    const [initialAsPeer, secondPeer] = connectedPeers("initial", "second", {
+        peer1role: "server",
+        peer2role: "client",
+    });
+
+    if (!isControlledAccount(me)) {
+        throw "me is not a controlled account";
+    }
+    me._raw.core.node.syncManager.addPeer(secondPeer);
+    const { account: meOnSecondPeer } = await createJazzContext({
+        auth: fixedCredentialsAuth({
+            accountID: me.id,
+            secret: me._raw.agentSecret,
+        }),
+        sessionProvider: randomSessionProvider,
+        peersToLoadFrom: [initialAsPeer],
+        crypto: Crypto,
+    });
+
+    return { me, meOnSecondPeer };
+}
+
+function createChatRoom(me: Account | Group, name: string) {
+    return ChatRoom.create(
+        { messages: MessagesList.create([], { owner: me }), name },
+        { owner: me },
+    );
+}
+
+function createMessage(me: Account | Group, text: string) {
+    return Message.create(
+        { text, reactions: ReactionsStream.create([], { owner: me }) },
+        { owner: me },
+    );
+}
+
+describe("subscribeToCoValue", () => {
+    it("subscribes to a CoMap", async () => {
+        const { me, meOnSecondPeer } = await setupAccount();
+
+        const chatRoom = createChatRoom(me, "General");
+        const updateFn = vi.fn();
+
+        const unsubscribe = subscribeToCoValue(
+            ChatRoom,
+            chatRoom.id,
+            meOnSecondPeer,
+            {},
+            updateFn,
+        );
+
+        onTestFinished(unsubscribe);
+
+        await waitFor(() => {
+            expect(updateFn).toHaveBeenCalled();
+        });
+
+        expect(updateFn).toHaveBeenCalledWith(
+            expect.objectContaining({
+                id: chatRoom.id,
+                messages: null,
+                name: "General",
+            }),
+        );
+
+        updateFn.mockClear();
+
+        await waitFor(() => {
+            expect(updateFn).toHaveBeenCalled();
+        });
+
+        expect(updateFn).toHaveBeenCalledWith(
+            expect.objectContaining({
+                id: chatRoom.id,
+                name: "General",
+                messages: expect.any(Array),
+            }),
+        );
+
+        updateFn.mockClear();
+        chatRoom.name = "Lounge";
+
+        await waitFor(() => {
+            expect(updateFn).toHaveBeenCalled();
+        });
+
+        expect(updateFn).toHaveBeenCalledWith(
+            expect.objectContaining({
+                id: chatRoom.id,
+                name: "Lounge",
+                messages: expect.any(Array),
+            }),
+        );
+    });
+
+    it("shouldn't fire updates until the declared load depth isn't reached", async () => {
+        const { me, meOnSecondPeer } = await setupAccount();
+
+        const chatRoom = createChatRoom(me, "General");
+        const updateFn = vi.fn();
+
+        const unsubscribe = subscribeToCoValue(
+            ChatRoom,
+            chatRoom.id,
+            meOnSecondPeer,
+            {
+                messages: [],
+            },
+            updateFn,
+        );
+
+        onTestFinished(unsubscribe);
+
+        await waitFor(() => {
+            expect(updateFn).toHaveBeenCalled();
+        });
+
+        expect(updateFn).toHaveBeenCalledTimes(1);
+        expect(updateFn).toHaveBeenCalledWith(
+            expect.objectContaining({
+                id: chatRoom.id,
+                name: "General",
+                messages: expect.any(Array),
+            }),
+        );
+    });
+
+    it("should fire updates when a ref entity is updates", async () => {
+        const { me, meOnSecondPeer } = await setupAccount();
+
+        const chatRoom = createChatRoom(me, "General");
+        const message = createMessage(me, "Hello Luigi, are you ready to save the princess?");
+        chatRoom.messages?.push(message);
+
+        const updateFn = vi.fn()
+
+        const unsubscribe = subscribeToCoValue(
+            ChatRoom,
+            chatRoom.id,
+            meOnSecondPeer,
+            {
+                messages: [{
+                }],
+            },
+            updateFn,
+        );
+
+        onTestFinished(unsubscribe);
+
+        await waitFor(() => {
+            const lastValue = updateFn.mock.lastCall[0];
+
+            expect(lastValue?.messages?.[0]?.text).toBe(message.text);
+        });
+
+        message.text = "Nevermind, she was gone to the supermarket";
+        updateFn.mockClear();
+
+        await waitFor(() => {
+            expect(updateFn).toHaveBeenCalled();
+        });
+        
+        const lastValue = updateFn.mock.lastCall[0];
+        expect(lastValue?.messages?.[0]?.text).toBe("Nevermind, she was gone to the supermarket");
+    });
+
+    it("should handle the updates as immutable changes", async () => {
+        const { me, meOnSecondPeer } = await setupAccount();
+
+        const chatRoom = createChatRoom(me, "General");
+        const message = createMessage(me, "Hello Luigi, are you ready to save the princess?");
+        const message2 = createMessage(me, "Let's go!");
+        chatRoom.messages?.push(message);
+        chatRoom.messages?.push(message2);
+
+        const updateFn = vi.fn()
+
+        const unsubscribe = subscribeToCoValue(
+            ChatRoom,
+            chatRoom.id,
+            meOnSecondPeer,
+            {
+                messages: [{
+                    reactions: [],
+                }],
+            },
+            updateFn,
+        );
+
+        onTestFinished(unsubscribe);
+
+        await waitFor(() => {
+            const lastValue = updateFn.mock.lastCall[0];
+
+            expect(lastValue?.messages?.[0]?.text).toBe(message.text);
+        });
+
+        const initialValue = updateFn.mock.lastCall[0];
+        const initialMessagesList = initialValue?.messages;
+        const initialMessage1 = initialValue?.messages[0];
+        const initialMessage2 = initialValue?.messages[1];
+        const initialMessageReactions = initialValue?.messages[0].reactions;
+
+        message.reactions?.push("👍");
+
+        updateFn.mockClear();
+
+        await waitFor(() => {
+            expect(updateFn).toHaveBeenCalled();
+        });
+        
+        const lastValue = updateFn.mock.lastCall[0];
+        expect(lastValue).not.toBe(initialValue);
+        expect(lastValue.messages).not.toBe(initialMessagesList);
+        expect(lastValue.messages[0]).not.toBe(initialMessage1);
+        expect(lastValue.messages[0].reactions).not.toBe(initialMessageReactions);
+
+        // This shouldn't change
+        expect(lastValue.messages[1]).toBe(initialMessage2);
+
+        // TODO: The initial should point at that snapshot in time
+        // expect(lastValue.messages).not.toBe(initialValue.messages);
+        // expect(lastValue.messages[0]).not.toBe(initialValue.messages[0]);
+        // expect(lastValue.messages[1]).toBe(initialValue.messages[1]);
+        // expect(lastValue.messages[0].reactions).not.toBe(initialValue.messages[0].reactions);
+    });
+
+    it("should keep the same identity on the ref entities when a property is updated", async () => {
+        const { me, meOnSecondPeer } = await setupAccount();
+
+        const chatRoom = createChatRoom(me, "General");
+        const message = createMessage(me, "Hello Luigi, are you ready to save the princess?");
+        const message2 = createMessage(me, "Let's go!");
+        chatRoom.messages?.push(message);
+        chatRoom.messages?.push(message2);
+
+        const updateFn = vi.fn()
+
+        const unsubscribe = subscribeToCoValue(
+            ChatRoom,
+            chatRoom.id,
+            meOnSecondPeer,
+            {
+                messages: [{
+                    reactions: [],
+                }],
+            },
+            updateFn,
+        );
+
+        onTestFinished(unsubscribe);
+
+        await waitFor(() => {
+            const lastValue = updateFn.mock.lastCall[0];
+
+            expect(lastValue?.messages?.[0]?.text).toBe(message.text);
+            expect(lastValue?.messages?.[1]?.text).toBe(message2.text);
+        });
+
+        const initialValue = updateFn.mock.lastCall[0];
+        chatRoom.name = "Me and Luigi";
+
+        updateFn.mockClear();
+
+        await waitFor(() => {
+            expect(updateFn).toHaveBeenCalled();
+        });
+        
+        const lastValue = updateFn.mock.lastCall[0];
+        expect(lastValue).not.toBe(initialValue);
+        expect(lastValue.name).toBe("Me and Luigi");
+        expect(initialValue.name).toBe("General");
+        
+        expect(lastValue.messages).toBe(initialValue.messages);
+        expect(lastValue.messages[0]).toBe(initialValue.messages[0]);
+        expect(lastValue.messages[1]).toBe(initialValue.messages[1]);
+    });
+});
+
+
+function waitFor(callback: () => boolean | void) {
+    return new Promise<void>((resolve, reject) => {
+        const checkPassed = () => {
+            try {
+                return { ok: callback(), error: null };
+            } catch (error) {
+                return { ok: false, error };
+            }
+        };
+
+        let retries = 0;
+
+        const interval = setInterval(() => {
+            const { ok, error } = checkPassed();
+
+            if (ok !== false) {
+                clearInterval(interval);
+                resolve();
+            }
+
+            if (++retries > 10) {
+                clearInterval(interval);
+                reject(error);
+            }
+        }, 100);
+    });
+}

--- a/packages/jazz-tools/src/tests/subscribe.test.ts
+++ b/packages/jazz-tools/src/tests/subscribe.test.ts
@@ -11,7 +11,7 @@ import {
     isControlledAccount,
     createJazzContext,
     fixedCredentialsAuth,
-} from "../index.js";
+} from "../index.web.js";
 import {
     BinaryCoStream,
     Group,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -870,6 +870,9 @@ importers:
       eslint:
         specifier: ^8.46.0
         version: 8.56.0
+      eslint-plugin-react-compiler:
+        specifier: 0.0.0-experimental-fa06e2c-20241014
+        version: 0.0.0-experimental-fa06e2c-20241014(eslint@8.56.0)
       eslint-plugin-react-hooks:
         specifier: ^4.6.0
         version: 4.6.0(eslint@8.56.0)
@@ -1774,6 +1777,13 @@ packages:
     resolution: {integrity: sha512-p4zeefM72gpmEe2fkUr/OnOXpWEf8nAgk7ZYVqqfFiyIG7oFfVZcCrU64hWn5xp4tQ9LkV4bTIa5rD0KANpKNA==}
     engines: {node: '>=6.9.0'}
     deprecated: This proposal has been merged to the ECMAScript standard and thus this plugin is no longer maintained. Please use @babel/plugin-transform-optional-chaining instead.
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
+  '@babel/plugin-proposal-private-methods@7.18.6':
+    resolution: {integrity: sha512-nutsvktDItsNn4rpGItSNV2sz1XwS+nfU0Rg8aCx3W3NOKVzdMjJRu0O5OkgDp3ZGICSTbgRpxZoWsxoKRvbeA==}
+    engines: {node: '>=6.9.0'}
+    deprecated: This proposal has been merged to the ECMAScript standard and thus this plugin is no longer maintained. Please use @babel/plugin-transform-private-methods instead.
     peerDependencies:
       '@babel/core': ^7.0.0-0
 
@@ -3294,7 +3304,7 @@ packages:
   '@radix-ui/react-compose-refs@1.1.0':
     resolution: {integrity: sha512-b4inOtiaOnYf9KWyO3jAeeCG6FeyfY6ldiEPanbUjWd+xIk5wZeHa8yVwmrJ2vderhu/BQvzCrJI0lHd+wIiqw==}
     peerDependencies:
-      '@types/react': '*'
+      '@types/react': ^18.2.32
       react: 18.3.1
     peerDependenciesMeta:
       '@types/react':
@@ -3378,8 +3388,8 @@ packages:
   '@radix-ui/react-focus-scope@1.1.0':
     resolution: {integrity: sha512-200UD8zylvEyL8Bx+z76RJnASR2gRMuxlgFCPAe/Q/679a/r0eK3MBVYMb7vZODZcffZBdob1EGnky78xmVvcA==}
     peerDependencies:
-      '@types/react': '*'
-      '@types/react-dom': '*'
+      '@types/react': ^18.2.32
+      '@types/react-dom': ^18.2.14
       react: 18.3.1
       react-dom: 18.3.1
     peerDependenciesMeta:
@@ -3391,7 +3401,7 @@ packages:
   '@radix-ui/react-id@1.1.0':
     resolution: {integrity: sha512-EJUrI8yYh7WOjNOqpoJaf1jlFIH2LvtgAl+YcFqNCa+4hj64ZXmPkAKOFs/ukjz3byN6bdb/AVUqHkI8/uWWMA==}
     peerDependencies:
-      '@types/react': '*'
+      '@types/react': ^18.2.32
       react: 18.3.1
     peerDependenciesMeta:
       '@types/react':
@@ -3413,8 +3423,8 @@ packages:
   '@radix-ui/react-popper@1.2.0':
     resolution: {integrity: sha512-ZnRMshKF43aBxVWPWvbj21+7TQCvhuULWJ4gNIKYpRlQt5xGRhLx66tMp8pya2UkGHTSlhpXwmjqltDYHhw7Vg==}
     peerDependencies:
-      '@types/react': '*'
-      '@types/react-dom': '*'
+      '@types/react': ^18.2.32
+      '@types/react-dom': ^18.2.14
       react: 18.3.1
       react-dom: 18.3.1
     peerDependenciesMeta:
@@ -3491,8 +3501,8 @@ packages:
   '@radix-ui/react-primitive@2.0.0':
     resolution: {integrity: sha512-ZSpFm0/uHa8zTvKBDjLFWLo8dkr4MBsiDLz0g3gMUwqgLHz9rTaRRGYDgvZPtBJgYCBKXkS9fzmoySgr8CO6Cw==}
     peerDependencies:
-      '@types/react': '*'
-      '@types/react-dom': '*'
+      '@types/react': ^18.2.32
+      '@types/react-dom': ^18.2.14
       react: 18.3.1
       react-dom: 18.3.1
     peerDependenciesMeta:
@@ -5887,6 +5897,12 @@ packages:
       eslint-config-prettier:
         optional: true
 
+  eslint-plugin-react-compiler@0.0.0-experimental-fa06e2c-20241014:
+    resolution: {integrity: sha512-tHntZz8Kx/6RgCLn7aDGfBQizqTUUfHEDaBcrvJi1GhKzgDxmAbdn85Y6z8eGSh4s0gufNWyO9WRCYLf0hP0ow==}
+    engines: {node: ^14.17.0 || ^16.0.0 || >= 18.0.0}
+    peerDependencies:
+      eslint: '>=7'
+
   eslint-plugin-react-hooks@4.6.0:
     resolution: {integrity: sha512-oFc7Itz9Qxh2x4gNHStv3BqJq54ExXmfC+a1NjAta66IAN87Wu0R/QArgIS9qKzX3dXKPI9H5crl9QchNMY9+g==}
     engines: {node: '>=10'}
@@ -6599,11 +6615,17 @@ packages:
   hermes-estree@0.19.1:
     resolution: {integrity: sha512-daLGV3Q2MKk8w4evNMKwS8zBE/rcpA800nu1Q5kM08IKijoSnPe9Uo1iIxzPKRkn95IxxsgBMPeYHt3VG4ej2g==}
 
+  hermes-estree@0.20.1:
+    resolution: {integrity: sha512-SQpZK4BzR48kuOg0v4pb3EAGNclzIlqMj3Opu/mu7bbAoFw6oig6cEt/RAi0zTFW/iW6Iz9X9ggGuZTAZ/yZHg==}
+
   hermes-estree@0.23.1:
     resolution: {integrity: sha512-eT5MU3f5aVhTqsfIReZ6n41X5sYn4IdQL0nvz6yO+MMlPxw49aSARHLg/MSehQftyjnrE8X6bYregzSumqc6cg==}
 
   hermes-parser@0.19.1:
     resolution: {integrity: sha512-Vp+bXzxYJWrpEuJ/vXxUsLnt0+y4q9zyi4zUlkLqD8FKv4LjIfOvP69R/9Lty3dCyKh0E2BU7Eypqr63/rKT/A==}
+
+  hermes-parser@0.20.1:
+    resolution: {integrity: sha512-BL5P83cwCogI8D7rrDCgsFY0tdYUtmFP9XaXtl2IQjC+2Xo+4okjfXintlTxcIwl4qeGddEl28Z11kbVIw0aNA==}
 
   hermes-parser@0.23.1:
     resolution: {integrity: sha512-oxl5h2DkFW83hT4DAUJorpah8ou4yvmweUzLJmmr6YV2cezduCdlil1AvU/a/xSsAFo4WUcNA4GoV5Bvq6JffA==}
@@ -10334,6 +10356,12 @@ packages:
     peerDependencies:
       zod: ^3.18.0
 
+  zod-validation-error@3.4.0:
+    resolution: {integrity: sha512-ZOPR9SVY6Pb2qqO5XHt+MkkTRxGXb4EVtnjc9JpXUOtUB1T9Ru7mZOT361AN3MsetVe7R0a1KZshJDZdgp9miQ==}
+    engines: {node: '>=18.0.0'}
+    peerDependencies:
+      zod: ^3.18.0
+
   zod@3.23.8:
     resolution: {integrity: sha512-XBx9AXhXktjUqnepgTiE5flcKIYWi/rme0Eaj+5Y0lftuGBq+jyRu/md4WnuxqgP1ubdpNCsYEYPxrzVHD8d6g==}
 
@@ -10653,6 +10681,14 @@ snapshots:
       '@babel/helper-plugin-utils': 7.24.8
       '@babel/helper-skip-transparent-expression-wrappers': 7.24.7
       '@babel/plugin-syntax-optional-chaining': 7.8.3(@babel/core@7.25.2)
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/plugin-proposal-private-methods@7.18.6(@babel/core@7.25.2)':
+    dependencies:
+      '@babel/core': 7.25.2
+      '@babel/helper-create-class-features-plugin': 7.25.4(@babel/core@7.25.2)
+      '@babel/helper-plugin-utils': 7.24.8
     transitivePeerDependencies:
       - supports-color
 
@@ -15894,6 +15930,18 @@ snapshots:
       '@types/eslint': 9.6.0
       eslint-config-prettier: 9.1.0(eslint@8.57.1)
 
+  eslint-plugin-react-compiler@0.0.0-experimental-fa06e2c-20241014(eslint@8.56.0):
+    dependencies:
+      '@babel/core': 7.25.2
+      '@babel/parser': 7.25.6
+      '@babel/plugin-proposal-private-methods': 7.18.6(@babel/core@7.25.2)
+      eslint: 8.56.0
+      hermes-parser: 0.20.1
+      zod: 3.23.8
+      zod-validation-error: 3.4.0(zod@3.23.8)
+    transitivePeerDependencies:
+      - supports-color
+
   eslint-plugin-react-hooks@4.6.0(eslint@8.56.0):
     dependencies:
       eslint: 8.56.0
@@ -16810,11 +16858,17 @@ snapshots:
 
   hermes-estree@0.19.1: {}
 
+  hermes-estree@0.20.1: {}
+
   hermes-estree@0.23.1: {}
 
   hermes-parser@0.19.1:
     dependencies:
       hermes-estree: 0.19.1
+
+  hermes-parser@0.20.1:
+    dependencies:
+      hermes-estree: 0.20.1
 
   hermes-parser@0.23.1:
     dependencies:
@@ -21015,6 +21069,10 @@ snapshots:
       readable-stream: 3.6.2
 
   zod-validation-error@2.1.0(zod@3.23.8):
+    dependencies:
+      zod: 3.23.8
+
+  zod-validation-error@3.4.0(zod@3.23.8):
     dependencies:
       zod: 3.23.8
 


### PR DESCRIPTION
Migrate the React subscription logic to [useSyncExternalStore](https://react.dev/reference/react/useSyncExternalStore).

The main advantage of adopting `useSyncExternalStore` is to follow "The React Way" to subscribe to external stores, which should give us better compatibility and hopefully less surprises with the latest React features.

`useSyncExternalStore` also comes with a dedicated getter which should hopefully help with the SSR integration.

TODO:
- [x] Check how references are managed within Jazz
- [x] Test all the example apps to see if we are breaking some of them
- [x] Add unit tests
- [x] Check the React Compiler compatibility
- [x] Write an issue related to the immutable state and the references graph https://github.com/gardencmp/jazz/issues/565
- [ ] Non blocking: Do some resarch on how we could use Suspense (would probably be very useful for SSR)
