### PR TITLE
fix: throw an error if an invite is create from an account owned CoValue

### DIFF
--- a/.changeset/eleven-cobras-report.md
+++ b/.changeset/eleven-cobras-report.md
@@ -1,0 +1,6 @@
+---
+"jazz-browser": patch
+"cojson": patch
+---
+
+Throw an error if an invite is created from an account owned coValue

--- a/packages/cojson/src/coValues/account.ts
+++ b/packages/cojson/src/coValues/account.ts
@@ -16,6 +16,7 @@ import {
 import { AgentID } from "../ids.js";
 import { JsonObject } from "../jsonValue.js";
 import { LocalNode } from "../localNode.js";
+import type { AccountRole } from "../permissions.js";
 import { RawCoMap } from "./coMap.js";
 import { InviteSecret, RawGroup } from "./group.js";
 
@@ -64,6 +65,10 @@ export class RawAccount<
     this._cachedCurrentAgentID = agents[0];
 
     return ok(agents[0]!);
+  }
+
+  createInvite(_: AccountRole): InviteSecret {
+    throw new Error("Cannot create invite from an account");
   }
 }
 

--- a/packages/cojson/src/tests/account.test.ts
+++ b/packages/cojson/src/tests/account.test.ts
@@ -52,12 +52,9 @@ test("Can create account with one node, and then load it on another", async () =
   expect(map.get("foo")).toEqual("bar");
 
   const [node1asPeer, node2asPeer] = connectedPeers("node1", "node2", {
-    trace: true,
     peer1role: "server",
     peer2role: "client",
   });
-
-  console.log("After connected peers");
 
   node.syncManager.addPeer(node2asPeer);
 
@@ -73,4 +70,18 @@ test("Can create account with one node, and then load it on another", async () =
   if (map2 === "unavailable") throw new Error("Map unavailable");
 
   expect(map2.get("foo")).toEqual("bar");
+});
+
+test("throws an error if the user tried to create an invite from an account", async () => {
+  const { node, accountID } = await LocalNode.withNewlyCreatedAccount({
+    creationProps: { name: "Hermes Puggington" },
+    crypto: Crypto,
+  });
+
+  const account = await node.load(accountID);
+  if (account === "unavailable") throw new Error("Account unavailable");
+
+  expect(() => account.createInvite("admin")).toThrow(
+    "Cannot create invite from an account",
+  );
 });

--- a/packages/jazz-browser/src/index.ts
+++ b/packages/jazz-browser/src/index.ts
@@ -218,7 +218,9 @@ export function createInviteLink<C extends CoValue>(
     currentCoValue = currentCoValue.getGroup().core;
   }
 
-  if (currentCoValue.header.ruleset.type !== "group") {
+  const { ruleset, meta } = currentCoValue.header;
+
+  if (ruleset.type !== "group" || meta?.type === "account") {
     throw new Error("Can't create invite link for object without group");
   }
 

--- a/packages/jazz-browser/src/tests/createInviteLink.test.ts
+++ b/packages/jazz-browser/src/tests/createInviteLink.test.ts
@@ -1,0 +1,18 @@
+import { CoMap, co } from "jazz-tools";
+import { expect, test } from "vitest";
+import { createInviteLink } from "../index.js";
+import { setupTwoNodes } from "./utils.js";
+
+test("throws an error if the user tried to create an invite from an account owned coValue", async () => {
+  class TestMap extends CoMap {
+    name = co.string;
+  }
+
+  const { clientAccount } = await setupTwoNodes();
+
+  const map = TestMap.create({ name: "Alice" }, { owner: clientAccount });
+
+  expect(() =>
+    createInviteLink(map, "admin", { baseURL: "http://localhost:3000" }),
+  ).toThrow("Can't create invite link for object without group");
+});

--- a/packages/jazz-browser/src/tests/utils.ts
+++ b/packages/jazz-browser/src/tests/utils.ts
@@ -1,0 +1,92 @@
+import { CoID, LocalNode, RawCoValue } from "cojson";
+import { connectedPeers } from "cojson/src/streamUtils.js";
+import { Account, WasmCrypto } from "jazz-tools";
+
+const Crypto = await WasmCrypto.create();
+
+export async function setupTwoNodes() {
+  const [serverAsPeer, clientAsPeer] = connectedPeers(
+    "clientToServer",
+    "serverToClient",
+    {
+      peer1role: "server",
+      peer2role: "client",
+    },
+  );
+
+  const client = await LocalNode.withNewlyCreatedAccount({
+    peersToLoadFrom: [serverAsPeer],
+    crypto: Crypto,
+    creationProps: { name: "Client" },
+    migration: async (rawAccount, _node, creationProps) => {
+      const account = new Account({
+        fromRaw: rawAccount,
+      });
+
+      await account.migrate?.(creationProps);
+    },
+  });
+
+  const server = await LocalNode.withNewlyCreatedAccount({
+    peersToLoadFrom: [clientAsPeer],
+    crypto: Crypto,
+    creationProps: { name: "Server" },
+    migration: async (rawAccount, _node, creationProps) => {
+      const account = new Account({
+        fromRaw: rawAccount,
+      });
+
+      await account.migrate?.(creationProps);
+    },
+  });
+
+  return {
+    clientNode: client.node,
+    serverNode: server.node,
+    clientAccount: Account.fromRaw(
+      await loadCoValueOrFail(client.node, client.accountID),
+    ),
+    serverAccount: Account.fromRaw(
+      await loadCoValueOrFail(server.node, server.accountID),
+    ),
+  };
+}
+
+export function waitFor(callback: () => boolean | void) {
+  return new Promise<void>((resolve, reject) => {
+    const checkPassed = () => {
+      try {
+        return { ok: callback(), error: null };
+      } catch (error) {
+        return { ok: false, error };
+      }
+    };
+
+    let retries = 0;
+
+    const interval = setInterval(() => {
+      const { ok, error } = checkPassed();
+
+      if (ok !== false) {
+        clearInterval(interval);
+        resolve();
+      }
+
+      if (++retries > 10) {
+        clearInterval(interval);
+        reject(error);
+      }
+    }, 100);
+  });
+}
+
+export async function loadCoValueOrFail<V extends RawCoValue>(
+  node: LocalNode,
+  id: CoID<V>,
+): Promise<V> {
+  const value = await node.load(id);
+  if (value === "unavailable") {
+    throw new Error("CoValue not found");
+  }
+  return value;
+}


### PR DESCRIPTION
This PR prevents users from creating invites from account owned CoValues (which weren't working anyway)

This should fix the "Account has X agents" issue