### PR TITLE
fix(permissions): fixes the transactions collection to avoid RangeError issues

### DIFF
--- a/.changeset/honest-insects-relax.md
+++ b/.changeset/honest-insects-relax.md
@@ -1,0 +1,5 @@
+---
+"cojson": patch
+---
+
+Fixes the transactions collection on permissions to avoid RangeError issues

--- a/packages/cojson/src/permissions.ts
+++ b/packages/cojson/src/permissions.ts
@@ -172,19 +172,17 @@ function determineValidTransactionsForGroup(
   coValue: CoValueCore,
   initialAdmin: RawAccountID | AgentID,
 ): { validTransactions: ValidTransactionsResult[]; memberState: MemberState } {
-  const allTransactionsSorted = [...coValue.sessionLogs.entries()].flatMap(
-    ([sessionID, sessionLog]) => {
-      return sessionLog.transactions.map((tx, txIndex) => ({
-        sessionID,
-        txIndex,
-        tx,
-      })) as {
-        sessionID: SessionID;
-        txIndex: number;
-        tx: Transaction;
-      }[];
-    },
-  );
+  const allTransactionsSorted: {
+    sessionID: SessionID;
+    txIndex: number;
+    tx: Transaction;
+  }[] = [];
+
+  for (const [sessionID, sessionLog] of coValue.sessionLogs.entries()) {
+    sessionLog.transactions.forEach((tx, txIndex) => {
+      allTransactionsSorted.push({ sessionID, txIndex, tx });
+    });
+  }
 
   allTransactionsSorted.sort((a, b) => {
     return a.tx.madeAt - b.tx.madeAt;


### PR DESCRIPTION
Fixes this error happening on the Cloud:

```
RangeError: Maximum call stack size exceeded
    at cojson@0.8.44/node_modules/cojson/dist/web/permissions.js:98:78
    at Array.flatMap (<anonymous>)
    at determineValidTransactionsForGroup (cojson@0.8.44/node_modules/cojson/dist/web/permissions.js:98:70)
    at resolveMemberStateFromParentReference (cojson@0.8.44/node_modules/cojson/dist/web/permissions.js:88:53)
    at determineValidTransactionsForGroup (cojson@0.8.44/node_modules/cojson/dist/web/permissions.js:193:13)
    at resolveMemberStateFromParentReference (cojson@0.8.44/node_modules/cojson/dist/web/permissions.js:88:53)
    at determineValidTransactionsForGroup (cojson@0.8.44/node_modules/cojson/dist/web/permissions.js:193:13)
    at resolveMemberStateFromParentReference (cojson@0.8.44/node_modules/cojson/dist/web/permissions.js:88:53)
    at determineValidTransactionsForGroup (cojson@0.8.44/node_modules/cojson/dist/web/permissions.js:193:13)
    at resolveMemberStateFromParentReference (cojson@0.8.44/node_modules/cojson/dist/web/permissions.js:88:53)
```

