### PR TITLE
feat: simplify the .create calls by accepting Account | Group as second param

### DIFF
--- a/.changeset/loud-llamas-compare.md
+++ b/.changeset/loud-llamas-compare.md
@@ -1,0 +1,5 @@
+---
+"jazz-tools": patch
+---
+
+Simplify the .create calls by accepting directly "Account | Group" as second param

--- a/examples/form/src/CreateOrder.tsx
+++ b/examples/form/src/CreateOrder.tsx
@@ -32,9 +32,9 @@ export function CreateOrder() {
     // reset the draft
     me.root.draft = DraftBubbleTeaOrder.create(
       {
-        addOns: ListOfBubbleTeaAddOns.create([], { owner: me }),
+        addOns: ListOfBubbleTeaAddOns.create([], me),
       },
-      { owner: me },
+      me,
     );
 
     router.navigate("/");

--- a/examples/form/src/schema.ts
+++ b/examples/form/src/schema.ts
@@ -69,18 +69,19 @@ export class AccountRoot extends CoMap {
 export class JazzAccount extends Account {
   root = co.ref(AccountRoot);
 
-  migrate(this: JazzAccount) {
+  migrate() {
+    const account = this;
+
     if (!this._refs.root) {
-      const ownership = { owner: this };
-      const orders = ListOfBubbleTeaOrders.create([], ownership);
+      const orders = ListOfBubbleTeaOrders.create([], account);
       const draft = DraftBubbleTeaOrder.create(
         {
-          addOns: ListOfBubbleTeaAddOns.create([], ownership),
+          addOns: ListOfBubbleTeaAddOns.create([], account),
         },
-        ownership,
+        account,
       );
 
-      this.root = AccountRoot.create({ draft, orders }, ownership);
+      this.root = AccountRoot.create({ draft, orders }, account);
     }
   }
 }

--- a/packages/jazz-tools/src/coValues/coList.ts
+++ b/packages/jazz-tools/src/coValues/coList.ts
@@ -23,6 +23,7 @@ import {
   isRefEncoded,
   loadCoValue,
   makeRefs,
+  parseCoValueCreateOptions,
   subscribeToCoValue,
   subscribeToExistingCoValue,
   subscriptionsScopes,
@@ -220,10 +221,11 @@ export class CoList<Item = any> extends Array<Item> implements CoValue {
   static create<L extends CoList>(
     this: CoValueClass<L>,
     items: UnCo<L[number]>[],
-    options: { owner: Account | Group },
+    options: { owner: Account | Group } | Account | Group,
   ) {
-    const instance = new this({ init: items, owner: options.owner });
-    const raw = options.owner._raw.createList(
+    const { owner } = parseCoValueCreateOptions(options);
+    const instance = new this({ init: items, owner });
+    const raw = owner._raw.createList(
       toRawItems(items, instance._schema[ItemsSym]),
     );
 

--- a/packages/jazz-tools/src/coValues/coMap.ts
+++ b/packages/jazz-tools/src/coValues/coMap.ts
@@ -30,6 +30,7 @@ import {
   isRefEncoded,
   loadCoValue,
   makeRefs,
+  parseCoValueCreateOptions,
   subscribeToCoValue,
   subscribeToExistingCoValue,
   subscriptionsScopes,
@@ -271,17 +272,19 @@ export class CoMap extends CoValueBase implements CoValue {
   static create<M extends CoMap>(
     this: CoValueClass<M>,
     init: Simplify<CoMapInit<M>>,
-    options: {
-      owner: Account | Group;
-      unique?: CoValueUniqueness["uniqueness"];
-    },
+    options:
+      | {
+          owner: Account | Group;
+          unique?: CoValueUniqueness["uniqueness"];
+        }
+      | Account
+      | Group,
   ) {
     const instance = new this();
-    const raw = instance.rawFromInit(
-      init,
-      options.owner,
-      options.unique === undefined ? undefined : { uniqueness: options.unique },
-    );
+
+    const { owner, uniqueness } = parseCoValueCreateOptions(options);
+    const raw = instance.rawFromInit(init, owner, uniqueness);
+
     Object.defineProperties(instance, {
       id: {
         value: raw.id,

--- a/packages/jazz-tools/src/coValues/group.ts
+++ b/packages/jazz-tools/src/coValues/group.ts
@@ -14,6 +14,7 @@ import {
   Ref,
   ensureCoValueLoaded,
   loadCoValue,
+  parseCoValueCreateOptions,
   subscribeToCoValue,
   subscribeToExistingCoValue,
 } from "../internal.js";
@@ -123,9 +124,9 @@ export class Group extends CoValueBase implements CoValue {
 
   static create<G extends Group>(
     this: CoValueClass<G>,
-    options: { owner: Account },
+    options: { owner: Account } | Account,
   ) {
-    return new this(options);
+    return new this(parseCoValueCreateOptions(options));
   }
 
   myRole(): Role | undefined {

--- a/packages/jazz-tools/src/coValues/interfaces.ts
+++ b/packages/jazz-tools/src/coValues/interfaces.ts
@@ -1,4 +1,8 @@
-import type { CojsonInternalTypes, RawCoValue } from "cojson";
+import type {
+  CoValueUniqueness,
+  CojsonInternalTypes,
+  RawCoValue,
+} from "cojson";
 import { RawAccount } from "cojson";
 import { AnonymousJazzAgent } from "../implementation/anonymousJazzAgent.js";
 import type { DeeplyLoaded, DepthsIn } from "../internal.js";
@@ -284,4 +288,22 @@ export function subscribeToExistingCoValue<V extends CoValue, Depth>(
     depth,
     listener,
   );
+}
+
+export function parseCoValueCreateOptions(
+  options:
+    | {
+        owner: Account | Group;
+        unique?: CoValueUniqueness["uniqueness"];
+      }
+    | Account
+    | Group,
+) {
+  return "_type" in options &&
+    (options._type === "Account" || options._type === "Group")
+    ? { owner: options, uniqueness: undefined }
+    : {
+        owner: options.owner,
+        uniqueness: options.unique ? { uniqueness: options.unique } : undefined,
+      };
 }

--- a/packages/jazz-tools/src/tests/coFeed.test.ts
+++ b/packages/jazz-tools/src/tests/coFeed.test.ts
@@ -4,6 +4,7 @@ import {
   Account,
   CoFeed,
   FileStream,
+  Group,
   ID,
   WasmCrypto,
   co,
@@ -30,6 +31,21 @@ describe("Simple CoFeed operations", async () => {
   const stream = TestStream.create(["milk"], { owner: me });
 
   test("Construction", () => {
+    expect(stream[me.id]?.value).toEqual("milk");
+    expect(stream.perSession[me.sessionID]?.value).toEqual("milk");
+  });
+
+  test("Construction with an Account", () => {
+    const stream = TestStream.create(["milk"], me);
+
+    expect(stream[me.id]?.value).toEqual("milk");
+    expect(stream.perSession[me.sessionID]?.value).toEqual("milk");
+  });
+
+  test("Construction with a Group", () => {
+    const group = Group.create(me);
+    const stream = TestStream.create(["milk"], group);
+
     expect(stream[me.id]?.value).toEqual("milk");
     expect(stream.perSession[me.sessionID]?.value).toEqual("milk");
   });

--- a/packages/jazz-tools/src/tests/coList.test.ts
+++ b/packages/jazz-tools/src/tests/coList.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, test } from "vitest";
 import {
   Account,
   CoList,
+  Group,
   WasmCrypto,
   co,
   cojsonInternals,
@@ -35,6 +36,19 @@ describe("Simple CoList operations", async () => {
       "BUTTER",
       "ONION",
     ]);
+  });
+
+  test("Construction with an Account", () => {
+    const list = TestList.create(["milk"], me);
+
+    expect(list[0]).toEqual("milk");
+  });
+
+  test("Construction with a Group", () => {
+    const group = Group.create(me);
+    const list = TestList.create(["milk"], group);
+
+    expect(list[0]).toEqual("milk");
   });
 
   describe("Mutation", () => {

--- a/packages/jazz-tools/src/tests/coMap.test.ts
+++ b/packages/jazz-tools/src/tests/coMap.test.ts
@@ -66,6 +66,25 @@ describe("Simple CoMap operations", async () => {
     ]);
   });
 
+  test("Construction with an Account", () => {
+    const map = TestMap.create(
+      { color: "red", _height: 10, birthday: birthday },
+      me,
+    );
+
+    expect(map.color).toEqual("red");
+  });
+
+  test("Construction with a Group", () => {
+    const group = Group.create(me);
+    const map = TestMap.create(
+      { color: "red", _height: 10, birthday: birthday },
+      group,
+    );
+
+    expect(map.color).toEqual("red");
+  });
+
   test("Construction with too many things provided", () => {
     const mapWithExtra = TestMap.create(
       {


### PR DESCRIPTION
Making the CoValues creation less verbose by accepting the owner as second param:

```ts
      const orders = ListOfBubbleTeaOrders.create([], account);
      const draft = DraftBubbleTeaOrder.create(
        {
          addOns: ListOfBubbleTeaAddOns.create([], account),
        },
        account,
      );

      this.root = AccountRoot.create({ draft, orders }, account);
```