### PR TITLE
fix: fix --json option on the account create command

### DIFF
--- a/.changeset/mean-ghosts-hunt.md
+++ b/.changeset/mean-ghosts-hunt.md
@@ -1,0 +1,5 @@
+---
+"jazz-run": patch
+---
+
+Fix the --json option on the account create command

--- a/packages/jazz-nodejs/src/test/startWorker.test.ts
+++ b/packages/jazz-nodejs/src/test/startWorker.test.ts
@@ -1,11 +1,9 @@
-import { Peer } from "cojson";
-import { createWebSocketPeer } from "cojson-transport-ws";
 import { createWorkerAccount } from "jazz-run/createWorkerAccount";
 import { startSyncServer } from "jazz-run/startSyncServer";
-import { CoMap, Group, co } from "jazz-tools";
-import { describe, expect, onTestFinished, test, vi } from "vitest";
-import { WebSocket } from "ws";
+import { CoMap, Group, InboxSender, co } from "jazz-tools";
+import { describe, expect, onTestFinished, test } from "vitest";
 import { startWorker } from "../index";
+import { waitFor } from "./utils";
 
 async function setup() {
   const { server, port } = await setupSyncServer();
@@ -34,13 +32,13 @@ async function setupSyncServer(defaultPort = "0") {
 }
 
 async function setupWorker(syncServer: string) {
-  const { accountId, agentSecret } = await createWorkerAccount({
+  const { accountID, agentSecret } = await createWorkerAccount({
     name: "test-worker",
     peer: syncServer,
   });
 
   return startWorker({
-    accountID: accountId,
+    accountID: accountID,
     accountSecret: agentSecret,
     syncServer,
   });

--- a/packages/jazz-run/src/createWorkerAccount.ts
+++ b/packages/jazz-run/src/createWorkerAccount.ts
@@ -27,19 +27,10 @@ export const createWorkerAccount = async ({
     throw new Error("account is not a controlled account");
   }
 
-  const accountCoValue = account._raw.core;
-  const accountProfileCoValue = account.profile!._raw.core;
-  const syncManager = account._raw.core.node.syncManager;
-
-  await Promise.all([
-    syncManager.syncCoValue(accountCoValue),
-    syncManager.syncCoValue(accountProfileCoValue),
-  ]);
-
   await account.waitForAllCoValuesSync({ timeout: 4_000 });
 
   return {
-    accountId: account.id,
+    accountID: account.id,
     agentSecret: account._raw.agentSecret,
   };
 };

--- a/packages/jazz-run/src/index.ts
+++ b/packages/jazz-run/src/index.ts
@@ -19,15 +19,15 @@ const createAccountCommand = Command.make(
   { name: nameOption, peer: peerOption, json: jsonOption },
   ({ name, peer, json }) => {
     return Effect.gen(function* () {
-      const { accountId, agentSecret } = yield* Effect.promise(() =>
+      const { accountID, agentSecret } = yield* Effect.promise(() =>
         createWorkerAccount({ name, peer }),
       );
 
       if (json) {
-        Console.log(JSON.stringify({ accountId, agentSecret }));
+        yield* Console.log(JSON.stringify({ accountID, agentSecret }));
       } else {
         yield* Console.log(`# Credentials for Jazz account "${name}":
-JAZZ_WORKER_ACCOUNT=${accountId}
+JAZZ_WORKER_ACCOUNT=${accountID}
 JAZZ_WORKER_SECRET=${agentSecret}
 `);
       }

--- a/packages/jazz-run/src/test/createWorkerAccount.test.ts
+++ b/packages/jazz-run/src/test/createWorkerAccount.test.ts
@@ -25,12 +25,12 @@ describe("createWorkerAccount - integration tests", () => {
       throw new Error("Server address is not an object");
     }
 
-    const { accountId, agentSecret } = await createWorkerAccount({
+    const { accountID, agentSecret } = await createWorkerAccount({
       name: "test",
       peer: `ws://localhost:${address.port}`,
     });
 
-    expect(accountId).toBeDefined();
+    expect(accountID).toBeDefined();
     expect(agentSecret).toBeDefined();
 
     const peer = createWebSocketPeer({
@@ -46,16 +46,16 @@ describe("createWorkerAccount - integration tests", () => {
       crypto,
     });
 
-    expect(await node.load(accountId as any)).not.toBe("unavailable");
+    expect(await node.load(accountID as any)).not.toBe("unavailable");
   });
 
   it("should create a worker account using the Jazz cloud", async () => {
-    const { accountId, agentSecret } = await createWorkerAccount({
+    const { accountID, agentSecret } = await createWorkerAccount({
       name: "test",
       peer: `wss://cloud.jazz.tools`,
     });
 
-    expect(accountId).toBeDefined();
+    expect(accountID).toBeDefined();
     expect(agentSecret).toBeDefined();
 
     const peer = createWebSocketPeer({
@@ -71,6 +71,6 @@ describe("createWorkerAccount - integration tests", () => {
       crypto,
     });
 
-    expect(await node.load(accountId as any)).not.toBe("unavailable");
+    expect(await node.load(accountID as any)).not.toBe("unavailable");
   });
 });


### PR DESCRIPTION
Fixed the --json option on the account create command and aligned "accountID" case with the Worker API