### PR TITLE
feat: add the assign method to RawCoMap to create bulk transactions and optimize RawCoMap init

### DIFF
--- a/.changeset/tiny-trains-vanish.md
+++ b/.changeset/tiny-trains-vanish.md
@@ -1,0 +1,5 @@
+---
+"cojson": patch
+---
+
+Add the assign method to RawCoMap to create bulk transactions and optimize RawCoMap init

--- a/packages/cojson/src/coValues/coMap.ts
+++ b/packages/cojson/src/coValues/coMap.ts
@@ -383,6 +383,26 @@ export class RawCoMap<
     this.processNewTransactions();
   }
 
+  assign(
+    entries: Partial<Shape>,
+    privacy: "private" | "trusting" = "private",
+  ): void {
+    if (this.isTimeTravelEntity()) {
+      throw new Error("Cannot set value on a time travel entity");
+    }
+
+    this.core.makeTransaction(
+      Object.entries(entries).map(([key, value]) => ({
+        op: "set",
+        key,
+        value: isCoValue(value) ? value.id : value,
+      })),
+      privacy,
+    );
+
+    this.processNewTransactions();
+  }
+
   /** Delete the given key (setting it to undefined).
    *
    * If `privacy` is `"private"` **(default)**, `key` is encrypted in the transaction, only readable by other members of the group this `CoMap` belongs to. Not even sync servers can see the content in plaintext.

--- a/packages/cojson/src/coValues/group.ts
+++ b/packages/cojson/src/coValues/group.ts
@@ -653,10 +653,8 @@ export class RawGroup<
       })
       .getCurrentContent() as L;
 
-    if (init) {
-      for (const item of init) {
-        list.append(item, undefined, initPrivacy);
-      }
+    if (init?.length) {
+      list.appendItems(init, undefined, initPrivacy);
     }
 
     return list;

--- a/packages/cojson/src/coValues/group.ts
+++ b/packages/cojson/src/coValues/group.ts
@@ -623,9 +623,7 @@ export class RawGroup<
       .getCurrentContent() as M;
 
     if (init) {
-      for (const [key, value] of Object.entries(init)) {
-        map.set(key, value, initPrivacy);
-      }
+      map.assign(init, initPrivacy);
     }
 
     return map;

--- a/packages/cojson/src/tests/coList.test.ts
+++ b/packages/cojson/src/tests/coList.test.ts
@@ -75,6 +75,26 @@ test("Push is equivalent to append after last item", () => {
   expect(content.toJSON()).toEqual(["hello", "world", "hooray"]);
 });
 
+test("appendItems add an array of items at the end of the list", () => {
+  const node = new LocalNode(...randomAnonymousAccountAndSessionID(), Crypto);
+
+  const coValue = node.createCoValue({
+    type: "colist",
+    ruleset: { type: "unsafeAllowAll" },
+    meta: null,
+    ...Crypto.createdNowUnique(),
+  });
+
+  const content = expectList(coValue.getCurrentContent());
+
+  expect(content.type).toEqual("colist");
+
+  content.append("hello", 0, "trusting");
+  expect(content.toJSON()).toEqual(["hello"]);
+  content.appendItems(["world", "hooray", "universe"], undefined, "trusting");
+  expect(content.toJSON()).toEqual(["hello", "world", "hooray", "universe"]);
+});
+
 test("Can push into empty list", () => {
   const node = new LocalNode(...randomAnonymousAccountAndSessionID(), Crypto);
 
@@ -91,4 +111,24 @@ test("Can push into empty list", () => {
 
   content.append("hello", undefined, "trusting");
   expect(content.toJSON()).toEqual(["hello"]);
+});
+
+test("init the list correctly", () => {
+  const node = new LocalNode(...randomAnonymousAccountAndSessionID(), Crypto);
+
+  const group = node.createGroup();
+
+  const content = group.createList(["hello", "world", "hooray", "universe"]);
+
+  expect(content.type).toEqual("colist");
+  expect(content.toJSON()).toEqual(["hello", "world", "hooray", "universe"]);
+
+  content.append("hello", content.toJSON().length - 1, "trusting");
+  expect(content.toJSON()).toEqual([
+    "hello",
+    "world",
+    "hooray",
+    "universe",
+    "hello",
+  ]);
 });

--- a/packages/cojson/src/tests/coMap.test.ts
+++ b/packages/cojson/src/tests/coMap.test.ts
@@ -175,3 +175,35 @@ test("Can get last tx ID for a key in CoMap", () => {
   content.set("hello", "C", "trusting");
   expect(content.lastEditAt("hello")?.tx.txIndex).toEqual(2);
 });
+
+test("Can set items in bulk with assign", () => {
+  const node = new LocalNode(...randomAnonymousAccountAndSessionID(), Crypto);
+
+  const coValue = node.createCoValue({
+    type: "comap",
+    ruleset: { type: "unsafeAllowAll" },
+    meta: null,
+    ...Crypto.createdNowUnique(),
+  });
+
+  const content = expectMap(coValue.getCurrentContent());
+
+  expect(content.type).toEqual("comap");
+
+  content.set("key1", "set1", "trusting");
+
+  content.assign(
+    {
+      key1: "assign1",
+      key2: "assign2",
+      key3: "assign3",
+    },
+    "trusting",
+  );
+
+  expect(content.toJSON()).toEqual({
+    key1: "assign1",
+    key2: "assign2",
+    key3: "assign3",
+  });
+});

--- a/packages/jazz-tools/src/coValues/coList.ts
+++ b/packages/jazz-tools/src/coValues/coList.ts
@@ -239,9 +239,11 @@ export class CoList<Item = any> extends Array<Item> implements CoValue {
   }
 
   push(...items: Item[]): number {
-    for (const item of toRawItems(items as Item[], this._schema[ItemsSym])) {
-      this._raw.append(item);
-    }
+    this._raw.appendItems(
+      toRawItems(items, this._schema[ItemsSym]),
+      undefined,
+      "private",
+    );
 
     return this._raw.entries().length;
   }


### PR DESCRIPTION
Adding more operations in a single transaction helps us on optimize the encrypt/decrypt/sign/veirfy operations by having a single payload to handle instead of many.

In this PR we are adding a new method to RawCoMap to perform set operations in bulk and used assign to optimize the RawCoMap init

The performance gain depends on the size of the payload, but we can see some improvements even with small datasets