### PR TITLE
Move to use turbo build

### DIFF
--- a/homepage/homepage/README.md
+++ b/homepage/homepage/README.md
@@ -1,36 +1,22 @@
-This is a [Next.js](https://nextjs.org/) project bootstrapped with [`create-next-app`](https://github.com/vercel/next.js/tree/canary/packages/create-next-app).
+# Jazz Homepage
 
-## Getting Started
+The homepage of the [Jazz](https://github.com/garden-co/jazz) project, including information about the project, features, and resources.
 
-First, run the development server:
+## Build
+
+The homepage is built using [Next.js](https://nextjs.org/) and [Tailwind CSS](https://tailwindcss.com/).
+
+To install the homepage locally, run the following command:
 
 ```bash
-npm run dev
-# or
-yarn dev
-# or
-pnpm dev
-# or
-bun dev
+cd homepage/homepage
+pnpm install
+turbo build
 ```
 
-Open [http://localhost:3000](http://localhost:3000) with your browser to see the result.
+## Development
 
-You can start editing the page by modifying `app/page.tsx`. The page auto-updates as you edit the file.
-
-This project uses [`next/font`](https://nextjs.org/docs/basic-features/font-optimization) to automatically optimize and load Inter, a custom Google Font.
-
-## Learn More
-
-To learn more about Next.js, take a look at the following resources:
-
--   [Next.js Documentation](https://nextjs.org/docs) - learn about Next.js features and API.
--   [Learn Next.js](https://nextjs.org/learn) - an interactive Next.js tutorial.
-
-You can check out [the Next.js GitHub repository](https://github.com/vercel/next.js/) - your feedback and contributions are welcome!
-
-## Deploy on Vercel
-
-The easiest way to deploy your Next.js app is to use the [Vercel Platform](https://vercel.com/new?utm_medium=default-template&filter=next.js&utm_source=create-next-app&utm_campaign=create-next-app-readme) from the creators of Next.js.
-
-Check out our [Next.js deployment documentation](https://nextjs.org/docs/deployment) for more details.
+```bash
+turbo build
+pnpm dev
+```

--- a/homepage/homepage/package.json
+++ b/homepage/homepage/package.json
@@ -5,8 +5,9 @@
   "type": "module",
   "scripts": {
     "dev": "NODE_OPTIONS=--max-old-space-size=8192 next dev",
+    "build:render-code-samples": "node renderCodeSamples.mjs",
     "build:generate-docs": "node genDocs.mjs --build",
-    "build": "pnpm run build:generate-docs && node renderCodeSamples.mjs && next build",
+    "build": "next build",
     "start": "next start",
     "format-and-lint": "biome check .",
     "format-and-lint:fix": "biome check . --write"

--- a/homepage/homepage/renderCodeSamples.mjs
+++ b/homepage/homepage/renderCodeSamples.mjs
@@ -36,7 +36,7 @@ await rm("./codeSamples", { recursive: true, force: true });
       ).filter((entry) => entry !== undefined),
     );
 
-    console.log(allFiles);
+    // console.log(allFiles);
 
     const components = (
       await Promise.all(

--- a/homepage/homepage/turbo.json
+++ b/homepage/homepage/turbo.json
@@ -2,12 +2,20 @@
   "$schema": "https://turbo.build/schema.json",
   "tasks": {
     "build": {
-      "dependsOn": ["^build", "build:generate-docs"],
+      "dependsOn": ["^build", "build:generate-docs", "build:render-code-samples"],
       "outputs": [".next/**", "!.next/cache/**"]
     },
     "build:generate-docs": {
       "inputs": ["../../../packages/*/src/**"],
-      "outputs": ["typedocs/**"],
+      "outputs": ["typedoc/**"],
+      "dependsOn": ["^build"]
+    },
+    "build:render-code-samples": {
+      "inputs": [
+        "../../../packages/*/src/**",
+        "app/examples/page.tsx"
+      ],
+      "outputs": ["codeSamples/**"],
       "dependsOn": ["^build"]
     },
     "dev": {

--- a/homepage/homepage/turbo.json
+++ b/homepage/homepage/turbo.json
@@ -2,7 +2,11 @@
   "$schema": "https://turbo.build/schema.json",
   "tasks": {
     "build": {
-      "dependsOn": ["^build", "build:generate-docs", "build:render-code-samples"],
+      "dependsOn": [
+        "^build",
+        "build:generate-docs",
+        "build:render-code-samples"
+      ],
       "outputs": [".next/**", "!.next/cache/**"]
     },
     "build:generate-docs": {
@@ -11,10 +15,7 @@
       "dependsOn": ["^build"]
     },
     "build:render-code-samples": {
-      "inputs": [
-        "../../../packages/*/src/**",
-        "app/examples/page.tsx"
-      ],
+      "inputs": ["../../../packages/*/src/**", "app/examples/page.tsx"],
       "outputs": ["codeSamples/**"],
       "dependsOn": ["^build"]
     },


### PR DESCRIPTION
To run the homepage build more effectively, we should use `turbo build` rather than `pnpm build` as there are a number of dependencies that can be cached by turbo, which aren't when run with pnpm.

Adds generating code samples to turbo's scripts.