### PR TITLE
feat(browser): refactor the WebSocket reconnection to assign the peer as id

### DIFF
--- a/.changeset/heavy-eagles-grow.md
+++ b/.changeset/heavy-eagles-grow.md
@@ -1,0 +1,5 @@
+---
+"cojson-transport-ws": patch
+---
+
+Add the onClose handler and improve the closing operation

--- a/.changeset/tame-ducks-add.md
+++ b/.changeset/tame-ducks-add.md
@@ -1,0 +1,5 @@
+---
+"jazz-browser": patch
+---
+
+Improve the WebSocket reconnect logic

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
         "@changesets/cli": "^2.27.3",
         "@vitest/coverage-istanbul": "1.5.3",
         "@vitest/ui": "1.5.3",
+        "happy-dom": "^15.8.3",
         "prettier": "^3.1.1",
         "ts-node": "^10.9.1",
         "turbo": "^1.11.2",

--- a/packages/cojson-transport-ws/src/serialization.ts
+++ b/packages/cojson-transport-ws/src/serialization.ts
@@ -8,7 +8,14 @@ export function addMessageToBacklog(backlog: string, message: SyncMessage) {
     return `${backlog}\n${JSON.stringify(message)}`;
 }
 
-export function deserializeMessages(messages: string)  {
+export function deserializeMessages(messages: unknown)  {
+    if (typeof messages !== "string") {
+        return {
+            ok: false,
+            error: new Error("Expected a string"),
+        } as const;
+    }
+
     try {
         return {
             ok: true,

--- a/packages/cojson-transport-ws/src/tests/createWebSocketPeer.test.ts
+++ b/packages/cojson-transport-ws/src/tests/createWebSocketPeer.test.ts
@@ -18,6 +18,9 @@ function setup(opts: Partial<CreateWebSocketPeerOpts> = {}) {
         addEventListener: vi.fn().mockImplementation((type, listener) => {
             listeners.set(type, listener);
         }),
+        removeEventListener: vi.fn().mockImplementation((type) => {
+            listeners.delete(type);
+        }),
         close: vi.fn(),
         send: vi.fn(),
     } as unknown as Mocked<AnyWebSocket>;

--- a/packages/jazz-browser/src/createWebSocketPeerWithReconnection.ts
+++ b/packages/jazz-browser/src/createWebSocketPeerWithReconnection.ts
@@ -1,0 +1,69 @@
+import { Peer } from "cojson";
+import { createWebSocketPeer } from "cojson-transport-ws";
+
+export function createWebSocketPeerWithReconnection(peer: string, reconnectionTimeout: number | undefined, addPeer: (peer: Peer) => void) {
+    const firstWsPeer = createWebSocketPeer({
+        websocket: new WebSocket(peer),
+        id: peer,
+        role: "server",
+        onClose: reconnectWebSocket,
+    });
+
+    let shouldTryToReconnect = true;
+    let currentReconnectionTimeout = reconnectionTimeout || 500;
+
+    function onOnline() {
+        console.log("Online, resetting reconnection timeout");
+        currentReconnectionTimeout = reconnectionTimeout || 500;
+    }
+
+    window.addEventListener("online", onOnline);
+
+    async function reconnectWebSocket() {
+        if (!shouldTryToReconnect) return;
+
+        console.log(
+            "Websocket disconnected, trying to reconnect in " +
+            currentReconnectionTimeout +
+            "ms"
+        );
+        currentReconnectionTimeout = Math.min(
+            currentReconnectionTimeout * 2,
+            30000
+        );
+
+        await waitForOnline(currentReconnectionTimeout);
+
+        if (!shouldTryToReconnect) return;
+
+        addPeer(
+            createWebSocketPeer({
+                websocket: new WebSocket(peer),
+                id: peer,
+                role: "server",
+                onClose: reconnectWebSocket,
+            })
+        );
+    }
+
+    return {
+        peer: firstWsPeer,
+        done: () => {
+            shouldTryToReconnect = false;
+            window.removeEventListener("online", onOnline);
+        }
+    };
+}
+function waitForOnline(timeout: number) {
+    return new Promise<void>((resolve) => {
+        function handleTimeoutOrOnline() {
+            clearTimeout(timer);
+            window.removeEventListener('online', handleTimeoutOrOnline);
+            resolve();
+        }
+
+        const timer = setTimeout(handleTimeoutOrOnline, timeout);
+
+        window.addEventListener('online', handleTimeoutOrOnline);
+    });
+}

--- a/packages/jazz-browser/src/tests/createWebSocketPeerWithReconnection.test.ts
+++ b/packages/jazz-browser/src/tests/createWebSocketPeerWithReconnection.test.ts
@@ -1,0 +1,148 @@
+// @vitest-environment happy-dom
+
+import { describe, test, expect, vi, beforeEach, afterEach } from "vitest";
+import { createWebSocketPeer } from "cojson-transport-ws";
+import { createWebSocketPeerWithReconnection } from "../createWebSocketPeerWithReconnection.js";
+
+// Mock WebSocket
+class MockWebSocket {
+    addEventListener = vi.fn();
+    removeEventListener = vi.fn();
+    close = vi.fn();
+    readyState = 1;
+}
+
+vi.stubGlobal("WebSocket", MockWebSocket);
+vi.stubGlobal("window", global);
+vi.stubGlobal("navigator", {
+    onLine: true,
+});
+
+vi.mock("cojson-transport-ws", () => ({
+    createWebSocketPeer: vi.fn().mockImplementation(({ onClose }) => ({
+        id: "test-peer",
+        incoming: { push: vi.fn() },
+        outgoing: { push: vi.fn(), close: vi.fn() },
+        onClose,
+    })),
+}));
+
+describe("createWebSocketPeerWithReconnection", () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        vi.stubGlobal("WebSocket", MockWebSocket);
+        vi.stubGlobal("removeEventListener", vi.fn());
+    });
+
+    afterEach(() => {
+        vi.useRealTimers();
+    });
+
+    test("should reset reconnection timeout when coming online", async () => {
+        vi.useFakeTimers();
+        const addPeerMock = vi.fn();
+
+        const { done } = createWebSocketPeerWithReconnection(
+            "ws://localhost:8080",
+            500,
+            addPeerMock,
+        );
+
+        // Simulate multiple disconnections to increase timeout
+        const initialPeer =
+            vi.mocked(createWebSocketPeer).mock.results[0]!.value;
+        initialPeer.onClose();
+
+        await vi.advanceTimersByTimeAsync(1000);
+
+        expect(addPeerMock).toHaveBeenCalledTimes(1);
+
+        vi.mocked(createWebSocketPeer).mock.results[1]!.value.onClose();
+        await vi.advanceTimersByTimeAsync(2000);
+
+
+        expect(addPeerMock).toHaveBeenCalledTimes(2);
+
+        // Resets the timeout to initial value
+        window.dispatchEvent(new Event("online"));
+
+        // Next reconnection should use initial timeout
+        vi.mocked(createWebSocketPeer).mock.results[2]!.value.onClose();
+        await vi.advanceTimersByTimeAsync(1000);
+
+        expect(addPeerMock).toHaveBeenCalledTimes(3);
+
+        done();
+    });
+
+    test("should wait for online event or timeout before reconnecting", async () => {
+        vi.useFakeTimers();
+
+        const addPeerMock = vi.fn();
+        const { done } = createWebSocketPeerWithReconnection(
+            "ws://localhost:8080",
+            500,
+            addPeerMock,
+        );
+
+        const initialPeer =
+            vi.mocked(createWebSocketPeer).mock.results[0]!.value;
+
+        // Simulate offline state
+        vi.stubGlobal("navigator", { onLine: false });
+
+        initialPeer.onClose();
+
+        // Advance timer but not enough to trigger reconnection
+        await vi.advanceTimersByTimeAsync(500);
+        expect(createWebSocketPeer).toHaveBeenCalledTimes(1);
+
+        // Simulate coming back online
+        window.dispatchEvent(new Event("online"));
+
+        // Wait for event loop to settle
+        await Promise.resolve().then();
+
+        // Should reconnect immediately after coming online
+        expect(createWebSocketPeer).toHaveBeenCalledTimes(2);
+
+        done();
+    });
+
+    test("should clean up event listeners when done", () => {
+        const addPeerMock = vi.fn();
+        const { done } = createWebSocketPeerWithReconnection(
+            "ws://localhost:8080",
+            1000,
+            addPeerMock,
+        );
+
+        done();
+
+        expect(window.removeEventListener).toHaveBeenCalledWith(
+            "online",
+            expect.any(Function),
+        );
+    });
+
+    test("should not attempt reconnection after done is called", async () => {
+        vi.useFakeTimers();
+
+        const addPeerMock = vi.fn();
+        const { done } = createWebSocketPeerWithReconnection(
+            "ws://localhost:8080",
+            500,
+            addPeerMock,
+        );
+
+        const initialPeer =
+            vi.mocked(createWebSocketPeer).mock.results[0]!.value;
+
+        done();
+
+        initialPeer.onClose();
+        await vi.advanceTimersByTimeAsync(1000);
+
+        expect(createWebSocketPeer).toHaveBeenCalledTimes(1);
+    });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,10 +17,13 @@ importers:
         version: 2.27.3
       '@vitest/coverage-istanbul':
         specifier: 1.5.3
-        version: 1.5.3(vitest@1.5.3(@types/node@22.5.1)(@vitest/ui@1.5.3)(jsdom@20.0.3)(terser@5.33.0))
+        version: 1.5.3(vitest@1.5.3(@types/node@22.5.1)(@vitest/ui@1.5.3)(happy-dom@15.8.3)(jsdom@20.0.3)(terser@5.33.0))
       '@vitest/ui':
         specifier: 1.5.3
         version: 1.5.3(vitest@1.5.3)
+      happy-dom:
+        specifier: ^15.8.3
+        version: 15.8.3
       prettier:
         specifier: ^3.1.1
         version: 3.1.1
@@ -35,7 +38,7 @@ importers:
         version: 0.25.13(typescript@5.6.2)
       vitest:
         specifier: 1.5.3
-        version: 1.5.3(@types/node@22.5.1)(@vitest/browser@0.34.6)(@vitest/ui@1.5.3)(jsdom@20.0.3)(terser@5.33.0)
+        version: 1.5.3(@types/node@22.5.1)(@vitest/browser@0.34.6)(@vitest/ui@1.5.3)(happy-dom@15.8.3)(jsdom@20.0.3)(terser@5.33.0)
 
   e2e/BinaryCoStream:
     dependencies:
@@ -1223,7 +1226,7 @@ importers:
         version: 5.3.3
       vitest:
         specifier: 1.5.3
-        version: 1.5.3(@types/node@22.5.1)(@vitest/browser@0.34.6)(@vitest/ui@1.5.3)(jsdom@20.0.3)(terser@5.33.0)
+        version: 1.5.3(@types/node@22.5.1)(@vitest/browser@0.34.6)(@vitest/ui@1.5.3)(happy-dom@15.8.3)(jsdom@20.0.3)(terser@5.33.0)
 
   packages/cojson-storage-indexeddb:
     dependencies:
@@ -1242,7 +1245,7 @@ importers:
         version: 6.0.0
       vitest:
         specifier: 1.5.3
-        version: 1.5.3(@types/node@22.5.1)(@vitest/browser@0.34.6)(@vitest/ui@1.5.3)(jsdom@20.0.3)(terser@5.33.0)
+        version: 1.5.3(@types/node@22.5.1)(@vitest/browser@0.34.6)(@vitest/ui@1.5.3)(happy-dom@15.8.3)(jsdom@20.0.3)(terser@5.33.0)
       webdriverio:
         specifier: ^8.15.0
         version: 8.26.3(typescript@5.3.3)
@@ -1535,7 +1538,7 @@ importers:
         version: 5.3.3
       vitest:
         specifier: 1.5.3
-        version: 1.5.3(@types/node@22.5.1)(@vitest/browser@0.34.6)(@vitest/ui@1.5.3)(jsdom@20.0.3)(terser@5.33.0)
+        version: 1.5.3(@types/node@22.5.1)(@vitest/browser@0.34.6)(@vitest/ui@1.5.3)(happy-dom@15.8.3)(jsdom@20.0.3)(terser@5.33.0)
 
 packages:
 
@@ -2748,11 +2751,17 @@ packages:
   '@expo/code-signing-certificates@0.0.5':
     resolution: {integrity: sha512-BNhXkY1bblxKZpltzAx98G2Egj9g1Q+JRcvR7E99DOj862FTCX+ZPsAUtPTr7aHxwtrL7+fL3r0JSmM9kBm+Bw==}
 
+  '@expo/config-plugins@7.2.5':
+    resolution: {integrity: sha512-w+5ccu1IxBHgyQk9CPFKLZOk8yZQEyTjbJwOzESK1eR7QwosbcsLkN1c1WWUZYiCXwORu3UTwJYll4+X2xxJhQ==}
+
   '@expo/config-plugins@8.0.10':
     resolution: {integrity: sha512-KG1fnSKRmsudPU9BWkl59PyE0byrE2HTnqbOrgwr2FAhqh7tfr9nRs6A9oLS/ntpGzmFxccTEcsV0L4apsuxxg==}
 
   '@expo/config-plugins@8.0.9':
     resolution: {integrity: sha512-dNCG45C7BbDPV9MdWvCbsFtJtVn4w/TJbb5b7Yr6FA8HYIlaaVM0wqUMzTPmGj54iYXw8X/Vge8uCPxg7RWgeA==}
+
+  '@expo/config-types@49.0.0':
+    resolution: {integrity: sha512-8eyREVi+K2acnMBe/rTIu1dOfyR2+AMnTLHlut+YpMV9OZPdeKV0Bs9BxAewGqBA2slslbQ9N39IS2CuTKpXkA==}
 
   '@expo/config-types@51.0.2':
     resolution: {integrity: sha512-IglkIoiDwJMY01lYkF/ZSBoe/5cR+O3+Gx6fpLFjLfgZGBTdyPkKa1g8NWoWQCk+D3cKL2MDbszT2DyRRB0YqQ==}
@@ -2775,6 +2784,9 @@ packages:
   '@expo/image-utils@0.5.1':
     resolution: {integrity: sha512-U/GsFfFox88lXULmFJ9Shfl2aQGcwoKPF7fawSCLixIKtMCpsI+1r0h+5i0nQnmt9tHuzXZDL8+Dg1z6OhkI9A==}
 
+  '@expo/json-file@8.2.37':
+    resolution: {integrity: sha512-YaH6rVg11JoTS2P6LsW7ybS2CULjf40AbnAHw2F1eDPuheprNjARZMnyHFPkKv7GuxCy+B9GPcbOKgc4cgA80Q==}
+
   '@expo/json-file@8.3.3':
     resolution: {integrity: sha512-eZ5dld9AD0PrVRiIWpRkm5aIoWBw3kAyd8VkuWEy92sEthBKDDDHAnK2a0dw0Eil6j7rK7lS/Qaq/Zzngv2h5A==}
 
@@ -2792,6 +2804,9 @@ packages:
 
   '@expo/package-manager@1.5.2':
     resolution: {integrity: sha512-IuA9XtGBilce0q8cyxtWINqbzMB1Fia0Yrug/O53HNuRSwQguV/iqjV68bsa4z8mYerePhcFgtvISWLAlNEbUA==}
+
+  '@expo/plist@0.0.20':
+    resolution: {integrity: sha512-UXQ4LXCfTZ580LDHGJ5q62jSTwJFFJ1GqBu8duQMThiHKWbMJ+gajJh6rsB6EJ3aLUr9wcauxneL5LVRFxwBEA==}
 
   '@expo/plist@0.1.3':
     resolution: {integrity: sha512-GW/7hVlAylYg1tUrEASclw1MMk9FP4ZwyFAY/SUTJIhPDQHtfOlXREyWV3hhrHdX/K+pS73GNgdfT6E/e+kBbg==}
@@ -3307,7 +3322,7 @@ packages:
   '@radix-ui/react-compose-refs@1.1.0':
     resolution: {integrity: sha512-b4inOtiaOnYf9KWyO3jAeeCG6FeyfY6ldiEPanbUjWd+xIk5wZeHa8yVwmrJ2vderhu/BQvzCrJI0lHd+wIiqw==}
     peerDependencies:
-      '@types/react': '*'
+      '@types/react': ^18.2.32
       react: 18.3.1
     peerDependenciesMeta:
       '@types/react':
@@ -3391,8 +3406,8 @@ packages:
   '@radix-ui/react-focus-scope@1.1.0':
     resolution: {integrity: sha512-200UD8zylvEyL8Bx+z76RJnASR2gRMuxlgFCPAe/Q/679a/r0eK3MBVYMb7vZODZcffZBdob1EGnky78xmVvcA==}
     peerDependencies:
-      '@types/react': '*'
-      '@types/react-dom': '*'
+      '@types/react': ^18.2.32
+      '@types/react-dom': ^18.2.14
       react: 18.3.1
       react-dom: 18.3.1
     peerDependenciesMeta:
@@ -3404,7 +3419,7 @@ packages:
   '@radix-ui/react-id@1.1.0':
     resolution: {integrity: sha512-EJUrI8yYh7WOjNOqpoJaf1jlFIH2LvtgAl+YcFqNCa+4hj64ZXmPkAKOFs/ukjz3byN6bdb/AVUqHkI8/uWWMA==}
     peerDependencies:
-      '@types/react': '*'
+      '@types/react': ^18.2.32
       react: 18.3.1
     peerDependenciesMeta:
       '@types/react':
@@ -3426,8 +3441,8 @@ packages:
   '@radix-ui/react-popper@1.2.0':
     resolution: {integrity: sha512-ZnRMshKF43aBxVWPWvbj21+7TQCvhuULWJ4gNIKYpRlQt5xGRhLx66tMp8pya2UkGHTSlhpXwmjqltDYHhw7Vg==}
     peerDependencies:
-      '@types/react': '*'
-      '@types/react-dom': '*'
+      '@types/react': ^18.2.32
+      '@types/react-dom': ^18.2.14
       react: 18.3.1
       react-dom: 18.3.1
     peerDependenciesMeta:
@@ -3504,8 +3519,8 @@ packages:
   '@radix-ui/react-primitive@2.0.0':
     resolution: {integrity: sha512-ZSpFm0/uHa8zTvKBDjLFWLo8dkr4MBsiDLz0g3gMUwqgLHz9rTaRRGYDgvZPtBJgYCBKXkS9fzmoySgr8CO6Cw==}
     peerDependencies:
-      '@types/react': '*'
-      '@types/react-dom': '*'
+      '@types/react': ^18.2.32
+      '@types/react-dom': ^18.2.14
       react: 18.3.1
       react-dom: 18.3.1
     peerDependenciesMeta:
@@ -3788,6 +3803,9 @@ packages:
     engines: {node: '>=18'}
     peerDependencies:
       '@babel/core': '*'
+
+  '@react-native/normalize-color@2.1.0':
+    resolution: {integrity: sha512-Z1jQI2NpdFJCVgpY+8Dq/Bt3d+YUi1928Q+/CZm/oh66fzM0RUl54vvuXlPJKybH4pdCZey1eDTPaLHkMPNgWA==}
 
   '@react-native/normalize-colors@0.74.84':
     resolution: {integrity: sha512-Y5W6x8cC5RuakUcTVUFNAIhUZ/tYpuqHZlRBoAuakrTwVuoNHXfQki8lj1KsYU7rW6e3VWgdEx33AfOQpdNp6A==}
@@ -6578,6 +6596,10 @@ packages:
   graphql@15.8.0:
     resolution: {integrity: sha512-5gghUc24tP9HRznNpV2+FIoq3xKkj5dTQqf4v0CpdPbFVwFkWoxOM+o+2OC9ZSvjEMTjfmG9QT+gcvggTwW1zw==}
     engines: {node: '>= 10.x'}
+
+  happy-dom@15.8.3:
+    resolution: {integrity: sha512-YR9nUWN/T2bH7pPLEYMhTp4DQExPH+mC4KulJDgimCb+FY3Er0Vp6SOOcBXrNfMTri3lAk9uSZqUTG2hgZOYwg==}
+    engines: {node: '>=18.0.0'}
 
   hard-rejection@2.1.0:
     resolution: {integrity: sha512-VIZB+ibDhx7ObhAe7OVtoEbuP4h/MuOTHJ+J8h/eBXotJYl0fBgR72xDFCKgIh22OJZIOVNxBMWuhAr10r8HdA==}
@@ -11977,6 +11999,26 @@ snapshots:
       node-forge: 1.3.1
       nullthrows: 1.1.1
 
+  '@expo/config-plugins@7.2.5':
+    dependencies:
+      '@expo/config-types': 49.0.0
+      '@expo/json-file': 8.2.37
+      '@expo/plist': 0.0.20
+      '@expo/sdk-runtime-versions': 1.0.0
+      '@react-native/normalize-color': 2.1.0
+      chalk: 4.1.2
+      debug: 4.3.7
+      find-up: 5.0.0
+      getenv: 1.0.0
+      glob: 7.1.6
+      resolve-from: 5.0.0
+      semver: 7.6.3
+      slash: 3.0.0
+      xcode: 3.0.1
+      xml2js: 0.6.0
+    transitivePeerDependencies:
+      - supports-color
+
   '@expo/config-plugins@8.0.10':
     dependencies:
       '@expo/config-types': 51.0.3
@@ -12017,6 +12059,8 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@expo/config-types@49.0.0': {}
+
   '@expo/config-types@51.0.2': {}
 
   '@expo/config-types@51.0.3': {}
@@ -12040,7 +12084,7 @@ snapshots:
   '@expo/config@9.0.4':
     dependencies:
       '@babel/code-frame': 7.10.4
-      '@expo/config-plugins': 8.0.10
+      '@expo/config-plugins': 7.2.5
       '@expo/config-types': 51.0.3
       '@expo/json-file': 8.3.3
       getenv: 1.0.0
@@ -12095,6 +12139,12 @@ snapshots:
     transitivePeerDependencies:
       - encoding
 
+  '@expo/json-file@8.2.37':
+    dependencies:
+      '@babel/code-frame': 7.10.4
+      json5: 2.2.3
+      write-file-atomic: 2.4.3
+
   '@expo/json-file@8.3.3':
     dependencies:
       '@babel/code-frame': 7.10.4
@@ -12147,6 +12197,12 @@ snapshots:
       ora: 3.4.0
       split: 1.0.1
       sudo-prompt: 9.1.1
+
+  '@expo/plist@0.0.20':
+    dependencies:
+      '@xmldom/xmldom': 0.7.13
+      base64-js: 1.5.1
+      xmlbuilder: 14.0.0
 
   '@expo/plist@0.1.3':
     dependencies:
@@ -13452,6 +13508,8 @@ snapshots:
       - '@babel/preset-env'
       - supports-color
 
+  '@react-native/normalize-color@2.1.0': {}
+
   '@react-native/normalize-colors@0.74.84': {}
 
   '@react-native/normalize-colors@0.74.85': {}
@@ -14212,12 +14270,12 @@ snapshots:
       magic-string: 0.30.5
       modern-node-polyfills: 1.0.0(esbuild@0.19.10)(rollup@4.9.1)
       sirv: 2.0.4
-      vitest: 1.5.3(@types/node@22.5.1)(@vitest/browser@0.34.6)(@vitest/ui@1.5.3)(jsdom@20.0.3)(terser@5.33.0)
+      vitest: 1.5.3(@types/node@22.5.1)(@vitest/browser@0.34.6)(@vitest/ui@1.5.3)(happy-dom@15.8.3)(jsdom@20.0.3)(terser@5.33.0)
     transitivePeerDependencies:
       - esbuild
       - rollup
 
-  '@vitest/coverage-istanbul@1.5.3(vitest@1.5.3(@types/node@22.5.1)(@vitest/ui@1.5.3)(jsdom@20.0.3)(terser@5.33.0))':
+  '@vitest/coverage-istanbul@1.5.3(vitest@1.5.3(@types/node@22.5.1)(@vitest/ui@1.5.3)(happy-dom@15.8.3)(jsdom@20.0.3)(terser@5.33.0))':
     dependencies:
       debug: 4.3.7
       istanbul-lib-coverage: 3.2.2
@@ -14228,7 +14286,7 @@ snapshots:
       magicast: 0.3.5
       picocolors: 1.1.0
       test-exclude: 6.0.0
-      vitest: 1.5.3(@types/node@22.5.1)(@vitest/browser@0.34.6)(@vitest/ui@1.5.3)(jsdom@20.0.3)(terser@5.33.0)
+      vitest: 1.5.3(@types/node@22.5.1)(@vitest/browser@0.34.6)(@vitest/ui@1.5.3)(happy-dom@15.8.3)(jsdom@20.0.3)(terser@5.33.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -14263,7 +14321,7 @@ snapshots:
       pathe: 1.1.2
       picocolors: 1.1.0
       sirv: 2.0.4
-      vitest: 1.5.3(@types/node@22.5.1)(@vitest/browser@0.34.6)(@vitest/ui@1.5.3)(jsdom@20.0.3)(terser@5.33.0)
+      vitest: 1.5.3(@types/node@22.5.1)(@vitest/browser@0.34.6)(@vitest/ui@1.5.3)(happy-dom@15.8.3)(jsdom@20.0.3)(terser@5.33.0)
 
   '@vitest/utils@1.5.3':
     dependencies:
@@ -15720,7 +15778,7 @@ snapshots:
       '@typescript-eslint/eslint-plugin': 7.18.0(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.3.3))(eslint@8.57.1)(typescript@5.3.3)
       '@typescript-eslint/parser': 7.18.0(eslint@8.57.1)(typescript@5.3.3)
       eslint: 8.57.1
-      eslint-import-resolver-typescript: 3.6.3(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.3.3))(eslint-plugin-import@2.31.0(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.3.3))(eslint@8.57.1))(eslint@8.57.1)
+      eslint-import-resolver-typescript: 3.6.3(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.3.3))(eslint-plugin-import@2.31.0)(eslint@8.57.1)
       eslint-plugin-expo: 0.0.1(eslint@8.57.1)(typescript@5.3.3)
       eslint-plugin-import: 2.31.0(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.3.3))(eslint-import-resolver-typescript@3.6.3)(eslint@8.57.1)
       eslint-plugin-react: 7.37.1(eslint@8.57.1)
