### PR TITLE
fix(typescript): replace private symbols with prefixed strings

### DIFF
--- a/.changeset/late-shrimps-clap.md
+++ b/.changeset/late-shrimps-clap.md
@@ -1,0 +1,5 @@
+---
+"jazz-tools": patch
+---
+
+Switches from symbols to prefixes strings for private properties

--- a/packages/jazz-tools/src/implementation/schema.ts
+++ b/packages/jazz-tools/src/implementation/schema.ts
@@ -5,6 +5,7 @@ import {
   type CoValueClass,
   CoValueFromRaw,
   ItemsSym,
+  JazzToolsSymbol,
   MembersSym,
   SchemaInit,
   isCoValueClass,
@@ -23,7 +24,9 @@ export type CoMarker = { readonly __co: unique symbol };
 export type co<T> = T | (T & CoMarker);
 export type IfCo<C, R> = C extends infer _A | infer B
   ? B extends CoMarker
-    ? R
+    ? R extends JazzToolsSymbol // Exclude symbol properties like co.items or co.members from the refs/init types
+      ? never
+      : R
     : never
   : never;
 export type UnCo<T> = T extends co<infer A> ? A : T;

--- a/packages/jazz-tools/src/implementation/symbols.ts
+++ b/packages/jazz-tools/src/implementation/symbols.ts
@@ -1,8 +1,10 @@
-export const SchemaInit = Symbol.for("SchemaInit");
+export type JazzToolsSymbol = SchemaInit | ItemsSym | MembersSym;
+
+export const SchemaInit = "$SchemaInit$";
 export type SchemaInit = typeof SchemaInit;
 
-export const ItemsSym = Symbol.for("items");
+export const ItemsSym = "$items$";
 export type ItemsSym = typeof ItemsSym;
 
-export const MembersSym = Symbol.for("members");
+export const MembersSym = "$members$";
 export type MembersSym = typeof MembersSym;


### PR DESCRIPTION
Fixes the type error `'extends' clause of exported class 'ClassName' has or is using private name 'ItemsSym'` that occasionally happen in some projects.
