### PR TITLE
perf: optimize queue processing under heavy load

### DIFF
--- a/.changeset/silver-sheep-perform.md
+++ b/.changeset/silver-sheep-perform.md
@@ -1,0 +1,5 @@
+---
+"cojson": patch
+---
+
+Optimize queue management

--- a/packages/cojson/src/PeerState.ts
+++ b/packages/cojson/src/PeerState.ts
@@ -92,7 +92,7 @@ export class PeerState {
 
     this.processing = true;
 
-    let entry: QueueEntry | undefined;
+    let entry: QueueEntry<SyncMessage> | undefined;
     while ((entry = this.queue.pull())) {
       // Awaiting the push to send one message at a time
       // This way when the peer is "under pressure" we can enqueue all
@@ -129,7 +129,7 @@ export class PeerState {
   }
 
   private closeQueue() {
-    let entry: QueueEntry | undefined;
+    let entry: QueueEntry<SyncMessage> | undefined;
     while ((entry = this.queue.pull())) {
       // Using resolve here to avoid unnecessary noise in the logs
       entry.resolve();

--- a/packages/cojson/src/tests/PriorityBasedMessageQueue.test.ts
+++ b/packages/cojson/src/tests/PriorityBasedMessageQueue.test.ts
@@ -22,7 +22,7 @@ describe("PriorityBasedMessageQueue", () => {
     const { queue } = setup();
     expect(queue["defaultPriority"]).toBe(CO_VALUE_PRIORITY.MEDIUM);
     expect(queue["queues"].length).toBe(8);
-    expect(queue["queues"].every((q) => q.length === 0)).toBe(true);
+    expect(queue["queues"].every((q) => !q.isNonEmpty())).toBe(true);
   });
 
   test("should push message with default priority", async () => {


### PR DESCRIPTION
When inspecting the production performance I've observed that the queue pull is becoming slow when the sync server is under pressure.

This is related to the `unshift` call we do on pull, which is linear on the number of array elements.

Switching to a linked list which gives us O(1) cost on the push and pull operations. (taking inspiration from [fastq](https://github.com/mcollina/fastq)) 