### PR TITLE
fix: 'ErrorLoadingCoValueCore',  IndexedDB peer doesn't deliver dependencies

### DIFF
--- a/.changeset/cool-readers-share.md
+++ b/.changeset/cool-readers-share.md
@@ -2,4 +2,4 @@
 "cojson-storage-indexeddb": patch
 ---
 
-Fix: IndexedDB not delivering dependencies
+Fix: IndexedDB not delivering depended-on CoValues

--- a/.changeset/cool-readers-share.md
+++ b/.changeset/cool-readers-share.md
@@ -1,0 +1,5 @@
+---
+"cojson-storage-indexeddb": patch
+---
+
+Fix: IndexedDB not delivering dependencies

--- a/packages/cojson-storage-indexeddb/src/index.ts
+++ b/packages/cojson-storage-indexeddb/src/index.ts
@@ -703,7 +703,7 @@ function getDependedOnCoValues(
           coValueRow?.header.ruleset.group,
           ...new Set(
             newContentPieces.flatMap((piece) =>
-              Object.keys(piece)
+              Object.keys(piece.new)
                 .map((sessionID) =>
                   cojsonInternals.accountOrAgentIDfromSessionID(
                     sessionID as SessionID,


### PR DESCRIPTION
Linked GH [issue](https://github.com/gardencmp/jazz/issues/502)
 
Fixes s bug - IndexedDB peer doesn't deliver dependencies from sessions on co-value load.
<img width="1078" alt="Screenshot 2024-11-19 at 19 01 31" src="https://github.com/user-attachments/assets/dd29f42a-f1df-456a-9443-0404229d0e8a">
