### PR TITLE
fix: removed a no more valid error on the known state message sync

### DIFF
--- a/.changeset/quick-bats-prove.md
+++ b/.changeset/quick-bats-prove.md
@@ -1,0 +1,5 @@
+---
+"cojson": patch
+---
+
+Removed a no more valid error on the known state message sync

--- a/packages/cojson/src/sync.ts
+++ b/packages/cojson/src/sync.ts
@@ -462,15 +462,7 @@ export class SyncManager {
                 e,
               );
             });
-        } else {
-          throw new Error(
-            "Expected coValue dependency entry to be created, missing subscribe?",
-          );
         }
-      } else {
-        throw new Error(
-          `Expected coValue entry for ${msg.id} to be created on known state, missing subscribe?`,
-        );
       }
     }
 


### PR DESCRIPTION
In the refactoring to CoValueStore I've forgot to remove these two errors that were handling the undefined entry case.

Now an entry is always provided, so we don't need these errors anymore.