### PR TITLE
Check for clerk.user before rendering the app

### DIFF
--- a/examples/chat-clerk/src/main.tsx
+++ b/examples/chat-clerk/src/main.tsx
@@ -18,7 +18,7 @@ function JazzAndAuth({ children }: { children: React.ReactNode }) {
       {state.errors.map((error) => (
         <div key={error}>{error}</div>
       ))}
-      {auth ? (
+      {clerk.user && auth ? (
         <Jazz.Provider
           auth={auth}
           peer="wss://cloud.jazz.tools/?key=chat-example-jazz-clerk@gcmp.io"


### PR DESCRIPTION
The chat-clerk app hangs on load (if not yet authenticated): https://chat-clerk-demo.jazz.tools/
This is because it tries to render the App before actually being authenticated. 

Changes: 
Check if we're actually authed before rendering children (App component). This is done properly in the docs so I could simply copy from there:
https://jazz.tools/docs/authentication/auth-methods#clerk