### PR TITLE
chore(LocalNode): move the coValues states management in a CoValueStore

### DIFF
--- a/packages/cojson/src/CoValuesStore.ts
+++ b/packages/cojson/src/CoValuesStore.ts
@@ -1,0 +1,38 @@
+import { CoValueCore } from "./coValueCore.js";
+import { CoValueState } from "./coValueState.js";
+import { RawCoID } from "./ids.js";
+
+export class CoValuesStore {
+  coValues = new Map<RawCoID, CoValueState>();
+
+  get(id: RawCoID) {
+    let entry = this.coValues.get(id);
+
+    if (!entry) {
+      entry = CoValueState.Unknown(id);
+      this.coValues.set(id, entry);
+    }
+
+    return entry;
+  }
+
+  setAsAvailable(id: RawCoID, coValue: CoValueCore) {
+    const entry = this.get(id);
+    entry.dispatch({
+      type: "available",
+      coValue,
+    });
+  }
+
+  getEntries() {
+    return this.coValues.entries();
+  }
+
+  getValues() {
+    return this.coValues.values();
+  }
+
+  getKeys() {
+    return this.coValues.keys();
+  }
+}

--- a/packages/cojson/src/SyncStateSubscriptionManager.ts
+++ b/packages/cojson/src/SyncStateSubscriptionManager.ts
@@ -86,9 +86,9 @@ export class SyncStateSubscriptionManager {
 
   getIsCoValueFullyUploadedIntoPeer(peerId: PeerID, id: RawCoID) {
     const peer = this.syncManager.peers[peerId];
-    const entry = this.syncManager.local.coValues[id];
+    const entry = this.syncManager.local.coValuesStore.get(id);
 
-    if (!peer || !entry) {
+    if (!peer) {
       return false;
     }
 

--- a/packages/cojson/src/tests/coValueState.test.ts
+++ b/packages/cojson/src/tests/coValueState.test.ts
@@ -1,11 +1,7 @@
 import { describe, expect, test, vi } from "vitest";
 import { PeerState } from "../PeerState";
 import { CoValueCore } from "../coValueCore";
-import {
-  CO_VALUE_LOADING_MAX_RETRIES,
-  CoValueLoadingState,
-  CoValueState,
-} from "../coValueState";
+import { CO_VALUE_LOADING_MAX_RETRIES, CoValueState } from "../coValueState";
 import { RawCoID } from "../ids";
 
 describe("CoValueState", () => {
@@ -40,12 +36,10 @@ describe("CoValueState", () => {
     const mockCoValue = { id: mockCoValueId } as CoValueCore;
     const state = CoValueState.Loading(mockCoValueId, ["peer1", "peer2"]);
 
-    const innerState = state.state as CoValueLoadingState;
     const stateValuePromise = state.getCoValue();
 
     state.dispatch({
-      type: "found-in-peer",
-      peerId: "peer1",
+      type: "available",
       coValue: mockCoValue,
     });
 
@@ -230,8 +224,7 @@ describe("CoValueState", () => {
         if (retries === 2) {
           setTimeout(() => {
             state.dispatch({
-              type: "found-in-peer",
-              peerId: "peer1",
+              type: "available",
               coValue: { id: mockCoValueId } as CoValueCore,
             });
           }, 100);
@@ -281,8 +274,7 @@ describe("CoValueState", () => {
     }
 
     state.dispatch({
-      type: "found-in-peer",
-      peerId: "peer1",
+      type: "available",
       coValue: { id: mockCoValueId } as CoValueCore,
     });
 
@@ -307,8 +299,7 @@ describe("CoValueState", () => {
       pushOutgoingMessage: vi.fn().mockImplementation(async () => {
         if (run > 2) {
           state.dispatch({
-            type: "found-in-peer",
-            peerId: "peer1",
+            type: "available",
             coValue: { id: mockCoValueId } as CoValueCore,
           });
         }

--- a/packages/cojson/src/tests/sync.test.ts
+++ b/packages/cojson/src/tests/sync.test.ts
@@ -807,7 +807,7 @@ test.skip("When replaying creation and transactions of a coValue as new content,
     sessions: {},
   } satisfies SyncMessage);
 
-  expect(node2.coValues[map.core.id]?.state).toEqual("loading");
+  expect(node2.coValuesStore.get(map.core.id).state.type).toEqual("loading");
 
   await inTx2.push(mapNewContentMsg);
 
@@ -1102,7 +1102,7 @@ test("If we start loading a coValue before connecting to a peer that has it, it 
 
   const mapOnNode2Promise = node2.loadCoValueCore(map.core.id);
 
-  expect(node2.coValues[map.core.id]?.state.type).toEqual("loading");
+  expect(node2.coValuesStore.get(map.core.id).state.type).toEqual("unknown");
 
   node2.syncManager.addPeer(node1asPeer);
 


### PR DESCRIPTION
Move the coValues states management in a CoValueStore.

This way it is possible to always have an entry and becomes easier to do explicit state checks on the coValues states