### PR TITLE
Use example apps as starter with create-jazz-app

### DIFF
--- a/.changeset/neat-tomatoes-do.md
+++ b/.changeset/neat-tomatoes-do.md
@@ -1,0 +1,5 @@
+---
+"create-jazz-app": patch
+---
+
+Add example param to create-jazz-app

--- a/examples/chat-vue/README.md
+++ b/examples/chat-vue/README.md
@@ -1,28 +1,58 @@
 # Chat example with Jazz and Vue
 
-## Installing & running the example locally
+## Getting started
 
-(This requires `pnpm` to be installed, see [https://pnpm.io/installation](https://pnpm.io/installation))
+You can either
+1. Clone the jazz repository, and run the app within the monorepo.
+2. Or create a new Jazz project using this example as a template.
 
-Start by downloading the [jazz repository](https://github.com/garden-co/jazz):
+
+### Using the example as a template
+
+Create a new Jazz project, and use this example as a template.
 ```bash
-npx degit gardencmp/jazz jazz
+npm create jazz-app@latest --example chat-vue --project-name chat-vue
+```
+or
+```bash
+npx create-jazz-app@latest --example chat-vue --project-name chat-vue
 ```
 
-Go to the todo-vue example directory:
+Go to the new project directory.
 ```bash
-cd jazz/examples/chat-vue
+cd chat-vue
 ```
 
-Install and build dependencies:
+Run the dev server.
+```bash
+npm run dev
+```
+
+### Using the monorepo
+
+This requires `pnpm` to be installed, see [https://pnpm.io/installation](https://pnpm.io/installation).
+
+Clone the jazz repository.
+```bash
+git clone https://github.com/garden-co/jazz.git
+```
+
+Install and build dependencies.
 ```bash
 pnpm i && npx turbo build
 ```
 
-Start the dev server:
+Go to the example directory.
+```bash
+cd jazz/examples/chat-vue/
+```
+
+Start the dev server.
 ```bash
 pnpm dev
 ```
+
+Open [http://localhost:5173](http://localhost:5173) with your browser to see the result.
 
 ## Questions / problems / feedback
 

--- a/examples/chat/README.md
+++ b/examples/chat/README.md
@@ -2,29 +2,59 @@
 
 Live version: [https://chat.jazz.tools](https://chat.jazz.tools)
 
-## Installing & running the example locally
+## Getting started
 
-(This requires `pnpm` to be installed, see [https://pnpm.io/installation](https://pnpm.io/installation))
+You can either
+1. Clone the jazz repository, and run the app within the monorepo.
+2. Or create a new Jazz project using this example as a template.
 
-Start by downloading the [jazz repository](https://github.com/garden-co/jazz):
+
+### Using the example as a template
+
+Create a new Jazz project, and use this example as a template.
 ```bash
-npx degit gardencmp/jazz jazz
+npm create jazz-app@latest --example chat --project-name chat
+```
+or
+```bash
+npx create-jazz-app@latest --example chat --project-name chat
 ```
 
-Go to the chat example directory:
+Go to the new project directory.
 ```bash
-cd jazz/examples/chat
+cd chat
 ```
 
-Install and build dependencies:
+Run the dev server.
+```bash
+npm run dev
+```
+
+### Using the monorepo
+
+This requires `pnpm` to be installed, see [https://pnpm.io/installation](https://pnpm.io/installation).
+
+Clone the jazz repository.
+```bash
+git clone https://github.com/garden-co/jazz.git
+```
+
+Install and build dependencies.
 ```bash
 pnpm i && npx turbo build
 ```
 
-Start the dev server:
+Go to the example directory.
+```bash
+cd jazz/examples/chat/
+```
+
+Start the dev server.
 ```bash
 pnpm dev
 ```
+
+Open [http://localhost:5173](http://localhost:5173) with your browser to see the result.
 
 ## Questions / problems / feedback
 

--- a/examples/clerk/README.md
+++ b/examples/clerk/README.md
@@ -4,29 +4,59 @@ This is an example of how to use clerk authentication with Jazz.
 
 Live version: https://clerk-demo.jazz.tools
 
-## Installing & running the example locally
+## Getting started
 
-(This requires `pnpm` to be installed, see [https://pnpm.io/installation](https://pnpm.io/installation))
+You can either
+1. Clone the jazz repository, and run the app within the monorepo.
+2. Or create a new Jazz project using this example as a template.
 
-Start by downloading the [jazz repository](https://github.com/garden-co/jazz):
+
+### Using the example as a template
+
+Create a new Jazz project, and use this example as a template.
 ```bash
-npx degit gardencmp/jazz jazz
+npm create jazz-app@latest --start clerk --project-name clerk
+```
+or
+```bash
+npx create-jazz-app@latest --start clerk --project-name clerk
 ```
 
-Go to the clerk example directory:
+Go to the new project directory.
 ```bash
-cd jazz/examples/clerk
+cd clerk
 ```
 
-Install and build dependencies:
+Run the dev server.
+```bash
+npm run dev
+```
+
+### Using the monorepo
+
+This requires `pnpm` to be installed, see [https://pnpm.io/installation](https://pnpm.io/installation).
+
+Clone the jazz repository.
+```bash
+git clone https://github.com/garden-co/jazz.git
+```
+
+Install and build dependencies.
 ```bash
 pnpm i && npx turbo build
 ```
 
-Start the dev server:
+Go to the example directory.
+```bash
+cd jazz/examples/clerk/
+```
+
+Start the dev server.
 ```bash
 pnpm dev
 ```
+
+Open [http://localhost:5173](http://localhost:5173) with your browser to see the result.
 
 ## Questions / problems / feedback
 

--- a/examples/form/README.md
+++ b/examples/form/README.md
@@ -17,29 +17,59 @@ converting it into a `BubbleTeaOrder`.
 
 [See the full guide here.](https://jazz.tools/docs/react/design-patterns/form)
 
-## Installing & running the example locally
+## Getting started
 
-(This requires `pnpm` to be installed, see [https://pnpm.io/installation](https://pnpm.io/installation))
+You can either
+1. Clone the jazz repository, and run the app within the monorepo.
+2. Or create a new Jazz project using this example as a template.
 
-Start by downloading the [jazz repository](https://github.com/garden-co/jazz):
+
+### Using the example as a template
+
+Create a new Jazz project, and use this example as a template.
 ```bash
-npx degit gardencmp/jazz jazz
+npm create jazz-app@latest --start form --project-name form
+```
+or
+```bash
+npx create-jazz-app@latest --start form --project-name form
 ```
 
-Go to the form example directory:
+Go to the new project directory.
 ```bash
-cd jazz/examples/form
+cd form
 ```
 
-Install and build dependencies:
+Run the dev server.
+```bash
+npm run dev
+```
+
+### Using the monorepo
+
+This requires `pnpm` to be installed, see [https://pnpm.io/installation](https://pnpm.io/installation).
+
+Clone the jazz repository.
+```bash
+git clone https://github.com/garden-co/jazz.git
+```
+
+Install and build dependencies.
 ```bash
 pnpm i && npx turbo build
 ```
 
-Start the dev server:
+Go to the example directory.
+```bash
+cd jazz/examples/form/
+```
+
+Start the dev server.
 ```bash
 pnpm dev
 ```
+
+Open [http://localhost:5173](http://localhost:5173) with your browser to see the result.
 
 ## Questions / problems / feedback
 

--- a/examples/image-upload/README.md
+++ b/examples/image-upload/README.md
@@ -4,29 +4,59 @@ This is an example of how to upload and render images with Jazz.
 
 Live version: https://image-upload-demo.jazz.tools
 
-## Installing & running the example locally
+## Getting started
 
-(This requires `pnpm` to be installed, see [https://pnpm.io/installation](https://pnpm.io/installation))
+You can either
+1. Clone the jazz repository, and run the app within the monorepo.
+2. Or create a new Jazz project using this example as a template.
 
-Start by downloading the [jazz repository](https://github.com/garden-co/jazz):
+
+### Using the example as a template
+
+Create a new Jazz project, and use this example as a template.
 ```bash
-npx degit gardencmp/jazz jazz
+npm create jazz-app@latest --example image-upload --project-name image-upload
+```
+or
+```bash
+npx create-jazz-app@latest --example image-upload --project-name image-upload
 ```
 
-Go to the image-upload example directory:
+Go to the new project directory.
 ```bash
-cd jazz/examples/image-upload
+cd image-upload
 ```
 
-Install and build dependencies:
+Run the dev server.
+```bash
+npm run dev
+```
+
+### Using the monorepo
+
+This requires `pnpm` to be installed, see [https://pnpm.io/installation](https://pnpm.io/installation).
+
+Clone the jazz repository.
+```bash
+git clone https://github.com/garden-co/jazz.git
+```
+
+Install and build dependencies.
 ```bash
 pnpm i && npx turbo build
 ```
 
-Start the dev server:
+Go to the example directory.
+```bash
+cd jazz/examples/image-upload/
+```
+
+Start the dev server.
 ```bash
 pnpm dev
 ```
+
+Open [http://localhost:5173](http://localhost:5173) with your browser to see the result.
 
 ## Questions / problems / feedback
 

--- a/examples/music-player/README.md
+++ b/examples/music-player/README.md
@@ -2,29 +2,59 @@
 
 Live version: https://music-demo.jazz.tools
 
-## Installing & running the example locally
+## Getting started
 
-(This requires `pnpm` to be installed, see [https://pnpm.io/installation](https://pnpm.io/installation))
+You can either
+1. Clone the jazz repository, and run the app within the monorepo.
+2. Or create a new Jazz project using this example as a template.
 
-Start by downloading the [jazz repository](https://github.com/garden-co/jazz):
+
+### Using the example as a template
+
+Create a new Jazz project, and use this example as a template.
 ```bash
-npx degit gardencmp/jazz jazz
+npm create jazz-app@latest --example music-player --project-name music-player
+```
+or
+```bash
+npx create-jazz-app@latest --example music-player --project-name music-player
 ```
 
-Go to the music-player example directory:
+Go to the new project directory.
 ```bash
-cd jazz/examples/music-player
+cd music-player
 ```
 
-Install and build dependencies:
+Run the dev server.
+```bash
+npm run dev
+```
+
+### Using the monorepo
+
+This requires `pnpm` to be installed, see [https://pnpm.io/installation](https://pnpm.io/installation).
+
+Clone the jazz repository.
+```bash
+git clone https://github.com/garden-co/jazz.git
+```
+
+Install and build dependencies.
 ```bash
 pnpm i && npx turbo build
 ```
 
-Start the dev server:
+Go to the example directory.
+```bash
+cd jazz/examples/music-player/
+```
+
+Start the dev server.
 ```bash
 pnpm dev
 ```
+
+Open [http://localhost:5173](http://localhost:5173) with your browser to see the result.
 
 ## Questions / problems / feedback
 

--- a/examples/onboarding/README.md
+++ b/examples/onboarding/README.md
@@ -1,29 +1,58 @@
 # Onboarding example with Jazz and React
 
-## Installing & running the example locally
+## Getting started
 
-(This requires `pnpm` to be installed, see [https://pnpm.io/installation](https://pnpm.io/installation))
+You can either
+1. Clone the jazz repository, and run the app within the monorepo.
+2. Or create a new Jazz project using this example as a template.
 
-Start by downloading the [jazz repository](https://github.com/garden-co/jazz):
+
+### Using the example as a template
+
+Create a new Jazz project, and use this example as a template.
 ```bash
-npx degit gardencmp/jazz jazz
+npm create jazz-app@latest --example onboarding --project-name onboarding
+```
+or
+```bash
+npx create-jazz-app@latest --example onboarding --project-name onboarding
 ```
 
-Go to the onboarding example directory:
+Go to the new project directory.
 ```bash
-cd jazz/examples/onboarding
+cd onboarding
 ```
 
-Install and build dependencies:
+Run the dev server.
+```bash
+npm run dev
+```
+
+### Using the monorepo
+
+This requires `pnpm` to be installed, see [https://pnpm.io/installation](https://pnpm.io/installation).
+
+Clone the jazz repository.
+```bash
+git clone https://github.com/garden-co/jazz.git
+```
+
+Install and build dependencies.
 ```bash
 pnpm i && npx turbo build
 ```
 
-Start the dev server:
+Go to the example directory.
+```bash
+cd jazz/examples/onboarding/
+```
+
+Start the dev server.
 ```bash
 pnpm dev
 ```
 
+Open [http://localhost:5173](http://localhost:5173) with your browser to see the result.
 ## Questions / problems / feedback
 
 If you have feedback, let us know on [Discord](https://discord.gg/utDMjHYg42) or open an issue or PR to fix something that seems wrong.

--- a/examples/organization/README.md
+++ b/examples/organization/README.md
@@ -5,29 +5,59 @@ Different apps have different names for this concept, such as "teams" or "worksp
 
 Refer to the [documentation](https://jazz.tools/docs/react/design-patterns/organization)  for more information.
 
-## Installing & running the example locally
+## Getting started
 
-(This requires `pnpm` to be installed, see [https://pnpm.io/installation](https://pnpm.io/installation))
+You can either
+1. Clone the jazz repository, and run the app within the monorepo.
+2. Or create a new Jazz project using this example as a template.
 
-Start by downloading the [jazz repository](https://github.com/garden-co/jazz):
+
+### Using the example as a template
+
+Create a new Jazz project, and use this example as a template.
 ```bash
-npx degit gardencmp/jazz jazz
+npm create jazz-app@latest --example organization --project-name organization
+```
+or
+```bash
+npx create-jazz-app@latest --example organization --project-name organization
 ```
 
-Go to the organization example directory:
+Go to the new project directory.
 ```bash
-cd jazz/examples/organization
+cd organization
 ```
 
-Install and build dependencies:
+Run the dev server.
+```bash
+npm run dev
+```
+
+### Using the monorepo
+
+This requires `pnpm` to be installed, see [https://pnpm.io/installation](https://pnpm.io/installation).
+
+Clone the jazz repository.
+```bash
+git clone https://github.com/garden-co/jazz.git
+```
+
+Install and build dependencies.
 ```bash
 pnpm i && npx turbo build
 ```
 
-Start the dev server:
+Go to the example directory.
+```bash
+cd jazz/examples/organization/
+```
+
+Start the dev server.
 ```bash
 pnpm dev
 ```
+
+Open [http://localhost:5173](http://localhost:5173) with your browser to see the result.
 
 ## Questions / problems / feedback
 

--- a/examples/passkey-svelte/README.md
+++ b/examples/passkey-svelte/README.md
@@ -10,34 +10,59 @@ This example showcases how to:
 - Manage authentication state
 - Implement secure login/logout flows
 
-## Getting Started
+## Getting started
 
-1. Clone the repository:
+You can either
+1. Clone the jazz repository, and run the app within the monorepo.
+2. Or create a new Jazz project using this example as a template.
 
-```sh
+
+### Using the example as a template
+
+Create a new Jazz project, and use this example as a template.
+```bash
+npm create jazz-app@latest --example passkey-svelte --project-name passkey-svelte
+```
+or
+```bash
+npx create-jazz-app@latest --example passkey-svelte --project-name passkey-svelte
+```
+
+Go to the new project directory.
+```bash
+cd passkey-svelte
+```
+
+Run the dev server.
+```bash
+npm run dev
+```
+
+### Using the monorepo
+
+This requires `pnpm` to be installed, see [https://pnpm.io/installation](https://pnpm.io/installation).
+
+Clone the jazz repository.
+```bash
 git clone https://github.com/garden-co/jazz.git
 ```
 
-2. Navigate to the example directory:
-
-```sh
-cd examples/passkey-svelte
+Install and build dependencies.
+```bash
+pnpm i && npx turbo build
 ```
 
-3. Install dependencies:
-
-```sh
-pnpm install
+Go to the example directory.
+```bash
+cd jazz/examples/passkey-svelte/
 ```
 
-4. Start the development server:
-
-```sh
+Start the dev server.
+```bash
 pnpm dev
 ```
 
-5. Open your browser and visit [http://localhost:5173](http://localhost:5173)
-
+Open [http://localhost:5173](http://localhost:5173) with your browser to see the result.
 
 ## Learn More
 

--- a/examples/passkey/README.md
+++ b/examples/passkey/README.md
@@ -4,30 +4,59 @@ This is an example of how to use passkey authentication with Jazz.
 
 Live version: https://passkey-demo.jazz.tools
 
-## Installing & running the example locally
+## Getting started
 
-(This requires `pnpm` to be installed, see [https://pnpm.io/installation](https://pnpm.io/installation))
+You can either
+1. Clone the jazz repository, and run the app within the monorepo.
+2. Or create a new Jazz project using this example as a template.
 
-Start by downloading the [jazz repository](https://github.com/garden-co/jazz):
+
+### Using the example as a template
+
+Create a new Jazz project, and use this example as a template.
 ```bash
-npx degit gardencmp/jazz jazz
+npm create jazz-app@latest --example passkey --project-name passkey
+```
+or
+```bash
+npx create-jazz-app@latest --example passkey --project-name passkey
 ```
 
-Go to the passkey example directory:
+Go to the new project directory.
 ```bash
-cd jazz/examples/passkey
+cd passkey
 ```
 
-Install and build dependencies:
+Run the dev server.
+```bash
+npm run dev
+```
+
+### Using the monorepo
+
+This requires `pnpm` to be installed, see [https://pnpm.io/installation](https://pnpm.io/installation).
+
+Clone the jazz repository.
+```bash
+git clone https://github.com/garden-co/jazz.git
+```
+
+Install and build dependencies.
 ```bash
 pnpm i && npx turbo build
 ```
 
-Start the dev server:
+Go to the example directory.
+```bash
+cd jazz/examples/passkey/
+```
+
+Start the dev server.
 ```bash
 pnpm dev
 ```
 
+Open [http://localhost:5173](http://localhost:5173) with your browser to see the result.
 ## Questions / problems / feedback
 
 If you have feedback, let us know on [Discord](https://discord.gg/utDMjHYg42) or open an issue or PR to fix something that seems wrong.

--- a/examples/password-manager/README.md
+++ b/examples/password-manager/README.md
@@ -4,29 +4,59 @@ Live version: https://passwords-demo.jazz.tools
 
 ![Password Manager Screenshot](demo.png "Screenshot")
 
-## Installing & running the example locally
+## Getting started
 
-(This requires `pnpm` to be installed, see [https://pnpm.io/installation](https://pnpm.io/installation))
+You can either
+1. Clone the jazz repository, and run the app within the monorepo.
+2. Or create a new Jazz project using this example as a template.
 
-Start by downloading the [jazz repository](https://github.com/garden-co/jazz):
+
+### Using the example as a template
+
+Create a new Jazz project, and use this example as a template.
 ```bash
-npx degit gardencmp/jazz jazz
+npm create jazz-app@latest --example password-manager --project-name password-manager
+```
+or
+```bash
+npx create-jazz-app@latest --example password-manager --project-name password-manager
 ```
 
-Go to the password-manager example directory:
+Go to the new project directory.
 ```bash
-cd jazz/examples/password-manager
+cd password-manager
 ```
 
-Install and build dependencies:
+Run the dev server.
+```bash
+npm run dev
+```
+
+### Using the monorepo
+
+This requires `pnpm` to be installed, see [https://pnpm.io/installation](https://pnpm.io/installation).
+
+Clone the jazz repository.
+```bash
+git clone https://github.com/garden-co/jazz.git
+```
+
+Install and build dependencies.
 ```bash
 pnpm i && npx turbo build
 ```
 
-Start the dev server:
+Go to the example directory.
+```bash
+cd jazz/examples/password-manager/
+```
+
+Start the dev server.
 ```bash
 pnpm dev
 ```
+
+Open [http://localhost:5173](http://localhost:5173) with your browser to see the result.
 
 ## Structure
 

--- a/examples/pets/README.md
+++ b/examples/pets/README.md
@@ -2,30 +2,59 @@
 
 Live version: https://pets-demo.jazz.tools/
 
-## Installing & running the example locally
+## Getting started
 
-(This requires `pnpm` to be installed, see [https://pnpm.io/installation](https://pnpm.io/installation))
+You can either
+1. Clone the jazz repository, and run the app within the monorepo.
+2. Or create a new Jazz project using this example as a template.
 
-Start by downloading the [jazz repository](https://github.com/garden-co/jazz):
+
+### Using the example as a template
+
+Create a new Jazz project, and use this example as a template.
 ```bash
-npx degit gardencmp/jazz jazz
+npm create jazz-app@latest --example pets --project-name pets
+```
+or
+```bash
+npx create-jazz-app@latest --example pets --project-name pets
 ```
 
-Go to the pets example directory:
+Go to the new project directory.
 ```bash
-cd jazz/examples/pets
+cd pets
 ```
 
-Install and build dependencies:
+Run the dev server.
+```bash
+npm run dev
+```
+
+### Using the monorepo
+
+This requires `pnpm` to be installed, see [https://pnpm.io/installation](https://pnpm.io/installation).
+
+Clone the jazz repository.
+```bash
+git clone https://github.com/garden-co/jazz.git
+```
+
+Install and build dependencies.
 ```bash
 pnpm i && npx turbo build
 ```
 
-Start the dev server:
+Go to the example directory.
+```bash
+cd jazz/examples/pets/
+```
+
+Start the dev server.
 ```bash
 pnpm dev
 ```
 
+Open [http://localhost:5173](http://localhost:5173) with your browser to see the result.
 
 ## Questions / problems / feedback
 

--- a/examples/reactions/README.md
+++ b/examples/reactions/README.md
@@ -2,29 +2,59 @@
 
 Live version: [https://reactions-demo.jazz.tools](https://reactions-demo.jazz.tools)
 
-## Installing & running the example locally
+## Getting started
 
-(This requires `pnpm` to be installed, see [https://pnpm.io/installation](https://pnpm.io/installation))
+You can either
+1. Clone the jazz repository, and run the app within the monorepo.
+2. Or create a new Jazz project using this example as a template.
 
-Start by downloading the [jazz repository](https://github.com/garden-co/jazz):
+
+### Using the example as a template
+
+Create a new Jazz project, and use this example as a template.
 ```bash
-npx degit gardencmp/jazz jazz
+npm create jazz-app@latest --example reactions --project-name reactions
+```
+or
+```bash
+npx create-jazz-app@latest --example reactions --project-name reactions
 ```
 
-Go to the reactions example directory:
+Go to the new project directory.
 ```bash
-cd jazz/examples/reactions
+cd reactions
 ```
 
-Install and build dependencies:
+Run the dev server.
+```bash
+npm run dev
+```
+
+### Using the monorepo
+
+This requires `pnpm` to be installed, see [https://pnpm.io/installation](https://pnpm.io/installation).
+
+Clone the jazz repository.
+```bash
+git clone https://github.com/garden-co/jazz.git
+```
+
+Install and build dependencies.
 ```bash
 pnpm i && npx turbo build
 ```
 
-Start the dev server:
+Go to the example directory.
+```bash
+cd jazz/examples/reactions/
+```
+
+Start the dev server.
 ```bash
 pnpm dev
 ```
+
+Open [http://localhost:5173](http://localhost:5173) with your browser to see the result.
 
 ## Questions / problems / feedback
 

--- a/examples/todo-vue/README.md
+++ b/examples/todo-vue/README.md
@@ -1,28 +1,58 @@
 # Todo list example with Jazz and Vue
 
-## Installing & running the example locally
+## Getting started
 
-(This requires `pnpm` to be installed, see [https://pnpm.io/installation](https://pnpm.io/installation))
+You can either
+1. Clone the jazz repository, and run the app within the monorepo.
+2. Or create a new Jazz project using this example as a template.
 
-Start by downloading the [jazz repository](https://github.com/garden-co/jazz):
+
+### Using the example as a template
+
+Create a new Jazz project, and use this example as a template.
 ```bash
-npx degit gardencmp/jazz jazz
+npm create jazz-app@latest --example todo-vue --project-name todo-vue
+```
+or
+```bash
+npx create-jazz-app@latest --example todo-vue --project-name todo-vue
 ```
 
-Go to the todo-vue example directory:
+Go to the new project directory.
 ```bash
-cd jazz/examples/todo-vue
+cd todo-vue
 ```
 
-Install and build dependencies:
+Run the dev server.
+```bash
+npm run dev
+```
+
+### Using the monorepo
+
+This requires `pnpm` to be installed, see [https://pnpm.io/installation](https://pnpm.io/installation).
+
+Clone the jazz repository.
+```bash
+git clone https://github.com/garden-co/jazz.git
+```
+
+Install and build dependencies.
 ```bash
 pnpm i && npx turbo build
 ```
 
-Start the dev server:
+Go to the example directory.
+```bash
+cd jazz/examples/todo-vue/
+```
+
+Start the dev server.
 ```bash
 pnpm dev
 ```
+
+Open [http://localhost:5173](http://localhost:5173) with your browser to see the result.
 
 ## Questions / problems / feedback
 

--- a/examples/todo/README.md
+++ b/examples/todo/README.md
@@ -2,29 +2,59 @@
 
 Live version: https://todo-demo.jazz.tools/
 
-## Installing & running the example locally
+## Getting started
 
-(This requires `pnpm` to be installed, see [https://pnpm.io/installation](https://pnpm.io/installation))
+You can either
+1. Clone the jazz repository, and run the app within the monorepo.
+2. Or create a new Jazz project using this example as a template.
 
-Start by downloading the [jazz repository](https://github.com/garden-co/jazz):
+
+### Using the example as a template
+
+Create a new Jazz project, and use this example as a template.
 ```bash
-npx degit gardencmp/jazz jazz
+npm create jazz-app@latest --example todo --project-name todo
+```
+or
+```bash
+npx create-jazz-app@latest --example todo --project-name todo
 ```
 
-Go to the todo example directory:
+Go to the new project directory.
 ```bash
-cd jazz/examples/todo
+cd todo
 ```
 
-Install and build dependencies:
+Run the dev server.
+```bash
+npm run dev
+```
+
+### Using the monorepo
+
+This requires `pnpm` to be installed, see [https://pnpm.io/installation](https://pnpm.io/installation).
+
+Clone the jazz repository.
+```bash
+git clone https://github.com/garden-co/jazz.git
+```
+
+Install and build dependencies.
 ```bash
 pnpm i && npx turbo build
 ```
 
-Start the dev server:
+Go to the example directory.
+```bash
+cd jazz/examples/todo/
+```
+
+Start the dev server.
 ```bash
 pnpm dev
 ```
+
+Open [http://localhost:5173](http://localhost:5173) with your browser to see the result.
 
 ## Structure
 

--- a/examples/version-history/README.md
+++ b/examples/version-history/README.md
@@ -2,29 +2,59 @@
 
 A minimal example showing how to use Jazz's built-in version history to show and restore changes.
 
-## Installing & running the example locally
+## Getting started
 
-(This requires `pnpm` to be installed, see [https://pnpm.io/installation](https://pnpm.io/installation))
+You can either
+1. Clone the jazz repository, and run the app within the monorepo.
+2. Or create a new Jazz project using this example as a template.
 
-Start by downloading the [jazz repository](https://github.com/garden-co/jazz):
+
+### Using the example as a template
+
+Create a new Jazz project, and use this example as a template.
 ```bash
-npx degit gardencmp/jazz jazz
+npm create jazz-app@latest --example version-history --project-name version-history
+```
+or
+```bash
+npx create-jazz-app@latest --example version-history --project-name version-history
 ```
 
-Go to the version-history example directory:
+Go to the new project directory.
 ```bash
-cd jazz/examples/version-history
+cd version-history
 ```
 
-Install and build dependencies:
+Run the dev server.
+```bash
+npm run dev
+```
+
+### Using the monorepo
+
+This requires `pnpm` to be installed, see [https://pnpm.io/installation](https://pnpm.io/installation).
+
+Clone the jazz repository.
+```bash
+git clone https://github.com/garden-co/jazz.git
+```
+
+Install and build dependencies.
 ```bash
 pnpm i && npx turbo build
 ```
 
-Start the dev server:
+Go to the example directory.
+```bash
+cd jazz/examples/version-history/
+```
+
+Start the dev server.
 ```bash
 pnpm dev
 ```
+
+Open [http://localhost:5173](http://localhost:5173) with your browser to see the result.
 
 ## Questions / problems / feedback
 

--- a/homepage/homepage/components/docs/docs-intro.mdx
+++ b/homepage/homepage/components/docs/docs-intro.mdx
@@ -7,9 +7,18 @@ The Jazz docs are currently heavily work in progress, sorry about that!
 ## Quickstart
 
 Run the following command to create a new Jazz project from one of our example apps:
+
 <CodeGroup>
 ```sh
-npx create-jazz-app
+npm create jazz-app@latest
+```
+</CodeGroup>
+
+or
+
+<CodeGroup>
+```sh
+npx create-jazz-app@latest
 ```
 </CodeGroup>
 

--- a/packages/create-jazz-app/README.md
+++ b/packages/create-jazz-app/README.md
@@ -14,7 +14,7 @@
 
 You can create a new Jazz app in two ways:
 
-### Interactive Mode
+### Interactive mode
 
 Simply run:
 
@@ -33,7 +33,7 @@ Then follow the interactive prompts to select your:
 - Package manager
 - Project name
 
-### Command Line Mode
+### Command line mode
 
 Or specify all options directly:
 
@@ -41,7 +41,18 @@ Or specify all options directly:
 npm create jazz-app@latest -- --starter react-demo-auth --project-name my-app --package-manager npm
 ```
 
-## Available Starters
+### Start with an example app
+
+You can use any of our example apps as a template for your own app, instead of choosing one of the starters.
+
+Use the `--example` parameter, and pass
+the directory name of the example app found [here](https://github.com/garden-co/jazz/tree/main/examples).
+
+```bash
+npm create jazz-app@latest --example chat
+```
+
+## Available starters
 
 Currently implemented starters:
 
@@ -55,12 +66,12 @@ Currently implemented starters:
 
 More starters coming soon! Check the help menu (`create-jazz-app --help`) for the latest list.
 
-## System Requirements
+## System requirements
 
 - Node.js 14.0.0 or later
 - Package manager of your choice (npm, yarn, pnpm, bun, or deno)
 
-## What Happens When You Run It?
+## What happens when you run it?
 
 1. 🎭 Prompts for your preferences (or uses command line arguments)
 2. 📥 Clones the appropriate starter template


### PR DESCRIPTION
Added an example param to create-jazz-app to get started with examples quickly

Added the following to examples README

```
npm create-jazz-app@latest --example chat --project-name chat
```

Updated create-jazz-app to accept partial options (project name only, starter only, etc).