### PR TITLE
test(e2e): use the local server to reduce the flakyiness

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -45,13 +45,13 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
+      - name: Setup .env
+        run: echo "VITE_WS_PEER=ws://localhost:4200/" >> .env
+        working-directory: ./${{ matrix.project }}
+
       - name: Pnpm Build
         run: pnpm turbo build
         working-directory: ./${{ matrix.project }}
-      
-      - name: Build jazz-run
-        run: pnpm exec turbo build && chmod +x dist/index.js;
-        working-directory: ./packages/jazz-run
 
       - name: Install Playwright Browsers
         run: pnpm exec playwright install

--- a/examples/pets/playwright.config.ts
+++ b/examples/pets/playwright.config.ts
@@ -27,7 +27,7 @@ export default defineConfig({
   /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
   use: {
     /* Base URL to use in actions like `await page.goto('/')`. */
-    baseURL: "http://localhost:5173/?peer=ws://localhost:1234",
+    baseURL: "http://localhost:5173/",
 
     /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
     trace: "on-first-retry",
@@ -47,11 +47,6 @@ export default defineConfig({
     {
       command: "pnpm preview --port 5173",
       url: "http://localhost:5173/",
-      reuseExistingServer: !isCI,
-    },
-    {
-      command: "pnpm sync --in-memory --port 1234",
-      url: "http://localhost:1234/health",
       reuseExistingServer: !isCI,
     },
   ],

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1753,6 +1753,9 @@ importers:
       '@vitejs/plugin-react-swc':
         specifier: ^3.3.2
         version: 3.5.0(@swc/helpers@0.5.5)(vite@5.4.11(@types/node@22.5.1)(lightningcss@1.27.0)(terser@5.33.0))
+      jazz-run:
+        specifier: workspace:*
+        version: link:../../packages/jazz-run
       jstat:
         specifier: ^1.9.6
         version: 1.9.6

--- a/tests/e2e/package.json
+++ b/tests/e2e/package.json
@@ -10,6 +10,7 @@
     "format-and-lint": "biome check .",
     "format-and-lint:fix": "biome check . --write",
     "test": "playwright test",
+    "sync": "jazz-run sync",
     "test:ui": "playwright test --ui"
   },
   "dependencies": {
@@ -31,6 +32,7 @@
     "@vitejs/plugin-react-swc": "^3.3.2",
     "jstat": "^1.9.6",
     "typescript": "^5.3.3",
+    "jazz-run": "workspace:*",
     "vite": "^5.0.10"
   }
 }

--- a/tests/e2e/playwright.config.ts
+++ b/tests/e2e/playwright.config.ts
@@ -49,5 +49,10 @@ export default defineConfig({
       url: "http://localhost:5173/",
       reuseExistingServer: !isCI,
     },
+    {
+      command: "pnpm sync --in-memory",
+      url: "http://localhost:4200/health",
+      reuseExistingServer: !isCI,
+    },
   ],
 });

--- a/tests/e2e/src/jazz.tsx
+++ b/tests/e2e/src/jazz.tsx
@@ -13,6 +13,10 @@ if (url.searchParams.has("local")) {
   peer = `ws://localhost:4200/?key=${key}`;
 }
 
+if (import.meta.env.VITE_WS_PEER) {
+  peer = import.meta.env.VITE_WS_PEER;
+}
+
 const Jazz = createJazzReactApp();
 
 export const { useAccount, useCoState, useAcceptInvite } = Jazz;

