### PR TITLE
feat: introduce the storage peer role

### DIFF
--- a/.changeset/swift-fireants-type.md
+++ b/.changeset/swift-fireants-type.md
@@ -1,0 +1,7 @@
+---
+"cojson-storage-indexeddb": patch
+"cojson-storage-sqlite": patch
+"cojson": patch
+---
+
+Introduce "storage" peer role

--- a/packages/cojson-storage-indexeddb/src/index.ts
+++ b/packages/cojson-storage-indexeddb/src/index.ts
@@ -94,7 +94,7 @@ export class IDBStorage {
             "storage",
             {
                 peer1role: "client",
-                peer2role: "server",
+                peer2role: "storage",
                 trace,
                 crashOnClose: true,
             },

--- a/packages/cojson-storage-sqlite/src/index.ts
+++ b/packages/cojson-storage-sqlite/src/index.ts
@@ -94,7 +94,7 @@ export class SQLiteStorage {
         const [localNodeAsPeer, storageAsPeer] = cojsonInternals.connectedPeers(
             localNodeName,
             "storage",
-            { peer1role: "client", peer2role: "server", trace, crashOnClose: true },
+            { peer1role: "client", peer2role: "storage", trace, crashOnClose: true },
         );
 
         await SQLiteStorage.open(

--- a/packages/cojson/src/PeerState.ts
+++ b/packages/cojson/src/PeerState.ts
@@ -29,6 +29,10 @@ export class PeerState {
         return this.peer.crashOnClose;
     }
 
+    isServerOrStoragePeer() {
+        return this.peer.role === "server" || this.peer.role === "storage";
+    }
+
     /**
      * We set as default priority HIGH to handle all the messages without a
      * priority property as HIGH priority.

--- a/packages/cojson/src/localNode.ts
+++ b/packages/cojson/src/localNode.ts
@@ -281,7 +281,7 @@ export class LocalNode {
         if (!entry) {
             const peersToWaitFor = new Set(
                 Object.values(this.syncManager.peers)
-                    .filter((peer) => peer.role === "server")
+                    .filter((peer) => peer.isServerOrStoragePeer())
                     .map((peer) => peer.id),
             );
             if (options.dontWaitFor) peersToWaitFor.delete(options.dontWaitFor);

--- a/packages/cojson/src/storage/index.ts
+++ b/packages/cojson/src/storage/index.ts
@@ -560,7 +560,7 @@ export class LSMStorage<WH, RH, FS extends FileSystem<WH, RH>> {
             "storage",
             {
                 peer1role: "client",
-                peer2role: "server",
+                peer2role: "storage",
                 trace,
                 crashOnClose: true,
             },


### PR DESCRIPTION
Introducing the "storage" peer role that is going to be used as part of #307 for the initial discovery of which peer is elegible to store the other peers known states.

This kind of flow is implemented in the POC #616 and can be summarized this way:
- During the app lifecycle the localNode will subscribe to the known states of all the server peers
- An extra trigger will be added inside [actuallySyncCoValue](https://github.com/gardencmp/jazz/pull/616/files#diff-c90e0211d2243ec0555557cabc377441df15b3b8ca4b76caa07882039f29da68R745) to track the synced state of each CoValue/Peer
- All these known states plus a synced flag are going to be stored inside the storage peers
- On the next app start the localNode will query the storage peers for all the CoValues that are not fully synced and try to resume the sync for them.

What has yet to be figured out is:
- We can't rely on the optimisticKnownState to determine if a CoValue is fully synced. Most of the reason is that optimisticKnownState is updated when an update is pushed to the peers but our WebSocket peer has an internal buffer that might be not empty when the user logs out.
  - A good start could be to try to track the "sent" messages and update a parallel known state (non-optimistic) that would be more reliable to track the actual sync state. Once added this "ack" flow we improve it by adding a real "ack" system in our WebSocket peers if we see the need.
- The peers don't have an unique identifier that can be used for storage. We need to find a stable way to identify them over the sessions.