### PR TITLE
Add user prop to demo auth to skip login on demos

### DIFF
--- a/packages/jazz-react/src/auth/DemoAuth.tsx
+++ b/packages/jazz-react/src/auth/DemoAuth.tsx
@@ -69,15 +69,28 @@ export function useDemoAuth({
 export const DemoAuthBasicUI = ({
   appName,
   state,
+  user,
 }: {
   appName: string;
   state: DemoAuthState;
+  user?: string;
 }) => {
   const [username, setUsername] = useState<string>("");
   const darkMode =
     typeof window !== "undefined"
       ? window.matchMedia("(prefers-color-scheme: dark)").matches
       : false;
+
+  if (user && state.state === "ready") {
+    if (state.existingUsers.includes(user)) {
+      state.logInAs(user);
+      return <></>;
+    } else {
+      state.signUp(user);
+    }
+
+    return <></>;
+  }
 
   return (
     <div


### PR DESCRIPTION
This won't affect any existing demos.

If you pass a user prop, you won't be able to log out anymore but hopefully we just won't need that. If we do then I'll fix it.