### PR TITLE
Fix PasskeyAuth forgetting authentication on reload

### DIFF
--- a/.changeset/tidy-foxes-carry.md
+++ b/.changeset/tidy-foxes-carry.md
@@ -1,0 +1,5 @@
+---
+"jazz-browser": patch
+---
+
+Persist PasskeyAuth credentials on reload

--- a/packages/jazz-browser/src/auth/PasskeyAuth.ts
+++ b/packages/jazz-browser/src/auth/PasskeyAuth.ts
@@ -148,6 +148,12 @@ export class BrowserPasskeyAuth implements AuthMethod {
             resolve({
               type: "existing",
               credentials: { accountID, secret },
+              saveCredentials: async ({ accountID, secret }) => {
+                localStorage[localStorageKey] = JSON.stringify({
+                  accountID,
+                  accountSecret: secret,
+                } satisfies LocalStorageData);
+              },
               onSuccess: () => {
                 this.driver.onSignedIn({ logOut });
               },


### PR DESCRIPTION
Adds `saveCredentials` on successful login for PasskeyAuth

![CleanShot 2024-11-18 at 14 13 14](https://github.com/user-attachments/assets/4dd20cf1-d9b1-49c8-9f28-0aa677a4ea94)

