### PR TITLE
fix(useAcceptInvite): trigger the onAccept callback on hashchange

### DIFF
--- a/.changeset/twenty-carrots-tickle.md
+++ b/.changeset/twenty-carrots-tickle.md
@@ -1,0 +1,5 @@
+---
+"jazz-react": patch
+---
+
+Trigger invite accept on hashchange

--- a/packages/jazz-react/src/index.tsx
+++ b/packages/jazz-react/src/index.tsx
@@ -240,19 +240,25 @@ export function createJazzReactApp<Acc extends Account>({
     }
 
     useEffect(() => {
-      if (!context) return;
-
-      const result = consumeInviteLinkFromWindowLocation({
-        as: context.me,
-        invitedObjectSchema,
-        forValueHint,
-      });
-
-      result
-        .then((result) => result && onAccept(result?.valueID))
-        .catch((e) => {
-          console.error("Failed to accept invite", e);
+      const handleInvite = () => {
+        const result = consumeInviteLinkFromWindowLocation({
+          as: context.me,
+          invitedObjectSchema,
+          forValueHint,
         });
+
+        result
+          .then((result) => result && onAccept(result?.valueID))
+          .catch((e) => {
+            console.error("Failed to accept invite", e);
+          });
+      };
+
+      handleInvite();
+
+      window.addEventListener("hashchange", handleInvite);
+
+      return () => window.removeEventListener("hashchange", handleInvite);
     }, [onAccept]);
   }
 


### PR DESCRIPTION
When the invitation link is navigated on top on a url that has the same origin/pathname the `onAccept` callback is not triggered unless coincidentally the component that hosts `useAcceptInvite` is mounted/re-rendered after the URL has been pasted. 

To fix this I'm adding a subscription to the `hashchange` event, which sould catch such cases. 