### PR TITLE
fix(jazz-nodejs): wait for sync before closing and fix the reconnection

### DIFF
--- a/.changeset/honest-planes-drive.md
+++ b/.changeset/honest-planes-drive.md
@@ -1,0 +1,5 @@
+---
+"jazz-run": patch
+---
+
+Make possible to use startSyncServer and createWorkerAccount via code

--- a/.changeset/kind-kings-cover.md
+++ b/.changeset/kind-kings-cover.md
@@ -1,0 +1,5 @@
+---
+"jazz-nodejs": patch
+---
+
+Wait for all coValues to be synced before resolving done and improve WebSocket reconnection

--- a/packages/jazz-nodejs/package.json
+++ b/packages/jazz-nodejs/package.json
@@ -14,7 +14,8 @@
   },
   "devDependencies": {
     "@types/ws": "8.5.10",
-    "typescript": "^5.3.3"
+    "typescript": "^5.3.3",
+    "jazz-run": "workspace:*"
   },
   "scripts": {
     "dev": "tsc --watch --sourceMap --outDir dist",

--- a/packages/jazz-nodejs/src/index.ts
+++ b/packages/jazz-nodejs/src/index.ts
@@ -55,6 +55,8 @@ export async function startWorker<Acc extends Account>({
   node = context.account._raw.core.node;
 
   async function done() {
+    await context.account.waitForAllCoValuesSync();
+
     wsPeer.done();
     context.done();
   }

--- a/packages/jazz-nodejs/src/test/startWorker.test.ts
+++ b/packages/jazz-nodejs/src/test/startWorker.test.ts
@@ -1,0 +1,101 @@
+import { Peer } from "cojson";
+import { createWebSocketPeer } from "cojson-transport-ws";
+import { createWorkerAccount } from "jazz-run/createWorkerAccount";
+import { startSyncServer } from "jazz-run/startSyncServer";
+import { CoMap, Group, co } from "jazz-tools";
+import { describe, expect, onTestFinished, test, vi } from "vitest";
+import { WebSocket } from "ws";
+import { startWorker } from "../index";
+
+async function setup() {
+  const { server, port } = await setupSyncServer();
+
+  const syncServer = `ws://localhost:${port}`;
+
+  const { worker, done } = await setupWorker(syncServer);
+
+  return { worker, done, syncServer, server, port };
+}
+
+async function setupSyncServer(defaultPort = "0") {
+  const server = await startSyncServer({
+    port: defaultPort,
+    inMemory: true,
+    db: "",
+  });
+
+  const port = (server.address() as { port: number }).port.toString();
+
+  onTestFinished(() => {
+    server.close();
+  });
+
+  return { server, port };
+}
+
+async function setupWorker(syncServer: string) {
+  const { accountId, agentSecret } = await createWorkerAccount({
+    name: "test-worker",
+    peer: syncServer,
+  });
+
+  return startWorker({
+    accountID: accountId,
+    accountSecret: agentSecret,
+    syncServer,
+  });
+}
+
+class TestMap extends CoMap {
+  value = co.string;
+}
+
+describe("startWorker integration", () => {
+  test("worker connects to sync server successfully", async () => {
+    const worker1 = await setup();
+    const worker2 = await setupWorker(worker1.syncServer);
+
+    const group = Group.create({ owner: worker1.worker });
+    group.addMember("everyone", "reader");
+
+    const map = TestMap.create(
+      {
+        value: "test",
+      },
+      { owner: group },
+    );
+
+    await map.waitForSync();
+
+    const mapOnWorker2 = await TestMap.load(map.id, worker2.worker, {});
+
+    expect(mapOnWorker2?.value).toBe("test");
+
+    await worker1.done();
+    await worker2.done();
+  });
+
+  test("waits for all coValues to sync before resolving done", async () => {
+    const worker1 = await setup();
+
+    const group = Group.create({ owner: worker1.worker });
+    group.addMember("everyone", "reader");
+
+    const map = TestMap.create(
+      {
+        value: "test",
+      },
+      { owner: group },
+    );
+
+    await worker1.done();
+
+    const worker2 = await setupWorker(worker1.syncServer);
+
+    const mapOnWorker2 = await TestMap.load(map.id, worker2.worker, {});
+
+    expect(mapOnWorker2?.value).toBe("test");
+
+    await worker2.done();
+  });
+});

--- a/packages/jazz-nodejs/src/test/webSocketWithReconnection.test.ts
+++ b/packages/jazz-nodejs/src/test/webSocketWithReconnection.test.ts
@@ -1,0 +1,123 @@
+import { createWebSocketPeer } from "cojson-transport-ws";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+import { WebSocket } from "ws";
+import { webSocketWithReconnection } from "../webSocketWithReconnection";
+
+// Mock dependencies
+vi.mock("cojson-transport-ws", () => ({
+  createWebSocketPeer: vi.fn().mockImplementation(({ onClose }) => ({
+    id: "upstream",
+    incoming: { push: vi.fn() },
+    outgoing: { push: vi.fn(), close: vi.fn() },
+    onClose,
+  })),
+}));
+
+vi.mock("ws", () => ({
+  WebSocket: vi.fn().mockImplementation(() => ({
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+    close: vi.fn(),
+    readyState: 1,
+  })),
+}));
+
+describe("webSocketWithReconnection", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  test("should create initial websocket connection", () => {
+    const addPeerMock = vi.fn();
+    const { peer } = webSocketWithReconnection(
+      "ws://localhost:8080",
+      addPeerMock,
+    );
+
+    expect(WebSocket).toHaveBeenCalledWith("ws://localhost:8080");
+    expect(createWebSocketPeer).toHaveBeenCalledWith(
+      expect.objectContaining({
+        id: "upstream",
+        role: "server",
+      }),
+    );
+    expect(peer).toBeDefined();
+  });
+
+  test("should attempt reconnection when websocket closes", async () => {
+    const addPeerMock = vi.fn();
+    webSocketWithReconnection("ws://localhost:8080", addPeerMock);
+
+    // Get the onClose handler from the first createWebSocketPeer call
+    const initialPeer = vi.mocked(createWebSocketPeer).mock.results[0]!.value;
+
+    // Simulate websocket close
+    initialPeer.onClose();
+
+    // Fast-forward timer to trigger reconnection
+    await vi.advanceTimersByTimeAsync(1000);
+
+    expect(WebSocket).toHaveBeenCalledTimes(2);
+    expect(createWebSocketPeer).toHaveBeenCalledTimes(2);
+    expect(addPeerMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        id: "upstream",
+      }),
+    );
+  });
+
+  test("should clean up when done is called", () => {
+    const addPeerMock = vi.fn();
+    const { done } = webSocketWithReconnection(
+      "ws://localhost:8080",
+      addPeerMock,
+    );
+
+    // Get the onClose handler
+    const initialPeer = vi.mocked(createWebSocketPeer).mock.results[0]!.value;
+
+    done();
+
+    // Simulate websocket close
+    initialPeer.onClose();
+
+    // Fast-forward timer
+    vi.advanceTimersByTime(1000);
+
+    // Should not attempt reconnection
+    expect(WebSocket).toHaveBeenCalledTimes(1);
+    expect(createWebSocketPeer).toHaveBeenCalledTimes(1);
+  });
+
+  test("should not attempt reconnection after done is called", async () => {
+    const addPeerMock = vi.fn();
+    const { done } = webSocketWithReconnection(
+      "ws://localhost:8080",
+      addPeerMock,
+    );
+
+    // Get the onClose handler
+    const initialPeer = vi.mocked(createWebSocketPeer).mock.results[0]!.value;
+
+    // Simulate first close and reconnection
+    initialPeer.onClose();
+    await vi.advanceTimersByTimeAsync(1000);
+
+    expect(WebSocket).toHaveBeenCalledTimes(2);
+
+    // Call done
+    done();
+
+    // Simulate another close
+    vi.mocked(createWebSocketPeer).mock.results[1]!.value.onClose();
+    await vi.advanceTimersByTimeAsync(1000);
+
+    // Should not create another connection
+    expect(WebSocket).toHaveBeenCalledTimes(2);
+  });
+});

