### PR TITLE
fix: ensure that the react provider doesn't run twice on dev

### DIFF
--- a/.changeset/wicked-icons-repeat.md
+++ b/.changeset/wicked-icons-repeat.md
@@ -1,0 +1,5 @@
+---
+"jazz-react": patch
+---
+
+Temporary fix to prevent double creation of Jazz context in React StrictMode

--- a/e2e/BinaryCoStream/playwright.config.ts
+++ b/e2e/BinaryCoStream/playwright.config.ts
@@ -27,10 +27,11 @@ export default defineConfig({
     /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
     use: {
         /* Base URL to use in actions like `await page.goto('/')`. */
-        baseURL: isCI ? "http://localhost:4173/" : "http://localhost:5173",
+        baseURL: "http://localhost:5173/",
 
         /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
         trace: "on-first-retry",
+        permissions: ["clipboard-read", "clipboard-write"],
     },
 
     /* Configure projects for major browsers */
@@ -42,8 +43,11 @@ export default defineConfig({
     ],
 
     /* Run your local dev server before starting the tests */
-    webServer: isCI ? {
-        command: "pnpm preview",
-        url: "http://localhost:4173/",
-    } : undefined,
+    webServer: [
+        {
+            command: "pnpm preview --port 5173",
+            url: "http://localhost:5173/",
+            reuseExistingServer: !isCI,
+        },
+    ],
 });

--- a/examples/chat/playwright.config.ts
+++ b/examples/chat/playwright.config.ts
@@ -27,7 +27,7 @@ export default defineConfig({
     /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
     use: {
         /* Base URL to use in actions like `await page.goto('/')`. */
-        baseURL: isCI ? "http://localhost:4173/" : "http://localhost:5173",
+        baseURL: "http://localhost:5173/",
 
         /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
         trace: "on-first-retry",
@@ -43,8 +43,11 @@ export default defineConfig({
     ],
 
     /* Run your local dev server before starting the tests */
-    webServer: isCI ? {
-        command: "pnpm preview",
-        url: "http://localhost:4173/",
-    } : undefined,
+    webServer: [
+        {
+            command: "pnpm preview --port 5173",
+            url: "http://localhost:5173/",
+            reuseExistingServer: !isCI,
+        },
+    ],
 });


### PR DESCRIPTION
Over time while testing my changes on our examples I've found some weird behavoir with the auth that made our apps lock in the loading state.

Everything was working well on the E2E tests, which made me even more confused.

I've finally found some time to debug the issue and noticed that the problem started with the double execution of `useEffect` in dev mode.

In this PR I'm setting up a quick fix to the issue by blocking the double execution of the useEffect inside the Provider.

We will probably need to redesign the API to not handle this kind of intialization inside of a `useEffect` and let the users control the creation of the jazz context to give them more flexibility on how to handle the setup of the auth and the app in general.

Looking at the `useEffect` dependencies it seems too easy to get in the situation where multiple contexts are created in a single session.

I'm thinking about something like this:

```ts
const jazz = createJazzBrowserContext({ AccountSchema, auth: new PasskeyAuth(), peer, storage });

function App() {
  const authState = usePasskeyAuth(jazz);
  
  return <>
       <JazzProvider value={jazz}><MyAppComponents /></JazzProvider>
       <MyAuthUI auth={authState} />
   </>
}
```

We can plan the redesing along with #562 so we introduce the breaking changes in the React API only once.