@@ -15786,13 +15844,13 @@ snapshots:
       - eslint-import-resolver-webpack
       - supports-color
 
-  eslint-import-resolver-typescript@3.6.3(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.3.3))(eslint-plugin-import@2.31.0(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.3.3))(eslint@8.57.1))(eslint@8.57.1):
+  eslint-import-resolver-typescript@3.6.3(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.3.3))(eslint-plugin-import@2.31.0)(eslint@8.57.1):
     dependencies:
       '@nolyfill/is-core-module': 1.0.39
       debug: 4.3.7
       enhanced-resolve: 5.17.1
       eslint: 8.57.1
-      eslint-module-utils: 2.12.0(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.3.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.3.3))(eslint-plugin-import@2.31.0(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.3.3))(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1)
+      eslint-module-utils: 2.12.0(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.3.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.3.3))(eslint-plugin-import@2.31.0)(eslint@8.57.1))(eslint@8.57.1)
       fast-glob: 3.3.2
       get-tsconfig: 4.8.1
       is-bun-module: 1.2.1
@@ -15816,14 +15874,14 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.0(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.3.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.3.3))(eslint-plugin-import@2.31.0(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.3.3))(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1):
+  eslint-module-utils@2.12.0(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.3.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.3.3))(eslint-plugin-import@2.31.0)(eslint@8.57.1))(eslint@8.57.1):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
       '@typescript-eslint/parser': 7.18.0(eslint@8.57.1)(typescript@5.3.3)
       eslint: 8.57.1
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.6.3(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.3.3))(eslint-plugin-import@2.31.0(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.3.3))(eslint@8.57.1))(eslint@8.57.1)
+      eslint-import-resolver-typescript: 3.6.3(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.3.3))(eslint-plugin-import@2.31.0)(eslint@8.57.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -15876,7 +15934,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 8.57.1
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.0(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.3.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.3.3))(eslint-plugin-import@2.31.0(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.3.3))(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1)
+      eslint-module-utils: 2.12.0(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.3.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.3.3))(eslint-plugin-import@2.31.0)(eslint@8.57.1))(eslint@8.57.1)
       hasown: 2.0.2
       is-core-module: 2.15.1
       is-glob: 4.0.3
