### PR TITLE
chore(ci): optimize playwright browsers install

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -41,7 +41,7 @@ jobs:
           key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
           restore-keys: |
             ${{ runner.os }}-pnpm-store-
-      
+
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
@@ -53,9 +53,18 @@ jobs:
         run: pnpm exec turbo build && chmod +x dist/index.js;
         working-directory: ./packages/jazz-run
 
+      - name: Cache playwright binaries
+        uses: actions/cache@v3
+        id: playwright-cache
+        with:
+          path: |
+            ~/.cache/ms-playwright
+          key: ${{ runner.os }}-playwright-${{ hashFiles('**/pnpm-lock.yaml') }}
+
       - name: Install Playwright Browsers
-        run: pnpm exec playwright install --with-deps
+        run: pnpm exec playwright install
         working-directory: ./${{ matrix.project }}
+        if: steps.playwright-cache.outputs.cache-hit != 'true'
 
       - name: Run Playwright tests
         run: pnpm exec playwright test

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -53,18 +53,9 @@ jobs:
         run: pnpm exec turbo build && chmod +x dist/index.js;
         working-directory: ./packages/jazz-run
 
-      - name: Cache playwright binaries
-        uses: actions/cache@v3
-        id: playwright-cache
-        with:
-          path: |
-            ~/.cache/ms-playwright
-          key: ${{ runner.os }}-playwright-${{ hashFiles('**/pnpm-lock.yaml') }}
-
       - name: Install Playwright Browsers
         run: pnpm exec playwright install
         working-directory: ./${{ matrix.project }}
-        if: steps.playwright-cache.outputs.cache-hit != 'true'
 
       - name: Run Playwright tests
         run: pnpm exec playwright test


### PR DESCRIPTION
Looks like we don't use the features that rely on the system dependencies and removing `--with-deps` we spare around a minute on the installation phase

Also tried caching the browsers installation but it's faster to just download them.