### PR TITLE
feat: make the PeerKnownState subscribable

### DIFF
--- a/packages/cojson/src/PeerKnownStates.test.ts
+++ b/packages/cojson/src/PeerKnownStates.test.ts
@@ -1,0 +1,100 @@
+import { PeerKnownStates } from './PeerKnownStates.js';
+import { CoValueKnownState, emptyKnownState } from './sync.js';
+import { RawCoID, SessionID } from './ids.js';
+import { vi, describe, test, expect } from 'vitest';
+
+
+describe('PeerKnownStates', () => {
+  test('should set and get a known state', () => {
+    const peerKnownStates = new PeerKnownStates();
+    const id = 'test-id' as RawCoID;
+    const knownState: CoValueKnownState = emptyKnownState(id);
+
+    peerKnownStates.dispatch({ type: 'SET', id, value: knownState });
+
+    expect(peerKnownStates.get(id)).toEqual(knownState);
+    expect(peerKnownStates.has(id)).toBe(true);
+  });
+
+  test('should update header', () => {
+    const peerKnownStates = new PeerKnownStates();
+    const id = 'test-id' as RawCoID;
+
+    peerKnownStates.dispatch({ type: 'UPDATE_HEADER', id, header: true });
+
+    const result = peerKnownStates.get(id);
+    expect(result?.header).toBe(true);
+  });
+
+  test('should update session counter', () => {
+    const peerKnownStates = new PeerKnownStates();
+    const id = 'test-id' as RawCoID;
+    const sessionId = 'session-1' as SessionID;
+
+    peerKnownStates.dispatch({ type: 'UPDATE_SESSION_COUNTER', id, sessionId, value: 5 });
+
+    const result = peerKnownStates.get(id);
+    expect(result?.sessions[sessionId]).toBe(5);
+  });
+
+  test('should combine with existing state', () => {
+    const peerKnownStates = new PeerKnownStates();
+    const id = 'test-id' as RawCoID;
+    const session1 = 'session-1' as SessionID;
+    const session2 = 'session-2' as SessionID;
+    const initialState: CoValueKnownState = {
+      ...emptyKnownState(id),
+      sessions: { [session1]: 5 },
+    };
+    const combineState: CoValueKnownState = {
+      ...emptyKnownState(id),
+      sessions: { [session2]: 10 },
+    };
+
+    peerKnownStates.dispatch({ type: 'SET', id, value: initialState });
+    peerKnownStates.dispatch({ type: 'COMBINE_WITH', id, value: combineState });
+
+    const result = peerKnownStates.get(id);
+    expect(result?.sessions).toEqual({ [session1]: 5, [session2]: 10 });
+  });
+
+  test('should set as empty', () => {
+    const peerKnownStates = new PeerKnownStates();
+    const id = 'test-id' as RawCoID;
+    const sessionId = 'session-1' as SessionID;
+    const initialState: CoValueKnownState = {
+      ...emptyKnownState(id),
+      sessions: { [sessionId]: 5 },
+    };
+
+    peerKnownStates.dispatch({ type: 'SET', id, value: initialState });
+    peerKnownStates.dispatch({ type: 'SET_AS_EMPTY', id });
+
+    const result = peerKnownStates.get(id);
+    expect(result).toEqual(emptyKnownState(id));
+  });
+
+  test('should trigger listeners on dispatch', () => {
+    const peerKnownStates = new PeerKnownStates();
+    const id = 'test-id' as RawCoID;
+    const listener = vi.fn();
+
+    peerKnownStates.subscribe(listener);
+    peerKnownStates.dispatch({ type: 'SET_AS_EMPTY', id });
+
+    expect(listener).toHaveBeenCalledWith(id, emptyKnownState(id));
+  });
+
+  test('should unsubscribe listener', () => {
+    const peerKnownStates = new PeerKnownStates();
+    const id = 'test-id' as RawCoID;
+    const listener = vi.fn();
+
+    const unsubscribe = peerKnownStates.subscribe(listener);
+    unsubscribe();
+
+    peerKnownStates.dispatch({ type: 'SET_AS_EMPTY', id });
+
+    expect(listener).not.toHaveBeenCalled();
+  });
+});

