### PR TITLE
feat: Bring Your Own Store to demo auth

### DIFF
--- a/packages/jazz-react-native/src/auth/DemoAuthMethod.ts
+++ b/packages/jazz-react-native/src/auth/DemoAuthMethod.ts
@@ -100,8 +100,9 @@ export class RNDemoAuth implements AuthMethod {
         accountSecret: AgentSecret;
       };
     },
+    store?: KvStore | undefined,
   ) {
-    const kvStore = KvStoreContext.getInstance().getStorage();
+    const kvStore = store ? store : KvStoreContext.getInstance().getStorage();
 
     await migrateExistingUsersKeys(kvStore);
 


### PR DESCRIPTION
Allow for providing a `KvStore` to the DemoAuth rig in React Native.  This is useful when code execution happens before calling `createJazzRNApp()` and is outside `<Jazz.Provider />`.  Before this, the code would default to using `expo-secure-store`.

This furthers the ability to use Jazz without Expo.