### PR TITLE
Make passkeys discoverable

### DIFF
--- a/.changeset/bright-impalas-fetch.md
+++ b/.changeset/bright-impalas-fetch.md
@@ -1,0 +1,5 @@
+---
+"jazz-browser": patch
+---
+
+Set created passkey credentials as discoverable

--- a/packages/jazz-browser/src/auth/PasskeyAuth.ts
+++ b/packages/jazz-browser/src/auth/PasskeyAuth.ts
@@ -104,6 +104,8 @@ export class BrowserPasskeyAuth implements AuthMethod {
                     pubKeyCredParams: [{ alg: -7, type: "public-key" }],
                     authenticatorSelection: {
                       authenticatorAttachment: "platform",
+                      requireResidentKey: true,
+                      residentKey: "required",
                     },
                     timeout: 60000,
                     attestation: "direct",


### PR DESCRIPTION
Reference: https://web.dev/articles/webauthn-discoverable-credentials

"To ensure your credentials are created as passkeys (discoverable credentials), specify residentKey and requireResidentKey when the credential is created."

Bitwarden (and possibly other password managers) won't find passkeys created on other devices unless they are discoverable.