--- a/tests/e2e/tests/Sharing.test.ts
+++ b/tests/e2e/tests/Sharing.test.ts
@@ -34,7 +34,6 @@ test.describe("Sharing", () => {
       "CoValue root ---> CoValue child 1",
     );
 
-    const id = await page.getByTestId("id").textContent();
     const inviteLink = await page
       .getByTestId("invite-link-reader")
       .textContent();
@@ -43,14 +42,13 @@ test.describe("Sharing", () => {
     const newUserPage = await (await browser.newContext()).newPage();
     await newUserPage.goto(inviteLink!);
 
-    await expect(newUserPage.getByTestId("id")).toHaveText(id ?? "", {
-      timeout: 20_000,
-    });
-
     // The user should not have access to the internal values
     // because they are part of a different group
     await expect(newUserPage.getByTestId("values")).toContainText(
       "CoValue root",
+      {
+        timeout: 20_000,
+      },
     );
     await expect(newUserPage.getByTestId("values")).not.toContainText(
       "CoValue root ---> CoValue child 1",
@@ -73,7 +71,6 @@ test.describe("Sharing", () => {
 
     await page.getByRole("button", { name: "Create the root" }).click();
 
-    const id = await page.getByTestId("id").textContent();
     const inviteLink = await page
       .getByTestId("invite-link-admin")
       .textContent();
@@ -82,9 +79,12 @@ test.describe("Sharing", () => {
     const newUserPage = await (await browser.newContext()).newPage();
     await newUserPage.goto(inviteLink!);
 
-    await expect(newUserPage.getByTestId("id")).toHaveText(id ?? "", {
-      timeout: 20_000,
-    });
+    await expect(newUserPage.getByTestId("values")).toContainText(
+      "CoValue root",
+      {
+        timeout: 20_000,
+      },
+    );
 
     await newUserPage.getByRole("button", { name: "Add a child" }).click();
     await newUserPage.getByRole("button", { name: "Add a child" }).click();
@@ -111,7 +111,6 @@ test.describe("Sharing", () => {
 
     await page.getByRole("button", { name: "Create the root" }).click();
 
-    const id = await page.getByTestId("id").textContent();
     const inviteLink = await page
       .getByTestId("invite-link-writer")
       .textContent();
@@ -120,9 +119,12 @@ test.describe("Sharing", () => {
     const newUserPage = await (await browser.newContext()).newPage();
     await newUserPage.goto(inviteLink!);
 
-    await expect(newUserPage.getByTestId("id")).toHaveText(id ?? "", {
-      timeout: 20_000,
-    });
+    await expect(newUserPage.getByTestId("values")).toContainText(
+      "CoValue root",
+      {
+        timeout: 20_000,
+      },
+    );
 
     await newUserPage.getByRole("button", { name: "Add a child" }).click();
     await newUserPage
@@ -146,7 +148,6 @@ test.describe("Sharing", () => {
     await page.getByRole("button", { name: "Add a child" }).click();
     await page.getByRole("button", { name: "Share the children" }).click();
 
-    const id = await page.getByTestId("id").textContent();
     const inviteLink = await page
       .getByTestId("invite-link-reader")
       .textContent();
@@ -155,9 +156,12 @@ test.describe("Sharing", () => {
     const newUserPage = await (await browser.newContext()).newPage();
     await newUserPage.goto(inviteLink!);
 
-    await expect(newUserPage.getByTestId("id")).toHaveText(id ?? "", {
-      timeout: 20_000,
-    });
+    await expect(newUserPage.getByTestId("values")).toContainText(
+      "CoValue root",
+      {
+        timeout: 20_000,
+      },
+    );
 
     await page.getByRole("button", { name: "Revoke access" }).click();
     await page.getByRole("button", { name: "Add a child" }).click();
@@ -203,6 +207,20 @@ test.describe("Sharing", () => {
 
     await otherAdminPage.goto(adminInviteLink!);
     await readerPage.goto(readerInviteLink!);
+
+    await expect(otherAdminPage.getByTestId("values")).toContainText(
+      "CoValue root",
+      {
+        timeout: 20_000,
+      },
+    );
+
+    await expect(readerPage.getByTestId("values")).toContainText(
+      "CoValue root",
+      {
+        timeout: 20_000,
+      },
+    );
 
     await initialOwnerPage.getByRole("button", { name: "Add a child" }).click();
     await initialOwnerPage
@@ -308,6 +326,20 @@ test.describe("Sharing", () => {
 
     await otherAdminPage.goto(adminInviteLink!);
     await readerPage.goto(readerInviteLink!);
+
+    await expect(otherAdminPage.getByTestId("values")).toContainText(
+      "CoValue root",
+      {
+        timeout: 20_000,
+      },
+    );
+
+    await expect(readerPage.getByTestId("values")).toContainText(
+      "CoValue root",
+      {
+        timeout: 20_000,
+      },
+    );
 
     await initialOwnerPage.getByRole("button", { name: "Add a child" }).click();
     await initialOwnerPage


### PR DESCRIPTION
Switches to the local sync server for tests/e2e and add some fixes to make them less flaky.

Looks like the situation is better now: https://github.com/garden-co/jazz/actions/runs/12221100944/job/34089728012?pr=971

Will restore the jazz-cloud target once we release the 0.8.38 on production