### PR TITLE
Improve the jazz-run create command and make it possible to subscribe to the peer sync state

### DIFF
--- a/.changeset/gentle-weeks-serve.md
+++ b/.changeset/gentle-weeks-serve.md
@@ -1,0 +1,5 @@
+---
+"cojson": patch
+---
+
+Make the peer known states subscribable

--- a/.changeset/long-ligers-hear.md
+++ b/.changeset/long-ligers-hear.md
@@ -1,0 +1,5 @@
+---
+"jazz-run": patch
+---
+
+Improve the jazz-run create command by subscribing to the peer sync state

--- a/.github/workflows/jazz-run.yml
+++ b/.github/workflows/jazz-run.yml
@@ -1,4 +1,4 @@
-name: Playwright Tests
+name: Jazz Run Tests
 
 on:
   push:
@@ -8,7 +8,6 @@ on:
 
 jobs:
   test:
-    timeout-minutes: 1
     runs-on: ubuntu-latest
     continue-on-error: true
 
@@ -47,6 +46,6 @@ jobs:
         working-directory: ./packages/jazz-run
 
       - name: Run create account
-        run: ./dist/index.js create account --name "Jazz Run CI test"
+        run: ./dist/index.js account create --name "Jazz Run CI test"
         working-directory: ./packages/jazz-run
   

--- a/.github/workflows/jazz-run.yml
+++ b/.github/workflows/jazz-run.yml
@@ -1,0 +1,52 @@
+name: Playwright Tests
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+jobs:
+  test:
+    timeout-minutes: 1
+    runs-on: ubuntu-latest
+    continue-on-error: true
+
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          submodules: true
+
+      - name: Enable corepack
+        run: corepack enable
+
+      - name: Install Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version-file: '.node-version'
+          cache: 'pnpm'
+
+      - name: Get pnpm store directory
+        shell: bash
+        run: |
+          echo "STORE_PATH=$(pnpm store path --silent)" >> $GITHUB_ENV
+
+      - uses: actions/cache@v3
+        name: Setup pnpm cache
+        with:
+          path: ${{ env.STORE_PATH }}
+          key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-pnpm-store-
+      
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build jazz-run
+        run: pnpm exec turbo build && chmod +x dist/index.js;
+        working-directory: ./packages/jazz-run
+
+      - name: Run create account
+        run: ./dist/index.js create account --name "Jazz Run CI test"
+        working-directory: ./packages/jazz-run
+  

