### PR TITLE
fix: enable linting for import extensions on packages

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -25,18 +25,48 @@
   "linter": {
     "enabled": false,
     "rules": {
-      "recommended": true
+      "recommended": true,
+      "correctness": {
+        "useImportExtensions": {
+          "level": "error",
+          "options": {
+            "suggestedExtensions": {
+              "ts": {
+                "module": "js",
+                "component": "jsx"
+              }
+            }
+          }
+        }
+      }
     }
   },
   "overrides": [
+    {
+      "include": ["packages/**/src/**"],
+      "linter": {
+        "enabled": true,
+        "rules": {
+          "recommended": false
+        }
+      }
+    },
+    {
+      "include": ["packages/**/src/tests/**", "packages/**/src/test/**"],
+      "linter": {
+        "rules": {
+          "correctness": {
+            "useImportExtensions": "off"
+          }
+        }
+      }
+    },
     {
       "include": ["packages/cojson-storage-indexeddb/**"],
       "linter": {
         "enabled": true,
         "rules": {
-          "correctness": {
-            "useImportExtensions": "error"
-          },
+          "recommended": true,
           "suspicious": {
             "noExplicitAny": "info"
           }

--- a/packages/jazz-nodejs/src/index.ts
+++ b/packages/jazz-nodejs/src/index.ts
@@ -8,7 +8,7 @@ import {
   randomSessionProvider,
 } from "jazz-tools";
 import { WebSocket } from "ws";
-import { webSocketWithReconnection } from "./webSocketWithReconnection";
+import { webSocketWithReconnection } from "./webSocketWithReconnection.js";
 
 /** @category Context Creation */
 export async function startWorker<Acc extends Account>({


### PR DESCRIPTION
Enable "useImportExtensions" on packages to avoid that we cause issues on the builds by forgotting import extensions.