### PR TITLE
fix: reuse the crypto instance when creating the browser context

### DIFF
--- a/.changeset/proud-bats-pay.md
+++ b/.changeset/proud-bats-pay.md
@@ -1,0 +1,5 @@
+---
+"jazz-browser": patch
+---
+
+Reuse the crypto instance between OPFS and the jazz context

--- a/.changeset/selfish-socks-jump.md
+++ b/.changeset/selfish-socks-jump.md
@@ -1,0 +1,5 @@
+---
+"cojson-storage-indexeddb": patch
+---
+
+Set up a unique peer id for the indexeddb storage

--- a/packages/cojson-storage-indexeddb/src/index.ts
+++ b/packages/cojson-storage-indexeddb/src/index.ts
@@ -91,7 +91,7 @@ export class IDBStorage {
   ): Promise<Peer> {
     const [localNodeAsPeer, storageAsPeer] = cojsonInternals.connectedPeers(
       localNodeName,
-      "storage",
+      "indexedDB",
       {
         peer1role: "client",
         peer2role: "storage",

--- a/packages/jazz-browser/src/index.ts
+++ b/packages/jazz-browser/src/index.ts
@@ -97,12 +97,12 @@ export async function createJazzBrowserContext<Acc extends Account>(
       ? await createJazzContext({
           AccountSchema: options.AccountSchema,
           auth: options.auth,
-          crypto: await WasmCrypto.create(),
+          crypto,
           peersToLoadFrom,
           sessionProvider: provideBrowserLockSession,
         })
       : await createJazzContext({
-          crypto: await WasmCrypto.create(),
+          crypto,
           peersToLoadFrom,
         });
 


### PR DESCRIPTION
When using both the `IndexedDB` and the OPFS storage peers we were getting:

```
index.esm.js:248 Uncaught (in promise) RangeError: WebAssembly.instantiate(): Out of memory: Cannot allocate Wasm memory for new instance
    at index.esm.js:248:46
    at Generator.next (<anonymous>)
    at fulfilled (index.esm.js:27:58)
```

Reusing the crypto instance fixes the issue.