### PR TITLE
[react native] don't require faceid for every KV operation

### DIFF
--- a/.changeset/dull-walls-crash.md
+++ b/.changeset/dull-walls-crash.md
@@ -1,0 +1,5 @@
+---
+"jazz-react-native": minor
+---
+
+Fix auth when using custom KV implementation

--- a/packages/jazz-react-native/src/auth/DemoAuthMethod.ts
+++ b/packages/jazz-react-native/src/auth/DemoAuthMethod.ts
@@ -111,19 +111,21 @@ export class RNDemoAuth implements AuthMethod {
   ) {
     let kvStore = store;
 
-    if (!kvStore) {
-      const kvStoreContext = KvStoreContext.getInstance();
+    const kvStoreContext = KvStoreContext.getInstance();
 
-      if (!kvStoreContext.isInitialized()) {
+    if (!kvStoreContext.isInitialized()) {
+      if (!kvStore) {
         const { ExpoSecureStoreAdapter } = await import(
           "../storage/expo-secure-store-adapter.js"
         );
 
         kvStoreContext.initialize(new ExpoSecureStoreAdapter());
+      } else {
+        kvStoreContext.initialize(kvStore);
       }
-
-      kvStore = kvStoreContext.getStorage();
     }
+
+    kvStore = kvStoreContext.getStorage();
 
     await migrateExistingUsersKeys(kvStore);
 

--- a/packages/jazz-react-native/src/storage/expo-secure-store-adapter.ts
+++ b/packages/jazz-react-native/src/storage/expo-secure-store-adapter.ts
@@ -4,21 +4,21 @@ import type { KvStore } from "./kv-store-context.js";
 export class ExpoSecureStoreAdapter implements KvStore {
   get(key: string): Promise<string | null> {
     return SecureStore.getItemAsync(key, {
-      requireAuthentication: SecureStore.canUseBiometricAuthentication(),
+      requireAuthentication: false,
       keychainAccessible: SecureStore.AFTER_FIRST_UNLOCK,
     });
   }
 
   async set(key: string, value: string): Promise<void> {
     return SecureStore.setItemAsync(key, value, {
-      requireAuthentication: SecureStore.canUseBiometricAuthentication(),
+      requireAuthentication: false,
       keychainAccessible: SecureStore.AFTER_FIRST_UNLOCK,
     });
   }
 
   async delete(key: string): Promise<void> {
     return SecureStore.deleteItemAsync(key, {
-      requireAuthentication: SecureStore.canUseBiometricAuthentication(),
+      requireAuthentication: false,
       keychainAccessible: SecureStore.AFTER_FIRST_UNLOCK,
     });
   }


### PR DESCRIPTION
We need to make the control more granular or opt-in.

I think the default should be without faceId required for every get/set

Also resolves #1184 