### PR TITLE
chore(cojson): add @opentlementry/api as a dependency

### DIFF
--- a/.changeset/plenty-jars-listen.md
+++ b/.changeset/plenty-jars-listen.md
@@ -1,0 +1,5 @@
+---
+"cojson": patch
+---
+
+Remove @opentelemetry/api as a peer dependency and add it as a dependency

--- a/packages/cojson/package.json
+++ b/packages/cojson/package.json
@@ -31,13 +31,11 @@
     "@noble/ciphers": "^0.1.3",
     "@noble/curves": "^1.3.0",
     "@noble/hashes": "^1.4.0",
+    "@opentelemetry/api": "^1.0.0",
     "@scure/base": "^1.1.1",
     "hash-wasm": "^4.9.0",
     "neverthrow": "^7.0.1",
     "queueueue": "^4.1.2"
-  },
-  "peerDependencies": {
-    "@opentelemetry/api": "^1.0.0"
   },
   "scripts": {
     "dev": "tsc --watch --sourceMap --outDir dist/web -p tsconfig.web.json",


### PR DESCRIPTION
Mark `@opentelementry/api` as a dependency instead of  a peer dependency.