--- a/packages/cojson/src/PeerKnownStates.ts
+++ b/packages/cojson/src/PeerKnownStates.ts
@@ -1,0 +1,103 @@
+import { RawCoID, SessionID } from "./ids.js";
+import { CoValueKnownState, emptyKnownState, combinedKnownStates } from "./sync.js";
+
+type PeerKnownStateActions = {
+    type: "SET_AS_EMPTY";
+    id: RawCoID;
+} | {
+    type: "UPDATE_HEADER";
+    id: RawCoID;
+    header: boolean;
+} |
+{
+    type: "UPDATE_SESSION_COUNTER";
+    id: RawCoID;
+    sessionId: SessionID;
+    value: number;
+} |
+{
+    type: "SET";
+    id: RawCoID;
+    value: CoValueKnownState;
+} |
+{
+    type: "COMBINE_WITH";
+    id: RawCoID;
+    value: CoValueKnownState;
+};
+export class PeerKnownStates {
+    private coValues = new Map<RawCoID, CoValueKnownState>();
+
+    private updateHeader(id: RawCoID, header: boolean) {
+        const knownState = this.coValues.get(id) ?? emptyKnownState(id);
+        knownState.header = header;
+        this.coValues.set(id, knownState);
+    }
+
+    private combineWith(id: RawCoID, value: CoValueKnownState) {
+        const knownState = this.coValues.get(id) ?? emptyKnownState(id);
+        this.coValues.set(id, combinedKnownStates(knownState, value));
+    }
+
+    private updateSessionCounter(
+        id: RawCoID,
+        sessionId: SessionID,
+        value: number
+    ) {
+        const knownState = this.coValues.get(id) ?? emptyKnownState(id);
+        const currentValue = knownState.sessions[sessionId] || 0;
+        knownState.sessions[sessionId] = Math.max(currentValue, value);
+
+        this.coValues.set(id, knownState);
+    }
+
+    get(id: RawCoID) {
+        return this.coValues.get(id);
+    }
+
+    has(id: RawCoID) {
+        return this.coValues.has(id);
+    }
+
+    dispatch(action: PeerKnownStateActions) {
+        switch (action.type) {
+            case "UPDATE_HEADER":
+                this.updateHeader(action.id, action.header);
+                break;
+            case "UPDATE_SESSION_COUNTER":
+                this.updateSessionCounter(
+                    action.id,
+                    action.sessionId,
+                    action.value
+                );
+                break;
+            case "SET":
+                this.coValues.set(action.id, action.value);
+                break;
+            case "COMBINE_WITH":
+                this.combineWith(action.id, action.value);
+                break;
+            case "SET_AS_EMPTY":
+                this.coValues.set(action.id, emptyKnownState(action.id));
+                break;
+        }
+
+        this.trigger(action.id, this.coValues.get(action.id));
+    }
+
+    listeners = new Set<(id: RawCoID, knownState: CoValueKnownState | undefined) => void>();
+
+    private trigger(id: RawCoID, knownState: CoValueKnownState | undefined) {
+        for (const listener of this.listeners) {
+            listener(id, knownState);
+        }
+    }
+
+    subscribe(listener: (id: RawCoID, knownState: CoValueKnownState | undefined) => void) {
+        this.listeners.add(listener);
+
+        return () => {
+            this.listeners.delete(listener);
+        };
+    }
+}

--- a/packages/cojson/src/PeerState.ts
+++ b/packages/cojson/src/PeerState.ts
@@ -1,94 +1,21 @@
-import { RawCoID, SessionID } from "./ids.js";
+import { RawCoID } from "./ids.js";
+import { PeerKnownStates } from "./PeerKnownStates.js";
 import { CO_VALUE_PRIORITY } from "./priority.js";
 import {
     PriorityBasedMessageQueue,
     QueueEntry,
 } from "./PriorityBasedMessageQueue.js";