--- a/packages/cojson/src/PeerKnownStates.ts
+++ b/packages/cojson/src/PeerKnownStates.ts
@@ -1,0 +1,108 @@
+import { RawCoID, SessionID } from "./ids.js";
+import { CoValueKnownState, emptyKnownState, combinedKnownStates } from "./sync.js";
+
+type PeerKnownStateActions = {
+    type: "SET_AS_EMPTY";
+    id: RawCoID;
+} | {
+    type: "UPDATE_HEADER";
+    id: RawCoID;
+    header: boolean;
+} |
+{
+    type: "UPDATE_SESSION_COUNTER";
+    id: RawCoID;
+    sessionId: SessionID;
+    value: number;
+} |
+{
+    type: "SET";
+    id: RawCoID;
+    value: CoValueKnownState;
+} |
+{
+    type: "COMBINE_WITH";
+    id: RawCoID;
+    value: CoValueKnownState;
+};
+
+export class PeerKnownStates {
+    private coValues = new Map<RawCoID, CoValueKnownState>();
+
+    private updateHeader(id: RawCoID, header: boolean) {
+        const knownState = this.coValues.get(id) ?? emptyKnownState(id);
+        knownState.header = header;
+        this.coValues.set(id, knownState);
+    }
+
+    private combineWith(id: RawCoID, value: CoValueKnownState) {
+        const knownState = this.coValues.get(id) ?? emptyKnownState(id);
+        this.coValues.set(id, combinedKnownStates(knownState, value));
+    }
+
+    private updateSessionCounter(
+        id: RawCoID,
+        sessionId: SessionID,
+        value: number
+    ) {
+        const knownState = this.coValues.get(id) ?? emptyKnownState(id);
+        const currentValue = knownState.sessions[sessionId] || 0;
+        knownState.sessions[sessionId] = Math.max(currentValue, value);
+
+        this.coValues.set(id, knownState);
+    }
+
+    get(id: RawCoID) {
+        return this.coValues.get(id);
+    }
+
+    has(id: RawCoID) {
+        return this.coValues.has(id);
+    }
+
+    dispatch(action: PeerKnownStateActions) {
+        switch (action.type) {
+            case "UPDATE_HEADER":
+                this.updateHeader(action.id, action.header);
+                break;
+            case "UPDATE_SESSION_COUNTER":
+                this.updateSessionCounter(
+                    action.id,
+                    action.sessionId,
+                    action.value
+                );
+                break;
+            case "SET":
+                this.coValues.set(action.id, action.value);
+                break;
+            case "COMBINE_WITH":
+                this.combineWith(action.id, action.value);
+                break;
+            case "SET_AS_EMPTY":
+                this.coValues.set(action.id, emptyKnownState(action.id));
+                break;
+        }
+
+        this.triggerUpdate(action.id);
+    }
+
+    listeners = new Set<(id: RawCoID, knownState: CoValueKnownState) => void>();
+
+    triggerUpdate(id: RawCoID) {
+        this.trigger(id, this.coValues.get(id) ?? emptyKnownState(id));
+    }
+
+    private trigger(id: RawCoID, knownState: CoValueKnownState) {
+        for (const listener of this.listeners) {
+            listener(id, knownState);
+        }
+    }
+
+    subscribe(listener: (id: RawCoID, knownState: CoValueKnownState) => void) {
+        this.listeners.add(listener);
+
+        return () => {
+            this.listeners.delete(listener);
+        };
+    }
+}

--- a/packages/cojson/src/PeerState.ts
+++ b/packages/cojson/src/PeerState.ts
@@ -1,16 +1,18 @@
 import { RawCoID } from "./ids.js";
+import { PeerKnownStates } from "./PeerKnownStates.js";
 import { CO_VALUE_PRIORITY } from "./priority.js";
 import {
     PriorityBasedMessageQueue,
     QueueEntry,
 } from "./PriorityBasedMessageQueue.js";
