### PR TITLE
perf: skip coValue content creation on access

### DIFF
--- a/.changeset/cold-points-chew.md
+++ b/.changeset/cold-points-chew.md
@@ -1,0 +1,5 @@
+---
+"cojson": patch
+---
+
+Handle unkown coValue content type and optimize content access


### PR DESCRIPTION
The coValue content was always created when creating a coValue with a group.

This is an unnecessary operation on the sync servers that we can avoid to reduce the memory footprint and the CPU cost of creating a coValue.

This PR fixes that by centralizing the notify method and ensuring that the content is created only when there are listeners (which should be never the case on sync servers)