-import { combinedKnownStates, CoValueKnownState, emptyKnownState, Peer, SyncMessage } from "./sync.js";
-
-
-class PeerCoValueKnownState {
-    constructor(public value: CoValueKnownState) {}
-
-    get() {
-        return this.value;
-    }
-
-    updateHeader(header: boolean) {
-        this.value.header = header;
-    }
-
-    combineWith(value: CoValueKnownState) {
-        this.value = combinedKnownStates(this.value, value);
-    }
-
-    set(value: CoValueKnownState) {
-        this.value = value;
-    }
-
-    updateSessionCounter(sessionId: SessionID, value: number) {
-        const currentValue = this.value.sessions[sessionId] || 0;
-        this.value.sessions[sessionId] = Math.max(currentValue, value);
-    }
-}
-
-class PeerKnownStates {
-    private coValues = new Map<RawCoID, PeerCoValueKnownState>();
-    private sent = new Set<RawCoID>();
-
-    constructor() {}
-
-    get(id: RawCoID, createIfMissing: true): PeerCoValueKnownState;
-    get(id: RawCoID, createIfMissing?: false): PeerCoValueKnownState | undefined;
-    get(id: RawCoID, createIfMissing = false) {
-        const entry = this.coValues.get(id);
-
-        if (createIfMissing && !entry) {
-            return this.setAsEmpty(id);
-        }
-
-        return entry;
-    }
-
-    has(id: RawCoID) {
-        return this.coValues.has(id);
-    }
-
-    set(id: RawCoID, value: CoValueKnownState) {
-        const previousEntry = this.get(id);
-
-        if (previousEntry) {
-            previousEntry.set(value);
-            return previousEntry;
-        }
-
-        const knownState = new PeerCoValueKnownState(value);
-
-        this.coValues.set(id, knownState);
-
-        return knownState;
-    }
-
-    setAsEmpty(id: RawCoID) {
-        return this.set(id, emptyKnownState(id));
-    }
-
-    hasBeenSent(id: RawCoID) {
-        return this.sent.has(id);
-    }
-
-    trackSent(id: RawCoID) {
-        this.sent.add(id);
-    }
-}
+import {
+    Peer,
+    SyncMessage,
+} from "./sync.js";
 
 export class PeerState {
     constructor(private peer: Peer) {}
 
     public knownStates = new PeerKnownStates();
+    readonly toldKnownState: Set<RawCoID> = new Set();
 
-    // readonly optimisticKnownStates: { [id: RawCoID]: CoValueKnownState } = {};
-    // readonly toldKnownState: Set<RawCoID> = new Set();
     get id() {
         return this.peer.id;
     }
@@ -121,7 +48,6 @@ export class PeerState {
         }
 
         this.processing = true;
-
 
         let entry: QueueEntry | undefined;
         while ((entry = this.queue.pull())) {

--- a/packages/cojson/src/coValueState.ts
+++ b/packages/cojson/src/coValueState.ts
@@ -1,15 +1,6 @@
 import { CoValueCore } from "./coValueCore.js";
 import { PeerID } from "./sync.js";
-
-function createResolvablePromise<T>() {
-    let resolve!: (value: T) => void;
-
-    const promise = new Promise<T>((res) => {
-        resolve = res;
-    });
-
-    return { promise, resolve };
-}
+import { createResolvablePromise } from "./utils.js";
 
 class CoValueUnknownState {
     type = "unknown" as const;

--- a/packages/cojson/src/tests/PeerState.test.ts
+++ b/packages/cojson/src/tests/PeerState.test.ts
@@ -27,8 +27,6 @@ describe("PeerState", () => {
         expect(peerState.priority).toBe(1);
         expect(peerState.crashOnClose).toBe(false);
         expect(peerState.closed).toBe(false);
-        expect(peerState.optimisticKnownStates).toEqual({});
-        expect(peerState.toldKnownState).toEqual(new Set());
     });
 
     test("should push outgoing message to peer", async () => {

--- a/packages/cojson/src/tests/sync.test.ts
+++ b/packages/cojson/src/tests/sync.test.ts
@@ -761,8 +761,8 @@ test.skip("When replaying creation and transactions of a coValue as new content,
     expect(groupTellKnownStateMsg).toMatchObject(groupStateEx(group));
 
     expect(
-        node2.syncManager.peers["test1"]!.optimisticKnownStates[group.core.id],
-    ).toBeDefined();
+        node2.syncManager.peers["test1"]!.knownStates.has(group.core.id),
+    ).toBe(true);
 
     // await inTx1.push(adminTellKnownStateMsg);
     await inTx1.push(groupTellKnownStateMsg);

--- a/packages/cojson/src/utils.ts
+++ b/packages/cojson/src/utils.ts
@@ -1,0 +1,9 @@
+export function createResolvablePromise<T>() {
+    let resolve!: (value: T) => void;
+
+    const promise = new Promise<T>((res) => {
+        resolve = res;
+    });
+
+    return { promise, resolve };
+}


### PR DESCRIPTION
Part of #307 

The idea is to make possible to subscribe to the PeerKnownState updates in order to sent them to the storage peers.

So when building the Jazz context we could create a "WebSocket PeerKnownState" -> "Storage Peer" stream to continuously persist the sync state of the co values.
