### PR TITLE
chore(dx): configure vitest to run in watch mode on the local machine

### DIFF
--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -44,4 +44,4 @@ jobs:
         run: pnpm turbo build
 
       - name: Unit Tests
-        run: pnpm test
+        run: pnpm test:ci

--- a/package.json
+++ b/package.json
@@ -22,8 +22,9 @@
         "dev": "turbo dev",
         "build": "turbo build && cd homepage/homepage && pnpm run build",
         "lint": "turbo lint && cd homepage/homepage && pnpm run lint",
-        "test": "vitest --coverage.enabled=false",
-        "test:coverage": "vitest --ui --coverage --watch",
+        "test": "vitest",
+        "test:ci": "vitest --coverage.enabled=true",
+        "test:coverage": "vitest --ui --coverage.enabled=true",
         "format": "pnpm run -r format && cd homepage/homepage && pnpm run format",
         "changeset": "changeset",
         "changeset-version": "changeset version",
@@ -41,7 +42,7 @@
                 "expo-modules-*",
                 "typescript"
             ]
-},
+        },
         "overrides": {
             "react": "18.3.1",
             "react-dom": "18.3.1"

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -5,7 +5,7 @@ export default defineConfig({
     root: "./",
     test: {
         coverage: {
-            enabled: true,
+            enabled: false,
             provider: "istanbul",
             include: ["packages/*/src/**/*.ts"],
             exclude: ["packages/*/src/tests"],
@@ -20,7 +20,6 @@ export default defineConfig({
             },
         },
         include: ["packages/*/tests/**/*.test.ts"],
-        watch: false,
         watchExclude: ["**/node_modules/**", "**/dist/**"],
         maxConcurrency: 5,
     },


### PR DESCRIPTION
Vitest automatically disable the watch mode on CI, so I've changed the settings to let vitest control the watch mode based on the environment.

This simplifies the local execution of the tests, where it's helpful to have the watch mode enabled by default