### PR TITLE
fix(SyncManager): add flag to delete peers on close

### DIFF
--- a/.changeset/modern-zebras-invent.md
+++ b/.changeset/modern-zebras-invent.md
@@ -1,0 +1,5 @@
+---
+"jazz-run": patch
+---
+
+Enable the deletePeerStateOnClose on the Websocket peers

--- a/.changeset/strong-jobs-wait.md
+++ b/.changeset/strong-jobs-wait.md
@@ -1,0 +1,6 @@
+---
+"cojson-transport-ws": patch
+"cojson": patch
+---
+
+Add a flag to delete a peer when it is closed

--- a/packages/cojson-transport-ws/src/index.ts
+++ b/packages/cojson-transport-ws/src/index.ts
@@ -18,6 +18,7 @@ export type CreateWebSocketPeerOpts = {
   role: Peer["role"];
   expectPings?: boolean;
   batchingByDefault?: boolean;
+  deletePeerStateOnClose?: boolean;
   onClose?: () => void;
 };
 
@@ -118,6 +119,7 @@ export function createWebSocketPeer({
   role,
   expectPings = true,
   batchingByDefault = true,
+  deletePeerStateOnClose = false,
   onClose,
 }: CreateWebSocketPeerOpts): Peer {
   const incoming = new cojsonInternals.Channel<
@@ -212,5 +214,6 @@ export function createWebSocketPeer({
     },
     role,
     crashOnClose: false,
+    deletePeerStateOnClose,
   };
 }

--- a/packages/cojson/src/sync.ts
+++ b/packages/cojson/src/sync.ts
@@ -79,6 +79,7 @@ export interface Peer {
   role: "peer" | "server" | "client" | "storage";
   priority?: number;
   crashOnClose: boolean;
+  deletePeerStateOnClose?: boolean;
 }
 
 export function combinedKnownStates(
@@ -392,6 +393,10 @@ export class SyncManager {
         const state = this.peers[peer.id];
         state?.gracefulShutdown();
         unsubscribeFromKnownStatesUpdates();
+
+        if (peer.deletePeerStateOnClose) {
+          delete this.peers[peer.id];
+        }
       });
   }
 

--- a/packages/cojson/src/tests/sync.test.ts
+++ b/packages/cojson/src/tests/sync.test.ts
@@ -875,7 +875,7 @@ test("Can sync a coValue through a server to another client", async () => {
     {
       peer1role: "server",
       peer2role: "client",
-      trace: true,
+      // trace: true,
     },
   );
 
@@ -894,7 +894,7 @@ test("Can sync a coValue through a server to another client", async () => {
     {
       peer1role: "server",
       peer2role: "client",
-      trace: true,
+      // trace: true,
     },
   );
 
@@ -926,7 +926,7 @@ test("Can sync a coValue with private transactions through a server to another c
   const server = new LocalNode(serverUser, serverSession, Crypto);
 
   const [serverAsPeer, client1AsPeer] = connectedPeers("server", "client1", {
-    trace: true,
+    // trace: true,
     peer1role: "server",
     peer2role: "client",
   });
@@ -944,7 +944,7 @@ test("Can sync a coValue with private transactions through a server to another c
     "server",
     "client2",
     {
-      trace: true,
+      // trace: true,
       peer1role: "server",
       peer2role: "client",
     },
@@ -1095,7 +1095,7 @@ test("If we start loading a coValue before connecting to a peer that has it, it 
   const [node1asPeer, node2asPeer] = connectedPeers("peer1", "peer2", {
     peer1role: "server",
     peer2role: "client",
-    trace: true,
+    // trace: true,
   });
 
   node1.syncManager.addPeer(node2asPeer);
@@ -1114,6 +1114,59 @@ test("If we start loading a coValue before connecting to a peer that has it, it 
   expect(expectMap(mapOnNode2.getCurrentContent()).get("hello")).toEqual(
     "world",
   );
+});
+
+test("should keep the peer state when the peer closes", async () => {
+  const {
+    client,
+    jazzCloud,
+    jazzCloudConnectionAsPeer,
+    connectionWithClientAsPeer,
+  } = createTwoConnectedNodes();
+
+  const group = jazzCloud.createGroup();
+  const map = group.createMap();
+  map.set("hello", "world", "trusting");
+
+  await client.loadCoValueCore(map.core.id);
+
+  const syncManager = client.syncManager;
+  const peerState = syncManager.peers[jazzCloudConnectionAsPeer.id];
+
+  // @ts-expect-error Simulating a peer closing, leveraging the direct connection between the client/server peers
+  await connectionWithClientAsPeer.outgoing.push("Disconnected");
+
+  await waitFor(() => peerState?.closed);
+
+  expect(syncManager.peers[jazzCloudConnectionAsPeer.id]).not.toBeUndefined();
+});
+
+test("should delete the peer state when the peer closes if deletePeerStateOnClose is true", async () => {
+  const {
+    client,
+    jazzCloud,
+    jazzCloudConnectionAsPeer,
+    connectionWithClientAsPeer,
+  } = createTwoConnectedNodes();
+
+  jazzCloudConnectionAsPeer.deletePeerStateOnClose = true;
+
+  const group = jazzCloud.createGroup();
+  const map = group.createMap();
+  map.set("hello", "world", "trusting");
+
+  await client.loadCoValueCore(map.core.id);
+
+  const syncManager = client.syncManager;
+
+  const peerState = syncManager.peers[jazzCloudConnectionAsPeer.id];
+
+  // @ts-expect-error Simulating a peer closing, leveraging the direct connection between the client/server peers
+  await connectionWithClientAsPeer.outgoing.push("Disconnected");
+
+  await waitFor(() => peerState?.closed);
+
+  expect(syncManager.peers[jazzCloudConnectionAsPeer.id]).toBeUndefined();
 });
 
 describe("sync - extra tests", () => {
@@ -1519,7 +1572,7 @@ describe("sync - extra tests", () => {
       {
         peer1role: "server",
         peer2role: "client",
-        trace: true,
+        // trace: true,
       },
     );
 
@@ -1529,7 +1582,7 @@ describe("sync - extra tests", () => {
       {
         peer1role: "server",
         peer2role: "client",
-        trace: true,
+        // trace: true,
       },
     );
 

--- a/packages/jazz-run/package.json
+++ b/packages/jazz-run/package.json
@@ -7,8 +7,8 @@
   "scripts": {
     "format-and-lint": "biome check .",
     "format-and-lint:fix": "biome check . --write",
-    "build": "rm -rf ./dist && tsc --sourceMap --outDir dist",
-    "build-and-run": "pnpm turbo build && chmod +x ./dist/index.js && ./dist/index.js sync --in-memory",
+    "build": "rm -rf ./dist && tsc --sourceMap --outDir dist && chmod +x ./dist/index.js",
+    "build-and-run": "pnpm turbo build && ./dist/index.js sync --in-memory",
     "prepublishOnly": "npm run build"
   },
   "dependencies": {

--- a/packages/jazz-run/src/startSyncServer.ts
+++ b/packages/jazz-run/src/startSyncServer.ts
@@ -73,6 +73,7 @@ export const startSyncServer = async ({
         websocket: ws,
         expectPings: false,
         batchingByDefault: false,
+        deletePeerStateOnClose: true,
       }),
     );
 


### PR DESCRIPTION
Keeping the PeerState of the client websocket peers that are connecting to our sync servers is causing their memory to grow over time.

Since keeping the PeerState is something we need only in client apps and between the sync servers in our cloud I've added a flag to be able to selectively delete the peer states that we don't need to keep.