### PR TITLE
fix: restore PureJSCrypto as default and make RNQuickCrypto an opt-in import

### DIFF
--- a/.changeset/loud-adults-sneeze.md
+++ b/.changeset/loud-adults-sneeze.md
@@ -1,0 +1,5 @@
+---
+"jazz-react-native": patch
+---
+
+Added RNQuickCrypto, an optional crypto provider that provides faster signatures and removed expo-linking dependency

--- a/packages/jazz-react-native/package.json
+++ b/packages/jazz-react-native/package.json
@@ -11,6 +11,11 @@
       "react-native": "./dist/index.js",
       "types": "./dist/index.d.ts",
       "default": "./dist/index.js"
+    },
+    "./crypto": {
+      "react-native": "./dist/crypto/index.js",
+      "types": "./dist/crypto/index.d.ts",
+      "default": "./dist/crypto/index.js"
     }
   },
   "license": "MIT",
@@ -24,13 +29,11 @@
   },
   "peerDependencies": {
     "@react-native-community/netinfo": "*",
-    "expo-linking": "*",
     "expo-secure-store": "*",
     "react-native": "*"
   },
   "devDependencies": {
     "@react-native-community/netinfo": "^11.4.1",
-    "expo-linking": "~7.0.3",
     "expo-secure-store": "~14.0.0",
     "react-native": "~0.76.3",
     "typescript": "~5.6.2"

--- a/packages/jazz-react-native/src/crypto/index.ts
+++ b/packages/jazz-react-native/src/crypto/index.ts
@@ -1,0 +1,1 @@
+export { RNQuickCrypto } from "./RNQuickCrypto.js";

--- a/packages/jazz-react-native/src/index.ts
+++ b/packages/jazz-react-native/src/index.ts
@@ -15,15 +15,13 @@ import {
   createJazzContext,
 } from "jazz-tools";
 
-import NetInfo from "@react-native-community/netinfo";
 import { RawAccountID } from "cojson";
-import { createWebSocketPeer } from "cojson-transport-ws";
-// import * as Linking from "expo-linking";
-import { RNQuickCrypto } from "./crypto/RNQuickCrypto.js";
 
 export { RNDemoAuth } from "./auth/DemoAuthMethod.js";
 
+import { PureJSCrypto } from "cojson/native";
 import { createWebSocketPeerWithReconnection } from "./createWebSocketPeerWithReconnection.js";
+import type { RNQuickCrypto } from "./crypto/RNQuickCrypto.js";
 import { KvStoreContext } from "./storage/kv-store-context.js";
 
 /** @category Context Creation */
@@ -51,7 +49,7 @@ export type BaseReactNativeContextOptions = {
   peer: `wss://${string}` | `ws://${string}`;
   reconnectionTimeout?: number;
   storage?: "indexedDB" | "singleTabOPFS";
-  crypto?: CryptoProvider;
+  CryptoProvider?: typeof PureJSCrypto | typeof RNQuickCrypto;
 };
 
 /** @category Context Creation */
@@ -75,17 +73,19 @@ export async function createJazzRNContext<Acc extends Account>(
     },
   );
 
+  const CryptoProvider = options.CryptoProvider || PureJSCrypto;
+
   const context =
     "auth" in options
       ? await createJazzContext({
           AccountSchema: options.AccountSchema,
           auth: options.auth,
-          crypto: await RNQuickCrypto.create(),
+          crypto: await CryptoProvider.create(),
           peersToLoadFrom: [websocketPeer.peer],
           sessionProvider: provideLockSession,
         })
       : await createJazzContext({
-          crypto: await RNQuickCrypto.create(),
+          crypto: await CryptoProvider.create(),
           peersToLoadFrom: [websocketPeer.peer],
         });
 
@@ -241,4 +241,3 @@ export function parseInviteLink<C extends CoValue>(
 export * from "./provider.js";
 export * from "./auth/auth.js";
 export * from "./storage/kv-store-context.js";
-export * from "./crypto/RNQuickCrypto.js";

--- a/packages/jazz-react-native/src/provider.tsx
+++ b/packages/jazz-react-native/src/provider.tsx
@@ -14,6 +14,7 @@ import {
 } from "jazz-tools";
 import { Linking } from "react-native";
 import {
+  BaseReactNativeContextOptions,
   KvStore,
   KvStoreContext,
   ReactNativeContext,
@@ -27,6 +28,11 @@ import { ExpoSecureStoreAdapter } from "./storage/expo-secure-store-adapter.js";
 export function createJazzRNApp<Acc extends Account>({
   kvStore = new ExpoSecureStoreAdapter(),
   AccountSchema = Account as unknown as AccountClass<Acc>,
+  CryptoProvider,
+}: {
+  kvStore?: KvStore;
+  AccountSchema?: AccountClass<Acc>;
+  CryptoProvider?: BaseReactNativeContextOptions["CryptoProvider"];
 } = {}): JazzReactApp<Acc> {
   const JazzContext = React.createContext<
     ReactNativeContext<Acc> | ReactNativeGuestContext | undefined
@@ -61,12 +67,14 @@ export function createJazzRNApp<Acc extends Account>({
           ? {
               peer,
               storage,
+              CryptoProvider,
             }
           : {
               AccountSchema,
               auth: auth,
               peer,
               storage,
+              CryptoProvider,
             },
       ).then((context) => {
         setCtx({

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1751,9 +1751,6 @@ importers:
       '@react-native-community/netinfo':
         specifier: ^11.4.1
         version: 11.4.1(react-native@0.76.5(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@types/react@18.3.18)(react@18.3.1))
-      expo-linking:
-        specifier: ~7.0.3
-        version: 7.0.3(expo@52.0.21(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@expo/metro-runtime@4.0.0(react-native@0.76.5(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@types/react@18.3.18)(react@18.3.1)))(react-native@0.76.5(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@types/react@18.3.18)(react@18.3.1))(react@18.3.1))(react-native@0.76.5(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@types/react@18.3.18)(react@18.3.1))(react@18.3.1)
       expo-secure-store:
         specifier: ~14.0.0
         version: 14.0.0(expo@52.0.21(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@expo/metro-runtime@4.0.0(react-native@0.76.5(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@types/react@18.3.18)(react@18.3.1)))(react-native@0.76.5(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@types/react@18.3.18)(react@18.3.1))(react@18.3.1))


### PR DESCRIPTION
Making PureJSCrypto the default again and exporting `RNQuickCrypto` on `jazz-react-native/crypto`to make it possible to use it

Example:
```ts
import { createJazzRNApp } from "jazz-react-native";
import { RNQuickCrypto } from "jazz-react-native/crypto";

export const Jazz = createJazzRNApp({
  CryptoProvider: RNQuickCrypto,
});
export const { useAccount, useCoState, useAcceptInvite } = Jazz;
```