### PR TITLE
fix(jazz-run): fix error on account create

### DIFF
--- a/packages/jazz-run/src/index.ts
+++ b/packages/jazz-run/src/index.ts
@@ -56,7 +56,7 @@ const accountCreate = Command.make(
             );
 
             // TODO: remove this once we have a better way to wait for the sync
-            yield* Effect.sleep(500);
+            yield* Effect.sleep(2000);
 
             const peer2 = createWebSocketPeer({
                 id: "upstream2",


### PR DESCRIPTION
When running `npx jazz-run account create -m "Test"` the command fails with:

```
Error withLoadedAccount Error: Account unavailable from all peers
    at LocalNode.withLoadedAccount (file:///Users/guidodorsi/workspace/jazz/packages/cojson/dist/web/localNode.js:89:23)
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
    at async createJazzContext (file:///Users/guidodorsi/workspace/jazz/packages/jazz-tools/dist/web/implementation/createContext.js:55:34)
Expected optimisticKnownState to be set for coValue we receive new content for
```

Wasn't able to reproduce the error using a local sync server and then I've found that the error was thrown because the "consumption" of the account started before the sync was completed.

Increased the timeout, we probably need #331 to come up with a better solution.