### PR TITLE
feat: add writeOnly role on groups

### DIFF
--- a/.changeset/pretty-chefs-yawn.md
+++ b/.changeset/pretty-chefs-yawn.md
@@ -1,0 +1,6 @@
+---
+"jazz-browser": patch
+"cojson": patch
+---
+
+Add a new writeOnly role, to limit access only to their own changes. Useful to push objects into lists of moderated content.

--- a/packages/cojson/src/coValueCore.ts
+++ b/packages/cojson/src/coValueCore.ts
@@ -684,7 +684,7 @@ export class CoValueCore {
     if (this.header.ruleset.type === "group") {
       const content = expectGroup(this.getCurrentContent());
 
-      const currentKeyId = content.getCurrentKeyReadId();
+      const currentKeyId = content.getCurrentReadKeyId();
 
       if (!currentKeyId) {
         throw new Error("No readKey set");

--- a/packages/cojson/src/coValueCore.ts
+++ b/packages/cojson/src/coValueCore.ts
@@ -684,7 +684,7 @@ export class CoValueCore {
     if (this.header.ruleset.type === "group") {
       const content = expectGroup(this.getCurrentContent());
 
-      const currentKeyId = content.get("readKey");
+      const currentKeyId = content.getCurrentKeyReadId();
 
       if (!currentKeyId) {
         throw new Error("No readKey set");

--- a/packages/cojson/src/coValues/group.ts
+++ b/packages/cojson/src/coValues/group.ts
@@ -364,7 +364,7 @@ export class RawGroup<
     return keys;
   }
 
-  getCurrentKeyReadId() {
+  getCurrentReadKeyId() {
     if (this.myRole() === "writeOnly") {
       const accountId = this.core.node.account.id;
 

--- a/packages/cojson/src/coValues/group.ts
+++ b/packages/cojson/src/coValues/group.ts
@@ -13,7 +13,7 @@ import {
   isParentGroupReference,
 } from "../ids.js";
 import { JsonObject } from "../jsonValue.js";
-import { Role } from "../permissions.js";
+import { AccountRole, Role } from "../permissions.js";
 import { expectGroup } from "../typeUtils/expectGroup.js";
 import {
   ControlledAccountOrAgent,
@@ -33,6 +33,7 @@ export type GroupShape = {
   [key: RawAccountID | AgentID]: Role;
   [EVERYONE]?: Role;
   readKey?: KeyID;
+  [writeKeyFor: `writeKeyFor_${RawAccountID | AgentID}`]: KeyID;
   [revelationFor: `${KeyID}_for_${RawAccountID | AgentID}`]: Sealed<KeySecret>;
   [revelationFor: `${KeyID}_for_${Everyone}`]: KeySecret;
   [oldKeyForNewKey: `${KeyID}_for_${KeyID}`]: Encrypted<
@@ -213,18 +214,19 @@ export class RawGroup<
     account: RawAccount | ControlledAccountOrAgent | AgentID | Everyone,
     role: Role,
   ) {
-    const currentReadKey = this.core.getCurrentReadKey();
-
-    if (!currentReadKey.secret) {
-      throw new Error("Can't add member without read key secret");
-    }
-
     if (account === EVERYONE) {
       if (!(role === "reader" || role === "writer")) {
         throw new Error(
           "Can't make everyone something other than reader or writer",
         );
       }
+
+      const currentReadKey = this.core.getCurrentReadKey();
+
+      if (!currentReadKey.secret) {
+        throw new Error("Can't add member without read key secret");
+      }
+
       this.set(account, role, "trusting");
 
       if (this.get(account) !== role) {
@@ -236,44 +238,168 @@ export class RawGroup<
         currentReadKey.secret,
         "trusting",
       );
+
+      return;
+    }
+
+    const memberKey = typeof account === "string" ? account : account.id;
+    const agent =
+      typeof account === "string"
+        ? account
+        : account.currentAgentID()._unsafeUnwrap({ withStackTrace: true });
+
+    /**
+     * WriteOnly members can only see their own changes.
+     *
+     * We don't want to reveal the readKey to them so we create a new one and reveal it
+     * to everyone else.
+     *
+     * To never reveal the readKey to writeOnly members we also create a dedicated writeKey for the
+     * invite.
+     */
+    if (role === "writeOnly" || role === "writeOnlyInvite") {
+      const writeKeyForNewMember = this.core.crypto.newRandomKeySecret();
+
+      this.set(memberKey, role, "trusting");
+      this.set(`writeKeyFor_${memberKey}`, writeKeyForNewMember.id, "trusting");
+
+      this.storeKeyRevelationForMember(
+        memberKey,
+        agent,
+        writeKeyForNewMember.id,
+        writeKeyForNewMember.secret,
+      );
+
+      for (const otherMemberKey of this.getMemberKeys()) {
+        const memberRole = this.get(otherMemberKey);
+
+        if (
+          memberRole === "reader" ||
+          memberRole === "writer" ||
+          memberRole === "admin" ||
+          memberRole === "readerInvite" ||
+          memberRole === "writerInvite" ||
+          memberRole === "adminInvite"
+        ) {
+          const otherMemberAgent = this.core.node
+            .resolveAccountAgent(
+              otherMemberKey,
+              "Expected member agent to be loaded",
+            )
+            ._unsafeUnwrap({ withStackTrace: true });
+
+          this.storeKeyRevelationForMember(
+            otherMemberKey,
+            otherMemberAgent,
+            writeKeyForNewMember.id,
+            writeKeyForNewMember.secret,
+          );
+        }
+      }
     } else {
-      const memberKey = typeof account === "string" ? account : account.id;
-      const agent =
-        typeof account === "string"
-          ? account
-          : account.currentAgentID()._unsafeUnwrap({ withStackTrace: true });
+      const currentReadKey = this.core.getCurrentReadKey();
+
+      if (!currentReadKey.secret) {
+        throw new Error("Can't add member without read key secret");
+      }
+
       this.set(memberKey, role, "trusting");
 
       if (this.get(memberKey) !== role) {
         throw new Error("Failed to set role");
       }
 
-      this.set(
-        `${currentReadKey.id}_for_${memberKey}`,
-        this.core.crypto.seal({
-          message: currentReadKey.secret,
-          from: this.core.node.account.currentSealerSecret(),
-          to: this.core.crypto.getAgentSealerID(agent),
-          nOnceMaterial: {
-            in: this.id,
-            tx: this.core.nextTransactionID(),
-          },
-        }),
-        "trusting",
+      this.storeKeyRevelationForMember(
+        memberKey,
+        agent,
+        currentReadKey.id,
+        currentReadKey.secret,
       );
+
+      for (const keyID of this.getWriteOnlyKeys()) {
+        const secret = this.core.getReadKey(keyID);
+
+        if (!secret) {
+          console.error("Can't find key", keyID);
+          continue;
+        }
+
+        this.storeKeyRevelationForMember(memberKey, agent, keyID, secret);
+      }
     }
+  }
+
+  private storeKeyRevelationForMember(
+    memberKey: RawAccountID | AgentID,
+    agent: AgentID,
+    keyID: KeyID,
+    secret: KeySecret,
+  ) {
+    this.set(
+      `${keyID}_for_${memberKey}`,
+      this.core.crypto.seal({
+        message: secret,
+        from: this.core.node.account.currentSealerSecret(),
+        to: this.core.crypto.getAgentSealerID(agent),
+        nOnceMaterial: {
+          in: this.id,
+          tx: this.core.nextTransactionID(),
+        },
+      }),
+      "trusting",
+    );
+  }
+
+  private getWriteOnlyKeys() {
+    const keys: KeyID[] = [];
+
+    for (const key of this.keys()) {
+      if (key.startsWith("writeKeyFor_")) {
+        keys.push(
+          this.get(key as `writeKeyFor_${RawAccountID | AgentID}`) as KeyID,
+        );
+      }
+    }
+
+    return keys;
+  }
+
+  getCurrentKeyReadId() {
+    if (this.myRole() === "writeOnly") {
+      const accountId = this.core.node.account.id;
+
+      return this.get(`writeKeyFor_${accountId}`) as KeyID;
+    }
+
+    return this.get("readKey");
+  }
+
+  getMemberKeys(): (RawAccountID | AgentID)[] {
+    return this.keys().filter((key): key is RawAccountID | AgentID => {
+      return key.startsWith("co_") || isAgentID(key);
+    });
   }
 
   /** @internal */
   rotateReadKey() {
-    const currentlyPermittedReaders = this.keys().filter((key) => {
-      if (key.startsWith("co_") || isAgentID(key)) {
-        const role = this.get(key);
-        return role === "admin" || role === "writer" || role === "reader";
-      } else {
-        return false;
-      }
-    }) as (RawAccountID | AgentID)[];
+    const memberKeys = this.getMemberKeys();
+
+    const currentlyPermittedReaders = memberKeys.filter((key) => {
+      const role = this.get(key);
+      return (
+        role === "admin" ||
+        role === "writer" ||
+        role === "reader" ||
+        role === "adminInvite" ||
+        role === "writerInvite" ||
+        role === "readerInvite"
+      );
+    });
+
+    const writeOnlyMembers = memberKeys.filter((key) => {
+      const role = this.get(key);
+      return role === "writeOnly" || role === "writeOnlyInvite";
+    });
 
     // Get these early, so we fail fast if they are unavailable
     const parentGroups = this.getParentGroups();
@@ -293,26 +419,52 @@ export class RawGroup<
     const newReadKey = this.core.crypto.newRandomKeySecret();
 
     for (const readerID of currentlyPermittedReaders) {
-      const reader = this.core.node
+      const agent = this.core.node
         .resolveAccountAgent(
           readerID,
           "Expected to know currently permitted reader",
         )
         ._unsafeUnwrap({ withStackTrace: true });
 
-      this.set(
-        `${newReadKey.id}_for_${readerID}`,
-        this.core.crypto.seal({
-          message: newReadKey.secret,
-          from: this.core.node.account.currentSealerSecret(),
-          to: this.core.crypto.getAgentSealerID(reader),
-          nOnceMaterial: {
-            in: this.id,
-            tx: this.core.nextTransactionID(),
-          },
-        }),
-        "trusting",
+      this.storeKeyRevelationForMember(
+        readerID,
+        agent,
+        newReadKey.id,
+        newReadKey.secret,
       );
+    }
+
+    for (const writeOnlyMemberID of writeOnlyMembers) {
+      const agent = this.core.node
+        .resolveAccountAgent(
+          writeOnlyMemberID,
+          "Expected to know writeOnly member",
+        )
+        ._unsafeUnwrap({ withStackTrace: true });
+      const writeOnlyKey = this.core.crypto.newRandomKeySecret();
+      this.storeKeyRevelationForMember(
+        writeOnlyMemberID,
+        agent,
+        writeOnlyKey.id,
+        writeOnlyKey.secret,
+      );
+      this.set(`writeKeyFor_${writeOnlyMemberID}`, writeOnlyKey.id, "trusting");
+
+      for (const readerID of currentlyPermittedReaders) {
+        const agent = this.core.node
+          .resolveAccountAgent(
+            readerID,
+            "Expected to know currently permitted reader",
+          )
+          ._unsafeUnwrap({ withStackTrace: true });
+
+        this.storeKeyRevelationForMember(
+          readerID,
+          agent,
+          writeOnlyKey.id,
+          writeOnlyKey.secret,
+        );
+      }
     }
 
     this.set(
@@ -426,7 +578,7 @@ export class RawGroup<
    *
    * @category 2. Role changing
    */
-  createInvite(role: "reader" | "writer" | "admin"): InviteSecret {
+  createInvite(role: AccountRole): InviteSecret {
     const secretSeed = this.core.crypto.newRandomSecretSeed();
 
     const inviteSecret = this.core.crypto.agentSecretFromSecretSeed(secretSeed);
@@ -562,7 +714,7 @@ function isMorePermissiveAndShouldInherit(
   }
 
   if (roleInParent === "reader") {
-    return !roleInChild;
+    return !roleInChild || roleInChild === "writeOnly";
   }
 
   return false;

--- a/packages/cojson/src/coValues/group.ts
+++ b/packages/cojson/src/coValues/group.ts
@@ -251,7 +251,7 @@ export class RawGroup<
     /**
      * WriteOnly members can only see their own changes.
      *
-     * We don't want to reveal the readKey to them so we create a new one and reveal it
+     * We don't want to reveal the readKey to them so we create a new one specifically for them and also reveal it to everyone else with a reader or higher-capability role (but crucially not to other writer-only members)
      * to everyone else.
      *
      * To never reveal the readKey to writeOnly members we also create a dedicated writeKey for the

--- a/packages/cojson/src/coValues/group.ts
+++ b/packages/cojson/src/coValues/group.ts
@@ -719,7 +719,9 @@ function isMorePermissiveAndShouldInherit(
   }
 
   if (roleInParent === "writer") {
-    return !roleInChild || roleInChild === "reader";
+    return (
+      !roleInChild || roleInChild === "reader" || roleInChild === "writeOnly"
+    );
   }
 
   if (roleInParent === "reader") {

--- a/packages/cojson/src/localNode.ts
+++ b/packages/cojson/src/localNode.ts
@@ -387,7 +387,8 @@ export class LocalNode {
       existingRole === "admin" ||
       (existingRole === "writer" && inviteRole === "writerInvite") ||
       (existingRole === "writer" && inviteRole === "reader") ||
-      (existingRole === "reader" && inviteRole === "readerInvite")
+      (existingRole === "reader" && inviteRole === "readerInvite") ||
+      (existingRole && inviteRole === "writeOnlyInvite")
     ) {
       console.debug(
         "Not accepting invite that would replace or downgrade role",
@@ -410,7 +411,9 @@ export class LocalNode {
         ? "admin"
         : inviteRole === "writerInvite"
           ? "writer"
-          : "reader",
+          : inviteRole === "writeOnlyInvite"
+            ? "writeOnly"
+            : "reader",
     );
 
     group.core._sessionLogs = groupAsInvite.core.sessionLogs;

--- a/packages/cojson/src/permissions.ts
+++ b/packages/cojson/src/permissions.ts
@@ -266,6 +266,11 @@ function determineValidTransactionsForGroup(
         continue;
       }
 
+      /**
+       * We don't want to give the ability to invite members to override
+       * key revelations, otherwise they could hide a key revelation to any user
+       * blocking them from accessing the group.
+       */
       if (
         keyRevelations.has(change.key) &&
         memberState[transactor] !== "admin"
@@ -305,6 +310,14 @@ function determineValidTransactionsForGroup(
         continue;
       }
 
+      /**
+       * writeOnlyInvite need to be able to set writeKeys because every new writeOnly
+       * member comes with their own write key.
+       *
+       * We don't want to give the ability to invite members to override
+       * write keys, otherwise they could hide a write key to other writeOnly users
+       * blocking them from accessing the group.ß
+       */
       if (writeKeys.has(change.key) && memberState[transactor] !== "admin") {
         console.warn(
           "Write key already exists and can't be overridden by invite",

--- a/packages/cojson/src/permissions.ts
+++ b/packages/cojson/src/permissions.ts
@@ -22,14 +22,15 @@ export type PermissionsDef =
   | { type: "ownedByGroup"; group: RawCoID }
   | { type: "unsafeAllowAll" };
 
+export type AccountRole = "reader" | "writer" | "admin" | "writeOnly";
+
 export type Role =
-  | "reader"
-  | "writer"
-  | "admin"
+  | AccountRole
   | "revoked"
   | "adminInvite"
   | "writerInvite"
-  | "readerInvite";
+  | "readerInvite"
+  | "writeOnlyInvite";
 
 type ValidTransactionsResult = { txID: TransactionID; tx: Transaction };
 type MemberState = { [agent: RawAccountID | AgentID]: Role; [EVERYONE]?: Role };
@@ -81,7 +82,8 @@ export function determineValidTransactions(
 
         if (
           transactorRoleAtTxTime !== "admin" &&
-          transactorRoleAtTxTime !== "writer"
+          transactorRoleAtTxTime !== "writer" &&
+          transactorRoleAtTxTime !== "writeOnly"
         ) {
           return;
         }
@@ -177,6 +179,9 @@ function determineValidTransactionsForGroup(
   const memberState: MemberState = {};
   const validTransactions: ValidTransactionsResult[] = [];
 
+  const keyRevelations = new Set<string>();
+  const writeKeys = new Set<string>();
+
   for (const { sessionID, txIndex, tx } of allTransactionsSorted) {
     // console.log("before", { memberState, validTransactions });
     const transactor = accountOrAgentIDfromSessionID(sessionID);
@@ -254,14 +259,26 @@ function determineValidTransactionsForGroup(
         memberState[transactor] !== "admin" &&
         memberState[transactor] !== "adminInvite" &&
         memberState[transactor] !== "writerInvite" &&
-        memberState[transactor] !== "readerInvite"
+        memberState[transactor] !== "readerInvite" &&
+        memberState[transactor] !== "writeOnlyInvite"
       ) {
         console.warn("Only admins can reveal keys");
         continue;
       }
 
-      // TODO: check validity of agents who the key is revealed to?
+      if (
+        keyRevelations.has(change.key) &&
+        memberState[transactor] !== "admin"
+      ) {
+        console.warn(
+          "Key revelation already exists and can't be overridden by invite",
+        );
+        continue;
+      }
 
+      keyRevelations.add(change.key);
+
+      // TODO: check validity of agents who the key is revealed to?
       validTransactions.push({ txID: { sessionID, txIndex }, tx });
       continue;
     } else if (isParentExtension(change.key)) {
@@ -279,6 +296,26 @@ function determineValidTransactionsForGroup(
       }
       validTransactions.push({ txID: { sessionID, txIndex }, tx });
       continue;
+    } else if (isWriteKeyForMember(change.key)) {
+      if (
+        memberState[transactor] !== "admin" &&
+        memberState[transactor] !== "writeOnlyInvite"
+      ) {
+        console.warn("Only admins can set writeKeys");
+        continue;
+      }
+
+      if (writeKeys.has(change.key) && memberState[transactor] !== "admin") {
+        console.warn(
+          "Write key already exists and can't be overridden by invite",
+        );
+        continue;
+      }
+
+      writeKeys.add(change.key);
+
+      validTransactions.push({ txID: { sessionID, txIndex }, tx });
+      continue;
     }
 
     const affectedMember = change.key;
@@ -288,10 +325,12 @@ function determineValidTransactionsForGroup(
       change.value !== "admin" &&
       change.value !== "writer" &&
       change.value !== "reader" &&
+      change.value !== "writeOnly" &&
       change.value !== "revoked" &&
       change.value !== "adminInvite" &&
       change.value !== "writerInvite" &&
-      change.value !== "readerInvite"
+      change.value !== "readerInvite" &&
+      change.value !== "writeOnlyInvite"
     ) {
       console.warn("Group transaction must set a valid role");
       continue;
@@ -341,6 +380,11 @@ function determineValidTransactionsForGroup(
           console.warn("ReaderInvites can only create reader.");
           continue;
         }
+      } else if (memberState[transactor] === "writeOnlyInvite") {
+        if (change.value !== "writeOnly") {
+          console.warn("WriteOnlyInvites can only create writeOnly.");
+          continue;
+        }
       } else {
         console.warn(
           "Group transaction must be made by current admin or invite",
@@ -375,6 +419,12 @@ function agentInAccountOrMemberInGroup(
     );
   }
   return transactor;
+}
+
+export function isWriteKeyForMember(
+  co: string,
+): co is `writeKeyFor_${RawAccountID | AgentID}` {
+  return co.startsWith("writeKeyFor_");
 }
 
 export function isKeyForKeyField(co: string): co is `${KeyID}_for_${KeyID}` {

--- a/packages/cojson/src/tests/group.test.ts
+++ b/packages/cojson/src/tests/group.test.ts
@@ -60,8 +60,11 @@ test("Can create a FileStream in a group", () => {
 });
 
 test("Remove a member from a group where the admin role is inherited", async () => {
-  const { node1, node2, node3, node1ToNode2Peer, node2ToNode3Peer } =
-    await createThreeConnectedNodes("server", "server", "server");
+  const { node1, node2, node3 } = await createThreeConnectedNodes(
+    "server",
+    "server",
+    "server",
+  );
 
   const group = node1.node.createGroup();
 
@@ -112,8 +115,11 @@ test("Remove a member from a group where the admin role is inherited", async () 
 });
 
 test("An admin should be able to rotate the readKey on child groups and keep access to new coValues", async () => {
-  const { node1, node2, node3, node1ToNode2Peer, node2ToNode1Peer } =
-    await createThreeConnectedNodes("server", "server", "server");
+  const { node1, node2, node3 } = await createThreeConnectedNodes(
+    "server",
+    "server",
+    "server",
+  );
 
   const group = node1.node.createGroup();
 
@@ -152,8 +158,11 @@ test("An admin should be able to rotate the readKey on child groups and keep acc
 });
 
 test("An admin should be able to rotate the readKey on child groups even if it was unavailable when kicking out a member from a parent group", async () => {
-  const { node1, node2, node3, node1ToNode2Peer, node2ToNode1Peer } =
-    await createThreeConnectedNodes("server", "server", "server");
+  const { node1, node2, node3 } = await createThreeConnectedNodes(
+    "server",
+    "server",
+    "server",
+  );
 
   const group = node1.node.createGroup();
 
@@ -190,8 +199,11 @@ test("An admin should be able to rotate the readKey on child groups even if it w
 });
 
 test("An admin should be able to rotate the readKey on child groups even if it was unavailable when kicking out a member from a parent group (grandChild)", async () => {
-  const { node1, node2, node3, node1ToNode2Peer } =
-    await createThreeConnectedNodes("server", "server", "server");
+  const { node1, node2, node3 } = await createThreeConnectedNodes(
+    "server",
+    "server",
+    "server",
+  );
 
   const group = node1.node.createGroup();
 
@@ -231,8 +243,11 @@ test("An admin should be able to rotate the readKey on child groups even if it w
 });
 
 test("A user add after a key rotation should have access to the old transactions", async () => {
-  const { node1, node2, node3, node1ToNode2Peer, node2ToNode1Peer } =
-    await createThreeConnectedNodes("server", "server", "server");
+  const { node1, node2, node3 } = await createThreeConnectedNodes(
+    "server",
+    "server",
+    "server",
+  );
 
   const group = node1.node.createGroup();
 
@@ -263,8 +278,11 @@ test("A user add after a key rotation should have access to the old transactions
 });
 
 test("Invites should have access to the new keys", async () => {
-  const { node1, node2, node3, node1ToNode2Peer } =
-    await createThreeConnectedNodes("server", "server", "server");
+  const { node1, node2, node3 } = await createThreeConnectedNodes(
+    "server",
+    "server",
+    "server",
+  );
 
   const group = node1.node.createGroup();
   group.addMember(
@@ -302,8 +320,11 @@ describe("writeOnly", () => {
   });
 
   test("Edits by writeOnly members are visible to other members", async () => {
-    const { node1, node2, node3, node1ToNode2Peer, node2ToNode1Peer } =
-      await createThreeConnectedNodes("server", "server", "server");
+    const { node1, node2, node3 } = await createThreeConnectedNodes(
+      "server",
+      "server",
+      "server",
+    );
 
     const group = node1.node.createGroup();
 
@@ -334,10 +355,7 @@ describe("writeOnly", () => {
   });
 
   test("Edits by other members are not visible to writeOnly members", async () => {
-    const { node1, node2, node1ToNode2Peer } = await createTwoConnectedNodes(
-      "server",
-      "server",
-    );
+    const { node1, node2 } = await createTwoConnectedNodes("server", "server");
 
     const group = node1.node.createGroup();
 
@@ -355,14 +373,11 @@ describe("writeOnly", () => {
   });
 
   test("Write only member keys are rotated when a member is kicked out", async () => {
-    const {
-      node1,
-      node2,
-      node3,
-      node1ToNode2Peer,
-      node2ToNode1Peer,
-      node2ToNode3Peer,
-    } = await createThreeConnectedNodes("server", "server", "server");
+    const { node1, node2, node3 } = await createThreeConnectedNodes(
+      "server",
+      "server",
+      "server",
+    );
 
     const group = node1.node.createGroup();
 

--- a/packages/cojson/src/tests/group.test.ts
+++ b/packages/cojson/src/tests/group.test.ts
@@ -1,4 +1,4 @@
-import { expect, test } from "vitest";
+import { describe, expect, test } from "vitest";
 import { RawCoList } from "../coValues/coList.js";
 import { RawCoMap } from "../coValues/coMap.js";
 import { RawCoStream } from "../coValues/coStream.js";
@@ -7,6 +7,7 @@ import { WasmCrypto } from "../crypto/WasmCrypto.js";
 import { LocalNode } from "../localNode.js";
 import {
   createThreeConnectedNodes,
+  createTwoConnectedNodes,
   loadCoValueOrFail,
   randomAnonymousAccountAndSessionID,
 } from "./testUtils.js";
@@ -60,32 +61,40 @@ test("Can create a FileStream in a group", () => {
 
 test("Remove a member from a group where the admin role is inherited", async () => {
   const { node1, node2, node3, node1ToNode2Peer, node2ToNode3Peer } =
-    createThreeConnectedNodes("server", "server", "server");
+    await createThreeConnectedNodes("server", "server", "server");
 
-  const group = node1.createGroup();
+  const group = node1.node.createGroup();
 
-  group.addMember(node2.account, "admin");
-  group.addMember(node3.account, "reader");
+  group.addMember(
+    await loadCoValueOrFail(node1.node, node2.accountID),
+    "admin",
+  );
+  group.addMember(
+    await loadCoValueOrFail(node1.node, node3.accountID),
+    "reader",
+  );
 
-  const groupOnNode2 = await loadCoValueOrFail(node2, group.id);
+  await group.core.waitForSync();
+
+  const groupOnNode2 = await loadCoValueOrFail(node2.node, group.id);
 
   // The account of node2 create a child group and extend the initial group
   // This way the node1 account should become "admin" of the child group
   // by inheriting the admin role from the initial group
-  const childGroup = node2.createGroup();
+  const childGroup = node2.node.createGroup();
   childGroup.extend(groupOnNode2);
 
   const map = childGroup.createMap();
   map.set("test", "Available to everyone");
 
-  const mapOnNode3 = await loadCoValueOrFail(node3, map.id);
+  const mapOnNode3 = await loadCoValueOrFail(node3.node, map.id);
 
   // Check that the sync between node2 and node3 worked
   expect(mapOnNode3.get("test")).toEqual("Available to everyone");
 
   // The node1 account removes the reader from the group
   // The reader should be automatically kicked out of the child group
-  await group.removeMember(node3.account);
+  await group.removeMember(node3.node.account);
 
   await group.core.waitForSync();
 
@@ -97,26 +106,34 @@ test("Remove a member from a group where the admin role is inherited", async () 
   // Check that the value has not been updated on node3
   expect(mapOnNode3.get("test")).toEqual("Available to everyone");
 
-  const mapOnNode1 = await loadCoValueOrFail(node1, map.id);
+  const mapOnNode1 = await loadCoValueOrFail(node1.node, map.id);
 
   expect(mapOnNode1.get("test")).toEqual("Hidden to node3");
 });
 
 test("An admin should be able to rotate the readKey on child groups and keep access to new coValues", async () => {
   const { node1, node2, node3, node1ToNode2Peer, node2ToNode1Peer } =
-    createThreeConnectedNodes("server", "server", "server");
+    await createThreeConnectedNodes("server", "server", "server");
 
-  const group = node1.createGroup();
+  const group = node1.node.createGroup();
 
-  group.addMember(node2.account, "admin");
-  group.addMember(node3.account, "reader");
+  group.addMember(
+    await loadCoValueOrFail(node1.node, node2.accountID),
+    "admin",
+  );
+  group.addMember(
+    await loadCoValueOrFail(node1.node, node3.accountID),
+    "reader",
+  );
 
-  const groupOnNode2 = await loadCoValueOrFail(node2, group.id);
+  await group.core.waitForSync();
+
+  const groupOnNode2 = await loadCoValueOrFail(node2.node, group.id);
 
   // The account of node2 create a child group and extend the initial group
   // This way the node1 account should become "admin" of the child group
   // by inheriting the admin role from the initial group
-  const childGroup = node2.createGroup();
+  const childGroup = node2.node.createGroup();
   childGroup.extend(groupOnNode2);
 
   await childGroup.core.waitForSync();
@@ -124,78 +141,261 @@ test("An admin should be able to rotate the readKey on child groups and keep acc
   // The node1 account removes the reader from the group
   // In this case we want to ensure that node1 is still able to read new coValues
   // Even if some childs are not available when the readKey is rotated
-  await group.removeMember(node3.account);
+  await group.removeMember(node3.node.account);
   await group.core.waitForSync();
 
   const map = childGroup.createMap();
   map.set("test", "Available to node1");
 
-  const mapOnNode1 = await loadCoValueOrFail(node1, map.id);
+  const mapOnNode1 = await loadCoValueOrFail(node1.node, map.id);
   expect(mapOnNode1.get("test")).toEqual("Available to node1");
 });
 
 test("An admin should be able to rotate the readKey on child groups even if it was unavailable when kicking out a member from a parent group", async () => {
   const { node1, node2, node3, node1ToNode2Peer, node2ToNode1Peer } =
-    createThreeConnectedNodes("server", "server", "server");
+    await createThreeConnectedNodes("server", "server", "server");
 
-  const group = node1.createGroup();
+  const group = node1.node.createGroup();
 
-  group.addMember(node2.account, "admin");
-  group.addMember(node3.account, "reader");
+  group.addMember(
+    await loadCoValueOrFail(node1.node, node2.accountID),
+    "admin",
+  );
+  group.addMember(
+    await loadCoValueOrFail(node1.node, node3.accountID),
+    "reader",
+  );
 
-  const groupOnNode2 = await loadCoValueOrFail(node2, group.id);
+  await group.core.waitForSync();
+
+  const groupOnNode2 = await loadCoValueOrFail(node2.node, group.id);
 
   // The account of node2 create a child group and extend the initial group
   // This way the node1 account should become "admin" of the child group
   // by inheriting the admin role from the initial group
-  const childGroup = node2.createGroup();
+  const childGroup = node2.node.createGroup();
   childGroup.extend(groupOnNode2);
 
   // The node1 account removes the reader from the group
   // In this case we want to ensure that node1 is still able to read new coValues
   // Even if some childs are not available when the readKey is rotated
-  await group.removeMember(node3.account);
+  await group.removeMember(node3.node.account);
   await group.core.waitForSync();
 
   const map = childGroup.createMap();
   map.set("test", "Available to node1");
 
-  const mapOnNode1 = await loadCoValueOrFail(node1, map.id);
+  const mapOnNode1 = await loadCoValueOrFail(node1.node, map.id);
   expect(mapOnNode1.get("test")).toEqual("Available to node1");
 });
 
 test("An admin should be able to rotate the readKey on child groups even if it was unavailable when kicking out a member from a parent group (grandChild)", async () => {
-  const { node1, node2, node3, node1ToNode2Peer } = createThreeConnectedNodes(
-    "server",
-    "server",
-    "server",
+  const { node1, node2, node3, node1ToNode2Peer } =
+    await createThreeConnectedNodes("server", "server", "server");
+
+  const group = node1.node.createGroup();
+
+  group.addMember(
+    await loadCoValueOrFail(node1.node, node2.accountID),
+    "admin",
+  );
+  group.addMember(
+    await loadCoValueOrFail(node1.node, node3.accountID),
+    "reader",
   );
 
-  const group = node1.createGroup();
+  await group.core.waitForSync();
 
-  group.addMember(node2.account, "admin");
-  group.addMember(node3.account, "reader");
-
-  const groupOnNode2 = await loadCoValueOrFail(node2, group.id);
+  const groupOnNode2 = await loadCoValueOrFail(node2.node, group.id);
 
   // The account of node2 create a child group and extend the initial group
   // This way the node1 account should become "admin" of the child group
   // by inheriting the admin role from the initial group
-  const childGroup = node2.createGroup();
+  const childGroup = node2.node.createGroup();
   childGroup.extend(groupOnNode2);
-  const grandChildGroup = node2.createGroup();
+  const grandChildGroup = node2.node.createGroup();
   grandChildGroup.extend(childGroup);
 
   // The node1 account removes the reader from the group
   // In this case we want to ensure that node1 is still able to read new coValues
   // Even if some childs are not available when the readKey is rotated
-  await group.removeMember(node3.account);
+  await group.removeMember(node3.node.account);
   await group.core.waitForSync();
 
   const map = childGroup.createMap();
   map.set("test", "Available to node1");
 
-  const mapOnNode1 = await loadCoValueOrFail(node1, map.id);
+  const mapOnNode1 = await loadCoValueOrFail(node1.node, map.id);
 
   expect(mapOnNode1.get("test")).toEqual("Available to node1");
+});
+
+test("A user add after a key rotation should have access to the old transactions", async () => {
+  const { node1, node2, node3, node1ToNode2Peer, node2ToNode1Peer } =
+    await createThreeConnectedNodes("server", "server", "server");
+
+  const group = node1.node.createGroup();
+
+  group.addMember(
+    await loadCoValueOrFail(node1.node, node2.accountID),
+    "writer",
+  );
+
+  await group.core.waitForSync();
+
+  const groupOnNode2 = await loadCoValueOrFail(node2.node, group.id);
+
+  const map = groupOnNode2.createMap();
+  map.set("test", "Written from node2");
+
+  await map.core.waitForSync();
+
+  await group.removeMember(node3.node.account);
+  group.addMember(
+    await loadCoValueOrFail(node1.node, node3.accountID),
+    "reader",
+  );
+
+  await group.core.waitForSync();
+
+  const mapOnNode3 = await loadCoValueOrFail(node3.node, map.id);
+  expect(mapOnNode3.get("test")).toEqual("Written from node2");
+});
+
+test("Invites should have access to the new keys", async () => {
+  const { node1, node2, node3, node1ToNode2Peer } =
+    await createThreeConnectedNodes("server", "server", "server");
+
+  const group = node1.node.createGroup();
+  group.addMember(
+    await loadCoValueOrFail(node1.node, node3.accountID),
+    "reader",
+  );
+
+  const invite = group.createInvite("admin");
+
+  await group.removeMember(node3.node.account);
+
+  const map = group.createMap();
+  map.set("test", "Written from node1");
+
+  await map.core.waitForSync();
+
+  await node2.node.acceptInvite(group.id, invite);
+
+  const mapOnNode2 = await loadCoValueOrFail(node2.node, map.id);
+  expect(mapOnNode2.get("test")).toEqual("Written from node1");
+});
+
+describe("writeOnly", () => {
+  test("Admins can invite writeOnly members", async () => {
+    const { node1, node2 } = await createTwoConnectedNodes("server", "server");
+
+    const group = node1.node.createGroup();
+
+    const invite = group.createInvite("writeOnly");
+
+    await node2.node.acceptInvite(group.id, invite);
+
+    const groupOnNode2 = await loadCoValueOrFail(node2.node, group.id);
+    expect(groupOnNode2.myRole()).toEqual("writeOnly");
+  });
+
+  test("Edits by writeOnly members are visible to other members", async () => {
+    const { node1, node2, node3, node1ToNode2Peer, node2ToNode1Peer } =
+      await createThreeConnectedNodes("server", "server", "server");
+
+    const group = node1.node.createGroup();
+
+    group.addMember(
+      await loadCoValueOrFail(node1.node, node2.accountID),
+      "writeOnly",
+    );
+    group.addMember(
+      await loadCoValueOrFail(node1.node, node3.accountID),
+      "reader",
+    );
+
+    await group.core.waitForSync();
+
+    const groupOnNode2 = await loadCoValueOrFail(node2.node, group.id);
+    const map = groupOnNode2.createMap();
+
+    map.set("test", "Written from a writeOnly member");
+    expect(map.get("test")).toEqual("Written from a writeOnly member");
+
+    await map.core.waitForSync();
+
+    const mapOnNode1 = await loadCoValueOrFail(node1.node, map.id);
+    expect(mapOnNode1.get("test")).toEqual("Written from a writeOnly member");
+
+    const mapOnNode3 = await loadCoValueOrFail(node3.node, map.id);
+    expect(mapOnNode3.get("test")).toEqual("Written from a writeOnly member");
+  });
+
+  test("Edits by other members are not visible to writeOnly members", async () => {
+    const { node1, node2, node1ToNode2Peer } = await createTwoConnectedNodes(
+      "server",
+      "server",
+    );
+
+    const group = node1.node.createGroup();
+
+    group.addMember(
+      await loadCoValueOrFail(node1.node, node2.accountID),
+      "writeOnly",
+    );
+    const map = group.createMap();
+    map.set("test", "Written from the admin");
+
+    await map.core.waitForSync();
+
+    const mapOnNode2 = await loadCoValueOrFail(node2.node, map.id);
+    expect(mapOnNode2.get("test")).toEqual(undefined);
+  });
+
+  test("Write only member keys are rotated when a member is kicked out", async () => {
+    const {
+      node1,
+      node2,
+      node3,
+      node1ToNode2Peer,
+      node2ToNode1Peer,
+      node2ToNode3Peer,
+    } = await createThreeConnectedNodes("server", "server", "server");
+
+    const group = node1.node.createGroup();
+
+    group.addMember(
+      await loadCoValueOrFail(node1.node, node2.accountID),
+      "writeOnly",
+    );
+    group.addMember(
+      await loadCoValueOrFail(node1.node, node3.accountID),
+      "reader",
+    );
+
+    await group.core.waitForSync();
+
+    const groupOnNode2 = await loadCoValueOrFail(node2.node, group.id);
+    const map = groupOnNode2.createMap();
+
+    map.set("test", "Written from a writeOnly member");
+
+    await map.core.waitForSync();
+
+    await group.removeMember(node3.node.account);
+
+    await group.core.waitForSync();
+
+    map.set("test", "Updated after key rotation");
+
+    await map.core.waitForSync();
+
+    const mapOnNode1 = await loadCoValueOrFail(node1.node, map.id);
+    expect(mapOnNode1.get("test")).toEqual("Updated after key rotation");
+
+    const mapOnNode3 = await loadCoValueOrFail(node3.node, map.id);
+    expect(mapOnNode3.get("test")).toEqual("Written from a writeOnly member");
+  });
 });

--- a/packages/cojson/src/tests/permissions.test.ts
+++ b/packages/cojson/src/tests/permissions.test.ts
@@ -1574,6 +1574,330 @@ test("ReaderInvites can not invite writers", () => {
   expect(groupAsInvite.get(invitedWriterID)).toBeUndefined();
 });
 
+test("WriteOnlyInvites can not invite writers", () => {
+  const { groupCore, admin } = newGroup();
+
+  const inviteSecret = Crypto.newRandomAgentSecret();
+  const inviteID = Crypto.getAgentID(inviteSecret);
+
+  const group = expectGroup(groupCore.getCurrentContent());
+
+  const { secret: readKey, id: readKeyID } = Crypto.newRandomKeySecret();
+  const revelation = Crypto.seal({
+    message: readKey,
+    from: admin.currentSealerSecret(),
+    to: admin.currentSealerID()._unsafeUnwrap(),
+    nOnceMaterial: {
+      in: groupCore.id,
+      tx: groupCore.nextTransactionID(),
+    },
+  });
+
+  group.set(`${readKeyID}_for_${admin.id}`, revelation, "trusting");
+  group.set("readKey", readKeyID, "trusting");
+
+  group.set(inviteID, "writeOnlyInvite", "trusting");
+
+  expect(group.get(inviteID)).toEqual("writeOnlyInvite");
+
+  const revelationForInvite = Crypto.seal({
+    message: readKey,
+    from: admin.currentSealerSecret(),
+    to: Crypto.getAgentSealerID(inviteID),
+    nOnceMaterial: {
+      in: groupCore.id,
+      tx: groupCore.nextTransactionID(),
+    },
+  });
+
+  group.set(`${readKeyID}_for_${inviteID}`, revelationForInvite, "trusting");
+
+  const groupAsInvite = expectGroup(
+    groupCore
+      .testWithDifferentAccount(
+        new ControlledAgent(inviteSecret, Crypto),
+        Crypto.newRandomSessionID(inviteID),
+      )
+      .getCurrentContent(),
+  );
+
+  const invitedWriterSecret = Crypto.newRandomAgentSecret();
+  const invitedWriterID = Crypto.getAgentID(invitedWriterSecret);
+
+  groupAsInvite.set(invitedWriterID, "writer", "trusting");
+  expect(groupAsInvite.get(invitedWriterID)).toBeUndefined();
+});
+
+test("WriteOnlyInvites can not invite admins", () => {
+  const { groupCore, admin } = newGroup();
+
+  const inviteSecret = Crypto.newRandomAgentSecret();
+  const inviteID = Crypto.getAgentID(inviteSecret);
+
+  const group = expectGroup(groupCore.getCurrentContent());
+
+  const { secret: readKey, id: readKeyID } = Crypto.newRandomKeySecret();
+  const revelation = Crypto.seal({
+    message: readKey,
+    from: admin.currentSealerSecret(),
+    to: admin.currentSealerID()._unsafeUnwrap(),
+    nOnceMaterial: {
+      in: groupCore.id,
+      tx: groupCore.nextTransactionID(),
+    },
+  });
+
+  group.set(`${readKeyID}_for_${admin.id}`, revelation, "trusting");
+  group.set("readKey", readKeyID, "trusting");
+
+  group.set(inviteID, "writeOnlyInvite", "trusting");
+
+  expect(group.get(inviteID)).toEqual("writeOnlyInvite");
+
+  const revelationForInvite = Crypto.seal({
+    message: readKey,
+    from: admin.currentSealerSecret(),
+    to: Crypto.getAgentSealerID(inviteID),
+    nOnceMaterial: {
+      in: groupCore.id,
+      tx: groupCore.nextTransactionID(),
+    },
+  });
+
+  group.set(`${readKeyID}_for_${inviteID}`, revelationForInvite, "trusting");
+
+  const groupAsInvite = expectGroup(
+    groupCore
+      .testWithDifferentAccount(
+        new ControlledAgent(inviteSecret, Crypto),
+        Crypto.newRandomSessionID(inviteID),
+      )
+      .getCurrentContent(),
+  );
+
+  const invitedWriterSecret = Crypto.newRandomAgentSecret();
+  const invitedWriterID = Crypto.getAgentID(invitedWriterSecret);
+
+  groupAsInvite.set(invitedWriterID, "admin", "trusting");
+  expect(groupAsInvite.get(invitedWriterID)).toBeUndefined();
+});
+
+test("WriteOnlyInvites can invite writeOnly", () => {
+  const { groupCore, admin } = newGroup();
+
+  const inviteSecret = Crypto.newRandomAgentSecret();
+  const inviteID = Crypto.getAgentID(inviteSecret);
+
+  const group = expectGroup(groupCore.getCurrentContent());
+
+  const { secret: readKey, id: readKeyID } = Crypto.newRandomKeySecret();
+  const revelation = Crypto.seal({
+    message: readKey,
+    from: admin.currentSealerSecret(),
+    to: admin.currentSealerID()._unsafeUnwrap(),
+    nOnceMaterial: {
+      in: groupCore.id,
+      tx: groupCore.nextTransactionID(),
+    },
+  });
+
+  group.set(`${readKeyID}_for_${admin.id}`, revelation, "trusting");
+  group.set("readKey", readKeyID, "trusting");
+
+  group.set(inviteID, "writeOnlyInvite", "trusting");
+
+  expect(group.get(inviteID)).toEqual("writeOnlyInvite");
+
+  const revelationForInvite = Crypto.seal({
+    message: readKey,
+    from: admin.currentSealerSecret(),
+    to: Crypto.getAgentSealerID(inviteID),
+    nOnceMaterial: {
+      in: groupCore.id,
+      tx: groupCore.nextTransactionID(),
+    },
+  });
+
+  group.set(`${readKeyID}_for_${inviteID}`, revelationForInvite, "trusting");
+
+  const groupAsInvite = expectGroup(
+    groupCore
+      .testWithDifferentAccount(
+        new ControlledAgent(inviteSecret, Crypto),
+        Crypto.newRandomSessionID(inviteID),
+      )
+      .getCurrentContent(),
+  );
+
+  const invitedWriterSecret = Crypto.newRandomAgentSecret();
+  const invitedWriterID = Crypto.getAgentID(invitedWriterSecret);
+
+  groupAsInvite.set(invitedWriterID, "writeOnly", "trusting");
+  expect(groupAsInvite.get(invitedWriterID)).toEqual("writeOnly");
+});
+
+test("WriteOnlyInvites can set writeKeys", () => {
+  const { groupCore, admin } = newGroup();
+
+  const inviteSecret = Crypto.newRandomAgentSecret();
+  const inviteID = Crypto.getAgentID(inviteSecret);
+
+  const group = expectGroup(groupCore.getCurrentContent());
+
+  const { secret: readKey, id: readKeyID } = Crypto.newRandomKeySecret();
+  const revelation = Crypto.seal({
+    message: readKey,
+    from: admin.currentSealerSecret(),
+    to: admin.currentSealerID()._unsafeUnwrap(),
+    nOnceMaterial: {
+      in: groupCore.id,
+      tx: groupCore.nextTransactionID(),
+    },
+  });
+
+  group.set(`${readKeyID}_for_${admin.id}`, revelation, "trusting");
+  group.set("readKey", readKeyID, "trusting");
+
+  group.set(inviteID, "writeOnlyInvite", "trusting");
+
+  expect(group.get(inviteID)).toEqual("writeOnlyInvite");
+
+  const revelationForInvite = Crypto.seal({
+    message: readKey,
+    from: admin.currentSealerSecret(),
+    to: Crypto.getAgentSealerID(inviteID),
+    nOnceMaterial: {
+      in: groupCore.id,
+      tx: groupCore.nextTransactionID(),
+    },
+  });
+
+  group.set(`${readKeyID}_for_${inviteID}`, revelationForInvite, "trusting");
+
+  const groupAsInvite = expectGroup(
+    groupCore
+      .testWithDifferentAccount(
+        new ControlledAgent(inviteSecret, Crypto),
+        Crypto.newRandomSessionID(inviteID),
+      )
+      .getCurrentContent(),
+  );
+
+  groupAsInvite.set(`writeKeyFor_${admin.id}`, readKeyID, "trusting");
+  expect(groupAsInvite.get(`writeKeyFor_${admin.id}`)).toEqual(readKeyID);
+});
+
+test("Invites can't override key revelations", () => {
+  const { groupCore, admin } = newGroup();
+
+  const inviteSecret = Crypto.newRandomAgentSecret();
+  const inviteID = Crypto.getAgentID(inviteSecret);
+
+  const group = expectGroup(groupCore.getCurrentContent());
+
+  const { secret: readKey, id: readKeyID } = Crypto.newRandomKeySecret();
+  const revelation = Crypto.seal({
+    message: readKey,
+    from: admin.currentSealerSecret(),
+    to: admin.currentSealerID()._unsafeUnwrap(),
+    nOnceMaterial: {
+      in: groupCore.id,
+      tx: groupCore.nextTransactionID(),
+    },
+  });
+
+  group.set(`${readKeyID}_for_${admin.id}`, revelation, "trusting");
+  group.set("readKey", readKeyID, "trusting");
+
+  group.set(inviteID, "readerInvite", "trusting");
+
+  expect(group.get(inviteID)).toEqual("readerInvite");
+
+  const revelationForInvite = Crypto.seal({
+    message: readKey,
+    from: admin.currentSealerSecret(),
+    to: Crypto.getAgentSealerID(inviteID),
+    nOnceMaterial: {
+      in: groupCore.id,
+      tx: groupCore.nextTransactionID(),
+    },
+  });
+
+  group.set(`${readKeyID}_for_${inviteID}`, revelationForInvite, "trusting");
+
+  const groupAsInvite = expectGroup(
+    groupCore
+      .testWithDifferentAccount(
+        new ControlledAgent(inviteSecret, Crypto),
+        Crypto.newRandomSessionID(inviteID),
+      )
+      .getCurrentContent(),
+  );
+
+  groupAsInvite.set(
+    `${readKeyID}_for_${admin.id}`,
+    "Evil change" as any,
+    "trusting",
+  );
+  expect(groupAsInvite.get(`${readKeyID}_for_${admin.id}`)).toBe(revelation);
+});
+
+test("WriteOnlyInvites can't override writeKeys", () => {
+  const { groupCore, admin } = newGroup();
+
+  const inviteSecret = Crypto.newRandomAgentSecret();
+  const inviteID = Crypto.getAgentID(inviteSecret);
+
+  const group = expectGroup(groupCore.getCurrentContent());
+
+  const { secret: readKey, id: readKeyID } = Crypto.newRandomKeySecret();
+  const revelation = Crypto.seal({
+    message: readKey,
+    from: admin.currentSealerSecret(),
+    to: admin.currentSealerID()._unsafeUnwrap(),
+    nOnceMaterial: {
+      in: groupCore.id,
+      tx: groupCore.nextTransactionID(),
+    },
+  });
+
+  group.set(`${readKeyID}_for_${admin.id}`, revelation, "trusting");
+  group.set("readKey", readKeyID, "trusting");
+
+  group.set(inviteID, "writeOnlyInvite", "trusting");
+
+  expect(group.get(inviteID)).toEqual("writeOnlyInvite");
+
+  const revelationForInvite = Crypto.seal({
+    message: readKey,
+    from: admin.currentSealerSecret(),
+    to: Crypto.getAgentSealerID(inviteID),
+    nOnceMaterial: {
+      in: groupCore.id,
+      tx: groupCore.nextTransactionID(),
+    },
+  });
+
+  group.set(`${readKeyID}_for_${inviteID}`, revelationForInvite, "trusting");
+
+  const groupAsInvite = expectGroup(
+    groupCore
+      .testWithDifferentAccount(
+        new ControlledAgent(inviteSecret, Crypto),
+        Crypto.newRandomSessionID(inviteID),
+      )
+      .getCurrentContent(),
+  );
+
+  groupAsInvite.set(`writeKeyFor_${admin.id}`, readKeyID, "trusting");
+  groupAsInvite.set(
+    `writeKeyFor_${admin.id}`,
+    "Evil change" as any,
+    "trusting",
+  );
+  expect(groupAsInvite.get(`writeKeyFor_${admin.id}`)).toEqual(readKeyID);
+});
+
 test("Can give read permission to 'everyone'", () => {
   const { node, groupCore } = newGroup();
 

--- a/packages/cojson/src/tests/testUtils.ts
+++ b/packages/cojson/src/tests/testUtils.ts
@@ -67,17 +67,11 @@ export async function createTwoConnectedNodes(
   };
 }
 
-export function createThreeConnectedNodes(
+export async function createThreeConnectedNodes(
   node1Role: Peer["role"],
   node2Role: Peer["role"],
   node3Role: Peer["role"],
 ) {
-  // Setup nodes
-  const node1 = createTestNode();
-  const node2 = createTestNode();
-  const node3 = createTestNode();
-
-  // Connect nodes initially
   const [node1ToNode2Peer, node2ToNode1Peer] = connectedPeers(
     "node1ToNode2",
     "node2ToNode1",
@@ -105,12 +99,23 @@ export function createThreeConnectedNodes(
     },
   );
 
-  node1.syncManager.addPeer(node1ToNode2Peer);
-  node1.syncManager.addPeer(node1ToNode3Peer);
-  node2.syncManager.addPeer(node2ToNode1Peer);
-  node2.syncManager.addPeer(node2ToNode3Peer);
-  node3.syncManager.addPeer(node3ToNode1Peer);
-  node3.syncManager.addPeer(node3ToNode2Peer);
+  const node1 = await LocalNode.withNewlyCreatedAccount({
+    peersToLoadFrom: [node1ToNode2Peer, node1ToNode3Peer],
+    crypto: Crypto,
+    creationProps: { name: "Node 1" },
+  });
+
+  const node2 = await LocalNode.withNewlyCreatedAccount({
+    peersToLoadFrom: [node2ToNode1Peer, node2ToNode3Peer],
+    crypto: Crypto,
+    creationProps: { name: "Node 2" },
+  });
+
+  const node3 = await LocalNode.withNewlyCreatedAccount({
+    peersToLoadFrom: [node3ToNode1Peer, node3ToNode2Peer],
+    crypto: Crypto,
+    creationProps: { name: "Node 3" },
+  });
 
   return {
     node1,

--- a/packages/jazz-browser/src/index.ts
+++ b/packages/jazz-browser/src/index.ts
@@ -204,7 +204,7 @@ export function provideBrowserLockSession(
 /** @category Invite Links */
 export function createInviteLink<C extends CoValue>(
   value: C,
-  role: "reader" | "writer" | "admin",
+  role: "reader" | "writer" | "admin" | "writeOnly",
   // default to same address as window.location, but without hash
   {
     baseURL = window.location.href.replace(/#.*$/, ""),

--- a/tests/e2e/package.json
+++ b/tests/e2e/package.json
@@ -5,6 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
+    "dev:local": "VITE_WS_PEER=ws://localhost:4200/ vite",
     "build": "tsc && vite build",
     "preview": "vite preview",
     "format-and-lint": "biome check .",

--- a/tests/e2e/src/app.tsx
+++ b/tests/e2e/src/app.tsx
@@ -7,6 +7,7 @@ import { ResumeSyncState } from "./pages/ResumeSyncState";
 import { RetryUnavailable } from "./pages/RetryUnavailable";
 import { Sharing } from "./pages/Sharing";
 import { TestInput } from "./pages/TestInput";
+import { WriteOnlyRole } from "./pages/WriteOnly";
 
 function Index() {
   return (
@@ -25,6 +26,9 @@ function Index() {
       </li>
       <li>
         <Link to="/sharing">Sharing</Link>
+      </li>
+      <li>
+        <Link to="/write-only">Write Only</Link>
       </li>
     </ul>
   );
@@ -50,6 +54,10 @@ const router = createBrowserRouter([
   {
     path: "/sharing",
     element: <Sharing />,
+  },
+  {
+    path: "/write-only",
+    element: <WriteOnlyRole />,
   },
   {
     path: "/",

--- a/tests/e2e/src/pages/WriteOnly.tsx
+++ b/tests/e2e/src/pages/WriteOnly.tsx
@@ -1,0 +1,107 @@
+import { createInviteLink } from "jazz-react";
+import { CoList, CoMap, Group, ID, co } from "jazz-tools";
+import { useState } from "react";
+import { useAcceptInvite, useAccount, useCoState } from "../jazz";
+
+class SharedCoMap extends CoMap {
+  value = co.string;
+}
+
+class SharedCoList extends CoList.Of(co.ref(SharedCoMap)) {}
+
+export function WriteOnlyRole() {
+  const { me } = useAccount();
+  const [id, setId] = useState<ID<SharedCoList> | undefined>(undefined);
+  const [inviteLinks, setInviteLinks] = useState<Record<string, string>>({});
+  const coList = useCoState(SharedCoList, id, []);
+
+  const createCoList = async () => {
+    if (!me || id) return;
+
+    const group = Group.create({ owner: me });
+
+    const coList = SharedCoList.create([], { owner: group });
+
+    setInviteLinks({
+      writer: createInviteLink(coList, "writer"),
+      reader: createInviteLink(coList, "reader"),
+      admin: createInviteLink(coList, "admin"),
+      writeOnly: createInviteLink(coList, "writeOnly"),
+    });
+
+    await group.waitForSync();
+
+    setId(coList.id);
+  };
+
+  const addNewItem = async () => {
+    if (!me || !coList) return;
+
+    const group = coList._owner as Group;
+    const coMap = SharedCoMap.create({ value: "" }, { owner: group });
+
+    coList.push(coMap);
+  };
+
+  const revokeAccess = () => {
+    if (!coList) return;
+
+    const coListGroup = coList._owner as Group;
+
+    for (const member of coListGroup.members) {
+      if (
+        member.account &&
+        member.role !== "admin" &&
+        member.account.id !== me.id
+      ) {
+        coListGroup.removeMember(member.account);
+      }
+    }
+  };
+
+  useAcceptInvite({
+    invitedObjectSchema: SharedCoList,
+    onAccept: (id) => {
+      setId(id);
+    },
+  });
+
+  return (
+    <div>
+      <h1>Sharing</h1>
+      <p data-testid="id">{coList?.id}</p>
+      {Object.entries(inviteLinks).map(([role, inviteLink]) => (
+        <div key={role} style={{ display: "flex", gap: 5 }}>
+          <p style={{ fontWeight: "bold" }}>{role} invitation:</p>
+          <p data-testid={`invite-link-${role}`}>{inviteLink}</p>
+        </div>
+      ))}
+      <pre data-testid="values">
+        {coList?.map(
+          (map) => map && <EditSharedCoMap key={map.id} id={map.id} />,
+        )}
+      </pre>
+      {!id && <button onClick={createCoList}>Create the list</button>}
+      {id && <button onClick={addNewItem}>Add a new item</button>}
+      {coList && <button onClick={revokeAccess}>Revoke access</button>}
+    </div>
+  );
+}
+
+function EditSharedCoMap(props: {
+  id: ID<SharedCoMap>;
+}) {
+  const coMap = useCoState(SharedCoMap, props.id, {});
+
+  if (!coMap) return null;
+
+  return (
+    <>
+      <div>{coMap.value}</div>
+      <input
+        value={coMap.value}
+        onChange={(e) => (coMap.value = e.target.value)}
+      />
+    </>
+  );
+}

--- a/tests/e2e/tests/WriteOnly.test.ts
+++ b/tests/e2e/tests/WriteOnly.test.ts
@@ -1,0 +1,101 @@
+import { Browser, Page, expect, test } from "@playwright/test";
+
+test.describe("WriteOnly role", () => {
+  test("should share simple coValues", async ({ page, browser }) => {
+    await page.goto("/write-only");
+
+    await page.getByRole("button", { name: "Create the list" }).click();
+    await waitForReady(page);
+
+    const id = await page.getByTestId("id").textContent();
+    const inviteLink = await page
+      .getByTestId("invite-link-writeOnly")
+      .textContent();
+
+    // Create a new incognito instance and accept the invite
+    const newUserPage = await (await browser.newContext()).newPage();
+    await newUserPage.goto(inviteLink!);
+
+    await waitForReady(newUserPage);
+
+    await expect(newUserPage.getByTestId("id")).toHaveText(id ?? "");
+  });
+
+  test("writeOnly1 roles should be able to see only their own changes", async ({
+    page,
+    browser,
+    context,
+  }) => {
+    const pages = {
+      initialOwner: page,
+      writeOnly1: await createIsolatedPage(browser),
+      writeOnly2: await createIsolatedPage(browser),
+      reader: await createIsolatedPage(browser),
+    };
+
+    await pages.initialOwner.goto("/write-only?userName=InitialOwner");
+    await pages.writeOnly1.goto("/write-only?userName=WriteOnly");
+    await pages.writeOnly2.goto("/write-only?userName=WriteOnly2");
+
+    await pages.initialOwner
+      .getByRole("button", { name: "Create the list" })
+      .click();
+    await waitForReady(pages.initialOwner);
+
+    const writeOnlyInviteLink = await pages.initialOwner
+      .getByTestId("invite-link-writeOnly")
+      .textContent();
+
+    await pages.writeOnly1.goto(writeOnlyInviteLink!);
+    await pages.writeOnly2.goto(writeOnlyInviteLink!);
+
+    await waitForReady(pages.writeOnly1);
+    await waitForReady(pages.writeOnly2);
+
+    await pages.writeOnly1
+      .getByRole("button", { name: "Add a new item" })
+      .click();
+    await pages.writeOnly2
+      .getByRole("button", { name: "Add a new item" })
+      .click();
+
+    await pages.writeOnly1.getByRole("textbox").fill("From WriteOnly1");
+    await pages.writeOnly2.getByRole("textbox").fill("From WriteOnly2");
+
+    await expect(pages.initialOwner.getByText("From WriteOnly1")).toBeVisible();
+    await expect(pages.initialOwner.getByText("From WriteOnly2")).toBeVisible();
+
+    await expect(pages.writeOnly1.getByText("From WriteOnly1")).toBeVisible();
+    await expect(
+      pages.writeOnly1.getByText("From WriteOnly2"),
+    ).not.toBeVisible();
+
+    await expect(
+      pages.writeOnly2.getByText("From WriteOnly1"),
+    ).not.toBeVisible();
+    await expect(pages.writeOnly2.getByText("From WriteOnly2")).toBeVisible();
+
+    const readerInviteLink = await pages.initialOwner
+      .getByTestId("invite-link-reader")
+      .textContent();
+
+    await pages.reader.goto(readerInviteLink!);
+    await waitForReady(pages.reader);
+
+    await expect(pages.reader.getByText("From WriteOnly1")).toBeVisible();
+    await expect(pages.reader.getByText("From WriteOnly2")).toBeVisible();
+  });
+});
+
+async function waitForReady(page: Page) {
+  await expect(page.getByTestId("id")).not.toHaveText("", {
+    timeout: 20_000,
+  });
+}
+
+async function createIsolatedPage(browser: Browser) {
+  const context = await browser.newContext();
+  const page = await context.newPage();
+
+  return page;
+}


### PR DESCRIPTION
This PR adds a new "writeOnly" role intended to give users access only to their own changes.

This new role is intended as building block for #114 enabling a new patterns for workers subscriptions.
