### PR TITLE
feat: handle unknown coValue content instead of triggering an error

### DIFF
--- a/packages/cojson/src/coValue.ts
+++ b/packages/cojson/src/coValue.ts
@@ -35,6 +35,43 @@ export interface RawCoValue {
   subscribe(listener: (coValue: this) => void): () => void;
 }
 
+export class RawUnknownCoValue implements RawCoValue {
+  id: CoID<this>;
+  core: CoValueCore;
+
+  constructor(core: CoValueCore) {
+    this.id = core.id as CoID<this>;
+    this.core = core;
+  }
+
+  get type() {
+    return this.core.header.type;
+  }
+
+  get headerMeta() {
+    return this.core.header.meta as JsonObject;
+  }
+
+  /** @category 6. Meta */
+  get group(): RawGroup {
+    return this.core.getGroup();
+  }
+
+  toJSON() {
+    return {};
+  }
+
+  atTime() {
+    return this;
+  }
+
+  subscribe(listener: (value: this) => void): () => void {
+    return this.core.subscribe((content) => {
+      listener(content as this);
+    });
+  }
+}
+
 export type AnyRawCoValue =
   | RawCoMap
   | RawGroup

--- a/packages/cojson/src/coreToCoValue.ts
+++ b/packages/cojson/src/coreToCoValue.ts
@@ -1,3 +1,4 @@
+import { RawUnknownCoValue } from "./coValue.js";
 import type { CoValueCore } from "./coValueCore.js";
 import { RawAccount, RawControlledAccount } from "./coValues/account.js";
 import { RawCoList } from "./coValues/coList.js";
@@ -38,6 +39,6 @@ export function coreToCoValue(
       return new RawCoStream(core);
     }
   } else {
-    throw new Error(`Unknown coValue type ${core.header.type}`);
+    return new RawUnknownCoValue(core);
   }
 }

--- a/packages/cojson/src/tests/sync.test.ts
+++ b/packages/cojson/src/tests/sync.test.ts
@@ -1985,6 +1985,25 @@ describe("waitForSyncWithPeer", () => {
   });
 });
 
+test("Should not crash when syncing an unknown coValue type", async () => {
+  const { client, jazzCloud } = createTwoConnectedNodes();
+
+  const coValue = client.createCoValue({
+    type: "ooops" as any,
+    ruleset: { type: "unsafeAllowAll" },
+    meta: null,
+    ...Crypto.createdNowUnique(),
+  });
+
+  await coValue.waitForSync();
+
+  const coValueOnTheOtherNode = await loadCoValueOrFail(
+    jazzCloud,
+    coValue.getCurrentContent().id,
+  );
+  expect(coValueOnTheOtherNode.id).toBe(coValue.id);
+});
+
 describe("metrics", () => {
   afterEach(() => {
     tearDownTestMetricReader();


### PR DESCRIPTION
We were getting `Unknown coValue type` when testing the CoPlainText without upgrading the Jazz cloud.

This shouldn't have happened, because the sync server should acces only Group content and not care about anything else.

As a quick fix I'm introducing the RawUnknownCoValue because getting a new/unkown type should not be a source of errors, then I'm going to investigate why the sync server is accessing the CoValues content.