### PR TITLE
fix: dispatch more updates to knownState

### DIFF
--- a/.changeset/hot-rice-hammer.md
+++ b/.changeset/hot-rice-hammer.md
@@ -1,0 +1,5 @@
+---
+"cojson": patch
+---
+
+Improved the known state tracking within the PeerState.knownState property

--- a/packages/cojson/src/PeerKnownStates.ts
+++ b/packages/cojson/src/PeerKnownStates.ts
@@ -5,7 +5,7 @@ import {
   emptyKnownState,
 } from "./sync.js";
 
-type PeerKnownStateActions =
+export type PeerKnownStateActions =
   | {
       type: "SET_AS_EMPTY";
       id: RawCoID;

--- a/packages/cojson/src/PeerState.ts
+++ b/packages/cojson/src/PeerState.ts
@@ -1,4 +1,4 @@
-import { PeerKnownStates } from "./PeerKnownStates.js";
+import { PeerKnownStateActions, PeerKnownStates } from "./PeerKnownStates.js";
 import {
   PriorityBasedMessageQueue,
   QueueEntry,
@@ -33,6 +33,11 @@ export class PeerState {
    */
   readonly optimisticKnownStates: PeerKnownStates;
   readonly toldKnownState: Set<RawCoID> = new Set();
+
+  dispatchToKnownStates(action: PeerKnownStateActions) {
+    this.knownStates.dispatch(action);
+    this.optimisticKnownStates.dispatch(action);
+  }
 
   readonly erroredCoValues: Map<RawCoID, TryAddTransactionsError> = new Map();
 

--- a/packages/cojson/src/sync.ts
+++ b/packages/cojson/src/sync.ts
@@ -400,7 +400,7 @@ export class SyncManager {
   }
 
   async handleLoad(msg: LoadMessage, peer: PeerState) {
-    peer.optimisticKnownStates.dispatch({
+    peer.dispatchToKnownStates({
       type: "SET",
       id: msg.id,
       value: knownStateIn(msg),
@@ -454,7 +454,7 @@ export class SyncManager {
       const loaded = await entry.state.ready;
 
       if (loaded === "unavailable") {
-        peer.optimisticKnownStates.dispatch({
+        peer.dispatchToKnownStates({
           type: "SET",
           id: msg.id,
           value: knownStateIn(msg),
@@ -481,13 +481,7 @@ export class SyncManager {
   async handleKnownState(msg: KnownStateMessage, peer: PeerState) {
     let entry = this.local.coValues[msg.id];
 
-    peer.optimisticKnownStates.dispatch({
-      type: "COMBINE_WITH",
-      id: msg.id,
-      value: knownStateIn(msg),
-    });
-
-    peer.knownStates.dispatch({
+    peer.dispatchToKnownStates({
       type: "COMBINE_WITH",
       id: msg.id,
       value: knownStateIn(msg),
@@ -552,7 +546,7 @@ export class SyncManager {
         return;
       }
 
-      peer.optimisticKnownStates.dispatch({
+      peer.dispatchToKnownStates({
         type: "UPDATE_HEADER",
         id: msg.id,
         header: true,
@@ -645,7 +639,7 @@ export class SyncManager {
         continue;
       }
 
-      peer.optimisticKnownStates.dispatch({
+      peer.dispatchToKnownStates({
         type: "UPDATE_SESSION_COUNTER",
         id: msg.id,
         sessionId: sessionID,
@@ -688,7 +682,7 @@ export class SyncManager {
   }
 
   async handleCorrection(msg: KnownStateMessage, peer: PeerState) {
-    peer.optimisticKnownStates.dispatch({
+    peer.dispatchToKnownStates({
       type: "SET",
       id: msg.id,
       value: knownStateIn(msg),

--- a/packages/cojson/src/tests/PeerState.test.ts
+++ b/packages/cojson/src/tests/PeerState.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, test, vi } from "vitest";
+import { PeerKnownStateActions } from "../PeerKnownStates.js";
 import { PeerState } from "../PeerState.js";
 import { CO_VALUE_PRIORITY } from "../priority.js";
 import { Peer, SyncMessage } from "../sync.js";
@@ -15,7 +16,7 @@ function setup() {
       close: vi.fn(),
     },
   };
-  const peerState = new PeerState(mockPeer);
+  const peerState = new PeerState(mockPeer, undefined);
   return { mockPeer, peerState };
 }
 
@@ -114,5 +115,47 @@ describe("PeerState", () => {
       4,
       contentMessageMid,
     );
+  });
+
+  test("should clone the knownStates into optimisticKnownStates and knownStates when passed as argument", () => {
+    const { peerState, mockPeer } = setup();
+    const action: PeerKnownStateActions = {
+      type: "SET",
+      id: "co_z1",
+      value: {
+        id: "co_z1",
+        header: false,
+        sessions: {},
+      },
+    };
+    peerState.dispatchToKnownStates(action);
+
+    const newPeerState = new PeerState(mockPeer, peerState.knownStates);
+
+    expect(newPeerState.knownStates).toEqual(peerState.knownStates);
+    expect(newPeerState.optimisticKnownStates).toEqual(peerState.knownStates);
+  });
+
+  test("should dispatch to both states", () => {
+    const { peerState } = setup();
+    const knownStatesSpy = vi.spyOn(peerState.knownStates, "dispatch");
+    const optimisticKnownStatesSpy = vi.spyOn(
+      peerState.optimisticKnownStates,
+      "dispatch",
+    );
+
+    const action: PeerKnownStateActions = {
+      type: "SET",
+      id: "co_z1",
+      value: {
+        id: "co_z1",
+        header: false,
+        sessions: {},
+      },
+    };
+    peerState.dispatchToKnownStates(action);
+
+    expect(knownStatesSpy).toHaveBeenCalledWith(action);
+    expect(optimisticKnownStatesSpy).toHaveBeenCalledWith(action);
   });
 });


### PR DESCRIPTION
Reviewing the code to look for the next steps I've noticed that some of the update that shouldn't be optimistic only weren't send to known states.

So I've added an API to dispatch to both states and increased the coverage of the known states to all the "non-optimistic" updates.