### PR TITLE
feat: add the appendItems method to CoList to add many items in a single transaction

### DIFF
--- a/packages/cojson/src/coValues/group.ts
+++ b/packages/cojson/src/coValues/group.ts
@@ -653,10 +653,8 @@ export class RawGroup<
       })
       .getCurrentContent() as L;
 
-    if (init) {
-      for (const item of init) {
-        list.append(item, undefined, initPrivacy);
-      }
+    if (init?.length) {
+      list.appendItems(init, undefined, initPrivacy);
     }
 
     return list;

--- a/packages/cojson/src/tests/coList.test.ts
+++ b/packages/cojson/src/tests/coList.test.ts
@@ -75,6 +75,26 @@ test("Push is equivalent to append after last item", () => {
   expect(content.toJSON()).toEqual(["hello", "world", "hooray"]);
 });
 
+test("appendItems add an array of items at the end of the list", () => {
+  const node = new LocalNode(...randomAnonymousAccountAndSessionID(), Crypto);
+
+  const coValue = node.createCoValue({
+    type: "colist",
+    ruleset: { type: "unsafeAllowAll" },
+    meta: null,
+    ...Crypto.createdNowUnique(),
+  });
+
+  const content = expectList(coValue.getCurrentContent());
+
+  expect(content.type).toEqual("colist");
+
+  content.append("hello", 0, "trusting");
+  expect(content.toJSON()).toEqual(["hello"]);
+  content.appendItems(["world", "hooray", "universe"], undefined, "trusting");
+  expect(content.toJSON()).toEqual(["hello", "world", "hooray", "universe"]);
+});
+
 test("Can push into empty list", () => {
   const node = new LocalNode(...randomAnonymousAccountAndSessionID(), Crypto);
 
@@ -91,4 +111,24 @@ test("Can push into empty list", () => {
 
   content.append("hello", undefined, "trusting");
   expect(content.toJSON()).toEqual(["hello"]);
+});
+
+test("init the list correctly", () => {
+  const node = new LocalNode(...randomAnonymousAccountAndSessionID(), Crypto);
+
+  const group = node.createGroup();
+
+  const content = group.createList(["hello", "world", "hooray", "universe"]);
+
+  expect(content.type).toEqual("colist");
+  expect(content.toJSON()).toEqual(["hello", "world", "hooray", "universe"]);
+
+  content.append("hello", content.toJSON().length - 1, "trusting");
+  expect(content.toJSON()).toEqual([
+    "hello",
+    "world",
+    "hooray",
+    "universe",
+    "hello",
+  ]);
 });

--- a/packages/jazz-tools/src/coValues/coList.ts
+++ b/packages/jazz-tools/src/coValues/coList.ts
@@ -239,9 +239,11 @@ export class CoList<Item = any> extends Array<Item> implements CoValue {
   }
 
   push(...items: Item[]): number {
-    for (const item of toRawItems(items as Item[], this._schema[ItemsSym])) {
-      this._raw.append(item);
-    }
+    this._raw.appendItems(
+      toRawItems(items, this._schema[ItemsSym]),
+      undefined,
+      "private",
+    );
 
     return this._raw.entries().length;
   }


### PR DESCRIPTION
dding more operations in a single transaction helps us on optimize the encrypt/decrypt/sign/veirfy operations by having a single payload to handle instead of many.

In this PR we are adding a new method to RawCoList to perform append operations in bulk and used it to optimize the RawCoList init
