### PR TITLE
fix(jazz-tools): add a bundle step to fix the circular deps issue

### DIFF
--- a/.changeset/odd-numbers-mix.md
+++ b/.changeset/odd-numbers-mix.md
@@ -1,0 +1,5 @@
+---
+"jazz-tools": patch
+---
+
+Add a bundle step to not expose the circular deps to the lib consumers

--- a/.changeset/ten-toes-cross.md
+++ b/.changeset/ten-toes-cross.md
@@ -1,0 +1,5 @@
+---
+"jazz-tools": patch
+---
+
+Reduce the amount of circular deps

--- a/packages/jazz-tools/package.json
+++ b/packages/jazz-tools/package.json
@@ -6,14 +6,14 @@
   "react-native": "dist/native/index.native.js",
   "exports": {
     ".": {
-      "react-native": "./dist/native/index.native.js",
+      "react-native": "./dist/index.native.js",
       "types": "./src/index.web.ts",
-      "default": "./dist/web/index.web.js"
+      "default": "./dist/index.web.js"
     },
     "./native": {
-      "react-native": "./dist/native/index.native.js",
+      "react-native": "./dist/index.native.js",
       "types": "./src/index.native.ts",
-      "default": "./dist/native/index.native.js"
+      "default": "./dist/index.native.js"
     },
     "./src/*": "./src/*"
   },
@@ -21,22 +21,19 @@
   "license": "MIT",
   "version": "0.8.44",
   "dependencies": {
-    "cojson": "workspace:*",
-    "fast-check": "^3.17.2"
+    "cojson": "workspace:*"
   },
   "scripts": {
     "format-and-lint": "biome check .",
     "format-and-lint:fix": "biome check . --write",
-    "dev:web": "tsc --sourceMap --watch --outDir dist/web -p tsconfig.web.json",
-    "dev:native": "tsc --sourceMap --watch --outDir dist/native -p tsconfig.native.json",
+    "dev": "tsup --watch",
     "test": "vitest --run --root ../../ --project jazz-tools",
     "test:watch": "vitest --watch --root ../../ --project jazz-tools",
-    "build:web": "tsc --sourceMap --outDir dist/web -p tsconfig.web.json",
-    "build:native": "tsc --sourceMap --outDir dist/native -p tsconfig.native.json",
-    "build": "rm -rf ./dist && pnpm run build:web && pnpm run build:native",
+    "build": "tsup",
     "prepublishOnly": "npm run build"
   },
   "devDependencies": {
+    "tsup": "^8.3.5",
     "typescript": "~5.6.2",
     "vitest": "1.5.3"
   },