-import { CoValueKnownState, Peer, SyncMessage } from "./sync.js";
+import { Peer, SyncMessage } from "./sync.js";
 
 export class PeerState {
     constructor(private peer: Peer) {}
 
-    readonly optimisticKnownStates: { [id: RawCoID]: CoValueKnownState } = {};
+    readonly optimisticKnownStates = new PeerKnownStates();
     readonly toldKnownState: Set<RawCoID> = new Set();
+
     get id() {
         return this.peer.id;
     }

--- a/packages/cojson/src/storage/index.ts
+++ b/packages/cojson/src/storage/index.ts
@@ -79,7 +79,7 @@ export class LSMStorage<WH, RH, FS extends FileSystem<WH, RH>> {
 
                     if (msg.action === "content") {
                         await this.handleNewContent(msg);
-                    } else {
+                    } else if (msg.action === 'load' || msg.action === 'known') {
                         await this.sendNewContent(msg.id, msg, undefined);
                     }
                 } catch (e) {

--- a/packages/cojson/src/sync.ts
+++ b/packages/cojson/src/sync.ts
@@ -253,12 +253,12 @@ export class SyncManager {
         );
 
         const newContentPieces = coValue.newContentSince(
-            peer.optimisticKnownStates[id],
+            peer.optimisticKnownStates.get(id),
         );
 
         if (newContentPieces) {
             const optimisticKnownStateBefore =
-                peer.optimisticKnownStates[id] || emptyKnownState(id);
+                peer.optimisticKnownStates.get(id) || emptyKnownState(id);
 
             const sendPieces = async () => {
                 let lastYield = performance.now();
@@ -285,14 +285,19 @@ export class SyncManager {
 
             sendPieces().catch((e) => {
                 console.error("Error sending new content piece, retrying", e);
-                peer.optimisticKnownStates[id] = optimisticKnownStateBefore;
+                peer.optimisticKnownStates.dispatch({
+                    type: "SET",
+                    id,
+                    value: optimisticKnownStateBefore ?? emptyKnownState(id),
+                });
                 return this.sendNewContentIncludingDependencies(id, peer);
             });
 
-            peer.optimisticKnownStates[id] = combinedKnownStates(
-                optimisticKnownStateBefore,
-                coValue.knownState(),
-            );
+            peer.optimisticKnownStates.dispatch({
+                type: "COMBINE_WITH",
+                id,
+                value: coValue.knownState(),
+            });
         }
     }
 
@@ -308,11 +313,10 @@ export class SyncManager {
                     // console.log("subscribing to after peer added", id, peer.id)
                     await this.subscribeToIncludingDependencies(id, peerState);
 
-                    peerState.optimisticKnownStates[id] = {
-                        id: id,
-                        header: false,
-                        sessions: {},
-                    };
+                    peerState.optimisticKnownStates.dispatch({
+                        type: "SET_AS_EMPTY",
+                        id,
+                    });
                 }
             };
             void initialSync();
@@ -376,7 +380,11 @@ export class SyncManager {
     }
 
     async handleLoad(msg: LoadMessage, peer: PeerState) {
-        peer.optimisticKnownStates[msg.id] = knownStateIn(msg);
+        peer.optimisticKnownStates.dispatch({
+            type: "SET",
+            id: msg.id,
+            value: knownStateIn(msg),
+        });
         let entry = this.local.coValues[msg.id];
 
         if (!entry) {
@@ -426,7 +434,11 @@ export class SyncManager {
             const loaded = await entry.state.ready;
 
             if (loaded === "unavailable") {
-                peer.optimisticKnownStates[msg.id] = knownStateIn(msg);
+                peer.optimisticKnownStates.dispatch({
+                    type: "SET",
+                    id: msg.id,
+                    value: knownStateIn(msg),
+                });
                 peer.toldKnownState.add(msg.id);
 
                 this.trySendToPeer(peer, {
@@ -449,10 +461,11 @@ export class SyncManager {
     async handleKnownState(msg: KnownStateMessage, peer: PeerState) {
         let entry = this.local.coValues[msg.id];
 
-        peer.optimisticKnownStates[msg.id] = combinedKnownStates(
-            peer.optimisticKnownStates[msg.id] || emptyKnownState(msg.id),
-            knownStateIn(msg),
-        );
+        peer.optimisticKnownStates.dispatch({
+            type: "COMBINE_WITH",
+            id: msg.id,
+            value: knownStateIn(msg),
+        });
 
         if (!entry) {
             if (msg.asDependencyOf) {
@@ -479,7 +492,7 @@ export class SyncManager {
         }
 
         if (entry.state.type === "unknown") {
-            const availableOnPeer = peer.optimisticKnownStates[msg.id]?.header;
+            const availableOnPeer = peer.optimisticKnownStates.get(msg.id)?.header;
 
             if (!availableOnPeer) {
                 entry.dispatch({
@@ -505,15 +518,6 @@ export class SyncManager {
             return;
         }
 
-        const peerOptimisticKnownState = peer.optimisticKnownStates[msg.id];
-
-        if (!peerOptimisticKnownState) {
-            console.error(
-                "Expected optimisticKnownState to be set for coValue we receive new content for",
-            );
-            return;
-        }
-
         let coValue: CoValueCore;
 
         if (entry.state.type === "unknown") {
@@ -522,7 +526,11 @@ export class SyncManager {
                 return;
             }
 
-            peerOptimisticKnownState.header = true;
+            peer.optimisticKnownStates.dispatch({
+                type: "UPDATE_HEADER",
+                id: msg.id,
+                header: true,
+            });
 
             coValue = new CoValueCore(msg.header, this.local);
 
@@ -611,11 +619,14 @@ export class SyncManager {
                 continue;
             }
 
-            peerOptimisticKnownState.sessions[sessionID] = Math.max(
-                peerOptimisticKnownState.sessions[sessionID] || 0,
-                newContentForSession.after +
+            peer.optimisticKnownStates.dispatch({
+                type: "UPDATE_SESSION_COUNTER",
+                id: msg.id,
+                sessionId: sessionID,
+                value:
+                    newContentForSession.after +
                     newContentForSession.newTransactions.length,
-            );
+            });
         }
 
         await this.syncCoValue(coValue);
@@ -632,7 +643,11 @@ export class SyncManager {
     }
 
     async handleCorrection(msg: KnownStateMessage, peer: PeerState) {
-        peer.optimisticKnownStates[msg.id] = msg;
+        peer.optimisticKnownStates.dispatch({
+            type: "SET",
+            id: msg.id,
+            value: knownStateIn(msg),
+        });
 
         return this.sendNewContentIncludingDependencies(msg.id, peer);
     }
@@ -674,9 +689,7 @@ export class SyncManager {
             //     });
             //     blockingSince = performance.now();
             // }
-            const optimisticKnownState = peer.optimisticKnownStates[coValue.id];
-
-            if (optimisticKnownState) {
+            if (peer.optimisticKnownStates.has(coValue.id)) {
                 await this.tellUntoldKnownStateIncludingDependencies(
                     coValue.id,
                     peer,

--- a/packages/cojson/src/tests/PeerKnownStates.test.ts
+++ b/packages/cojson/src/tests/PeerKnownStates.test.ts
@@ -1,0 +1,100 @@
+import { PeerKnownStates } from '../PeerKnownStates.js';
+import { CoValueKnownState, emptyKnownState } from '../sync.js';
+import { RawCoID, SessionID } from '../ids.js';
+import { vi, describe, test, expect } from 'vitest';
+
+
+describe('PeerKnownStates', () => {
+  test('should set and get a known state', () => {
+    const peerKnownStates = new PeerKnownStates();
+    const id = 'test-id' as RawCoID;
+    const knownState: CoValueKnownState = emptyKnownState(id);
+
+    peerKnownStates.dispatch({ type: 'SET', id, value: knownState });
+
+    expect(peerKnownStates.get(id)).toEqual(knownState);
+    expect(peerKnownStates.has(id)).toBe(true);
+  });
+
+  test('should update header', () => {
+    const peerKnownStates = new PeerKnownStates();
+    const id = 'test-id' as RawCoID;
+
+    peerKnownStates.dispatch({ type: 'UPDATE_HEADER', id, header: true });
+
+    const result = peerKnownStates.get(id);
+    expect(result?.header).toBe(true);
+  });
+
+  test('should update session counter', () => {
+    const peerKnownStates = new PeerKnownStates();
+    const id = 'test-id' as RawCoID;
+    const sessionId = 'session-1' as SessionID;
+
+    peerKnownStates.dispatch({ type: 'UPDATE_SESSION_COUNTER', id, sessionId, value: 5 });
+
+    const result = peerKnownStates.get(id);
+    expect(result?.sessions[sessionId]).toBe(5);
+  });
+
+  test('should combine with existing state', () => {
+    const peerKnownStates = new PeerKnownStates();
+    const id = 'test-id' as RawCoID;
+    const session1 = 'session-1' as SessionID;
+    const session2 = 'session-2' as SessionID;
+    const initialState: CoValueKnownState = {
+      ...emptyKnownState(id),
+      sessions: { [session1]: 5 },
+    };
+    const combineState: CoValueKnownState = {
+      ...emptyKnownState(id),
+      sessions: { [session2]: 10 },
+    };
+
+    peerKnownStates.dispatch({ type: 'SET', id, value: initialState });
+    peerKnownStates.dispatch({ type: 'COMBINE_WITH', id, value: combineState });
+
+    const result = peerKnownStates.get(id);
+    expect(result?.sessions).toEqual({ [session1]: 5, [session2]: 10 });
+  });
+
+  test('should set as empty', () => {
+    const peerKnownStates = new PeerKnownStates();
+    const id = 'test-id' as RawCoID;
+    const sessionId = 'session-1' as SessionID;
+    const initialState: CoValueKnownState = {
+      ...emptyKnownState(id),
+      sessions: { [sessionId]: 5 },
+    };
+
+    peerKnownStates.dispatch({ type: 'SET', id, value: initialState });
+    peerKnownStates.dispatch({ type: 'SET_AS_EMPTY', id });
+
+    const result = peerKnownStates.get(id);
+    expect(result).toEqual(emptyKnownState(id));
+  });
+
+  test('should trigger listeners on dispatch', () => {
+    const peerKnownStates = new PeerKnownStates();
+    const id = 'test-id' as RawCoID;
+    const listener = vi.fn();
+
+    peerKnownStates.subscribe(listener);
+    peerKnownStates.dispatch({ type: 'SET_AS_EMPTY', id });
+
+    expect(listener).toHaveBeenCalledWith(id, emptyKnownState(id));
+  });
+
+  test('should unsubscribe listener', () => {
+    const peerKnownStates = new PeerKnownStates();
+    const id = 'test-id' as RawCoID;
+    const listener = vi.fn();
+
+    const unsubscribe = peerKnownStates.subscribe(listener);
+    unsubscribe();
+
+    peerKnownStates.dispatch({ type: 'SET_AS_EMPTY', id });
+
+    expect(listener).not.toHaveBeenCalled();
+  });
+});

--- a/packages/cojson/src/tests/PeerState.test.ts
+++ b/packages/cojson/src/tests/PeerState.test.ts
@@ -20,17 +20,6 @@ function setup() {
 }
 
 describe("PeerState", () => {
-    test("should initialize with correct properties", () => {
-        const { peerState } = setup();
-        expect(peerState.id).toBe("test-peer");
-        expect(peerState.role).toBe("peer");
-        expect(peerState.priority).toBe(1);
-        expect(peerState.crashOnClose).toBe(false);
-        expect(peerState.closed).toBe(false);
-        expect(peerState.optimisticKnownStates).toEqual({});
-        expect(peerState.toldKnownState).toEqual(new Set());
-    });
-
     test("should push outgoing message to peer", async () => {
         const { mockPeer, peerState } = setup();
         const message: SyncMessage = { action: "load", id: "co_ztest-id", header: false, sessions: {} };

--- a/packages/cojson/src/tests/sync.test.ts
+++ b/packages/cojson/src/tests/sync.test.ts
@@ -761,7 +761,7 @@ test.skip("When replaying creation and transactions of a coValue as new content,
     expect(groupTellKnownStateMsg).toMatchObject(groupStateEx(group));
 
     expect(
-        node2.syncManager.peers["test1"]!.optimisticKnownStates[group.core.id],
+        node2.syncManager.peers["test1"]!.optimisticKnownStates.has(group.core.id),
     ).toBeDefined();
 
     // await inTx1.push(adminTellKnownStateMsg);

--- a/packages/jazz-run/src/accountCreate.ts
+++ b/packages/jazz-run/src/accountCreate.ts
@@ -1,0 +1,125 @@
+import { Command, Options } from "@effect/cli";
+import { Console, Effect } from "effect";
+import { createWebSocketPeer } from "cojson-transport-ws";
+import { WebSocket } from "ws";
+import {
+    Account,
+    Peer,
+    WasmCrypto,
+    createJazzContext,
+    isControlledAccount,
+} from "jazz-tools";
+import { fixedCredentialsAuth, randomSessionProvider } from "jazz-tools";
+import { CoValueCore } from "cojson";
+
+const name = Options.text("name").pipe(Options.withAlias("n"));
+const peer = Options.text("peer")
+    .pipe(Options.withAlias("p"))
+    .pipe(Options.withDefault("wss://cloud.jazz.tools"));
+
+const accountCreate = Command.make(
+    "create",
+    { name, peer },
+    ({ name, peer: peerAddr }) => {
+        return Effect.gen(function* () {
+            const crypto = yield* Effect.promise(() => WasmCrypto.create());
+
+            const peer = createWebSocketPeer({
+                id: "upstream",
+                websocket: new WebSocket(peerAddr),
+                role: "server",
+            });
+
+            const account: Account = yield* Effect.promise(async () =>
+                Account.create({
+                    creationProps: { name },
+                    peersToLoadFrom: [peer],
+                    crypto,
+                }),
+            );
+            if (!isControlledAccount(account)) {
+                throw new Error("account is not a controlled account");
+            }
+
+            const accountCoValue = account._raw.core;
+            const accountProfileCoValue = account.profile!._raw.core;
+            const syncManager = account._raw.core.node.syncManager;
+
+            yield* Effect.promise(() =>
+                syncManager.syncCoValue(accountCoValue),
+            );
+            yield* Effect.promise(() =>
+                syncManager.syncCoValue(accountProfileCoValue),
+            );
+
+            yield* Effect.promise(() => Promise.all([
+                waitForSync(account, peer, accountCoValue),
+                waitForSync(account, peer, accountProfileCoValue),
+            ]));
+
+            // Spawn a second peer to double check that the account is fully synced
+            const peer2 = createWebSocketPeer({
+                id: "upstream2",
+                websocket: new WebSocket(peerAddr),
+                role: "server",
+            });
+
+            yield* Effect.promise(async () =>
+                createJazzContext({
+                    auth: fixedCredentialsAuth({
+                        accountID: account.id,
+                        secret: account._raw.agentSecret,
+                    }),
+                    sessionProvider: randomSessionProvider,
+                    peersToLoadFrom: [peer2],
+                    crypto,
+                }),
+            );
+
+            yield* Console.log(`# Credentials for Jazz account "${name}":
+JAZZ_WORKER_ACCOUNT=${account.id}
+JAZZ_WORKER_SECRET=${account._raw.agentSecret}
+`);
+        });
+    },
+);
+
+const accountBase = Command.make("account");
+
+export const account = accountBase.pipe(Command.withSubcommands([accountCreate]));
+
+function waitForSync(account: Account, peer: Peer, coValue: CoValueCore) {
+    const syncManager = account._raw.core.node.syncManager;
+    const peerState = syncManager.peers[peer.id];
+
+    return new Promise((resolve) => {
+        const unsubscribe = peerState?.optimisticKnownStates.subscribe((id, peerKnownState) => {
+            if (id !== coValue.id) return;
+
+            const knownState = coValue.knownState();
+
+            const synced = isEqualSession(knownState.sessions, peerKnownState.sessions);
+            if (synced) {
+                resolve(true);
+                unsubscribe?.();
+            }
+        });
+    });
+}
+
+function isEqualSession(a: Record<string, number>, b: Record<string, number>) {
+    const keysA = Object.keys(a);
+    const keysB = Object.keys(b);
+
+    if (keysA.length !== keysB.length) {
+        return false;
+    }
+
+    for (const sessionId of keysA) {
+        if (a[sessionId] !== b[sessionId]) {
+            return false;
+        }
+    }
+
+    return true;
+}

--- a/packages/jazz-run/src/index.ts
+++ b/packages/jazz-run/src/index.ts
@@ -1,97 +1,12 @@
 #!/usr/bin/env node
 /* istanbul ignore file -- @preserve */
-import { Command, Options } from "@effect/cli";
+import { Command } from "@effect/cli";
 import { NodeContext, NodeRuntime } from "@effect/platform-node";
-import { Console, Effect } from "effect";
-import { createWebSocketPeer } from "cojson-transport-ws";
-import { WebSocket } from "ws";
-import {
-    Account,
-    Peer,
-    WasmCrypto,
-    createJazzContext,
-    isControlledAccount,
-} from "jazz-tools";
-import { fixedCredentialsAuth, randomSessionProvider } from "jazz-tools";
+import { Effect } from "effect";
+import { account } from "./accountCreate.js";
 import { startSync } from "./startSync.js";
-import { CoValueCore } from "cojson";
 
 const jazzTools = Command.make("jazz-tools");
-
-const name = Options.text("name").pipe(Options.withAlias("n"));
-const peer = Options.text("peer")
-    .pipe(Options.withAlias("p"))
-    .pipe(Options.withDefault("wss://cloud.jazz.tools"));
-const accountCreate = Command.make(
-    "create",
-    { name, peer },
-    ({ name, peer: peerAddr }) => {
-        return Effect.gen(function* () {
-            const crypto = yield* Effect.promise(() => WasmCrypto.create());
-
-            const peer = createWebSocketPeer({
-                id: "upstream",
-                websocket: new WebSocket(peerAddr),
-                role: "server",
-            });
-
-            const account: Account = yield* Effect.promise(async () =>
-                Account.create({
-                    creationProps: { name },
-                    peersToLoadFrom: [peer],
-                    crypto,
-                }),
-            );
-            if (!isControlledAccount(account)) {
-                throw new Error("account is not a controlled account");
-            }
-
-            const accountCoValue = account._raw.core;
-            const accountProfileCoValue = account.profile!._raw.core;
-            const syncManager = account._raw.core.node.syncManager;
-
-            yield* Effect.promise(() =>
-                syncManager.syncCoValue(accountCoValue),
-            );
-            yield* Effect.promise(() =>
-                syncManager.syncCoValue(accountProfileCoValue),
-            );
-
-            yield* Effect.promise(() => Promise.all([
-                waitForSync(account, peer, accountCoValue),
-                waitForSync(account, peer, accountProfileCoValue),
-            ]));
-
-            // Spawn a second peer to double check that the account is fully synced
-            const peer2 = createWebSocketPeer({
-                id: "upstream2",
-                websocket: new WebSocket(peerAddr),
-                role: "server",
-            });
-
-            yield* Effect.promise(async () =>
-                createJazzContext({
-                    auth: fixedCredentialsAuth({
-                        accountID: account.id,
-                        secret: account._raw.agentSecret,
-                    }),
-                    sessionProvider: randomSessionProvider,
-                    peersToLoadFrom: [peer2],
-                    crypto,
-                }),
-            );
-
-            yield* Console.log(`# Credentials for Jazz account "${name}":
-JAZZ_WORKER_ACCOUNT=${account.id}
-JAZZ_WORKER_SECRET=${account._raw.agentSecret}
-`);
-        });
-    },
-);
-
-const accountBase = Command.make("account");
-
-const account = accountBase.pipe(Command.withSubcommands([accountCreate]));
 
 const command = jazzTools.pipe(Command.withSubcommands([account, startSync]));
 
@@ -104,39 +19,3 @@ Effect.suspend(() => cli(process.argv)).pipe(
     Effect.provide(NodeContext.layer),
     NodeRuntime.runMain,
 );
-
-function waitForSync(account: Account, peer: Peer, coValue: CoValueCore) {
-    const syncManager = account._raw.core.node.syncManager;
-    const peerState = syncManager.peers[peer.id];
-
-    return new Promise((resolve) => {
-        const unsubscribe = peerState?.optimisticKnownStates.subscribe((id, peerKnownState) => {
-            if (id !== coValue.id) return;
-
-            const knownState = coValue.knownState();
-
-            const synced = isEqualSession(knownState.sessions, peerKnownState.sessions);
-            if (synced) {
-                resolve(true);
-                unsubscribe?.();
-            }
-        });
-    });
-}
-
-function isEqualSession(a: Record<string, number>, b: Record<string, number>) {
-    const keysA = Object.keys(a);
-    const keysB = Object.keys(b);
-
-    if (keysA.length !== keysB.length) {
-        return false;
-    }
-
-    for (const sessionId of keysA) {
-        if (a[sessionId] !== b[sessionId]) {
-            return false;
-        }
-    }
-
-    return true;
-}


### PR DESCRIPTION
In this PR I'm encapsulating all the peers optimisticKnownStates updates in a class called PeerKnownStates.

The idea is to make possible to subscribe to the `optimisticKnownState` to check the sync status of a coValue.

I've used this new "feature" to improve the create account command on jazz-run by replacing the `sleep` with a `waitForSync` function.