### PR TITLE
fix(sqlite): improve the work scheduling when under pressure

### DIFF
--- a/.changeset/gold-numbers-agree.md
+++ b/.changeset/gold-numbers-agree.md
@@ -1,0 +1,5 @@
+---
+"cojson-storage-sqlite": patch
+---
+
+Improve work scheduling under pressure


### PR DESCRIPTION
Doing some load tests I've noticed that sometimes the sqlite peer may monopolize the main thread for seconds.

In order to avoid that I've added a workaround to wait with a timer.

This is meant to be a quick fix that we can use while we work at a better message scheduler.

|||
|---|---|
|Before|After|
|![Screenshot 2024-12-09 at 16 45 32](https://github.com/user-attachments/assets/8044c5c3-d752-4616-805f-14d146e3b017)|![Screenshot 2024-12-09 at 16 46 02](https://github.com/user-attachments/assets/4b28715a-8bb0-43c1-8f96-f16e9a242d5a)|

WIth this change the work on the main thread is more evenly splitted, but we risk that some other operation might take control of the microtask queue blocking the storage.