@@ -16833,6 +16891,12 @@ snapshots:
       tslib: 2.6.2
 
   graphql@15.8.0: {}
+
+  happy-dom@15.8.3:
+    dependencies:
+      entities: 4.5.0
+      webidl-conversions: 7.0.0
+      whatwg-mimetype: 3.0.0
 
   hard-rejection@2.1.0: {}
 
@@ -20714,7 +20778,7 @@ snapshots:
       fsevents: 2.3.3
       terser: 5.33.0
 
-  vitest@1.5.3(@types/node@22.5.1)(@vitest/browser@0.34.6)(@vitest/ui@1.5.3)(jsdom@20.0.3)(terser@5.33.0):
+  vitest@1.5.3(@types/node@22.5.1)(@vitest/browser@0.34.6)(@vitest/ui@1.5.3)(happy-dom@15.8.3)(jsdom@20.0.3)(terser@5.33.0):
     dependencies:
       '@vitest/expect': 1.5.3
       '@vitest/runner': 1.5.3
@@ -20740,6 +20804,7 @@ snapshots:
       '@types/node': 22.5.1
       '@vitest/browser': 0.34.6(esbuild@0.19.10)(rollup@4.9.1)(vitest@1.5.3)
       '@vitest/ui': 1.5.3(vitest@1.5.3)
+      happy-dom: 15.8.3
       jsdom: 20.0.3
     transitivePeerDependencies:
       - less


### PR DESCRIPTION
To achieve #307 we need a stable identifier for the WebSocket peer across the page sessions.

To achieve that goal I've refactored the WebSocket reconnection flow and added an "onClose" handler option to the websocket peer.