--- a/packages/jazz-nodejs/src/webSocketWithReconnection.ts
+++ b/packages/jazz-nodejs/src/webSocketWithReconnection.ts
@@ -1,0 +1,43 @@
+import { Peer } from "cojson";
+import { createWebSocketPeer } from "cojson-transport-ws";
+import { WebSocket } from "ws";
+
+export function webSocketWithReconnection(
+  peer: string,
+  addPeer: (peer: Peer) => void,
+) {
+  let done = false;
+  const wsPeer = createWebSocketPeer({
+    websocket: new WebSocket(peer),
+    id: "upstream",
+    role: "server",
+    onClose: handleClose,
+  });
+
+  let timer: ReturnType<typeof setTimeout>;
+  function handleClose() {
+    if (done) return;
+
+    clearTimeout(timer);
+    timer = setTimeout(() => {
+      console.log(new Date(), "Reconnecting to upstream " + peer);
+
+      const wsPeer: Peer = createWebSocketPeer({
+        id: "upstream",
+        websocket: new WebSocket(peer),
+        role: "server",
+        onClose: handleClose,
+      });
+
+      addPeer(wsPeer);
+    }, 1000);
+  }
+
+  return {
+    peer: wsPeer,
+    done: () => {
+      done = true;
+      clearTimeout(timer);
+    },
+  };
+}

--- a/packages/jazz-run/package.json
+++ b/packages/jazz-run/package.json
@@ -4,6 +4,16 @@
   "type": "module",
   "license": "MIT",
   "version": "0.8.38",
+  "exports": {
+    "./startSyncServer": {
+      "import": "./dist/startSyncServer.js",
+      "types": "./src/startSyncServer.ts"
+    },
+    "./createWorkerAccount": {
+      "import": "./dist/createWorkerAccount.js",
+      "types": "./src/createWorkerAccount.ts"
+    }
+  },
   "scripts": {
     "format-and-lint": "biome check .",
     "format-and-lint:fix": "biome check . --write",

--- a/packages/jazz-run/src/index.ts
+++ b/packages/jazz-run/src/index.ts
@@ -60,7 +60,7 @@ const dbOption = Options.file("db")
   )
   .pipe(Options.withDefault("sync-db/storage.db"));
 
-export const startSyncServerCommand = Command.make(
+const startSyncServerCommand = Command.make(
   "sync",
   { port: portOption, inMemory: inMemoryOption, db: dbOption },
   ({ port, inMemory, db }) => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1513,6 +1513,9 @@ importers:
       '@types/ws':
         specifier: 8.5.10
         version: 8.5.10
+      jazz-run:
+        specifier: workspace:*
+        version: link:../jazz-run
       typescript:
         specifier: ^5.3.3
         version: 5.3.3


### PR DESCRIPTION
Changes:
- Wait for the all coValues to be uploaded before closing the worker
- Improve the reconnection flow by reacting to the "close" handler and removing the setInterval
- Export startSyncServer and createWorkerAccount on jazz-tools to make possible to use them via code