### PR TITLE
Remove empty space in code example tab

### DIFF
--- a/homepage/homepage/app/shiki.css
+++ b/homepage/homepage/app/shiki.css
@@ -1,5 +1,6 @@
 pre.shiki {
     overflow: hidden;
+    height: 100%;
 }
 pre.shiki:hover .dim {
     opacity: 1;
@@ -78,7 +79,7 @@ pre.twoslash data-lsp:hover::before {
 }
 
 pre .code-container {
-    @apply overflow-auto p-2 pl-0 bg-white dark:bg-stone-925 rounded-b-xl text-xs dark:border-stone-900;
+    @apply overflow-auto p-2 pl-0 bg-white dark:bg-stone-925 rounded-b-xl text-xs h-full dark:border-stone-900;
 }
 /* The try button */
 pre .code-container > a {

--- a/homepage/homepage/renderCodeSamples.mjs
+++ b/homepage/homepage/renderCodeSamples.mjs
@@ -93,7 +93,7 @@ await rm("./codeSamples", { recursive: true, force: true });
                     const component = `export function ${
                         path.basename(filename).slice(0, 1).toUpperCase() +
                         path.basename(filename).slice(1).replace(".", "_")
-                    }() {\n\treturn <div className="not-prose" dangerouslySetInnerHTML={{__html: \`${html
+                    }() {\n\treturn <div className="not-prose h-full" dangerouslySetInnerHTML={{__html: \`${html
                         .replace(/`/g, "\\`")
                         .replace(/\$/g, "\\$")}\`\n\t}}/>;\n}`;
 


### PR DESCRIPTION
This removes the empty space at the bottom which is very obvious when the horizontal scrollbar is present:
![image](https://github.com/user-attachments/assets/f6c94eb5-ec22-4cb1-9163-04f7ec0e1f16)
