### PR TITLE
fix: restore offline support and faster load when storage is active

### DIFF
--- a/.changeset/shaggy-shirts-retire.md
+++ b/.changeset/shaggy-shirts-retire.md
@@ -1,0 +1,5 @@
+---
+"cojson": patch
+---
+
+Restore offline support and improve loading perfromance when values are cached

--- a/packages/cojson/src/PeerState.ts
+++ b/packages/cojson/src/PeerState.ts
@@ -97,6 +97,10 @@ export class PeerState {
   }
 
   pushOutgoingMessage(msg: SyncMessage) {
+    if (this.closed) {
+      return Promise.resolve();
+    }
+
     const promise = this.queue.push(msg);
 
     void this.processQueue();

--- a/packages/cojson/src/sync.ts
+++ b/packages/cojson/src/sync.ts
@@ -451,12 +451,17 @@ export class SyncManager {
           dependencyEntry.state.type === "available" ||
           dependencyEntry.state.type === "loading"
         ) {
-          this.local.loadCoValueCore(msg.id, peer.id).catch((e) => {
-            console.error(
-              `Error loading coValue ${msg.id} to create loading state, as dependency of ${msg.asDependencyOf}`,
-              e,
-            );
-          });
+          this.local
+            .loadCoValueCore(
+              msg.id,
+              peer.role === "storage" ? undefined : peer.id,
+            )
+            .catch((e) => {
+              console.error(
+                `Error loading coValue ${msg.id} to create loading state, as dependency of ${msg.asDependencyOf}`,
+                e,
+              );
+            });
         } else {
           throw new Error(
             "Expected coValue dependency entry to be created, missing subscribe?",

--- a/packages/cojson/src/tests/coValueState.test.ts
+++ b/packages/cojson/src/tests/coValueState.test.ts
@@ -388,6 +388,84 @@ describe("CoValueState", () => {
 
     vi.useRealTimers();
   });
+
+  test("should skip closed peers", async () => {
+    vi.useFakeTimers();
+
+    const mockCoValue = createMockCoValueCore(mockCoValueId);
+
+    const peer1 = createMockPeerState(
+      {
+        id: "peer1",
+        role: "storage",
+      },
+      async () => {
+        state.dispatch({
+          type: "available",
+          coValue: mockCoValue,
+        });
+      },
+    );
+    const peer2 = createMockPeerState(
+      {
+        id: "peer1",
+        role: "server",
+      },
+      async () => {
+        state.dispatch({
+          type: "available",
+          coValue: mockCoValue,
+        });
+      },
+    );
+
+    peer1.closed = true;
+
+    const state = CoValueState.Unknown(mockCoValueId);
+    const loadPromise = state.loadFromPeers([peer1, peer2]);
+
+    for (let i = 0; i < CO_VALUE_LOADING_MAX_RETRIES; i++) {
+      await vi.runAllTimersAsync();
+    }
+    await loadPromise;
+
+    expect(peer1.pushOutgoingMessage).toHaveBeenCalledTimes(0);
+    expect(peer2.pushOutgoingMessage).toHaveBeenCalledTimes(1);
+
+    expect(state.state.type).toBe("available");
+    await expect(state.getCoValue()).resolves.toEqual({ id: mockCoValueId });
+
+    vi.useRealTimers();
+  });
+
+  test("should not be stuck in loading state when not getting a response", async () => {
+    vi.useFakeTimers();
+
+    const peer1 = createMockPeerState(
+      {
+        id: "peer1",
+        role: "server",
+      },
+      async () => {
+        return new Promise(() => {});
+      },
+    );
+
+    const state = CoValueState.Unknown(mockCoValueId);
+    const loadPromise = state.loadFromPeers([peer1]);
+
+    for (let i = 0; i < CO_VALUE_LOADING_MAX_RETRIES * 2; i++) {
+      await vi.runAllTimersAsync();
+    }
+    await loadPromise;
+
+    expect(peer1.pushOutgoingMessage).toHaveBeenCalledTimes(5);
+
+    expect(state.state.type).toBe("unavailable");
+    await expect(state.getCoValue()).resolves.toEqual("unavailable");
+
+    vi.useRealTimers();
+  });
 });
 
 function createMockPeerState(

--- a/packages/cojson/src/tests/coValueState.test.ts
+++ b/packages/cojson/src/tests/coValueState.test.ts
@@ -400,10 +400,7 @@ describe("CoValueState", () => {
         role: "storage",
       },
       async () => {
-        state.dispatch({
-          type: "available",
-          coValue: mockCoValue,
-        });
+        return new Promise(() => {});
       },
     );
     const peer2 = createMockPeerState(
@@ -446,9 +443,7 @@ describe("CoValueState", () => {
         id: "peer1",
         role: "server",
       },
-      async () => {
-        return new Promise(() => {});
-      },
+      async () => {},
     );
 
     const state = CoValueState.Unknown(mockCoValueId);

--- a/packages/jazz-browser/src/index.ts
+++ b/packages/jazz-browser/src/index.ts
@@ -1,4 +1,4 @@
-import { LSMStorage, Peer, RawAccountID } from "cojson";
+import { LSMStorage, LocalNode, Peer, RawAccountID } from "cojson";
 import { IDBStorage } from "cojson-storage-indexeddb";
 import {
   Account,
@@ -64,12 +64,15 @@ export async function createJazzBrowserContext<Acc extends Account>(
   options: BrowserContextOptions<Acc> | BaseBrowserContextOptions,
 ): Promise<BrowserContext<Acc> | BrowserGuestContext> {
   const crypto = options.crypto || (await WasmCrypto.create());
+  let node: LocalNode | undefined = undefined;
 
   const wsPeer = createWebSocketPeerWithReconnection(
     options.peer,
     options.reconnectionTimeout,
     (peer) => {
-      node.syncManager.addPeer(peer);
+      if (node) {
+        node.syncManager.addPeer(peer);
+      }
     },
   );
 
@@ -106,7 +109,7 @@ export async function createJazzBrowserContext<Acc extends Account>(
           peersToLoadFrom,
         });
 
-  const node =
+  node =
     "account" in context ? context.account._raw.core.node : context.agent.node;
 
   return "account" in context


### PR DESCRIPTION


After some testing I've noticed that Jazz was generally faster with a local sync server even when the data was fully stored locally.

After some more debugging I've found where the extra waiting was and that we weren't operating correctly when the sync server is down.

This PR fixes the issue
