### PR TITLE
create-jazz-app gets the latest semver package version for jazz-* dependencies from NPM via HTTP

### DIFF
--- a/.changeset/gold-comics-battle.md
+++ b/.changeset/gold-comics-battle.md
@@ -1,0 +1,5 @@
+---
+"create-jazz-app": patch
+---
+
+Fix fetching latest semver jazz-\* package versions from NPM when using create-jazz-app, instead of using "latest"

--- a/packages/create-jazz-app/src/index.ts
+++ b/packages/create-jazz-app/src/index.ts
@@ -122,7 +122,7 @@ async function scaffoldProject({
 
       Object.entries(packageJson.dependencies).forEach(([pkg, version]) => {
         if (typeof version === "string" && version.includes("workspace:")) {
-          packageJson.dependencies[pkg] = latestVersions[pkg] || "latest";
+          packageJson.dependencies[pkg] = latestVersions[pkg];
         }
       });
     }

--- a/packages/create-jazz-app/src/index.ts
+++ b/packages/create-jazz-app/src/index.ts
@@ -21,6 +21,52 @@ type ScaffoldOptions = {
   packageManager: "npm" | "yarn" | "pnpm" | "bun" | "deno";
 };
 
+async function getLatestPackageVersions(
+  dependencies: Record<string, string>,
+): Promise<Record<string, string>> {
+  const versionsSpinner = ora({
+    text: chalk.blue("Fetching package versions..."),
+    spinner: "dots",
+  }).start();
+
+  const versions: Record<string, string> = {};
+  const failures: string[] = [];
+
+  await Promise.all(
+    Object.keys(dependencies).map(async (pkg) => {
+      if (
+        typeof dependencies[pkg] === "string" &&
+        dependencies[pkg].includes("workspace:")
+      ) {
+        try {
+          const response = await fetch(
+            `https://registry.npmjs.org/${pkg}/latest`,
+          );
+          if (!response.ok) throw new Error(`HTTP ${response.status}`);
+          const data = await response.json();
+          versions[pkg] = `^${data.version}`; // Using caret for minor version updates
+        } catch (error) {
+          failures.push(pkg);
+        }
+      }
+    }),
+  );
+
+  if (failures.length > 0) {
+    versionsSpinner.warn(
+      chalk.yellow(
+        `Failed to fetch versions for some packages: ${failures.join(", ")}. Using 'latest' instead.`,
+      ),
+    );
+  } else {
+    versionsSpinner.succeed(
+      chalk.green("Package versions fetched successfully"),
+    );
+  }
+
+  return versions;
+}
+
 async function scaffoldProject({
   starter,
   projectName,
@@ -72,9 +118,13 @@ async function scaffoldProject({
 
     // Replace workspace: dependencies with latest
     if (packageJson.dependencies) {
+      const latestVersions = await getLatestPackageVersions(
+        packageJson.dependencies,
+      );
+
       Object.entries(packageJson.dependencies).forEach(([pkg, version]) => {
         if (typeof version === "string" && version.includes("workspace:")) {
-          packageJson.dependencies[pkg] = "latest";
+          packageJson.dependencies[pkg] = latestVersions[pkg] || "latest";
         }
       });
     }

--- a/packages/create-jazz-app/src/index.ts
+++ b/packages/create-jazz-app/src/index.ts
@@ -53,17 +53,15 @@ async function getLatestPackageVersions(
   );
 
   if (failures.length > 0) {
-    versionsSpinner.warn(
-      chalk.yellow(
-        `Failed to fetch versions for some packages: ${failures.join(", ")}. Using 'latest' instead.`,
+    versionsSpinner.fail(
+      chalk.red(
+        `Failed to fetch versions for packages: ${failures.join(", ")}. Please check your internet connection and try again.`,
       ),
     );
-  } else {
-    versionsSpinner.succeed(
-      chalk.green("Package versions fetched successfully"),
-    );
+    throw new Error("Failed to fetch package versions");
   }
 
+  versionsSpinner.succeed(chalk.green("Package versions fetched successfully"));
   return versions;
 }
 


### PR DESCRIPTION
When cloning a starter/example app, `create-jazz-app` will get the latest semver package version for `jazz-*` dependencies from NPM via HTTP, instead of hardcoding `"latest"`