### PR TITLE
chore: added a feature flag to disable the retry on unavailable coValues

### DIFF
--- a/.changeset/spicy-geese-cheat.md
+++ b/.changeset/spicy-geese-cheat.md
@@ -1,0 +1,5 @@
+---
+"cojson": patch
+---
+
+Added a feature flag to disable the retry on unavailable coValues

--- a/packages/cojson/src/PeerState.ts
+++ b/packages/cojson/src/PeerState.ts
@@ -4,6 +4,7 @@ import {
   QueueEntry,
 } from "./PriorityBasedMessageQueue.js";
 import { TryAddTransactionsError } from "./coValueCore.js";
+import { isFeatureEnabled } from "./featureFlags.js";
 import { RawCoID } from "./ids.js";
 import { CO_VALUE_PRIORITY } from "./priority.js";
 import { Peer, SyncMessage } from "./sync.js";
@@ -58,7 +59,10 @@ export class PeerState {
   }
 
   shouldRetryUnavailableCoValues() {
-    return this.peer.role === "server";
+    return (
+      isFeatureEnabled("RetryUnavailableCoValues") &&
+      this.peer.role === "server"
+    );
   }
 
   isServerOrStoragePeer() {

--- a/packages/cojson/src/exports.ts
+++ b/packages/cojson/src/exports.ts
@@ -23,6 +23,7 @@ import {
   secretSeedLength,
   shortHashLength,
 } from "./crypto/crypto.js";
+import { setFeatureFlag } from "./featureFlags.js";
 import { isRawCoID, rawCoIDfromBytes, rawCoIDtoBytes } from "./ids.js";
 import { parseJSON } from "./jsonStringify.js";
 import { LocalNode } from "./localNode.js";
@@ -116,6 +117,7 @@ export {
   SyncMessage,
   isRawCoID,
   LSMStorage,
+  setFeatureFlag,
 };
 
 export type {

--- a/packages/cojson/src/featureFlags.ts
+++ b/packages/cojson/src/featureFlags.ts
@@ -1,0 +1,16 @@
+const featureFlags = {
+  RetryUnavailableCoValues: true,
+};
+
+export function isFeatureEnabled(feature: keyof typeof featureFlags) {
+  return featureFlags[feature];
+}
+
+export function setFeatureFlag(
+  feature: keyof typeof featureFlags,
+  enabled: boolean,
+) {
+  featureFlags[feature] = enabled;
+}
+
+export default featureFlags;


### PR DESCRIPTION
In some situation the retry may cause some issues.

As a quick escape hatch we have added a feature flag to disble it in case of issues.