### PR TITLE
fix(react-native): reconnect automatically when the WebSocket is closed by the server

### DIFF
--- a/.changeset/modern-dancers-worry.md
+++ b/.changeset/modern-dancers-worry.md
@@ -1,0 +1,5 @@
+---
+"jazz-react-native": patch
+---
+
+Reconnect automatically when the WebSocket is closed by the server

--- a/packages/jazz-react-native/src/createWebSocketPeerWithReconnection.ts
+++ b/packages/jazz-react-native/src/createWebSocketPeerWithReconnection.ts
@@ -1,0 +1,79 @@
+import NetInfo from "@react-native-community/netinfo";
+import { Peer } from "cojson";
+import { createWebSocketPeer } from "cojson-transport-ws";
+
+export function createWebSocketPeerWithReconnection(
+  peer: string,
+  reconnectionTimeout: number | undefined,
+  addPeer: (peer: Peer) => void,
+) {
+  const firstWsPeer = createWebSocketPeer({
+    websocket: new WebSocket(peer),
+    id: peer,
+    role: "server",
+    onClose: reconnectWebSocket,
+  });
+
+  const initialReconnectionTimeout = reconnectionTimeout || 500;
+  let shouldTryToReconnect = true;
+  let currentReconnectionTimeout = initialReconnectionTimeout;
+
+  const unsubscribeNetworkChange = NetInfo.addEventListener((state) => {
+    if (state.isConnected) {
+      currentReconnectionTimeout = initialReconnectionTimeout;
+    }
+  });
+
+  async function reconnectWebSocket() {
+    if (!shouldTryToReconnect) return;
+
+    console.log(
+      "Websocket disconnected, trying to reconnect in " +
+        currentReconnectionTimeout +
+        "ms",
+    );
+    currentReconnectionTimeout = Math.min(
+      currentReconnectionTimeout * 2,
+      30000,
+    );
+
+    await waitForOnline(currentReconnectionTimeout);
+
+    if (!shouldTryToReconnect) return;
+
+    addPeer(
+      createWebSocketPeer({
+        websocket: new WebSocket(peer),
+        id: peer,
+        role: "server",
+        onClose: reconnectWebSocket,
+      }),
+    );
+  }
+
+  return {
+    peer: firstWsPeer,
+    done: () => {
+      shouldTryToReconnect = false;
+      unsubscribeNetworkChange();
+    },
+  };
+}
+
+function waitForOnline(timeout: number) {
+  return new Promise<void>((resolve) => {
+    const unsubscribeNetworkChange = NetInfo.addEventListener((state) => {
+      if (state.isConnected) {
+        handleTimeoutOrOnline();
+      }
+    });
+
+    function handleTimeoutOrOnline() {
+      clearTimeout(timer);
+      unsubscribeNetworkChange();
+      resolve();
+    }
+
+    const timer = setTimeout(handleTimeoutOrOnline, timeout);
+  });
+}

