### PR TITLE
chore: adds message queue size metrics tests

### DIFF
--- a/packages/cojson/package.json
+++ b/packages/cojson/package.json
@@ -21,6 +21,7 @@
   "license": "MIT",
   "version": "0.8.37",
   "devDependencies": {
+    "@opentelemetry/sdk-metrics": "^1.29.0",
     "@types/jest": "^29.5.3",
     "typescript": "^5.3.3",
     "vitest": "1.5.3"

--- a/packages/cojson/src/tests/PriorityBasedMessageQueue.test.ts
+++ b/packages/cojson/src/tests/PriorityBasedMessageQueue.test.ts
@@ -1,11 +1,83 @@
+import { metrics } from "@opentelemetry/api";
+import {
+  AggregationTemporality,
+  InMemoryMetricExporter,
+  MeterProvider,
+  MetricReader,
+  type MetricReaderOptions,
+  type PushMetricExporter,
+} from "@opentelemetry/sdk-metrics";
 import { describe, expect, test } from "vitest";
 import { PriorityBasedMessageQueue } from "../PriorityBasedMessageQueue.js";
 import { CO_VALUE_PRIORITY } from "../priority.js";
-import { SyncMessage } from "../sync.js";
+import type { SyncMessage } from "../sync.js";
+
+interface A extends MetricReaderOptions {
+  exporter: PushMetricExporter;
+}
+
+/**
+ * This is a test metric reader that uses an in-memory metric exporter and exposes a method to get the value of a metric given its name and attributes.
+ *
+ * This is useful for testing the values of metrics that are collected by the SDK.
+ *
+ * TODO: We could move this to a separate file and make it a utility class that can be used in other tests.
+ * TODO: We may want to rethink how we access metrics (see `getMetricValue` method) to make it more flexible.
+ */
+class TestMetricReader extends MetricReader {
+  private _exporter = new InMemoryMetricExporter(
+    AggregationTemporality.CUMULATIVE,
+  );
+
+  protected onShutdown(): Promise<void> {
+    throw new Error("Method not implemented.");
+  }
+  protected onForceFlush(): Promise<void> {
+    throw new Error("Method not implemented.");
+  }
+
+  async getMetricValue(
+    name: string,
+    attributes: { [key: string]: string | number } = {},
+  ) {
+    await this.collectAndExport();
+    const metric = this._exporter
+      .getMetrics()[0]
+      ?.scopeMetrics[0]?.metrics.find((m) => m.descriptor.name === name);
+
+    const dp = metric?.dataPoints.find(
+      (dp) => JSON.stringify(dp.attributes) === JSON.stringify(attributes),
+    );
+
+    this._exporter.reset();
+
+    return dp?.value;
+  }
+
+  async collectAndExport(): Promise<void> {
+    const result = await this.collect();
+    await new Promise<void>((resolve, reject) => {
+      this._exporter.export(result.resourceMetrics, (result) => {
+        if (result.error != null) {
+          reject(result.error);
+        } else {
+          resolve();
+        }
+      });
+    });
+  }
+}
 
 function setup() {
+  const metricReader = new TestMetricReader();
+  metrics.setGlobalMeterProvider(
+    new MeterProvider({
+      readers: [metricReader],
+    }),
+  );
+
   const queue = new PriorityBasedMessageQueue(CO_VALUE_PRIORITY.MEDIUM);
-  return { queue };
+  return { queue, metricReader };
 }
 
 describe("PriorityBasedMessageQueue", () => {
@@ -43,7 +115,7 @@ describe("PriorityBasedMessageQueue", () => {
   });
 
   test("should pull messages in priority order", async () => {
-    const { queue } = setup();
+    const { queue, metricReader } = setup();
     const lowPriorityMsg: SyncMessage = {
       action: "content",
       id: "co_zlow",
@@ -64,12 +136,42 @@ describe("PriorityBasedMessageQueue", () => {
     };
 
     void queue.push(lowPriorityMsg);
+    expect(
+      await metricReader.getMetricValue("jazz.messagequeue.size", {
+        priority: lowPriorityMsg.priority,
+      }),
+    ).toBe(1);
     void queue.push(mediumPriorityMsg);
+    expect(
+      await metricReader.getMetricValue("jazz.messagequeue.size", {
+        priority: mediumPriorityMsg.priority,
+      }),
+    ).toBe(1);
     void queue.push(highPriorityMsg);
+    expect(
+      await metricReader.getMetricValue("jazz.messagequeue.size", {
+        priority: highPriorityMsg.priority,
+      }),
+    ).toBe(1);
 
     expect(queue.pull()?.msg).toEqual(highPriorityMsg);
+    expect(
+      await metricReader.getMetricValue("jazz.messagequeue.size", {
+        priority: highPriorityMsg.priority,
+      }),
+    ).toBe(0);
     expect(queue.pull()?.msg).toEqual(mediumPriorityMsg);
+    expect(
+      await metricReader.getMetricValue("jazz.messagequeue.size", {
+        priority: mediumPriorityMsg.priority,
+      }),
+    ).toBe(0);
     expect(queue.pull()?.msg).toEqual(lowPriorityMsg);
+    expect(
+      await metricReader.getMetricValue("jazz.messagequeue.size", {
+        priority: lowPriorityMsg.priority,
+      }),
+    ).toBe(0);
   });
 
   test("should return undefined when pulling from empty queue", () => {

--- a/packages/cojson/src/tests/PriorityBasedMessageQueue.test.ts
+++ b/packages/cojson/src/tests/PriorityBasedMessageQueue.test.ts
@@ -7,7 +7,7 @@ import {
   type MetricReaderOptions,
   type PushMetricExporter,
 } from "@opentelemetry/sdk-metrics";
-import { describe, expect, test } from "vitest";
+import { afterEach, describe, expect, test } from "vitest";
 import { PriorityBasedMessageQueue } from "../PriorityBasedMessageQueue.js";
 import { CO_VALUE_PRIORITY } from "../priority.js";
 import type { SyncMessage } from "../sync.js";
@@ -81,6 +81,10 @@ function setup() {
 }
 
 describe("PriorityBasedMessageQueue", () => {
+  afterEach(() => {
+    metrics.disable();
+  });
+
   test("should initialize with correct properties", () => {
     const { queue } = setup();
     expect(queue["defaultPriority"]).toBe(CO_VALUE_PRIORITY.MEDIUM);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1259,6 +1259,9 @@ importers:
         specifier: ^4.1.2
         version: 4.1.2
     devDependencies:
+      '@opentelemetry/sdk-metrics':
+        specifier: ^1.29.0
+        version: 1.29.0(@opentelemetry/api@1.9.0)
       '@types/jest':
         specifier: ^29.5.3
         version: 29.5.11
@@ -3715,6 +3718,28 @@ packages:
   '@opentelemetry/api@1.9.0':
     resolution: {integrity: sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==}
     engines: {node: '>=8.0.0'}
+
+  '@opentelemetry/core@1.29.0':
+    resolution: {integrity: sha512-gmT7vAreXl0DTHD2rVZcw3+l2g84+5XiHIqdBUxXbExymPCvSsGOpiwMmn8nkiJur28STV31wnhIDrzWDPzjfA==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.0.0 <1.10.0'
+
+  '@opentelemetry/resources@1.29.0':
+    resolution: {integrity: sha512-s7mLXuHZE7RQr1wwweGcaRp3Q4UJJ0wazeGlc/N5/XSe6UyXfsh1UQGMADYeg7YwD+cEdMtU1yJAUXdnFzYzyQ==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.0.0 <1.10.0'
+
+  '@opentelemetry/sdk-metrics@1.29.0':
+    resolution: {integrity: sha512-MkVtuzDjXZaUJSuJlHn6BSXjcQlMvHcsDV7LjY4P6AJeffMa4+kIGDjzsCf6DkAh6Vqlwag5EWEam3KZOX5Drw==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.3.0 <1.10.0'
+
+  '@opentelemetry/semantic-conventions@1.28.0':
+    resolution: {integrity: sha512-lp4qAiMTD4sNWW4DbKLBkfiMZ4jbAboJIGOQr5DvciMRI494OapieI9qiODpOt0XBr1LjIDy1xAGAnVs5supTA==}
+    engines: {node: '>=14'}
 
   '@parcel/watcher-android-arm64@2.4.1':
     resolution: {integrity: sha512-LOi/WTbbh3aTn2RYddrO8pnapixAziFl6SMxHM69r3tvdSm94JtCenaKgk1GRg5FJ5wpMCpHeW+7yqPlvZv7kg==}
@@ -13924,6 +13949,25 @@ snapshots:
       semver: 7.6.3
 
   '@opentelemetry/api@1.9.0': {}
+
+  '@opentelemetry/core@1.29.0(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/semantic-conventions': 1.28.0
+
+  '@opentelemetry/resources@1.29.0(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/core': 1.29.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/semantic-conventions': 1.28.0
+
+  '@opentelemetry/sdk-metrics@1.29.0(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/core': 1.29.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/resources': 1.29.0(@opentelemetry/api@1.9.0)
+
+  '@opentelemetry/semantic-conventions@1.28.0': {}
 
   '@parcel/watcher-android-arm64@2.4.1':
     optional: true


### PR DESCRIPTION
Follow up to https://github.com/garden-co/jazz/pull/975

adds tests to ensure the correct metrics are preoduced with the correct values.

i figured `should pull messages in priority order` was a good fit to add assertions related to this, but i'm happy to move them to a different tests if we prefer.