--- a/packages/jazz-tools/src/coValues/account.ts
+++ b/packages/jazz-tools/src/coValues/account.ts
@@ -14,16 +14,13 @@ import {
 } from "cojson";
 import {
   AnonymousJazzAgent,
-  CoMap,
   type CoValue,
   CoValueBase,
   CoValueClass,
   DeeplyLoaded,
   DepthsIn,
-  Group,
   ID,
   MembersSym,
-  Profile,
   Ref,
   type RefEncoded,
   RefIfCoValue,
@@ -37,6 +34,10 @@ import {
   subscriptionsScopes,
 } from "../internal.js";
 import { coValuesCache } from "../lib/cache.js";
+import { type CoMap } from "./coMap.js";
+import { type Group } from "./group.js";
+import { Profile } from "./profile.js";
+import { RegisteredSchemas } from "./registeredSchemas.js";
 
 /** @category Identity & Permissions */
 export class Account extends CoValueBase implements CoValue {
@@ -59,7 +60,7 @@ export class Account extends CoValueBase implements CoValue {
         optional: false,
       } satisfies RefEncoded<Profile>,
       root: {
-        ref: () => CoMap,
+        ref: () => RegisteredSchemas["CoMap"],
         optional: true,
       } satisfies RefEncoded<CoMap>,
     };
@@ -239,7 +240,7 @@ export class Account extends CoValueBase implements CoValue {
     creationProps?: { name: string },
   ): void | Promise<void> {
     if (creationProps) {
-      const profileGroup = Group.create({ owner: this });
+      const profileGroup = RegisteredSchemas["Group"].create({ owner: this });
       profileGroup.addMember("everyone", "reader");
       this.profile = Profile.create(
         { name: creationProps.name },
@@ -388,3 +389,5 @@ export function isControlledAccount(account: Account): account is Account & {
 export type AccountClass<Acc extends Account> = CoValueClass<Acc> & {
   fromNode: (typeof Account)["fromNode"];
 };
+
+RegisteredSchemas["Account"] = Account;

--- a/packages/jazz-tools/src/coValues/coFeed.ts
+++ b/packages/jazz-tools/src/coValues/coFeed.ts
@@ -16,7 +16,6 @@ import type {
   CoValueClass,
   DeeplyLoaded,
   DepthsIn,
-  Group,
   ID,
   IfCo,
   Schema,
@@ -24,7 +23,6 @@ import type {
   UnCo,
 } from "../internal.js";
 import {
-  Account,
   CoValueBase,
   ItemsSym,
   Ref,
@@ -37,6 +35,9 @@ import {
   subscribeToCoValue,
   subscribeToExistingCoValue,
 } from "../internal.js";
+import { type Account } from "./account.js";
+import { type Group } from "./group.js";
+import { RegisteredSchemas } from "./registeredSchemas.js";
 
 /** @deprecated Use CoFeedEntry instead */
 export type CoStreamEntry<Item> = CoFeedEntry<Item>;
@@ -436,7 +437,7 @@ function entryFromRawEntry<Item>(
       return (
         accountID &&
         new Ref<Account>(accountID as unknown as ID<Account>, loadedAs, {
-          ref: Account,
+          ref: RegisteredSchemas["Account"],
           optional: false,
         })?.accessFrom(
           accessFrom,

--- a/packages/jazz-tools/src/coValues/coList.ts
+++ b/packages/jazz-tools/src/coValues/coList.ts
@@ -13,9 +13,7 @@ import type {
   UnCo,
 } from "../internal.js";
 import {
-  Account,
   AnonymousJazzAgent,
-  Group,
   ItemsSym,
   Ref,
   SchemaInit,
@@ -30,6 +28,9 @@ import {
   subscriptionsScopes,
 } from "../internal.js";
 import { coValuesCache } from "../lib/cache.js";
+import { type Account } from "./account.js";
+import { type Group } from "./group.js";
+import { RegisteredSchemas } from "./registeredSchemas.js";
 
 /**
  * CoLists are collaborative versions of plain arrays.
@@ -108,8 +109,8 @@ export class CoList<Item = any> extends Array<Item> implements CoValue {
   /** @category Collaboration */
   get _owner(): Account | Group {
     return this._raw.group instanceof RawAccount
-      ? Account.fromRaw(this._raw.group)
-      : Group.fromRaw(this._raw.group);
+      ? RegisteredSchemas["Account"].fromRaw(this._raw.group)
+      : RegisteredSchemas["Group"].fromRaw(this._raw.group);
   }
 
   /**
@@ -162,7 +163,9 @@ export class CoList<Item = any> extends Array<Item> implements CoValue {
     const rawAccount = this._raw.core.node.account;
 
     if (rawAccount instanceof RawAccount) {
-      return coValuesCache.get(rawAccount, () => Account.fromRaw(rawAccount));
+      return coValuesCache.get(rawAccount, () =>
+        RegisteredSchemas["Account"].fromRaw(rawAccount),
+      );
     }
 
     return new AnonymousJazzAgent(this._raw.core.node);

--- a/packages/jazz-tools/src/coValues/coMap.ts
+++ b/packages/jazz-tools/src/coValues/coMap.ts
@@ -13,7 +13,6 @@ import type {
   CoValueClass,
   DeeplyLoaded,
   DepthsIn,
-  Group,
   ID,
   IfCo,
   RefEncoded,
@@ -22,7 +21,6 @@ import type {
   co,
 } from "../internal.js";
 import {
-  Account,
   CoValueBase,
   ItemsSym,
   Ref,
@@ -36,6 +34,9 @@ import {
   subscribeToExistingCoValue,
   subscriptionsScopes,
 } from "../internal.js";
+import { type Account } from "./account.js";
+import { type Group } from "./group.js";
+import { RegisteredSchemas } from "./registeredSchemas.js";
 
 type CoMapEdit<V> = {
   value?: V;
@@ -178,7 +179,7 @@ export class CoMap extends CoValueBase implements CoValue {
       by:
         rawEdit.by &&
         new Ref<Account>(rawEdit.by as ID<Account>, target._loadedAs, {
-          ref: Account,
+          ref: RegisteredSchemas["Account"],
           optional: false,
         }).accessFrom(target, "_edits." + key + ".by"),
       madeAt: rawEdit.at,
@@ -742,3 +743,5 @@ const CoMapProxyHandler: ProxyHandler<CoMap> = {
     }
   },
 };
+
+RegisteredSchemas["CoMap"] = CoMap;

--- a/packages/jazz-tools/src/coValues/deepLoading.ts
+++ b/packages/jazz-tools/src/coValues/deepLoading.ts
@@ -1,16 +1,10 @@
 import { SessionID } from "cojson";
-import {
-  Account,
-  CoFeed,
-  CoFeedEntry,
-  CoList,
-  ItemsSym,
-  Ref,
-  RefEncoded,
-  UnCo,
-} from "../internal.js";
-import { CoKeys, CoMap } from "./coMap.js";
-import { CoValue, ID } from "./interfaces.js";
+import { ItemsSym, type Ref, RefEncoded, UnCo } from "../internal.js";
+import { type Account } from "./account.js";
+import { type CoFeed, CoFeedEntry } from "./coFeed.js";
+import { type CoList } from "./coList.js";
+import { type CoKeys, type CoMap } from "./coMap.js";
+import { type CoValue, type ID } from "./interfaces.js";
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export function fulfillsDepth(depth: any, value: CoValue): boolean {

--- a/packages/jazz-tools/src/coValues/extensions/imageDef.ts
+++ b/packages/jazz-tools/src/coValues/extensions/imageDef.ts
@@ -1,4 +1,6 @@
-import { CoMap, FileStream, co, subscriptionsScopes } from "../../internal.js";
+import { co, subscriptionsScopes } from "../../internal.js";
+import { FileStream } from "../coFeed.js";
+import { CoMap } from "../coMap.js";
 
 /** @category Media */
 export class ImageDefinition extends CoMap {

--- a/packages/jazz-tools/src/coValues/group.ts
+++ b/packages/jazz-tools/src/coValues/group.ts
@@ -9,24 +9,19 @@ import type {
   Schema,
 } from "../internal.js";
 import {
-  Account,
-  AccountAndGroupProxyHandler,
-  CoMap,
   CoValueBase,
   MembersSym,
   Ref,
-  co,
   ensureCoValueLoaded,
-  isControlledAccount,
   loadCoValue,
   subscribeToCoValue,
   subscribeToExistingCoValue,
 } from "../internal.js";
-
-/** @category Identity & Permissions */
-export class Profile extends CoMap {
-  name = co.string;
-}
+import { AccountAndGroupProxyHandler, isControlledAccount } from "./account.js";
+import { type Account } from "./account.js";
+import { type CoMap } from "./coMap.js";
+import { type Profile } from "./profile.js";
+import { RegisteredSchemas } from "./registeredSchemas.js";
 
 /** @category Identity & Permissions */
 export class Group extends CoValueBase implements CoValue {
@@ -51,7 +46,7 @@ export class Group extends CoValueBase implements CoValue {
       profile: "json" satisfies Schema,
       root: "json" satisfies Schema,
       [MembersSym]: {
-        ref: () => Account,
+        ref: () => RegisteredSchemas["Account"],
         optional: false,
       } satisfies RefEncoded<Account>,
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -229,3 +224,5 @@ export class Group extends CoValueBase implements CoValue {
     return this._raw.core.waitForSync(options);
   }
 }
+
+RegisteredSchemas["Group"] = Group;

--- a/packages/jazz-tools/src/coValues/interfaces.ts
+++ b/packages/jazz-tools/src/coValues/interfaces.ts
@@ -1,17 +1,18 @@
 import type { CojsonInternalTypes, RawCoValue } from "cojson";
 import { RawAccount } from "cojson";
+import { AnonymousJazzAgent } from "../implementation/anonymousJazzAgent.js";
 import type { DeeplyLoaded, DepthsIn } from "../internal.js";
 import {
-  Account,
-  AnonymousJazzAgent,
-  Group,
   Ref,
   SubscriptionScope,
   inspect,
   subscriptionsScopes,
 } from "../internal.js";
 import { coValuesCache } from "../lib/cache.js";
+import { type Account } from "./account.js";
 import { fulfillsDepth } from "./deepLoading.js";
+import { type Group } from "./group.js";
+import { RegisteredSchemas } from "./registeredSchemas.js";
 
 /** @category Abstract interfaces */
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -85,8 +86,8 @@ export class CoValueBase implements CoValue {
   get _owner(): Account | Group {
     const owner =
       this._raw.group instanceof RawAccount
-        ? Account.fromRaw(this._raw.group)
-        : Group.fromRaw(this._raw.group);
+        ? RegisteredSchemas["Account"].fromRaw(this._raw.group)
+        : RegisteredSchemas["Group"].fromRaw(this._raw.group);
 
     const subScope = subscriptionsScopes.get(this);
     if (subScope) {
@@ -102,7 +103,9 @@ export class CoValueBase implements CoValue {
     const rawAccount = this._raw.core.node.account;
 
     if (rawAccount instanceof RawAccount) {
-      return coValuesCache.get(rawAccount, () => Account.fromRaw(rawAccount));
+      return coValuesCache.get(rawAccount, () =>
+        RegisteredSchemas["Account"].fromRaw(rawAccount),
+      );
     }
 
     return new AnonymousJazzAgent(this._raw.core.node);

--- a/packages/jazz-tools/src/coValues/profile.ts
+++ b/packages/jazz-tools/src/coValues/profile.ts
@@ -1,0 +1,7 @@
+import { co } from "../internal.js";
+import { CoMap } from "./coMap.js";
+
+/** @category Identity & Permissions */
+export class Profile extends CoMap {
+  name = co.string;
+}

--- a/packages/jazz-tools/src/coValues/registeredSchemas.ts
+++ b/packages/jazz-tools/src/coValues/registeredSchemas.ts
@@ -1,0 +1,12 @@
+import type { Account } from "./account.js";
+import type { CoMap } from "./coMap.js";
+import type { Group } from "./group.js";
+
+/**
+ * Regisering schemas into this Record to avoid circular dependencies.
+ */
+export const RegisteredSchemas = {} as {
+  Account: typeof Account;
+  Group: typeof Group;
+  CoMap: typeof CoMap;
+};

--- a/packages/jazz-tools/src/exports.ts
+++ b/packages/jazz-tools/src/exports.ts
@@ -14,23 +14,24 @@ export { Encoders, co } from "./internal.js";
 
 export {
   Account,
+  isControlledAccount,
+  type AccountClass,
+} from "./coValues/account.js";
+export { Group } from "./coValues/group.js";
+export {
+  CoStream,
+  CoFeed,
   FileStream,
   BinaryCoStream,
-  CoList,
-  CoMap,
-  CoFeed,
-  CoStream,
-  CoValueBase,
-  Group,
-  ImageDefinition,
-  Profile,
-  isControlledAccount,
-  SchemaUnion,
-  type AccountClass,
-  type CoMapInit,
-  type CoValueClass,
-} from "./internal.js";
-export type { DeeplyLoaded, DepthsIn } from "./internal.js";
+} from "./coValues/coFeed.js";
+export { CoList } from "./coValues/coList.js";
+export { CoMap, type CoMapInit } from "./coValues/coMap.js";
+export { CoValueBase } from "./coValues/interfaces.js";
+export { ImageDefinition } from "./coValues/extensions/imageDef.js";
+export { Profile } from "./coValues/profile.js";
+export { SchemaUnion } from "./coValues/schemaUnion.js";
+
+export type { CoValueClass, DeeplyLoaded, DepthsIn } from "./internal.js";
 
 export {
   createCoValueObservable,

--- a/packages/jazz-tools/src/implementation/anonymousJazzAgent.ts
+++ b/packages/jazz-tools/src/implementation/anonymousJazzAgent.ts
@@ -1,0 +1,6 @@
+import { LocalNode } from "cojson";
+
+export class AnonymousJazzAgent {
+  _type = "Anonymous" as const;
+  constructor(public node: LocalNode) {}
+}

--- a/packages/jazz-tools/src/implementation/createContext.ts
+++ b/packages/jazz-tools/src/implementation/createContext.ts
@@ -9,7 +9,10 @@ import {
   RawAccountID,
   SessionID,
 } from "cojson";
-import { Account, AccountClass, ID } from "../internal.js";
+import { type Account, type AccountClass } from "../coValues/account.js";
+import { RegisteredSchemas } from "../coValues/registeredSchemas.js";
+import type { ID } from "../internal.js";
+import { AnonymousJazzAgent } from "./anonymousJazzAgent.js";
 
 export type Credentials = {
   accountID: ID<Account>;
@@ -136,7 +139,8 @@ export async function createJazzContext<Acc extends Account>(
 
     const { auth, sessionProvider, peersToLoadFrom, crypto } = options;
     const AccountSchema =
-      options.AccountSchema ?? (Account as unknown as AccountClass<Acc>);
+      options.AccountSchema ??
+      (RegisteredSchemas["Account"] as unknown as AccountClass<Acc>);
     let authResult: AuthResult;
     try {
       authResult = await auth.start(crypto);
@@ -241,11 +245,6 @@ export async function createJazzContext<Acc extends Account>(
       }
     }
   }
-}
-
-export class AnonymousJazzAgent {
-  _type = "Anonymous" as const;
-  constructor(public node: LocalNode) {}
 }
 
 export async function createAnonymousJazzContext({

--- a/packages/jazz-tools/src/implementation/refs.ts
+++ b/packages/jazz-tools/src/implementation/refs.ts
@@ -1,6 +1,6 @@
 import type { CoID, RawCoValue } from "cojson";
+import { type Account } from "../coValues/account.js";
 import type {
-  Account,
   AnonymousJazzAgent,
   CoValue,
   ID,

--- a/packages/jazz-tools/src/implementation/subscriptionScope.ts
+++ b/packages/jazz-tools/src/implementation/subscriptionScope.ts
@@ -1,6 +1,6 @@
 import type { RawCoValue } from "cojson";
+import { type Account } from "../coValues/account.js";
 import type {
-  Account,
   AnonymousJazzAgent,
   CoValue,
   CoValueClass,

--- a/packages/jazz-tools/src/internal.ts
+++ b/packages/jazz-tools/src/internal.ts
@@ -2,20 +2,12 @@ export * from "./implementation/symbols.js";
 export * from "./implementation/inspect.js";
 export * from "./coValues/interfaces.js";
 
-export * from "./coValues/coMap.js";
-export * from "./coValues/account.js";
-export * from "./coValues/coList.js";
-export * from "./coValues/coFeed.js";
-export * from "./coValues/schemaUnion.js";
-export * from "./coValues/group.js";
-
 export * from "./implementation/errors.js";
+export * from "./implementation/anonymousJazzAgent.js";
 export * from "./implementation/refs.js";
 export * from "./implementation/schema.js";
 export * from "./implementation/subscriptionScope.js";
 export * from "./coValues/deepLoading.js";
-
-export * from "./coValues/extensions/imageDef.js";
 
 export * from "./implementation/createContext.js";
 

--- a/packages/jazz-tools/src/tests/account.test.ts
+++ b/packages/jazz-tools/src/tests/account.test.ts
@@ -1,6 +1,6 @@
 import { expect, test } from "vitest";
-import { CoMap, co } from "../internal";
-import { setupTwoNodes } from "./utils";
+import { CoMap, co } from "../exports.js";
+import { setupTwoNodes } from "./utils.js";
 
 test("waitForAllCoValuesSync should resolve when all the values are synced", async () => {
   class TestMap extends CoMap {

--- a/packages/jazz-tools/src/tests/coMap.test.ts
+++ b/packages/jazz-tools/src/tests/coMap.test.ts
@@ -1,5 +1,6 @@
 import { connectedPeers } from "cojson/src/streamUtils.ts";
 import { describe, expect, expectTypeOf, test } from "vitest";
+import { Group, randomSessionProvider } from "../exports.js";
 import {
   Account,
   CoMap,
@@ -11,8 +12,7 @@ import {
   fixedCredentialsAuth,
   isControlledAccount,
 } from "../index.web.js";
-import { Group, randomSessionProvider } from "../internal.js";
-import { loadCoValueOrFail, setupTwoNodes } from "./utils.js";
+import { setupTwoNodes } from "./utils.js";
 
 const Crypto = await WasmCrypto.create();
 

--- a/packages/jazz-tools/src/tests/groupsAndAccounts.test.ts
+++ b/packages/jazz-tools/src/tests/groupsAndAccounts.test.ts
@@ -1,7 +1,7 @@
 import { RawGroup } from "cojson";
 import { describe, expect, test } from "vitest";
 import { Account, CoMap, Group, WasmCrypto, co } from "../index.web.js";
-import { setupTwoNodes, waitFor } from "./utils.js";
+import { setupTwoNodes } from "./utils.js";
 
 const Crypto = await WasmCrypto.create();
 

--- a/packages/jazz-tools/src/tests/schemaUnion.test.ts
+++ b/packages/jazz-tools/src/tests/schemaUnion.test.ts
@@ -7,7 +7,7 @@ import {
   co,
   loadCoValue,
   subscribeToCoValue,
-} from "../internal.js";
+} from "../exports.js";
 
 class BaseWidget extends CoMap {
   type = co.string;

--- a/packages/jazz-tools/tsup.config.ts
+++ b/packages/jazz-tools/tsup.config.ts
@@ -1,0 +1,13 @@
+import { defineConfig } from "tsup";
+
+export default defineConfig({
+  entry: {
+    "index.web": "src/index.web.ts",
+    "index.native": "src/index.native.ts",
+  },
+  format: ["esm"],
+  dts: false,
+  sourcemap: true,
+  clean: true,
+  minify: false,
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1864,10 +1864,10 @@ importers:
       cojson:
         specifier: workspace:*
         version: link:../cojson
-      fast-check:
-        specifier: ^3.17.2
-        version: 3.17.2
     devDependencies:
+      tsup:
+        specifier: ^8.3.5
+        version: 8.3.5(@microsoft/api-extractor@7.47.7(@types/node@22.5.1))(@swc/core@1.7.22(@swc/helpers@0.5.5))(jiti@1.21.6)(postcss@8.4.47)(typescript@5.6.3)(yaml@2.5.0)
       typescript:
         specifier: ~5.6.2
         version: 5.6.3
@@ -5943,6 +5943,12 @@ packages:
     resolution: {integrity: sha512-tjwM5exMg6BGRI+kNmTntNsvdZS1X8BFYS6tnJ2hdH0kVxM6/eVZ2xy+FqStSWvYmtfFMDLIxurorHwDKfDz5Q==}
     engines: {node: '>=18'}
 
+  bundle-require@5.0.0:
+    resolution: {integrity: sha512-GuziW3fSSmopcx4KRymQEJVbZUfqlCqcq7dvs6TYwKRZiegK/2buMxQTPs6MGlNv50wms1699qYO54R8XfRX4w==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+    peerDependencies:
+      esbuild: '>=0.18'
+
   busboy@1.6.0:
     resolution: {integrity: sha512-8SFQbg/0hQ9xy3UNTB0YEnsNBbWfhf7RtnzpL7TkBiTBRfrQ9Fxcnz7VJsleJpyp6rVLvXiuORqjlHi5q+PYuA==}
     engines: {node: '>=10.16.0'}
@@ -6242,6 +6248,10 @@ packages:
   connect@3.7.0:
     resolution: {integrity: sha512-ZqRXc+tZukToSNmh5C2iWMSoV3X1YUcPbqEM4DkEG5tNQXrQUZCNVGGv3IuicnkMtPfGf3Xtp8WCXs295iQ1pQ==}
     engines: {node: '>= 0.10.0'}
+
+  consola@3.2.3:
+    resolution: {integrity: sha512-I5qxpzLv+sJhTVEoLYNcTW+bThDCPsit0vLNKShZx6rLtpilNpmmeTPaeqJb9ZE9dV3DGaeby6Vuhrw38WjeyQ==}
+    engines: {node: ^14.18.0 || >=16.10.0}
 
   console-control-strings@1.1.0:
     resolution: {integrity: sha512-ty/fTekppD2fIwRvnZAVdeOiGd1c7YXEixbgJTNzqcxJWKQnjJ/V1bNEEE6hygpM3WjwHFUVK6HTjWSzV4a8sQ==}
@@ -7112,10 +7122,6 @@ packages:
 
   fast-base64-decode@1.0.0:
     resolution: {integrity: sha512-qwaScUgUGBYeDNRnbc/KyllVU88Jk1pRHPStuF/lO7B0/RTRLj7U0lkdTAutlBblY08rwZDff6tNU9cjv6j//Q==}
-
-  fast-check@3.17.2:
-    resolution: {integrity: sha512-+3DPTxtxABLgmmVpYxrash3DHoq0cMa1jjLYNp3qqokKKhqVEaS4lbnaDKqWU5Dd6C2pEudPPBAEEQ9nUou9OQ==}
-    engines: {node: '>=8.0.0'}
 
   fast-check@3.21.0:
     resolution: {integrity: sha512-QpmbiqRFRZ+SIlBJh6xi5d/PgXciUc/xWKc4Vi2RWEHHIRx6oM3f0fWNna++zP9VB5HUBTObUK9gTKQP3vVcrQ==}
@@ -8109,6 +8115,10 @@ packages:
   join-component@1.1.0:
     resolution: {integrity: sha512-bF7vcQxbODoGK1imE2P9GS9aw4zD0Sd+Hni68IMZLj7zRnquH7dXUmMw9hDI5S/Jzt7q+IyTXN0rSg2GI0IKhQ==}
 
+  joycon@3.1.1:
+    resolution: {integrity: sha512-34wB/Y7MW7bzjKRjUKTa46I2Z7eV62Rkhva+KkopW7Qvv/OSWBqvkSY7vusOPrNuZcUG3tApvdVgNB8POj3SPw==}
+    engines: {node: '>=10'}
+
   js-cookie@2.2.1:
     resolution: {integrity: sha512-HvdH2LzI/EAZcUwA8+0nKNtWHqS+ZmijLA30RwZA0bo7ToCckjK5MkGhjED9KoRcXO6BaGI3I9UIzSA1FKFPOQ==}
 
@@ -8378,11 +8388,19 @@ packages:
     resolution: {integrity: sha512-K2U4W2Ff5ibV7j7ydLr+zLAkIg5JJ4lPn1Ltsdt+Tz/IjQ8buJ55pZAxoP34lqIiwtF9iAvtLv3JGv7CAyAg+g==}
     engines: {node: '>=14'}
 
+  lilconfig@3.1.3:
+    resolution: {integrity: sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw==}
+    engines: {node: '>=14'}
+
   lines-and-columns@1.2.4:
     resolution: {integrity: sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==}
 
   listenercount@1.0.1:
     resolution: {integrity: sha512-3mk/Zag0+IJxeDrxSgaDPy4zZ3w05PRZeJNnlWhzFz5OkX49J4krc+A8X2d2M69vGMBEX0uyl8M+W+8gH+kBqQ==}
+
+  load-tsconfig@0.2.5:
+    resolution: {integrity: sha512-IXO6OCs9yg8tMKzfPZ1YmheJbZCiEsnBdcB03l0OcfK9prKnJb96siuHCr5Fl37/yo9DnKU+TLpxzTUspw9shg==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
 
   loader-runner@4.3.0:
     resolution: {integrity: sha512-3R/1M+yS3j5ou80Me59j7F9IMs4PXs3VqRrm0TU3AbKPxlmpoY1TNscJV/oGJXo8qCatFGTfDbY6W6ipGOYXfg==}
@@ -8428,6 +8446,9 @@ packages:
 
   lodash.merge@4.6.2:
     resolution: {integrity: sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==}
+
+  lodash.sortby@4.7.0:
+    resolution: {integrity: sha512-HDWXG8isMntAyRF5vZ7xKuEvOhT4AhlRt/3czTSjvGUxjYCBVRQY48ViDHyfYz9VIoBkW4TMGQNapx+l3RUwdA==}
 
   lodash.startcase@4.4.0:
     resolution: {integrity: sha512-+WKqsK294HMSc2jEbNgpHpd0JfIBhp7rEV4aqXWqFr6AlXov+SlcgB1Fv01y2kGe3Gc8nMW7VA0SrGuSkRfIEg==}
@@ -9361,6 +9382,24 @@ packages:
       ts-node:
         optional: true
 
+  postcss-load-config@6.0.1:
+    resolution: {integrity: sha512-oPtTM4oerL+UXmx+93ytZVN82RrlY/wPUV8IeDxFrzIjXOLF1pN+EmKPLbubvKHT2HC20xXsCAH2Z+CKV6Oz/g==}
+    engines: {node: '>= 18'}
+    peerDependencies:
+      jiti: '>=1.21.0'
+      postcss: '>=8.0.9'
+      tsx: ^4.8.1
+      yaml: ^2.4.2
+    peerDependenciesMeta:
+      jiti:
+        optional: true
+      postcss:
+        optional: true
+      tsx:
+        optional: true
+      yaml:
+        optional: true
+
   postcss-nested@5.0.6:
     resolution: {integrity: sha512-rKqm2Fk0KbA8Vt3AdGN0FB9OBOMDVajMG6ZCf/GoHgdxUJ4sBFp0A/uMIRm+MJUdo33YXEtjqIz8u7DAp8B7DA==}
     engines: {node: '>=12.0'}
@@ -10278,6 +10317,10 @@ packages:
     resolution: {integrity: sha512-l3BikUxvPOcn5E74dZiq5BGsTb5yEwhaTSzccU6t4sDOH8NWJCstKO5QT2CvtFoK6F0saL7p9xHAqHOlCPJygA==}
     engines: {node: '>= 8'}
 
+  source-map@0.8.0-beta.0:
+    resolution: {integrity: sha512-2ymg6oRBpebeZi9UUNsgQ89bhx01TcTkmNTGnNO88imTmbSgy4nfujrgVEFKWpMTEGA11EDkTt7mqObTPdigIA==}
+    engines: {node: '>= 8'}
+
   spawndamnit@3.0.1:
     resolution: {integrity: sha512-MmnduQUuHCoFckZoWnXsTg7JaiLBJrKFj9UI2MbRPGaJeVpsLcVBu6P/IGZovziM/YBsellCmsprgNA+w0CzVg==}
 
@@ -10673,6 +10716,13 @@ packages:
   tinycolor2@1.6.0:
     resolution: {integrity: sha512-XPaBkWQJdsf3pLKJV9p4qN/S+fm2Oj8AIPo1BTUhg5oxkvm9+SVEGFdhyOz7tTdUTfvxMiAs4sp6/eZO2Ew+pw==}
 
+  tinyexec@0.3.1:
+    resolution: {integrity: sha512-WiCJLEECkO18gwqIp6+hJg0//p23HXp4S+gGtAKu3mI2F2/sXC4FvHvXvB0zJVVaTPhx1/tOwdbRsa1sOBIKqQ==}
+
+  tinyglobby@0.2.10:
+    resolution: {integrity: sha512-Zc+8eJlFMvgatPZTl6A9L/yht8QqdmUNtURHaKZLmKBE12hNPSrqNkUp2cs3M/UKmNVVAMFQYSjYIVHDjW5zew==}
+    engines: {node: '>=12.0.0'}
+
   tinygradient@1.1.5:
     resolution: {integrity: sha512-8nIfc2vgQ4TeLnk2lFj4tRLvvJwEfQuabdsmvDdQPT0xlk9TaNtpGd6nNRxXoK6vQhN6RSzj+Cnp5tTQmpxmbw==}
 
@@ -10731,6 +10781,9 @@ packages:
   tr46@0.0.3:
     resolution: {integrity: sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==}
 
+  tr46@1.0.1:
+    resolution: {integrity: sha512-dTpowEjclQ7Kgx5SdBkqRzVhERQXov8/l9Ft9dVM9fmg0W0KQSVaXX9T4i6twCPNtYiZM53lpSSUAwJbFPOHxA==}
+
   tr46@3.0.0:
     resolution: {integrity: sha512-l7FvfAHlcmulp8kr+flpQZmVwtu7nfRV7NZujtN0OqES8EL4O4e0qqzL0DC5gAvx/ZC/9lk6rhcUwYvkBnBnYA==}
     engines: {node: '>=12'}
@@ -10741,6 +10794,10 @@ packages:
 
   traverse@0.3.9:
     resolution: {integrity: sha512-iawgk0hLP3SxGKDfnDJf8wTz4p2qImnyihM5Hh/sGvQ3K37dPi/w8sRhdNIxYA1TwFwc5mDhIJq+O0RsvXBKdQ==}
+
+  tree-kill@1.2.2:
+    resolution: {integrity: sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==}
+    hasBin: true
 
   ts-api-utils@1.4.0:
     resolution: {integrity: sha512-032cPxaEKwM+GT3vA5JXNzIaizx388rhsSW79vGRNGXfRRAdEAn2mvk36PvK5HnOchyWZ7afLEXqYCvPCrzuzQ==}
@@ -10773,6 +10830,25 @@ packages:
 
   tslib@2.6.2:
     resolution: {integrity: sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==}
+
+  tsup@8.3.5:
+    resolution: {integrity: sha512-Tunf6r6m6tnZsG9GYWndg0z8dEV7fD733VBFzFJ5Vcm1FtlXB8xBD/rtrBi2a3YKEV7hHtxiZtW5EAVADoe1pA==}
+    engines: {node: '>=18'}
+    hasBin: true
+    peerDependencies:
+      '@microsoft/api-extractor': ^7.36.0
+      '@swc/core': ^1
+      postcss: ^8.4.12
+      typescript: '>=4.5.0'
+    peerDependenciesMeta:
+      '@microsoft/api-extractor':
+        optional: true
+      '@swc/core':
+        optional: true
+      postcss:
+        optional: true
+      typescript:
+        optional: true
 
   tunnel-agent@0.6.0:
     resolution: {integrity: sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==}
@@ -11241,6 +11317,9 @@ packages:
   webidl-conversions@3.0.1:
     resolution: {integrity: sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==}
 
+  webidl-conversions@4.0.2:
+    resolution: {integrity: sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg==}
+
   webidl-conversions@5.0.0:
     resolution: {integrity: sha512-VlZwKPCkYKxQgeSbH5EyngOmRp7Ww7I9rQLERETtf5ofd9pGeswWiOtogpEO850jziPRarreGxn5QIiTqpb2wA==}
     engines: {node: '>=8'}
@@ -11299,6 +11378,9 @@ packages:
 
   whatwg-url@5.0.0:
     resolution: {integrity: sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==}
+
+  whatwg-url@7.1.0:
+    resolution: {integrity: sha512-WUu7Rg1DroM7oQvGWfOiAK21n74Gg+T4elXEQYkOhtyLeWiJFoOGLXPKI/9gzIie9CtwVLm8wtw6YJdKyxSjeg==}
 
   which-module@2.0.1:
     resolution: {integrity: sha512-iBdZ57RDvnOR9AGBhML2vFZf7h8vmBjhoaZqODJBFWHVtKkDmKuHai3cx5PgVMrX5YDNp27AofYbAwctSS+vhQ==}
@@ -16298,6 +16380,11 @@ snapshots:
     dependencies:
       run-applescript: 7.0.0
 
+  bundle-require@5.0.0(esbuild@0.24.0):
+    dependencies:
+      esbuild: 0.24.0
+      load-tsconfig: 0.2.5
+
   busboy@1.6.0:
     dependencies:
       streamsearch: 1.1.0
@@ -16617,6 +16704,8 @@ snapshots:
       utils-merge: 1.0.1
     transitivePeerDependencies:
       - supports-color
+
+  consola@3.2.3: {}
 
   console-control-strings@1.1.0: {}
 
@@ -17579,10 +17668,6 @@ snapshots:
   fake-indexeddb@6.0.0: {}
 
   fast-base64-decode@1.0.0: {}
-
-  fast-check@3.17.2:
-    dependencies:
-      pure-rand: 6.1.0
 
   fast-check@3.21.0:
     dependencies:
@@ -18801,6 +18886,8 @@ snapshots:
 
   join-component@1.1.0: {}
 
+  joycon@3.1.1: {}
+
   js-cookie@2.2.1: {}
 
   js-cookie@3.0.5: {}
@@ -19074,9 +19161,13 @@ snapshots:
 
   lilconfig@3.0.0: {}
 
+  lilconfig@3.1.3: {}
+
   lines-and-columns@1.2.4: {}
 
   listenercount@1.0.1: {}
+
+  load-tsconfig@0.2.5: {}
 
   loader-runner@4.3.0: {}
 
@@ -19117,6 +19208,8 @@ snapshots:
   lodash.isplainobject@4.0.6: {}
 
   lodash.merge@4.6.2: {}
+
+  lodash.sortby@4.7.0: {}
 
   lodash.startcase@4.4.0: {}
 
@@ -20122,6 +20215,14 @@ snapshots:
     optionalDependencies:
       postcss: 8.4.47
       ts-node: 10.9.2(@swc/core@1.7.22(@swc/helpers@0.5.5))(@types/node@22.5.1)(typescript@5.6.3)
+
+  postcss-load-config@6.0.1(jiti@1.21.6)(postcss@8.4.47)(yaml@2.5.0):
+    dependencies:
+      lilconfig: 3.1.3
+    optionalDependencies:
+      jiti: 1.21.6
+      postcss: 8.4.47
+      yaml: 2.5.0
 
   postcss-nested@5.0.6(postcss@8.4.47):
     dependencies:
@@ -21129,6 +21230,10 @@ snapshots:
 
   source-map@0.7.4: {}
 
+  source-map@0.8.0-beta.0:
+    dependencies:
+      whatwg-url: 7.1.0
+
   spawndamnit@3.0.1:
     dependencies:
       cross-spawn: 7.0.6
@@ -21571,6 +21676,13 @@ snapshots:
 
   tinycolor2@1.6.0: {}
 
+  tinyexec@0.3.1: {}
+
+  tinyglobby@0.2.10:
+    dependencies:
+      fdir: 6.4.2(picomatch@4.0.2)
+      picomatch: 4.0.2
+
   tinygradient@1.1.5:
     dependencies:
       '@types/tinycolor2': 1.4.6
@@ -21619,6 +21731,10 @@ snapshots:
 
   tr46@0.0.3: {}
 
+  tr46@1.0.1:
+    dependencies:
+      punycode: 2.3.1
+
   tr46@3.0.0:
     dependencies:
       punycode: 2.3.1
@@ -21628,6 +21744,8 @@ snapshots:
       punycode: 2.3.1
 
   traverse@0.3.9: {}
+
+  tree-kill@1.2.2: {}
 
   ts-api-utils@1.4.0(typescript@5.6.3):
     dependencies:
@@ -21660,6 +21778,35 @@ snapshots:
   tslib@2.4.1: {}
 
   tslib@2.6.2: {}
+
+  tsup@8.3.5(@microsoft/api-extractor@7.47.7(@types/node@22.5.1))(@swc/core@1.7.22(@swc/helpers@0.5.5))(jiti@1.21.6)(postcss@8.4.47)(typescript@5.6.3)(yaml@2.5.0):
+    dependencies:
+      bundle-require: 5.0.0(esbuild@0.24.0)
+      cac: 6.7.14
+      chokidar: 4.0.1
+      consola: 3.2.3
+      debug: 4.3.7
+      esbuild: 0.24.0
+      joycon: 3.1.1
+      picocolors: 1.1.1
+      postcss-load-config: 6.0.1(jiti@1.21.6)(postcss@8.4.47)(yaml@2.5.0)
+      resolve-from: 5.0.0
+      rollup: 4.24.0
+      source-map: 0.8.0-beta.0
+      sucrase: 3.35.0
+      tinyexec: 0.3.1
+      tinyglobby: 0.2.10
+      tree-kill: 1.2.2
+    optionalDependencies:
+      '@microsoft/api-extractor': 7.47.7(@types/node@22.5.1)
+      '@swc/core': 1.7.22(@swc/helpers@0.5.5)
+      postcss: 8.4.47
+      typescript: 5.6.3
+    transitivePeerDependencies:
+      - jiti
+      - supports-color
+      - tsx
+      - yaml
 
   tunnel-agent@0.6.0:
     dependencies:
@@ -22166,6 +22313,8 @@ snapshots:
 
   webidl-conversions@3.0.1: {}
 
+  webidl-conversions@4.0.2: {}
+
   webidl-conversions@5.0.0: {}
 
   webidl-conversions@7.0.0: {}
@@ -22238,6 +22387,12 @@ snapshots:
     dependencies:
       tr46: 0.0.3
       webidl-conversions: 3.0.1
+
+  whatwg-url@7.1.0:
+    dependencies:
+      lodash.sortby: 4.7.0
+      tr46: 1.0.1
+      webidl-conversions: 4.0.2
 
   which-module@2.0.1: {}
 


### PR DESCRIPTION
Got some issues with circular deps [when working on the Inbox.](https://github.com/garden-co/jazz/actions/runs/12414405452/job/34658441210)

Fixed the errors in the tests by removing the `coValues` exports from internal and using an object to remove the circular imports between CoValues.

Then I've noticed that this fix also makes now possible to bundle `jazz-tools` using [tsup](https://tsup.egoist.dev/) finally fixing our compat issues with some bundlers (esbuild and parcel to name two).