--- a/packages/jazz-react-native/src/tests/createWebSocketPeerWithReconnection.test.ts
+++ b/packages/jazz-react-native/src/tests/createWebSocketPeerWithReconnection.test.ts
@@ -1,0 +1,163 @@
+// @vitest-environment happy-dom
+
+import NetInfo, {
+  NetInfoChangeHandler,
+  NetInfoState,
+} from "@react-native-community/netinfo";
+import { createWebSocketPeer } from "cojson-transport-ws";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+import { createWebSocketPeerWithReconnection } from "../createWebSocketPeerWithReconnection.js";
+
+// Mock WebSocket
+class MockWebSocket {
+  addEventListener = vi.fn();
+  removeEventListener = vi.fn();
+  close = vi.fn();
+  readyState = 1;
+}
+
+vi.mock("@react-native-community/netinfo", async () => {
+  return {
+    default: {
+      addEventListener: vi.fn(),
+    },
+  };
+});
+
+vi.mock("cojson-transport-ws", () => ({
+  createWebSocketPeer: vi.fn().mockImplementation(({ onClose }) => ({
+    id: "test-peer",
+    incoming: { push: vi.fn() },
+    outgoing: { push: vi.fn(), close: vi.fn() },
+    onClose,
+  })),
+}));
+
+let listeners = new Set<NetInfoChangeHandler>();
+let unsubscribe: (() => void) | undefined = undefined;
+
+function mockNetInfo() {
+  listeners.clear();
+  vi.mocked(NetInfo.addEventListener).mockImplementation((listener) => {
+    listeners.add(listener);
+    unsubscribe = vi.fn();
+    return unsubscribe;
+  });
+}
+
+function dispatchNetInfoChange(isConnected: boolean) {
+  listeners.forEach((listener) => listener({ isConnected } as NetInfoState));
+}
+
+describe("createWebSocketPeerWithReconnection", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.stubGlobal("WebSocket", MockWebSocket);
+    mockNetInfo();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  test("should reset reconnection timeout when coming online", async () => {
+    vi.useFakeTimers();
+    const addPeerMock = vi.fn();
+
+    const { done } = createWebSocketPeerWithReconnection(
+      "ws://localhost:8080",
+      500,
+      addPeerMock,
+    );
+
+    // Simulate multiple disconnections to increase timeout
+    const initialPeer = vi.mocked(createWebSocketPeer).mock.results[0]!.value;
+    initialPeer.onClose();
+
+    await vi.advanceTimersByTimeAsync(1000);
+
+    expect(addPeerMock).toHaveBeenCalledTimes(1);
+
+    vi.mocked(createWebSocketPeer).mock.results[1]!.value.onClose();
+    await vi.advanceTimersByTimeAsync(2000);
+
+    expect(addPeerMock).toHaveBeenCalledTimes(2);
+
+    // Resets the timeout to initial value
+    dispatchNetInfoChange(true);
+
+    // Next reconnection should use initial timeout
+    vi.mocked(createWebSocketPeer).mock.results[2]!.value.onClose();
+    await vi.advanceTimersByTimeAsync(1000);
+
+    expect(addPeerMock).toHaveBeenCalledTimes(3);
+
+    done();
+  });
+
+  test("should wait for online event or timeout before reconnecting", async () => {
+    vi.useFakeTimers();
+
+    const addPeerMock = vi.fn();
+    const { done } = createWebSocketPeerWithReconnection(
+      "ws://localhost:8080",
+      500,
+      addPeerMock,
+    );
+
+    const initialPeer = vi.mocked(createWebSocketPeer).mock.results[0]!.value;
+
+    // Simulate offline state
+    vi.stubGlobal("navigator", { onLine: false });
+
+    initialPeer.onClose();
+
+    // Advance timer but not enough to trigger reconnection
+    await vi.advanceTimersByTimeAsync(500);
+    expect(createWebSocketPeer).toHaveBeenCalledTimes(1);
+
+    // Simulate coming back online
+    dispatchNetInfoChange(true);
+
+    // Wait for event loop to settle
+    await Promise.resolve().then();
+
+    // Should reconnect immediately after coming online
+    expect(createWebSocketPeer).toHaveBeenCalledTimes(2);
+
+    done();
+  });
+
+  test("should clean up event listeners when done", () => {
+    const addPeerMock = vi.fn();
+    const { done } = createWebSocketPeerWithReconnection(
+      "ws://localhost:8080",
+      1000,
+      addPeerMock,
+    );
+
+    done();
+
+    expect(unsubscribe).toHaveBeenCalled();
+  });
+
+  test("should not attempt reconnection after done is called", async () => {
+    vi.useFakeTimers();
+
+    const addPeerMock = vi.fn();
+    const { done } = createWebSocketPeerWithReconnection(
+      "ws://localhost:8080",
+      500,
+      addPeerMock,
+    );
+
+    const initialPeer = vi.mocked(createWebSocketPeer).mock.results[0]!.value;
+
+    done();
+
+    initialPeer.onClose();
+    await vi.advanceTimersByTimeAsync(1000);
+
+    expect(createWebSocketPeer).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
Looking at the code I've found that we were missing the onClose handler on the RN websocket management.

Copied the logic from the browser package and adapted it to work with RN.

This code can be in theory shared between the two packages, but it's simple enough for now so it shoud be ok to have it duplicated.