### PR TITLE
fix(sync): send new content when a storage/server peer is re-added

### DIFF
--- a/.changeset/serious-needles-hunt.md
+++ b/.changeset/serious-needles-hunt.md
@@ -1,0 +1,5 @@
+---
+"cojson": patch
+---
+
+Upload new coValues when a peer is added

--- a/packages/cojson/src/sync.ts
+++ b/packages/cojson/src/sync.ts
@@ -304,14 +304,17 @@ export class SyncManager {
 
     if (peerState.isServerOrStoragePeer()) {
       const initialSync = async () => {
-        for (const id of this.local.coValuesStore.getKeys()) {
-          await this.subscribeToIncludingDependencies(id, peerState);
-          await this.sendNewContentIncludingDependencies(id, peerState);
+        for (const entry of this.local.coValuesStore.getValues()) {
+          await this.subscribeToIncludingDependencies(entry.id, peerState);
 
-          if (!peerState.optimisticKnownStates.has(id)) {
+          if (entry.state.type === "available") {
+            await this.sendNewContentIncludingDependencies(entry.id, peerState);
+          }
+
+          if (!peerState.optimisticKnownStates.has(entry.id)) {
             peerState.optimisticKnownStates.dispatch({
               type: "SET_AS_EMPTY",
-              id,
+              id: entry.id,
             });
           }
         }

--- a/packages/cojson/src/sync.ts
+++ b/packages/cojson/src/sync.ts
@@ -305,13 +305,15 @@ export class SyncManager {
     if (peerState.isServerOrStoragePeer()) {
       const initialSync = async () => {
         for (const id of this.local.coValuesStore.getKeys()) {
-          // console.log("subscribing to after peer added", id, peer.id)
           await this.subscribeToIncludingDependencies(id, peerState);
+          await this.sendNewContentIncludingDependencies(id, peerState);
 
-          peerState.optimisticKnownStates.dispatch({
-            type: "SET_AS_EMPTY",
-            id,
-          });
+          if (!peerState.optimisticKnownStates.has(id)) {
+            peerState.optimisticKnownStates.dispatch({
+              type: "SET_AS_EMPTY",
+              id,
+            });
+          }
         }
       };
       void initialSync();

--- a/tests/e2e/src/jazz.tsx
+++ b/tests/e2e/src/jazz.tsx
@@ -1,12 +1,17 @@
 import { createJazzReactApp, useDemoAuth } from "jazz-react";
 import { useEffect, useRef } from "react";
 
-const key = `test-comap@jazz.tools`;
-
 const url = new URL(window.location.href);
-const peer =
+
+const key = `${getUserInfo()}@jazz.tools`;
+
+let peer =
   (url.searchParams.get("peer") as `ws://${string}`) ??
-  `wss://cloud.jazz.tools/`;
+  `wss://cloud.jazz.tools/?key=${key}`;
+
+if (url.searchParams.has("local")) {
+  peer = `ws://localhost:4200/?key=${key}`;
+}
 
 const Jazz = createJazzReactApp();
 

--- a/tests/e2e/tests/Offline.spec.ts
+++ b/tests/e2e/tests/Offline.spec.ts
@@ -1,0 +1,28 @@
+import { setTimeout } from "node:timers/promises";
+import { expect, test } from "@playwright/test";
+
+test.describe("Offline & online sync", () => {
+  test("should sync when going online", async ({ page, browser }) => {
+    const context = page.context();
+
+    await page.goto("/retry-unavailable?userName=SuperMario");
+
+    await context.setOffline(true);
+
+    await page.getByRole("button", { name: "Create a new value!" }).click();
+
+    const id = await page.getByTestId("id").textContent();
+
+    await setTimeout(1000);
+
+    await context.setOffline(false);
+
+    // Create a new incognito instance and try to load the coValue
+    const newUserPage = await (await browser.newContext()).newPage();
+    await newUserPage.goto(`/retry-unavailable?userName=Luigi&id=${id}`);
+
+    await expect(newUserPage.getByTestId("id")).toBeInViewport({
+      timeout: 20_000,
+    });
+  });
+});

--- a/tests/e2e/tests/RetryUnavailable.test.ts
+++ b/tests/e2e/tests/RetryUnavailable.test.ts
@@ -21,7 +21,7 @@ test.describe("Retry unavailable states", () => {
       timeout: 20_000,
     });
 
-    await setTimeout(400);
+    await setTimeout(1000);
 
     await context.setOffline(false);
 


### PR DESCRIPTION
After debugging [the failing test on the retry](https://github.com/garden-co/jazz/actions/runs/12084415914/job/33709144732) I've isolated the issue and found that when a peer is disconnected and then re-added we don't upload the changes happened while offline.
 