### PR TITLE
perf: skip verify step when creating a new local transaction

### DIFF
--- a/.changeset/fast-chicken-build.md
+++ b/.changeset/fast-chicken-build.md
@@ -1,0 +1,5 @@
+---
+"cojson": patch
+---
+
+skip verify step when creating a new local transaction

--- a/packages/cojson/src/coValueCore.ts
+++ b/packages/cojson/src/coValueCore.ts
@@ -202,6 +202,7 @@ export class CoValueCore {
     newTransactions: Transaction[],
     givenExpectedNewHash: Hash | undefined,
     newSignature: Signature,
+    skipVerify: boolean = false,
   ): Result<true, TryAddTransactionsError> {
     return this.node
       .resolveAccountAgent(
@@ -231,8 +232,10 @@ export class CoValueCore {
           } satisfies InvalidHashError);
         }
 
-        // const beforeVerify = performance.now();
-        if (!this.crypto.verify(newSignature, expectedNewHash, signerID)) {
+        if (
+          skipVerify !== true &&
+          !this.crypto.verify(newSignature, expectedNewHash, signerID)
+        ) {
           return err({
             type: "InvalidSignature",
             id: this.id,
@@ -600,6 +603,7 @@ export class CoValueCore {
       [transaction],
       expectedNewHash,
       signature,
+      true,
     )._unsafeUnwrap({ withStackTrace: true });
 
     if (success) {


### PR DESCRIPTION
While profiling I've found that we are firing a redundant verify while creating a new transaction.

Fixing this gives us around a 2x improvement on our editing stress tests