### PR TITLE
feat: Inbox, a new experimental API to simplfy the communication with Workers

### DIFF
--- a/.changeset/proud-garlics-hope.md
+++ b/.changeset/proud-garlics-hope.md
@@ -1,0 +1,8 @@
+---
+"jazz-nodejs": patch
+"jazz-react": patch
+"jazz-tools": patch
+"cojson": patch
+---
+
+Add Inbox a new experimental API to simplfy the initial handshake between accounts

--- a/packages/cojson/src/exports.ts
+++ b/packages/cojson/src/exports.ts
@@ -14,7 +14,11 @@ import {
 } from "./coValues/account.js";
 import { RawCoList } from "./coValues/coList.js";
 import { RawCoMap } from "./coValues/coMap.js";
-import { RawBinaryCoStream, RawCoStream } from "./coValues/coStream.js";
+import {
+  CoStreamItem,
+  RawBinaryCoStream,
+  RawCoStream,
+} from "./coValues/coStream.js";
 import { EVERYONE, RawGroup } from "./coValues/group.js";
 import type { Everyone } from "./coValues/group.js";
 import {
@@ -145,6 +149,7 @@ export type {
   PingTimeoutError,
   CoValueUniqueness,
   Stringified,
+  CoStreamItem,
 };
 
 // eslint-disable-next-line @typescript-eslint/no-namespace

--- a/packages/jazz-nodejs/src/test/utils.ts
+++ b/packages/jazz-nodejs/src/test/utils.ts
@@ -1,0 +1,27 @@
+export function waitFor(callback: () => boolean | void) {
+  return new Promise<void>((resolve, reject) => {
+    const checkPassed = () => {
+      try {
+        return { ok: callback(), error: null };
+      } catch (error) {
+        return { ok: false, error };
+      }
+    };
+
+    let retries = 0;
+
+    const interval = setInterval(() => {
+      const { ok, error } = checkPassed();
+
+      if (ok !== false) {
+        clearInterval(interval);
+        resolve();
+      }
+
+      if (++retries > 10) {
+        clearInterval(interval);
+        reject(error);
+      }
+    }, 100);
+  });
+}

--- a/packages/jazz-react/src/index.tsx
+++ b/packages/jazz-react/src/index.tsx
@@ -5,7 +5,14 @@ import {
   consumeInviteLinkFromWindowLocation,
   createJazzBrowserContext,
 } from "jazz-browser";
-import React, { useEffect, useRef, useState } from "react";
+import React, {
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
 
 import {
   Account,
@@ -17,17 +24,32 @@ import {
   DeeplyLoaded,
   DepthsIn,
   ID,
+  Inbox,
+  InboxSender,
   createCoValueObservable,
 } from "jazz-tools";
 
 /** @category Context & Hooks */
-export function createJazzReactApp<Acc extends Account>({
+export function createJazzReactApp<
+  Acc extends Account,
+  InboxMessage extends CoValue = CoValue,
+>({
   AccountSchema = Account as unknown as AccountClass<Acc>,
+  InboxMessageSchema,
 }: {
   AccountSchema?: AccountClass<Acc>;
-} = {}): JazzReactApp<Acc> {
+  InboxMessageSchema?: CoValueClass<InboxMessage>;
+} = {}): JazzReactApp<Acc, InboxMessage> {
   const JazzContext = React.createContext<
     BrowserContext<Acc> | BrowserGuestContext | undefined
+  >(undefined);
+  const InboxContext = React.createContext<
+    | {
+        subscribe: (
+          callback: (message: InboxMessage) => Promise<void>,
+        ) => () => void;
+      }
+    | undefined
   >(undefined);
 
   function Provider({
@@ -121,7 +143,80 @@ export function createJazzReactApp<Acc extends Account>({
     );
 
     return (
-      <JazzContext.Provider value={ctx}>{ctx && children}</JazzContext.Provider>
+      <JazzContext.Provider value={ctx}>
+        {ctx && <InboxProvider>{children}</InboxProvider>}
+      </JazzContext.Provider>
+    );
+  }
+
+  function InboxProvider({ children }: { children: React.ReactNode }) {
+    const me = useAccount().me;
+    const [subscribed, setSubscribed] = useState(false);
+    const subscribersRef = useRef(
+      new Set<(message: InboxMessage) => Promise<void>>(),
+    );
+
+    const handleSubscribe = useCallback(
+      (subscriber: (message: InboxMessage) => Promise<void>) => {
+        if (!InboxMessageSchema) {
+          throw new Error(
+            "To subscribe to inbox messages, you must provide an InboxMessageSchema when creating the Jazz context.",
+          );
+        }
+
+        subscribersRef.current.add(subscriber);
+        setSubscribed(true);
+
+        return () => {
+          subscribersRef.current.delete(subscriber);
+          if (subscribersRef.current.size === 0) {
+            setSubscribed(false);
+          }
+        };
+      },
+      [],
+    );
+
+    useEffect(() => {
+      if (!InboxMessageSchema) return;
+      if (!subscribed) return;
+
+      let unsubscribe = () => {};
+      let unsubscribed = false;
+
+      const load = async () => {
+        const inbox = await Inbox.load(me);
+
+        if (unsubscribed) return;
+
+        unsubscribe = inbox.subscribe(
+          InboxMessageSchema,
+          async (message: InboxMessage) => {
+            const promises = [];
+            for (const subscriber of subscribersRef.current) {
+              promises.push(subscriber(message));
+            }
+            await Promise.all(promises);
+          },
+          { retries: 0 },
+        );
+      };
+
+      load();
+
+      return () => {
+        unsubscribed = true;
+        unsubscribe();
+      };
+    }, [subscribed]);
+
+    const context = useMemo(
+      () => ({ subscribe: handleSubscribe }),
+      [handleSubscribe],
+    );
+
+    return (
+      <InboxContext.Provider value={context}>{children}</InboxContext.Provider>
     );
   }
 
@@ -262,17 +357,74 @@ export function createJazzReactApp<Acc extends Account>({
     }, [onAccept]);
   }
 
+  function useInboxSender<V extends CoValue>(
+    inboxOwnerID: ID<Acc> | undefined,
+  ) {
+    const me = useAccount().me;
+    const inboxRef = useRef<InboxSender<V> | undefined>();
+    const messagesRef = useRef<V[]>([]);
+
+    useEffect(() => {
+      async function load() {
+        if (!inboxOwnerID) return;
+
+        const inbox = await InboxSender.load(inboxOwnerID, me);
+        inboxRef.current = inbox;
+
+        for (const message of messagesRef.current) {
+          inbox.sendMessage(message);
+        }
+        messagesRef.current.length = 0;
+      }
+      load();
+    }, [inboxOwnerID]);
+
+    const sendMessage = useCallback((message: V) => {
+      if (!inboxRef.current) {
+        // If not loaded yet, we store the message in a local array
+        // and wait for the inbox to be loaded.
+        messagesRef.current.push(message);
+      } else {
+        inboxRef.current.sendMessage(message);
+      }
+    }, []);
+
+    return { sendMessage };
+  }
+
+  function useInboxListener(
+    onMessage: (message: InboxMessage) => Promise<void>,
+  ) {
+    const { subscribe } = useContext(InboxContext)!;
+
+    const onMessageRef = useRef(onMessage);
+    onMessageRef.current = onMessage;
+
+    useEffect(() => {
+      return subscribe((message) => {
+        return onMessageRef.current(message);
+      });
+    }, []);
+  }
+
   return {
     Provider,
     useAccount,
     useAccountOrGuest,
     useCoState,
     useAcceptInvite,
+    experimental: {
+      useInboxListener,
+      useInboxSender,
+    },
   };
 }
 
 /** @category Context & Hooks */
-export interface JazzReactApp<Acc extends Account> {
+export interface JazzReactApp<
+  Acc extends Account,
+  InboxMessage extends CoValue = CoValue,
+> {
   /** @category Provider Component */
   Provider: React.FC<{
     children: React.ReactNode;
@@ -321,6 +473,16 @@ export interface JazzReactApp<Acc extends Account> {
     onAccept: (projectID: ID<V>) => void;
     forValueHint?: string;
   }): void;
+
+  experimental: {
+    useInboxSender<V extends CoValue>(
+      inboxOwnerID: ID<Acc> | undefined,
+    ): {
+      sendMessage: (message: V) => void;
+    };
+
+    useInboxListener(onMessage: (message: InboxMessage) => Promise<void>): void;
+  };
 }
 
 export { createInviteLink, parseInviteLink } from "jazz-browser";

--- a/packages/jazz-tools/src/coValues/inbox.ts
+++ b/packages/jazz-tools/src/coValues/inbox.ts
@@ -1,0 +1,301 @@
+import {
+  CoID,
+  InviteSecret,
+  RawAccount,
+  RawCoMap,
+  RawControlledAccount,
+  SessionID,
+} from "cojson";
+import { CoStreamItem, RawCoStream } from "cojson";
+import { type Account } from "./account.js";
+import { CoValue, CoValueClass, ID, loadCoValue } from "./interfaces.js";
+
+export type InboxInvite = `${CoID<MessagesStream>}/${InviteSecret}`;
+type TxKey = `${SessionID}/${number}`;
+
+type MessagesStream = RawCoStream<ID<CoValue>>;
+type FailedMessagesStream = RawCoStream<{
+  errors: string[];
+  value: ID<CoValue>;
+}>;
+type TxKeyStream = RawCoStream<TxKey>;
+export type InboxRoot = RawCoMap<{
+  messages: CoID<MessagesStream>;
+  processed: CoID<TxKeyStream>;
+  failed: CoID<FailedMessagesStream>;
+  inviteLink: InboxInvite;
+}>;
+
+export function createInboxRoot(account: Account) {
+  if (!account.isMe) {
+    throw new Error("Account is not controlled");
+  }
+
+  const rawAccount = account._raw as RawControlledAccount;
+
+  const group = rawAccount.createGroup();
+  const messagesFeed = group.createStream<MessagesStream>();
+
+  const inboxRoot = rawAccount.createMap<InboxRoot>();
+  const processedFeed = rawAccount.createStream<TxKeyStream>();
+  const failedFeed = rawAccount.createStream<FailedMessagesStream>();
+
+  const inviteLink =
+    `${messagesFeed.id}/${group.createInvite("writeOnly")}` as const;
+
+  inboxRoot.set("messages", messagesFeed.id);
+  inboxRoot.set("processed", processedFeed.id);
+  inboxRoot.set("failed", failedFeed.id);
+
+  return {
+    id: inboxRoot.id,
+    inviteLink,
+  };
+}
+
+export class Inbox {
+  account: Account;
+  messages: MessagesStream;
+  processed: TxKeyStream;
+  failed: FailedMessagesStream;
+  root: InboxRoot;
+  processing = new Set<`${SessionID}/${number}`>();
+
+  private constructor(
+    account: Account,
+    root: InboxRoot,
+    messages: MessagesStream,
+    processed: TxKeyStream,
+    failed: FailedMessagesStream,
+  ) {
+    this.account = account;
+    this.root = root;
+    this.messages = messages;
+    this.processed = processed;
+    this.failed = failed;
+  }
+
+  subscribe<I extends CoValue>(
+    Schema: CoValueClass<I>,
+    callback: (message: I, senderAccountID: ID<Account>) => Promise<void>,
+    options: { retries?: number } = {},
+  ) {
+    const processed = new Set<`${SessionID}/${number}`>();
+    const failed = new Map<`${SessionID}/${number}`, string[]>();
+
+    this.processed.subscribe((stream) => {
+      for (const items of Object.values(stream.items)) {
+        for (const item of items) {
+          processed.add(item.value as TxKey);
+        }
+      }
+    });
+
+    const { account } = this;
+    const { retries = 3 } = options;
+
+    let failTimer: ReturnType<typeof setTimeout> | number | undefined =
+      undefined;
+
+    const clearFailTimer = () => {
+      clearTimeout(failTimer);
+      failTimer = undefined;
+    };
+
+    const handleNewMessages = (stream: MessagesStream) => {
+      clearFailTimer(); // Stop the failure timers, we're going to process the failed entries anyway
+
+      for (const [sessionID, items] of Object.entries(stream.items) as [
+        SessionID,
+        CoStreamItem<ID<CoValue>>[],
+      ][]) {
+        const accountID = getAccountIDfromSessionID(sessionID);
+
+        if (!accountID) {
+          console.warn("Received message from unknown account", sessionID);
+          continue;
+        }
+
+        for (const item of items) {
+          const txKey = `${sessionID}/${item.tx.txIndex}` as const;
+
+          if (!processed.has(txKey) && !this.processing.has(txKey)) {
+            this.processing.add(txKey);
+
+            const id = item.value;
+
+            loadCoValue(Schema, id, account, [])
+              .then((value) => {
+                if (!value) {
+                  return Promise.reject(
+                    new Error("Unable to load inbox message " + id),
+                  );
+                }
+
+                return callback(value, accountID);
+              })
+              .then(() => {
+                this.processed.push(txKey);
+                this.processing.delete(txKey);
+              })
+              .catch((error) => {
+                console.error("Error processing inbox message", error);
+                this.processing.delete(txKey);
+                const errors = failed.get(txKey) ?? [];
+                errors.push(error.toString());
+
+                if (errors.length > retries) {
+                  this.processed.push(txKey);
+                  this.failed.push({ errors, value: item.value });
+                } else {
+                  failed.set(txKey, errors);
+                  if (!failTimer) {
+                    failTimer = setTimeout(
+                      () => handleNewMessages(stream),
+                      100,
+                    );
+                  }
+                }
+              });
+          }
+        }
+      }
+    };
+
+    return this.messages.subscribe(handleNewMessages);
+  }
+
+  static async load(account: Account) {
+    const profile = account.profile;
+
+    if (!profile) {
+      throw new Error("Account profile should already be loaded");
+    }
+
+    if (!profile.inbox) {
+      throw new Error("The account has not set up their inbox");
+    }
+
+    const node = account._raw.core.node;
+
+    const root = await node.load(profile.inbox as CoID<InboxRoot>);
+
+    if (root === "unavailable") {
+      throw new Error("Inbox not found");
+    }
+
+    const [messages, processed, failed] = await Promise.all([
+      node.load(root.get("messages")!),
+      node.load(root.get("processed")!),
+      node.load(root.get("failed")!),
+    ]);
+
+    if (
+      messages === "unavailable" ||
+      processed === "unavailable" ||
+      failed === "unavailable"
+    ) {
+      throw new Error("Inbox not found");
+    }
+
+    return new Inbox(account, root, messages, processed, failed);
+  }
+}
+
+export class InboxSender<V extends CoValue> {
+  currentAccount: Account;
+  owner: RawAccount;
+  messages: MessagesStream;
+
+  private constructor(
+    currentAccount: Account,
+    owner: RawAccount,
+    messages: MessagesStream,
+  ) {
+    this.currentAccount = currentAccount;
+    this.owner = owner;
+    this.messages = messages;
+  }
+
+  getOwnerAccount() {
+    return this.owner;
+  }
+
+  sendMessage(message: V) {
+    const content = message._raw;
+    const group = content.group;
+
+    if (group instanceof RawAccount) {
+      throw new Error("Inbox messages should be owned by a group");
+    }
+
+    if (!group.roleOf(this.owner.id)) {
+      group.addMember(this.owner, "writer");
+    }
+
+    this.messages.push(message.id);
+  }
+
+  static async load(inboxOwnerID: ID<Account>, currentAccount: Account) {
+    const node = currentAccount._raw.core.node;
+
+    const inboxOwnerRaw = await node.load(
+      inboxOwnerID as unknown as CoID<RawAccount>,
+    );
+
+    if (inboxOwnerRaw === "unavailable") {
+      throw new Error("Failed to load the inbox owner");
+    }
+
+    const inboxOwnerProfileRaw = await node.load(inboxOwnerRaw.get("profile")!);
+
+    if (inboxOwnerProfileRaw === "unavailable") {
+      throw new Error("Failed to load the inbox owner profile");
+    }
+
+    const inboxInvite = inboxOwnerProfileRaw.get("inboxInvite");
+
+    if (!inboxInvite) {
+      throw new Error("The user has not set up their inbox");
+    }
+
+    const id = await acceptInvite(inboxInvite as InboxInvite, currentAccount);
+
+    const messages = await node.load(id);
+
+    if (messages === "unavailable") {
+      throw new Error("Inbox not found");
+    }
+
+    return new InboxSender(currentAccount, inboxOwnerRaw, messages);
+  }
+}
+
+async function acceptInvite(invite: string, account: Account) {
+  const id = invite.slice(0, invite.indexOf("/")) as CoID<MessagesStream>;
+
+  const inviteSecret = invite.slice(invite.indexOf("/") + 1) as InviteSecret;
+
+  if (!id?.startsWith("co_z") || !inviteSecret.startsWith("inviteSecret_")) {
+    throw new Error("Invalid inbox ticket");
+  }
+
+  if (!account.isMe) {
+    throw new Error("Account is not controlled");
+  }
+
+  await (account._raw as RawControlledAccount).acceptInvite(id, inviteSecret);
+
+  return id;
+}
+
+function getAccountIDfromSessionID(sessionID: SessionID) {
+  const until = sessionID.indexOf("_session");
+  const accountID = sessionID.slice(0, until);
+
+  if (accountID.startsWith("co_z")) {
+    return accountID as ID<Account>;
+  }
+
+  return;
+}

--- a/packages/jazz-tools/src/coValues/profile.ts
+++ b/packages/jazz-tools/src/coValues/profile.ts
@@ -1,7 +1,11 @@
+import { CoID } from "cojson";
 import { co } from "../internal.js";
 import { CoMap } from "./coMap.js";
+import { InboxInvite, InboxRoot } from "./inbox.js";
 
 /** @category Identity & Permissions */
 export class Profile extends CoMap {
   name = co.string;
+  inbox = co.optional.json<CoID<InboxRoot>>();
+  inboxInvite = co.optional.json<InboxInvite>();
 }

--- a/packages/jazz-tools/src/exports.ts
+++ b/packages/jazz-tools/src/exports.ts
@@ -13,6 +13,11 @@ export type { CoValue, ID } from "./internal.js";
 export { Encoders, co } from "./internal.js";
 
 export {
+  Inbox,
+  InboxSender,
+} from "./coValues/inbox.js";
+
+export {
   Account,
   isControlledAccount,
   type AccountClass,

--- a/packages/jazz-tools/src/tests/coFeed.test.ts
+++ b/packages/jazz-tools/src/tests/coFeed.test.ts
@@ -192,15 +192,6 @@ describe("CoFeed resolution", async () => {
     const queue = new cojsonInternals.Channel();
 
     TestStream.subscribe(stream.id, meOnSecondPeer, [], (subscribedStream) => {
-      console.log("subscribedStream[me.id]", subscribedStream[me.id]);
-      console.log(
-        "subscribedStream[me.id]?.value?.[me.id]?.value",
-        subscribedStream[me.id]?.value?.[me.id]?.value,
-      );
-      console.log(
-        "subscribedStream[me.id]?.value?.[me.id]?.value?.[me.id]?.value",
-        subscribedStream[me.id]?.value?.[me.id]?.value?.[me.id]?.value,
-      );
       void queue.push(subscribedStream);
     });
 

--- a/packages/jazz-tools/src/tests/inbox.test.ts
+++ b/packages/jazz-tools/src/tests/inbox.test.ts
@@ -1,0 +1,170 @@
+import { describe, expect, it } from "vitest";
+import { CoMap } from "../coValues/coMap";
+import { Group } from "../coValues/group";
+import { Inbox, InboxSender } from "../coValues/inbox";
+import { co } from "../internal";
+import { setupTwoNodes, waitFor } from "./utils";
+
+class Message extends CoMap {
+  text = co.string;
+}
+
+describe("Inbox", () => {
+  it("should create inbox and allow message exchange between accounts", async () => {
+    const { clientAccount: sender, serverAccount: receiver } =
+      await setupTwoNodes();
+
+    const receiverInbox = await Inbox.load(receiver);
+
+    // Create a message from sender
+    const message = Message.create(
+      { text: "Hello" },
+      {
+        owner: Group.create({ owner: sender }),
+      },
+    );
+
+    // Setup inbox sender
+    const inboxSender = await InboxSender.load(receiver.id, sender);
+    inboxSender.sendMessage(message);
+
+    // Track received messages
+    const receivedMessages: Message[] = [];
+    let senderAccountID: unknown = undefined;
+
+    // Subscribe to inbox messages
+    const unsubscribe = receiverInbox.subscribe(
+      Message,
+      async (message, id) => {
+        senderAccountID = id;
+        receivedMessages.push(message);
+      },
+    );
+
+    // Wait for message to be received
+    await waitFor(() => receivedMessages.length === 1);
+
+    expect(receivedMessages.length).toBe(1);
+    expect(receivedMessages[0]?.text).toBe("Hello");
+    expect(senderAccountID).toBe(sender.id);
+
+    unsubscribe();
+  });
+
+  it("should mark messages as processed", async () => {
+    const { clientAccount: sender, serverAccount: receiver } =
+      await setupTwoNodes();
+
+    const receiverInbox = await Inbox.load(receiver);
+
+    // Create a message from sender
+    const message = Message.create(
+      { text: "Hello" },
+      {
+        owner: Group.create({ owner: sender }),
+      },
+    );
+
+    // Setup inbox sender
+    const inboxSender = await InboxSender.load(receiver.id, sender);
+    inboxSender.sendMessage(message);
+
+    // Track received messages
+    const receivedMessages: Message[] = [];
+
+    // Subscribe to inbox messages
+    const unsubscribe = receiverInbox.subscribe(Message, async (message) => {
+      receivedMessages.push(message);
+    });
+
+    // Wait for message to be received
+    await waitFor(() => receivedMessages.length === 1);
+
+    inboxSender.sendMessage(message);
+
+    await waitFor(() => receivedMessages.length === 2);
+
+    expect(receivedMessages.length).toBe(2);
+    expect(receivedMessages[0]?.text).toBe("Hello");
+    expect(receivedMessages[1]?.text).toBe("Hello");
+
+    unsubscribe();
+  });
+
+  it("should unsubscribe correctly", async () => {
+    const { clientAccount: sender, serverAccount: receiver } =
+      await setupTwoNodes();
+
+    const receiverInbox = await Inbox.load(receiver);
+
+    // Create a message from sender
+    const message = Message.create(
+      { text: "Hello" },
+      {
+        owner: Group.create({ owner: sender }),
+      },
+    );
+
+    // Setup inbox sender
+    const inboxSender = await InboxSender.load(receiver.id, sender);
+    inboxSender.sendMessage(message);
+
+    // Track received messages
+    const receivedMessages: Message[] = [];
+
+    // Subscribe to inbox messages
+    const unsubscribe = receiverInbox.subscribe(Message, async (message) => {
+      receivedMessages.push(message);
+    });
+
+    // Wait for message to be received
+    await waitFor(() => receivedMessages.length === 1);
+
+    unsubscribe();
+
+    inboxSender.sendMessage(message);
+
+    await new Promise((resolve) => setTimeout(resolve, 200));
+
+    expect(receivedMessages.length).toBe(1);
+    expect(receivedMessages[0]?.text).toBe("Hello");
+  });
+
+  it("should retry failed messages", async () => {
+    const { clientAccount: sender, serverAccount: receiver } =
+      await setupTwoNodes();
+
+    const receiverInbox = await Inbox.load(receiver);
+
+    // Create a message from sender
+    const message = Message.create(
+      { text: "Hello" },
+      {
+        owner: Group.create({ owner: sender }),
+      },
+    );
+
+    // Setup inbox sender
+    const inboxSender = await InboxSender.load(receiver.id, sender);
+    inboxSender.sendMessage(message);
+
+    let failures = 0;
+
+    // Subscribe to inbox messages
+    const unsubscribe = receiverInbox.subscribe(
+      Message,
+      async (message) => {
+        failures++;
+        throw new Error("Failed");
+      },
+      { retries: 2 },
+    );
+
+    await waitFor(() => failures === 3);
+    await new Promise((resolve) => setTimeout(resolve, 200));
+
+    const [failed] = Object.values(receiverInbox.failed.items).flat();
+    expect(failed?.value.errors.length).toBe(3);
+    unsubscribe();
+  });
+});

--- a/packages/jazz-tools/src/tests/utils.ts
+++ b/packages/jazz-tools/src/tests/utils.ts
@@ -54,12 +54,26 @@ export async function setupTwoNodes() {
     peersToLoadFrom: [serverAsPeer],
     crypto: Crypto,
     creationProps: { name: "Client" },
+    migration: async (rawAccount, _node, creationProps) => {
+      const account = new Account({
+        fromRaw: rawAccount,
+      });
+
+      await account.migrate?.(creationProps);
+    },
   });
 
   const server = await LocalNode.withNewlyCreatedAccount({
     peersToLoadFrom: [clientAsPeer],
     crypto: Crypto,
     creationProps: { name: "Server" },
+    migration: async (rawAccount, _node, creationProps) => {
+      const account = new Account({
+        fromRaw: rawAccount,
+      });
+
+      await account.migrate?.(creationProps);
+    },
   });
 
   return {

--- a/tests/e2e/src/app.tsx
+++ b/tests/e2e/src/app.tsx
@@ -3,6 +3,7 @@ import ReactDOM from "react-dom/client";
 import { Link, RouterProvider, createBrowserRouter } from "react-router-dom";
 import { AuthAndJazz } from "./jazz";
 import { FileStreamTest } from "./pages/FileStream";
+import { Inbox } from "./pages/Inbox";
 import { ResumeSyncState } from "./pages/ResumeSyncState";
 import { RetryUnavailable } from "./pages/RetryUnavailable";
 import { Sharing } from "./pages/Sharing";
@@ -29,6 +30,9 @@ function Index() {
       </li>
       <li>
         <Link to="/write-only">Write Only</Link>
+      </li>
+      <li>
+        <Link to="/inbox">Inbox</Link>
       </li>
     </ul>
   );
@@ -58,6 +62,10 @@ const router = createBrowserRouter([
   {
     path: "/write-only",
     element: <WriteOnlyRole />,
+  },
+  {
+    path: "/inbox",
+    element: <Inbox />,
   },
   {
     path: "/",

--- a/tests/e2e/src/jazz.tsx
+++ b/tests/e2e/src/jazz.tsx
@@ -1,5 +1,6 @@
 import { createJazzReactApp, useDemoAuth } from "jazz-react";
 import { useEffect, useRef } from "react";
+import { PingPong } from "./pages/Inbox";
 
 const url = new URL(window.location.href);
 
@@ -17,9 +18,16 @@ if (import.meta.env.VITE_WS_PEER) {
   peer = import.meta.env.VITE_WS_PEER;
 }
 
-const Jazz = createJazzReactApp();
+const Jazz = createJazzReactApp({
+  InboxMessageSchema: PingPong,
+});
 
-export const { useAccount, useCoState, useAcceptInvite } = Jazz;
+export const {
+  useAccount,
+  useCoState,
+  useAcceptInvite,
+  experimental: { useInboxListener, useInboxSender },
+} = Jazz;
 
 function getUserInfo() {
   return url.searchParams.get("userName") ?? "Mister X";

--- a/tests/e2e/src/pages/Inbox.tsx
+++ b/tests/e2e/src/pages/Inbox.tsx
@@ -1,0 +1,71 @@
+import { Account, CoMap, Group, ID, co } from "jazz-tools";
+import { useEffect, useRef, useState } from "react";
+import { useAccount, useInboxListener, useInboxSender } from "../jazz";
+import { createCredentiallessIframe } from "../lib/createCredentiallessIframe";
+
+export class PingPong extends CoMap {
+  ping = co.json<number>();
+  pong = co.optional.json<number>();
+}
+
+function getIdParam() {
+  const url = new URL(window.location.href);
+  return (url.searchParams.get("id") as ID<Account> | undefined) ?? undefined;
+}
+
+export function Inbox() {
+  const [id] = useState(getIdParam);
+  const { me } = useAccount();
+  const [pingPong, setPingPong] = useState<PingPong | null>(null);
+  const iframeRef = useRef<HTMLIFrameElement>();
+
+  useInboxListener(async (pingPong) => {
+    pingPong.pong = Date.now();
+    setPingPong(pingPong);
+    iframeRef.current?.remove();
+    iframeRef.current = undefined;
+  });
+
+  const { sendMessage } = useInboxSender(id);
+
+  useEffect(() => {
+    async function load() {
+      if (!id) return;
+      const account = await Account.load(id, me, {});
+
+      if (!account) return;
+
+      const group = Group.create({ owner: me });
+      group.addMember(account, "writer");
+      const pingPong = PingPong.create({ ping: Date.now() }, { owner: group });
+
+      sendMessage(pingPong);
+    }
+
+    load();
+  }, [id]);
+
+  const handlePingPong = () => {
+    if (!me || id) return;
+
+    const url = new URL(window.location.href);
+    url.searchParams.set("id", me.id);
+
+    const iframe = createCredentiallessIframe(url.toString());
+    document.body.appendChild(iframe);
+    iframeRef.current = iframe;
+  };
+
+  return (
+    <div>
+      <h1>Inbox test</h1>
+      <button onClick={handlePingPong}>Start a ping-pong</button>
+      {pingPong && (
+        <div data-testid="ping-pong">
+          <p>Ping: {new Date(pingPong.ping).toISOString()}</p>
+          <p>Pong: {new Date(pingPong.pong!).toISOString()}</p>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/tests/e2e/src/pages/Inbox.tsx
+++ b/tests/e2e/src/pages/Inbox.tsx
@@ -19,14 +19,15 @@ export function Inbox() {
   const [pingPong, setPingPong] = useState<PingPong | null>(null);
   const iframeRef = useRef<HTMLIFrameElement>();
 
-  useInboxListener(async (pingPong) => {
-    pingPong.pong = Date.now();
+  useInboxListener(async (message) => {
+    const pingPong = PingPong.create(
+      { ping: message.ping, pong: Date.now() },
+      { owner: message._owner },
+    );
     setPingPong(pingPong);
-    iframeRef.current?.remove();
-    iframeRef.current = undefined;
   });
 
-  const { sendMessage } = useInboxSender(id);
+  const sendPingPong = useInboxSender(id);
 
   useEffect(() => {
     async function load() {
@@ -39,7 +40,7 @@ export function Inbox() {
       group.addMember(account, "writer");
       const pingPong = PingPong.create({ ping: Date.now() }, { owner: group });
 
-      sendMessage(pingPong);
+      sendPingPong(pingPong);
     }
 
     load();
@@ -47,6 +48,8 @@ export function Inbox() {
 
   const handlePingPong = () => {
     if (!me || id) return;
+
+    iframeRef.current?.remove();
 
     const url = new URL(window.location.href);
     url.searchParams.set("id", me.id);

--- a/tests/e2e/tests/Inbox.spec.ts
+++ b/tests/e2e/tests/Inbox.spec.ts
@@ -1,0 +1,13 @@
+import { expect, test } from "@playwright/test";
+
+test.describe("Inbox - Sync", () => {
+  test("should pass the message between the two peers", async ({ page }) => {
+    await page.goto("/inbox");
+
+    await page.getByRole("button", { name: "Start a ping-pong" }).click();
+
+    await page.getByTestId("ping-pong").waitFor();
+
+    await expect(page.getByTestId("ping-pong")).toBeVisible();
+  });
+});


### PR DESCRIPTION
We're introducing a new experimental API to simplify the inital handshake between accounts (on both Workers and Users)

## The problem

We want to introduce a new API to let users model different flows for connecting accounts.

Currently the only "built-in" flow is invite based:
- The owner creates the CoValue and create an invite
- The other account consumes the invite to get access to the CoValue

While this works most of the time it can be too much manual for some scenarios, such as communication with Workers.

One example is the communication with the Workers, where we want to use the Inbox to make the following flow possible:
- Let's say we have a worker that generates a PDF of a given WebPage
- The Worker Account ID is known beforehand and passed as ENV variable
- An user account creates a PDFRequest CoValue and sends it to the Worker via Inbox
- The Worker gets the PDFRequest, starts the processing and assign the result to one of the PDFRequest props
- The user account subscribed to PDFRequest and gets the result through it once ready

In this flow the Inbox provides an easy-to-use API to send a CoValue to any account by knowing only their AccountID.
It also automatically tracks the processed values and manages failures with a configurable retry system.

## Code examples

This is the example code to implement the communication to a Worker that generates PDFs of a given website URL:

schema.ts
```ts
export class PDFRequest extends CoMap {
  url = co.string;
  error = co.optional.string;
}
```

worker.ts
```ts
const { worker, experimental: { inbox }, done } = await startWorker();

// The value is marked as processed as soon as the callback promise is resolved 
// We pass the senderAccountID so the Worker can more easily add the sender as
// group member of the result. 
// A much simpler solution can also be to reuse the value group but may not be fitted to every use case
inbox.subscribe(PDFRequest, async (value, senderAccountID)  => { 
  // We are going to introduce a Task API to better handle this async workflows
  return generatePDF(value, senderAccountID);
})
```

On the app side:
```ts
function PDFDownloader(props) {
   const { me } = useAccount();
   const { sendMessage } = useInboxSender(import.meta.env.VITE_WORKER_ID);
   
   function handleSubmit(url: string) {
     const group = Group.create({ owner: me });
     const request = PDFRequest({ url }, { owner: group });
     const fileId = await sendMessage(request); // The inbox owner is automatically added as Writer
     
     downloadFileStream(fileId);
    }
}
```

## Design choices

The general thinking done when designing this API can be summarized in these points:
- To connect the two accounts need only their "AccountID"
- Permissions for this kind of communication should be easy to implement
- The messages sent should be only visible to the reiceiver, for that we have introduced the "writeOnly" role
- Generally, an account should send a CoValue to the other account and the rest of the communication should be handled by updating that CoValue.
- Managing failures is HARD and requires a much more complex API. Anselm is designing a Task/Workflow API that's going to handle this kind of stuff more in-depth.
- Marking this a expermiental to let us play with the API in various apps and improve it further before releasing to the general public.

Along the way we found also that the Inbox can also be used for communication between users.

With the Inbox developers can implement an approval based flow, where the accounts that want to get access to a given resource can ask for access through the Inbox and owners can approve it.
We think this flow can be quite useful if used with the [Organization pattern](https://github.com/garden-co/jazz/pull/1045) where the users need to do it only once.

For that we have added a `useInboxListener` hook to subscribe to the current account Inbox messages but requires further exploration and it's outside of the main goals of this MVP.

### Scenarios

> What if the task fails

While the heavy lift should be done with a system designed to better handle failures (our next Task API or any other workflow system available in the wild) things may still be fail.

For that we provide:
- A "failed" stream that devs can use to check the failed CoValues
- A configurable retry system, which retries to run the callback for X times (default is 3) before giving up

> What if the user wants pass different possible schemas through the Inbox?

While we suggest to use different workers for most of the situations where this might be required it's possible to handle this scenario using a [SchemaUnion](https://jazz.tools/api-reference/jazz-tools#SchemaUnion):
```ts
const UnionOfMessageTypes = SchemaUnion.Of<CoMap>(value => {
   switch (value.get('type')) {
      case 'A':
         return MessageTypeA;
      case 'B':
         return MessageTypeB;
   }
})

inbox.subscribe(UnionOfMessageTypes, (value) => {
   if (value instanceof MessageTypeA) return processMessageTypeA(value);
   return  processMessageTypeB(value);
})
```

It would be very nice to support an API like the following one:
```ts
inbox.subscribe(MessageTypeA, (value) => {
})

inbox.subscribe(MessageTypeB, (value) => {
})
```

This would be very ergonomic especially on the App side, but we don't have the required level of introspection now and that's currently out of scope for now.

> What if the user subscribes multiple times on the same inbox

On the Worker side only one subscribe will work simply because we don't see the need for that there.

When using `useInboxListener` the update is pushed to every subscriber.

## Outside this MVP

There are some other stuff to figure out:
- What's our limit with the current message stream?
- How's going to be possible to distribute work across workers? (might steal the sharding approach from #763 or go for something like Raft)
- Explore the user-to-user communication use case and iterate the API around our findings there.