### PR TITLE
feat: add `react-native-quick-crypto` for `ed25519`

### DIFF
--- a/packages/cojson/src/exports.ts
+++ b/packages/cojson/src/exports.ts
@@ -34,7 +34,7 @@ import {
   rawCoIDfromBytes,
   rawCoIDtoBytes,
 } from "./ids.js";
-import { Stringified, parseJSON } from "./jsonStringify.js";
+import { Stringified, parseJSON, stableStringify } from "./jsonStringify.js";
 import { LocalNode } from "./localNode.js";
 import type { Role } from "./permissions.js";
 import { Channel, connectedPeers } from "./streamUtils.js";
@@ -87,6 +87,7 @@ export const cojsonInternals = {
   base64URLtoBytes,
   bytesToBase64url,
   parseJSON,
+  stableStringify,
   accountOrAgentIDfromSessionID,
   isAccountID,
   accountHeaderForInitialAgentSecret,
@@ -167,6 +168,7 @@ export namespace CojsonInternalTypes {
   export type RawCoID = import("./ids.js").RawCoID;
   export type ProfileShape = import("./coValues/account.js").ProfileShape;
   export type SealerSecret = import("./crypto/crypto.js").SealerSecret;
+  export type SignerID = import("./crypto/crypto.js").SignerID;
   export type SignerSecret = import("./crypto/crypto.js").SignerSecret;
   export type JsonObject = import("./jsonValue.js").JsonObject;
 }

--- a/packages/cojson/src/tests/crypto.test.ts
+++ b/packages/cojson/src/tests/crypto.test.ts
@@ -3,178 +3,187 @@ import { x25519 } from "@noble/curves/ed25519";
 import { blake3 } from "@noble/hashes/blake3";
 import { base58, base64url } from "@scure/base";
 import { expect, test } from "vitest";
+import { PureJSCrypto } from "../crypto/PureJSCrypto.js";
 import { WasmCrypto } from "../crypto/WasmCrypto.js";
 import { SessionID } from "../ids.js";
 import { stableStringify } from "../jsonStringify.js";
 
-const Crypto = await WasmCrypto.create();
+const wasmCrypto = await WasmCrypto.create();
+const pureJSCrypto = await PureJSCrypto.create();
 
-test("Signatures round-trip and use stable stringify", () => {
-  const data = { b: "world", a: "hello" };
-  const signer = Crypto.newRandomSigner();
-  const signature = Crypto.sign(signer, data);
+[wasmCrypto, pureJSCrypto].forEach((crypto) => {
+  const name = crypto.constructor.name;
 
-  expect(signature).toMatch(/^signature_z/);
-  expect(
-    Crypto.verify(
-      signature,
-      { a: "hello", b: "world" },
-      Crypto.getSignerID(signer),
-    ),
-  ).toBe(true);
-});
+  test(`Signatures round-trip and use stable stringify [${name}]`, () => {
+    const data = { b: "world", a: "hello" };
+    const signer = crypto.newRandomSigner();
+    const signature = crypto.sign(signer, data);
 
-test("Invalid signatures don't verify", () => {
-  const data = { b: "world", a: "hello" };
-  const signer = Crypto.newRandomSigner();
-  const signer2 = Crypto.newRandomSigner();
-  const wrongSignature = Crypto.sign(signer2, data);
-
-  expect(Crypto.verify(wrongSignature, data, Crypto.getSignerID(signer))).toBe(
-    false,
-  );
-});
-
-test("encrypting round-trips, but invalid receiver can't unseal", () => {
-  const data = { b: "world", a: "hello" };
-  const sender = Crypto.newRandomSealer();
-  const sealer = Crypto.newRandomSealer();
-  const wrongSealer = Crypto.newRandomSealer();
-
-  const nOnceMaterial = {
-    in: "co_zTEST",
-    tx: { sessionID: "co_zTEST_session_zTEST" as SessionID, txIndex: 0 },
-  } as const;
-
-  const sealed = Crypto.seal({
-    message: data,
-    from: sender,
-    to: Crypto.getSealerID(sealer),
-    nOnceMaterial,
+    expect(signature).toMatch(/^signature_z/);
+    expect(
+      crypto.verify(
+        signature,
+        { a: "hello", b: "world" },
+        crypto.getSignerID(signer),
+      ),
+    ).toBe(true);
   });
 
-  expect(
-    Crypto.unseal(sealed, sealer, Crypto.getSealerID(sender), nOnceMaterial),
-  ).toEqual(data);
-  expect(() =>
-    Crypto.unseal(
-      sealed,
-      wrongSealer,
-      Crypto.getSealerID(sender),
+  test(`Invalid signatures don't verify [${name}]`, () => {
+    const data = { b: "world", a: "hello" };
+    const signer = crypto.newRandomSigner();
+    const signer2 = crypto.newRandomSigner();
+    const wrongSignature = crypto.sign(signer2, data);
+
+    expect(
+      crypto.verify(wrongSignature, data, crypto.getSignerID(signer)),
+    ).toBe(false);
+  });
+
+  test(`encrypting round-trips, but invalid receiver can't unseal [${name}]`, () => {
+    const data = { b: "world", a: "hello" };
+    const sender = crypto.newRandomSealer();
+    const sealer = crypto.newRandomSealer();
+    const wrongSealer = crypto.newRandomSealer();
+
+    const nOnceMaterial = {
+      in: "co_zTEST",
+      tx: { sessionID: "co_zTEST_session_zTEST" as SessionID, txIndex: 0 },
+    } as const;
+
+    const sealed = crypto.seal({
+      message: data,
+      from: sender,
+      to: crypto.getSealerID(sealer),
       nOnceMaterial,
-    ),
-  ).toThrow(/Wrong tag/);
+    });
 
-  // trying with wrong sealer secret, by hand
-  const nOnce = blake3(
-    new TextEncoder().encode(stableStringify(nOnceMaterial)),
-  ).slice(0, 24);
-  const sealer3priv = base58.decode(
-    wrongSealer.substring("sealerSecret_z".length),
-  );
-  const senderPub = base58.decode(
-    Crypto.getSealerID(sender).substring("sealer_z".length),
-  );
-  const sealedBytes = base64url.decode(sealed.substring("sealed_U".length));
-  const sharedSecret = x25519.getSharedSecret(sealer3priv, senderPub);
+    expect(
+      crypto.unseal(sealed, sealer, crypto.getSealerID(sender), nOnceMaterial),
+    ).toEqual(data);
+    expect(() =>
+      crypto.unseal(
+        sealed,
+        wrongSealer,
+        crypto.getSealerID(sender),
+        nOnceMaterial,
+      ),
+    ).toThrow(/Wrong tag/);
 
-  expect(() => {
-    const _ = xsalsa20_poly1305(sharedSecret, nOnce).decrypt(sealedBytes);
-  }).toThrow("Wrong tag");
-});
+    // trying with wrong sealer secret, by hand
+    const nOnce = blake3(
+      new TextEncoder().encode(stableStringify(nOnceMaterial)),
+    ).slice(0, 24);
+    const sealer3priv = base58.decode(
+      wrongSealer.substring("sealerSecret_z".length),
+    );
+    const senderPub = base58.decode(
+      crypto.getSealerID(sender).substring("sealer_z".length),
+    );
+    const sealedBytes = base64url.decode(sealed.substring("sealed_U".length));
+    const sharedSecret = x25519.getSharedSecret(sealer3priv, senderPub);
 
-test("Hashing is deterministic", () => {
-  expect(Crypto.secureHash({ b: "world", a: "hello" })).toEqual(
-    Crypto.secureHash({ a: "hello", b: "world" }),
-  );
-
-  expect(Crypto.shortHash({ b: "world", a: "hello" })).toEqual(
-    Crypto.shortHash({ a: "hello", b: "world" }),
-  );
-});
-
-test("Encryption for transactions round-trips", () => {
-  const { secret } = Crypto.newRandomKeySecret();
-
-  const encrypted1 = Crypto.encryptForTransaction({ a: "hello" }, secret, {
-    in: "co_zTEST",
-    tx: { sessionID: "co_zTEST_session_zTEST" as SessionID, txIndex: 0 },
+    expect(() => {
+      const _ = xsalsa20_poly1305(sharedSecret, nOnce).decrypt(sealedBytes);
+    }).toThrow("Wrong tag");
   });
 
-  const encrypted2 = Crypto.encryptForTransaction({ b: "world" }, secret, {
-    in: "co_zTEST",
-    tx: { sessionID: "co_zTEST_session_zTEST" as SessionID, txIndex: 1 },
+  test(`Hashing is deterministic [${name}]`, () => {
+    expect(crypto.secureHash({ b: "world", a: "hello" })).toEqual(
+      crypto.secureHash({ a: "hello", b: "world" }),
+    );
+
+    expect(crypto.shortHash({ b: "world", a: "hello" })).toEqual(
+      crypto.shortHash({ a: "hello", b: "world" }),
+    );
   });
 
-  const decrypted1 = Crypto.decryptForTransaction(encrypted1, secret, {
-    in: "co_zTEST",
-    tx: { sessionID: "co_zTEST_session_zTEST" as SessionID, txIndex: 0 },
+  test(`Encryption for transactions round-trips [${name}]`, () => {
+    const { secret } = crypto.newRandomKeySecret();
+
+    const encrypted1 = crypto.encryptForTransaction({ a: "hello" }, secret, {
+      in: "co_zTEST",
+      tx: { sessionID: "co_zTEST_session_zTEST" as SessionID, txIndex: 0 },
+    });
+
+    const encrypted2 = crypto.encryptForTransaction({ b: "world" }, secret, {
+      in: "co_zTEST",
+      tx: { sessionID: "co_zTEST_session_zTEST" as SessionID, txIndex: 1 },
+    });
+
+    const decrypted1 = crypto.decryptForTransaction(encrypted1, secret, {
+      in: "co_zTEST",
+      tx: { sessionID: "co_zTEST_session_zTEST" as SessionID, txIndex: 0 },
+    });
+
+    const decrypted2 = crypto.decryptForTransaction(encrypted2, secret, {
+      in: "co_zTEST",
+      tx: { sessionID: "co_zTEST_session_zTEST" as SessionID, txIndex: 1 },
+    });
+
+    expect([decrypted1, decrypted2]).toEqual([{ a: "hello" }, { b: "world" }]);
   });
 
-  const decrypted2 = Crypto.decryptForTransaction(encrypted2, secret, {
-    in: "co_zTEST",
-    tx: { sessionID: "co_zTEST_session_zTEST" as SessionID, txIndex: 1 },
+  test(`Encryption for transactions doesn't decrypt with a wrong key [${name}]`, () => {
+    const { secret } = crypto.newRandomKeySecret();
+    const { secret: secret2 } = crypto.newRandomKeySecret();
+
+    const encrypted1 = crypto.encryptForTransaction({ a: "hello" }, secret, {
+      in: "co_zTEST",
+      tx: { sessionID: "co_zTEST_session_zTEST" as SessionID, txIndex: 0 },
+    });
+
+    const encrypted2 = crypto.encryptForTransaction({ b: "world" }, secret, {
+      in: "co_zTEST",
+      tx: { sessionID: "co_zTEST_session_zTEST" as SessionID, txIndex: 1 },
+    });
+
+    const decrypted1 = crypto.decryptForTransaction(encrypted1, secret2, {
+      in: "co_zTEST",
+      tx: { sessionID: "co_zTEST_session_zTEST" as SessionID, txIndex: 0 },
+    });
+
+    const decrypted2 = crypto.decryptForTransaction(encrypted2, secret2, {
+      in: "co_zTEST",
+      tx: { sessionID: "co_zTEST_session_zTEST" as SessionID, txIndex: 1 },
+    });
+
+    expect([decrypted1, decrypted2]).toEqual([undefined, undefined]);
   });
 
-  expect([decrypted1, decrypted2]).toEqual([{ a: "hello" }, { b: "world" }]);
-});
+  test(`Encryption of keySecrets round-trips [${name}]`, () => {
+    const toEncrypt = crypto.newRandomKeySecret();
+    const encrypting = crypto.newRandomKeySecret();
 
-test("Encryption for transactions doesn't decrypt with a wrong key", () => {
-  const { secret } = Crypto.newRandomKeySecret();
-  const { secret: secret2 } = Crypto.newRandomKeySecret();
+    const keys = {
+      toEncrypt,
+      encrypting,
+    };
 
-  const encrypted1 = Crypto.encryptForTransaction({ a: "hello" }, secret, {
-    in: "co_zTEST",
-    tx: { sessionID: "co_zTEST_session_zTEST" as SessionID, txIndex: 0 },
+    const encrypted = crypto.encryptKeySecret(keys);
+
+    const decrypted = crypto.decryptKeySecret(encrypted, encrypting.secret);
+
+    expect(decrypted).toEqual(toEncrypt.secret);
   });
 
-  const encrypted2 = Crypto.encryptForTransaction({ b: "world" }, secret, {
-    in: "co_zTEST",
-    tx: { sessionID: "co_zTEST_session_zTEST" as SessionID, txIndex: 1 },
+  test(`Encryption of keySecrets doesn't decrypt with a wrong key [${name}]`, () => {
+    const toEncrypt = crypto.newRandomKeySecret();
+    const encrypting = crypto.newRandomKeySecret();
+    const encryptingWrong = crypto.newRandomKeySecret();
+
+    const keys = {
+      toEncrypt,
+      encrypting,
+    };
+
+    const encrypted = crypto.encryptKeySecret(keys);
+
+    const decrypted = crypto.decryptKeySecret(
+      encrypted,
+      encryptingWrong.secret,
+    );
+
+    expect(decrypted).toBeUndefined();
   });
-
-  const decrypted1 = Crypto.decryptForTransaction(encrypted1, secret2, {
-    in: "co_zTEST",
-    tx: { sessionID: "co_zTEST_session_zTEST" as SessionID, txIndex: 0 },
-  });
-
-  const decrypted2 = Crypto.decryptForTransaction(encrypted2, secret2, {
-    in: "co_zTEST",
-    tx: { sessionID: "co_zTEST_session_zTEST" as SessionID, txIndex: 1 },
-  });
-
-  expect([decrypted1, decrypted2]).toEqual([undefined, undefined]);
-});
-
-test("Encryption of keySecrets round-trips", () => {
-  const toEncrypt = Crypto.newRandomKeySecret();
-  const encrypting = Crypto.newRandomKeySecret();
-
-  const keys = {
-    toEncrypt,
-    encrypting,
-  };
-
-  const encrypted = Crypto.encryptKeySecret(keys);
-
-  const decrypted = Crypto.decryptKeySecret(encrypted, encrypting.secret);
-
-  expect(decrypted).toEqual(toEncrypt.secret);
-});
-
-test("Encryption of keySecrets doesn't decrypt with a wrong key", () => {
-  const toEncrypt = Crypto.newRandomKeySecret();
-  const encrypting = Crypto.newRandomKeySecret();
-  const encryptingWrong = Crypto.newRandomKeySecret();
-
-  const keys = {
-    toEncrypt,
-    encrypting,
-  };
-
-  const encrypted = Crypto.encryptKeySecret(keys);
-
-  const decrypted = Crypto.decryptKeySecret(encrypted, encryptingWrong.secret);
-
-  expect(decrypted).toBeUndefined();
 });

--- a/packages/jazz-react-native/package.json
+++ b/packages/jazz-react-native/package.json
@@ -15,10 +15,12 @@
   },
   "license": "MIT",
   "dependencies": {
+    "@scure/base": "1.2.1",
     "@scure/bip39": "^1.3.0",
     "cojson": "workspace:*",
     "cojson-transport-ws": "workspace:*",
-    "jazz-tools": "workspace:*"
+    "jazz-tools": "workspace:*",
+    "react-native-quick-crypto": "1.0.0-beta.9"
   },
   "peerDependencies": {
     "@react-native-community/netinfo": "*",

--- a/packages/jazz-react-native/src/crypto/RNQuickCrypto.ts
+++ b/packages/jazz-react-native/src/crypto/RNQuickCrypto.ts
@@ -1,0 +1,58 @@
+import { base58 } from "@scure/base";
+import { JsonValue, PureJSCrypto } from "cojson/native";
+import { CojsonInternalTypes, cojsonInternals } from "cojson/native";
+import { Ed } from "react-native-quick-crypto";
+const { stableStringify } = cojsonInternals;
+
+const textEncoder = new TextEncoder();
+
+export class RNQuickCrypto extends PureJSCrypto {
+  ed: Ed;
+
+  constructor() {
+    super();
+    this.ed = new Ed("ed25519", {});
+  }
+
+  static async create(): Promise<RNQuickCrypto> {
+    return new RNQuickCrypto();
+  }
+
+  newEd25519SigningKey(): Uint8Array {
+    this.ed.generateKeyPairSync();
+    return new Uint8Array(this.ed.getPrivateKey());
+  }
+
+  getSignerID(
+    secret: CojsonInternalTypes.SignerSecret,
+  ): CojsonInternalTypes.SignerID {
+    return `signer_z${base58.encode(
+      base58.decode(secret.substring("signerSecret_z".length)),
+    )}`;
+  }
+
+  sign(
+    secret: CojsonInternalTypes.SignerSecret,
+    message: JsonValue,
+  ): CojsonInternalTypes.Signature {
+    const signature = new Uint8Array(
+      this.ed.signSync(
+        textEncoder.encode(stableStringify(message)),
+        base58.decode(secret.substring("signerSecret_z".length)),
+      ),
+    );
+    return `signature_z${base58.encode(signature)}`;
+  }
+
+  verify(
+    signature: CojsonInternalTypes.Signature,
+    message: JsonValue,
+    id: CojsonInternalTypes.SignerID,
+  ): boolean {
+    return this.ed.verifySync(
+      base58.decode(signature.substring("signature_z".length)),
+      textEncoder.encode(stableStringify(message)),
+      base58.decode(id.substring("signer_z".length)),
+    );
+  }
+}

--- a/packages/jazz-tools/src/index.native.ts
+++ b/packages/jazz-tools/src/index.native.ts
@@ -2,6 +2,5 @@ export * from "./exports.js";
 
 export {
   MAX_RECOMMENDED_TX_SIZE,
-  PureJSCrypto,
   cojsonInternals,
 } from "cojson/native";

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1729,6 +1729,9 @@ importers:
 
   packages/jazz-react-native:
     dependencies:
+      '@scure/base':
+        specifier: 1.2.1
+        version: 1.2.1
       '@scure/bip39':
         specifier: ^1.3.0
         version: 1.5.0
@@ -1741,6 +1744,9 @@ importers:
       jazz-tools:
         specifier: workspace:*
         version: link:../jazz-tools
+      react-native-quick-crypto:
+        specifier: 1.0.0-beta.9
+        version: 1.0.0-beta.9(react-native-nitro-modules@0.20.1(react-native@0.76.5(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@types/react@18.3.18)(react@18.3.1))(react@18.3.1))(react-native@0.76.5(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@types/react@18.3.18)(react@18.3.1))(react@18.3.1)
     devDependencies:
       '@react-native-community/netinfo':
         specifier: ^11.4.1
@@ -3045,6 +3051,9 @@ packages:
 
   '@coinbase/wallet-sdk@4.0.4':
     resolution: {integrity: sha512-74c040CRnGhfRjr3ArnkAgud86erIqdkPHNt5HR1k9u97uTIZCJww9eGYT67Qf7gHPpGS/xW8Be1D4dvRm63FA==}
+
+  '@craftzdog/react-native-buffer@6.0.5':
+    resolution: {integrity: sha512-Av+YqfwA9e7jhgI9GFE/gTpwl/H+dRRLmZyJPOpKTy107j9Oj7oXlm3/YiMNz+C/CEGqcKAOqnXDLs4OL6AAFw==}
 
   '@cspotcode/source-map-support@0.8.1':
     resolution: {integrity: sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==}
@@ -9470,6 +9479,12 @@ packages:
       react: 18.3.1
       react-native: '>=0.73.0'
 
+  react-native-nitro-modules@0.20.1:
+    resolution: {integrity: sha512-ffa8GbnLBs7irEx1ZCl7WdHzzA5uj4ngh7hIWbeUfBs8m2iAn+byowOJWHKmO+RA2hp9dVwTxHYSBOqIvTVvHA==}
+    peerDependencies:
+      react: 18.3.1
+      react-native: '*'
+
   react-native-polyfill-globals@3.1.0:
     resolution: {integrity: sha512-6ACmV1SjXvZP2LN6J2yK58yNACKddcvoiKLrSQdISx32IdYStfdmGXrbAfpd+TANrTlIaZ2SLoFXohNwhnqm/w==}
     peerDependencies:
@@ -9485,6 +9500,13 @@ packages:
     peerDependencies:
       react: 18.3.1
       react-native: '*'
+
+  react-native-quick-crypto@1.0.0-beta.9:
+    resolution: {integrity: sha512-P3WZRuBebFlmK716a2PdgG3Pw+ExPN6vBypa2iLSldc+LShiwL9WWtIk+5DmEPCsiI4od7RiivNgpy3pfQEb+w==}
+    peerDependencies:
+      react: 18.3.1
+      react-native: '*'
+      react-native-nitro-modules: '*'
 
   react-native-reanimated@3.16.5:
     resolution: {integrity: sha512-mq/5k14pimkhCeP9XwFJkEr8XufaHqIekum8fqpsn0fcBzbLvyiqfM2LEuBvi0+DTv5Bd2dHmUHkYqGYfkj3Jw==}
@@ -9630,6 +9652,10 @@ packages:
   readable-stream@3.6.2:
     resolution: {integrity: sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==}
     engines: {node: '>= 6'}
+
+  readable-stream@4.5.2:
+    resolution: {integrity: sha512-yjavECdqeZ3GLXNgRXgeQEdz9fvDDkNKyHnbHRFtOr7/LcfgBcmct7t/ET+HaCTqfh06OzoAxrkN/IfjJBVe+g==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
 
   readable-stream@4.6.0:
     resolution: {integrity: sha512-cbAdYt0VcnpN2Bekq7PU+k363ZRsPwJoEEJOEtSJQlJXzwaxt3FIo/uL+KeDSGIjJqtkwyge4KQgD2S2kd+CQw==}
@@ -12499,6 +12525,14 @@ snapshots:
       keccak: 3.0.4
       preact: 10.25.3
       sha.js: 2.4.11
+
+  '@craftzdog/react-native-buffer@6.0.5(react-native@0.76.5(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@types/react@18.3.18)(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      ieee754: 1.2.1
+      react-native-quick-base64: 2.1.2(react-native@0.76.5(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@types/react@18.3.18)(react@18.3.1))(react@18.3.1)
+    transitivePeerDependencies:
+      - react
+      - react-native
 
   '@cspotcode/source-map-support@0.8.1':
     dependencies:
@@ -19769,6 +19803,11 @@ snapshots:
       react: 18.3.1
       react-native: 0.76.5(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@types/react@18.3.18)(react@18.3.1)
 
+  react-native-nitro-modules@0.20.1(react-native@0.76.5(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@types/react@18.3.18)(react@18.3.1))(react@18.3.1):
+    dependencies:
+      react: 18.3.1
+      react-native: 0.76.5(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@types/react@18.3.18)(react@18.3.1)
+
   react-native-polyfill-globals@3.1.0(base-64@1.0.0)(react-native-fetch-api@3.0.0)(react-native-get-random-values@1.11.0(react-native@0.76.5(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@types/react@18.3.18)(react@18.3.1)))(react-native-url-polyfill@2.0.0(react-native@0.76.5(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@types/react@18.3.18)(react@18.3.1)))(text-encoding@0.7.0)(web-streams-polyfill@3.3.3):
     dependencies:
       base-64: 1.0.0
@@ -19783,6 +19822,18 @@ snapshots:
       base64-js: 1.5.1
       react: 18.3.1
       react-native: 0.76.5(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@types/react@18.3.18)(react@18.3.1)
+
+  react-native-quick-crypto@1.0.0-beta.9(react-native-nitro-modules@0.20.1(react-native@0.76.5(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@types/react@18.3.18)(react@18.3.1))(react@18.3.1))(react-native@0.76.5(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@types/react@18.3.18)(react@18.3.1))(react@18.3.1):
+    dependencies:
+      '@craftzdog/react-native-buffer': 6.0.5(react-native@0.76.5(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@types/react@18.3.18)(react@18.3.1))(react@18.3.1)
+      events: 3.3.0
+      react: 18.3.1
+      react-native: 0.76.5(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@types/react@18.3.18)(react@18.3.1)
+      react-native-nitro-modules: 0.20.1(react-native@0.76.5(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@types/react@18.3.18)(react@18.3.1))(react@18.3.1)
+      react-native-quick-base64: 2.1.2(react-native@0.76.5(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@types/react@18.3.18)(react@18.3.1))(react@18.3.1)
+      readable-stream: 4.5.2
+      string_decoder: 1.3.0
+      util: 0.12.5
 
   react-native-reanimated@3.16.5(@babel/core@7.26.0)(react-native@0.76.5(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@types/react@18.3.18)(react@18.3.1))(react@18.3.1):
     dependencies:
@@ -20015,6 +20066,14 @@ snapshots:
       inherits: 2.0.4
       string_decoder: 1.3.0
       util-deprecate: 1.0.2
+
+  readable-stream@4.5.2:
+    dependencies:
+      abort-controller: 3.0.0
+      buffer: 6.0.3
+      events: 3.3.0
+      process: 0.11.10
+      string_decoder: 1.3.0
 
   readable-stream@4.6.0:
     dependencies:


### PR DESCRIPTION
Add `react-native-quick-crypto` library for faster `ed25519` sign & verify functions.

Also WIP, trying to remove Expo from `jazz-react-native` as much as possible.