### PR TITLE
fix(permissions): fix group self-extension

### DIFF
--- a/.changeset/poor-gifts-admire.md
+++ b/.changeset/poor-gifts-admire.md
@@ -1,0 +1,5 @@
+---
+"cojson": patch
+---
+
+Fix groups self extension

--- a/packages/cojson/src/coValues/group.ts
+++ b/packages/cojson/src/coValues/group.ts
@@ -518,6 +518,10 @@ export class RawGroup<
   }
 
   extend(parent: RawGroup) {
+    if (this.id === parent.id) {
+      return;
+    }
+
     if (this.myRole() !== "admin") {
       throw new Error(
         "To extend a group, the current account must be an admin in the child group",

--- a/packages/cojson/src/permissions.ts
+++ b/packages/cojson/src/permissions.ts
@@ -10,6 +10,7 @@ import {
   RawCoID,
   SessionID,
   TransactionID,
+  getChildGroupId,
   getParentGroupId,
 } from "./ids.js";
 import { parseJSON } from "./jsonStringify.js";
@@ -305,6 +306,14 @@ function determineValidTransactionsForGroup(
         logPermissionError("Only admins can set parent extensions");
         continue;
       }
+
+      const parentGroupID = getParentGroupId(change.key);
+
+      if (parentGroupID === coValue.id) {
+        logPermissionError("Can't set parent extension to self");
+        continue;
+      }
+
       resolveMemberStateFromParentReference(coValue, memberState, change.key);
       validTransactions.push({ txID: { sessionID, txIndex }, tx });
       continue;
@@ -320,6 +329,14 @@ function determineValidTransactionsForGroup(
         );
         continue;
       }
+
+      const childGroupID = getChildGroupId(change.key);
+
+      if (childGroupID === coValue.id) {
+        logPermissionError("Can't set child extension to self");
+        continue;
+      }
+
       validTransactions.push({ txID: { sessionID, txIndex }, tx });
       continue;
     } else if (isWriteKeyForMember(change.key)) {

--- a/packages/cojson/src/tests/group.test.ts
+++ b/packages/cojson/src/tests/group.test.ts
@@ -609,4 +609,16 @@ describe("writeOnly", () => {
 
     expect(mapOnNode2.get("test")).toEqual("Written from node2");
   });
+
+  test("self-extend a group should not break anything", async () => {
+    const { node1 } = await createTwoConnectedNodes("server", "server");
+
+    const group = node1.node.createGroup();
+    group.extend(group);
+
+    const map = group.createMap();
+    map.set("test", "Hello!");
+
+    expect(map.get("test")).toEqual("Hello!");
+  });
 });

--- a/packages/cojson/src/tests/permissions.test.ts
+++ b/packages/cojson/src/tests/permissions.test.ts
@@ -2854,3 +2854,15 @@ test("High-level permissions work correctly when a group is extended", async () 
 
   expect(mapAsReaderAfterRemove.get("foo")).not.toEqual("baz");
 });
+
+test("self-extensions should not break the permissions checks", () => {
+  const { group, node } = newGroupHighLevel();
+
+  group.set(`child_${group.id}`, "extend", "trusting");
+  group.set(`parent_${group.id}`, "extend", "trusting");
+
+  const map = group.createMap();
+  map.set("test", "Hello!");
+
+  expect(map.get("test")).toEqual("Hello!");
+});


### PR DESCRIPTION
Drop self-extension changes when checking the valid transactions