### PR TITLE
Quick fix for features section being squished

### DIFF
--- a/homepage/design-system/src/app/components/molecules/LabelledFeatureIcon.tsx
+++ b/homepage/design-system/src/app/components/molecules/LabelledFeatureIcon.tsx
@@ -5,14 +5,17 @@ export function LabelledFeatureIcon({
     label,
     icon: Icon,
     explanation,
+    className,
 }: {
     label: string;
     icon: LucideIcon;
     explanation: React.ReactNode;
+    className?: string;
 }) {
     return (
         <div
             className={clsx(
+              className,
                 "p-4 flex flex-col gap-3",
                 "not-prose text-base",
                 "border border-stone-200 dark:border-stone-900 rounded-xl",

--- a/homepage/homepage/app/(home)/page.tsx
+++ b/homepage/homepage/app/(home)/page.tsx
@@ -188,7 +188,7 @@ export default function Home() {
             ),
         },
         {
-            title: "E2EE",
+            title: "E2E encryption",
             icon: KeyRoundIcon,
             description: (
                 <>

--- a/homepage/homepage/app/(home)/page.tsx
+++ b/homepage/homepage/app/(home)/page.tsx
@@ -172,7 +172,7 @@ export default function Home() {
             ),
         },
         {
-            title: "Sync",
+            title: "Real-time sync",
             icon: MonitorSmartphoneIcon,
             description: (
                 <>

--- a/homepage/homepage/app/(home)/page.tsx
+++ b/homepage/homepage/app/(home)/page.tsx
@@ -21,6 +21,7 @@ import {
     HardDriveDownloadIcon,
     KeyRoundIcon,
     MousePointerSquareDashedIcon,
+    UserIcon,
 } from "lucide-react";
 
 import {
@@ -42,7 +43,6 @@ import GroupDescription from "./coValueDescriptions/groupDescription.mdx";
 import AccountDescription from "./coValueDescriptions/accountDescription.mdx";
 import AutoSubDescription from "./toolkit/autoSub.mdx";
 import CursorsAndCaretsDescription from "./toolkit/cursorsAndCarets.mdx";
-import AuthProvidersDescription from "./toolkit/authProviders.mdx";
 import TwoWaySyncDescription from "./toolkit/twoWaySync.mdx";
 import FileUploadDownloadDescription from "./toolkit/fileUploadDownload.mdx";
 import VideoPresenceCallsDescription from "./toolkit/videoPresenceCalls.mdx";
@@ -52,7 +52,6 @@ import Link from "next/link";
 import { DiagramBeforeJazz } from "@/components/DiagramBeforeJazz";
 import { DiagramAfterJazz } from "@/components/DiagramAfterJazz";
 import { SupportedEnvironments } from "@/components/home/SupportedEnvironments";
-import { HairlineBleedGrid } from "gcmp-design-system/src/app/components/molecules/HairlineGrid";
 import { Hero } from "@/components/home/Hero";
 import { HowItWorks } from "@/components/home/HowItWorks";
 
@@ -87,23 +86,24 @@ const ArrowDoodle = ({ className }: { className?: string }) => (
 );
 
 export default function Home() {
+    const localFirst = {
+        title: "Local-first",
+        icon: HardDriveDownloadIcon,
+        description: (
+            <>
+                <p>
+                    All data you load or create is persisted locally, so your
+                    users can work offline.
+                </p>
+                <p>
+                    When you’re back online, your local changes are synced to
+                    the server.
+                </p>
+            </>
+        ),
+    };
+
     const features = [
-        {
-            title: "Local-first",
-            icon: HardDriveDownloadIcon,
-            description: (
-                <>
-                    <p>
-                        All data you load or create is persisted locally, so
-                        your users can work offline.
-                    </p>
-                    <p>
-                        When you’re back online, your local changes are synced
-                        to the server.
-                    </p>
-                </>
-            ),
-        },
         {
             title: "Multiplayer",
             icon: MousePointerSquareDashedIcon,
@@ -219,6 +219,23 @@ export default function Home() {
                 </>
             ),
         },
+        {
+            title: "Authentication",
+            icon: UserIcon,
+            description: (
+                <>
+                    <p>Plug and play different kinds of auth.</p>
+                    <ul className="pl-4 list-disc">
+                        <li>DemoAuth (for quick multi-user demos)</li>
+                        <li>WebAuthN (TouchID/FaceID)</li>
+                        <li>Clerk</li>
+                        <li>
+                            Auth0, Okta, NextAuth <ComingSoonBadge />
+                        </li>
+                    </ul>
+                </>
+            ),
+        },
     ];
 
     return (
@@ -329,16 +346,19 @@ export default function Home() {
                         slogan="Features that used to take months to build now work out-of-the-box."
                     />
 
-                    <HairlineBleedGrid>
-                        {features.map(({ title, icon: Icon, description }) => (
-                            <LabelledFeatureIcon
-                                key={title}
-                                label={title}
-                                icon={Icon}
-                                explanation={description}
-                            />
-                        ))}
-                    </HairlineBleedGrid>
+                    <GappedGrid>
+                        {[localFirst, ...features].map(
+                            ({ title, icon: Icon, description }) => (
+                                <LabelledFeatureIcon
+                                    className="col-span-2"
+                                    key={title}
+                                    label={title}
+                                    icon={Icon}
+                                    explanation={description}
+                                />
+                            ),
+                        )}
+                    </GappedGrid>
                 </div>
 
                 <div>
@@ -515,16 +535,6 @@ export default function Home() {
 
                     <GridCard>
                         <SectionHeader
-                            title="Auth Providers"
-                            slogan="Plug and play different kinds of auth."
-                        />
-                        <SmallProse>
-                            <AuthProvidersDescription />
-                        </SmallProse>
-                    </GridCard>
-
-                    <GridCard>
-                        <SectionHeader
                             title="Two-way sync to your DB"
                             slogan="Add Jazz to an existing app."
                         />
@@ -561,7 +571,7 @@ export default function Home() {
 
                 <div className="border border-stone-200 dark:border-stone-900 rounded-xl shadow-sm p-4 md:py-16">
                     <div className="flex flex-col lg:max-w-3xl md:text-center mx-auto justify-between gap-6">
-                        <p className="uppercase text-blue tracking-wide text-sm font-medium dark:text-stone-400">
+                        <p className="uppercase text-blue tracking-widest text-sm font-medium dark:text-stone-400">
                             Become an early adopter
                         </p>
                         <h3 className="font-display md:text-center text-stone-950 dark:text-white text-2xl md:text-3xl font-semibold tracking-tight">

--- a/homepage/homepage/app/(home)/toolkit/authProviders.mdx
+++ b/homepage/homepage/app/(home)/toolkit/authProviders.mdx
@@ -1,7 +1,0 @@
-import { ComingSoonBadge } from "gcmp-design-system/src/app/components/atoms/ComingSoonBadge";
-
-
-- DemoAuth (for quick multi-user demos)
-- WebAuthN (TouchID/FaceID)
-- Auth0, Clerk & Okta <ComingSoonBadge/>
-- NextAuth <ComingSoonBadge/>

--- a/homepage/homepage/components/home/Hero.tsx
+++ b/homepage/homepage/components/home/Hero.tsx
@@ -9,7 +9,7 @@ export function Hero({
     return (
         <div className="container grid gap-x-8 gap-y-10 py-12 md:py-16 lg:py-24 lg:gap-0 lg:grid-cols-3">
             <div className="flex flex-col justify-center gap-4 lg:col-span-3 lg:gap-8">
-                <p className="uppercase text-blue tracking-wide text-sm font-medium dark:text-stone-400">
+                <p className="uppercase text-blue tracking-widest text-sm font-medium dark:text-stone-400">
                     Local-first development toolkit
                 </p>
                 <h1 className="font-display text-stone-950 dark:text-white text-4xl md:text-5xl lg:text-6xl font-medium tracking-tighter">
@@ -19,9 +19,14 @@ export function Hero({
                 <div className="space-y-2 text-pretty md:leading-relaxed text-stone-700 max-w-2xl dark:text-stone-200 md:text-xl">
                     <p>
                         Jazz is a framework for building local-first apps
-                        &mdash; an architecture that lets apps like Figma and Linear play in a league of their own.
+                        &mdash; an architecture that lets apps like Figma and
+                        Linear play in a league of their own.
                     </p>
-                    <p>Open source. Self-host or use <Link href="/cloud">Jazz Cloud</Link> for zero-config magic.</p>
+                    <p>
+                        Open source. Self-host or use{" "}
+                        <Link href="/cloud">Jazz Cloud</Link> for zero-config
+                        magic.
+                    </p>
                 </div>
 
                 <div className="grid grid-cols-2 gap-2 max-w-3xl sm:grid-cols-4 sm:gap-4">

--- a/homepage/homepage/components/home/HowItWorks.tsx
+++ b/homepage/homepage/components/home/HowItWorks.tsx
@@ -85,7 +85,7 @@ export function HowItWorks() {
     return (
         <div className="grid gap-8">
             <div className="grid gap-3">
-                <p className="uppercase text-blue tracking-wide text-sm font-medium dark:text-stone-400">
+                <p className="uppercase text-blue tracking-widest text-sm font-medium dark:text-stone-400">
                     Collaborative Values
                 </p>
 


### PR DESCRIPTION
Since we had 8 features, they had to be squished into 4 columns. Adding one more makes it 3 col. 

In the hero, I removed local-first since we already mentioned it twice.
<img width="749" alt="image" src="https://github.com/user-attachments/assets/93d44a54-aeec-4935-9d7a-909a3c1237e8">

Renamed E2EE to E2E encryption
Renamed Sync to Real-time sync

We have space for more words and it feels more balanced