### PR TITLE
feat: move invite API in jazz-tools

### DIFF
--- a/.changeset/famous-swans-sniff.md
+++ b/.changeset/famous-swans-sniff.md
@@ -1,0 +1,5 @@
+---
+"jazz-tools": patch
+---
+
+Add cross-platform invite API

--- a/packages/jazz-browser/src/index.ts
+++ b/packages/jazz-browser/src/index.ts
@@ -12,7 +12,8 @@ import {
   InviteSecret,
   SessionID,
   WasmCrypto,
-  cojsonInternals,
+  createInviteLink as baseCreateInviteLink,
+  consumeInviteLink,
   createJazzContext,
 } from "jazz-tools";
 import { OPFSFilesystem } from "./OPFSFilesystem.js";
@@ -212,68 +213,19 @@ export function createInviteLink<C extends CoValue>(
     valueHint,
   }: { baseURL?: string; valueHint?: string } = {},
 ): string {
-  const coValueCore = value._raw.core;
-  let currentCoValue = coValueCore;
-
-  while (currentCoValue.header.ruleset.type === "ownedByGroup") {
-    currentCoValue = currentCoValue.getGroup().core;
-  }
-
-  const { ruleset, meta } = currentCoValue.header;
-
-  if (ruleset.type !== "group" || meta?.type === "account") {
-    throw new Error("Can't create invite link for object without group");
-  }
-
-  const group = cojsonInternals.expectGroup(currentCoValue.getCurrentContent());
-  const inviteSecret = group.createInvite(role);
-
-  return `${baseURL}#/invite/${valueHint ? valueHint + "/" : ""}${
-    value.id
-  }/${inviteSecret}`;
+  return baseCreateInviteLink(value, role, baseURL, valueHint);
 }
 
 /** @category Invite Links */
-export function parseInviteLink<C extends CoValue>(
-  inviteURL: string,
-):
-  | {
-      valueID: ID<C>;
-      valueHint?: string;
-      inviteSecret: InviteSecret;
-    }
-  | undefined {
-  const url = new URL(inviteURL);
-  const parts = url.hash.split("/");
-
-  let valueHint: string | undefined;
-  let valueID: ID<C> | undefined;
-  let inviteSecret: InviteSecret | undefined;
-
-  if (parts[0] === "#" && parts[1] === "invite") {
-    if (parts.length === 5) {
-      valueHint = parts[2];
-      valueID = parts[3] as ID<C>;
-      inviteSecret = parts[4] as InviteSecret;
-    } else if (parts.length === 4) {
-      valueID = parts[2] as ID<C>;
-      inviteSecret = parts[3] as InviteSecret;
-    }
-
-    if (!valueID || !inviteSecret) {
-      return undefined;
-    }
-    return { valueID, inviteSecret, valueHint };
-  }
-}
+export { parseInviteLink } from "jazz-tools";
 
 /** @category Invite Links */
-export function consumeInviteLinkFromWindowLocation<V extends CoValue>({
+export async function consumeInviteLinkFromWindowLocation<V extends CoValue>({
   as,
   forValueHint,
   invitedObjectSchema,
 }: {
-  as: Account;
+  as?: Account;
   forValueHint?: string;
   invitedObjectSchema: CoValueClass<V>;
 }): Promise<
@@ -284,22 +236,20 @@ export function consumeInviteLinkFromWindowLocation<V extends CoValue>({
     }
   | undefined
 > {
-  return new Promise((resolve, reject) => {
-    const result = parseInviteLink<V>(window.location.href);
-
-    if (result && result.valueHint === forValueHint) {
-      as.acceptInvite(result.valueID, result.inviteSecret, invitedObjectSchema)
-        .then(() => {
-          resolve(result);
-          window.history.replaceState(
-            {},
-            "",
-            window.location.href.replace(/#.*$/, ""),
-          );
-        })
-        .catch(reject);
-    } else {
-      resolve(undefined);
-    }
+  const result = await consumeInviteLink({
+    inviteURL: window.location.href,
+    as,
+    forValueHint,
+    invitedObjectSchema,
   });
+
+  if (result) {
+    window.history.replaceState(
+      {},
+      "",
+      window.location.href.replace(/#.*$/, ""),
+    );
+  }
+
+  return result;
 }

--- a/packages/jazz-react-native/src/hooks.tsx
+++ b/packages/jazz-react-native/src/hooks.tsx
@@ -1,9 +1,8 @@
 import { useEffect } from "react";
 
 import { createUseAccountHooks, useJazzContext } from "jazz-react-core";
-import { CoValue, CoValueClass, ID } from "jazz-tools";
+import { CoValue, CoValueClass, ID, parseInviteLink } from "jazz-tools";
 import { Linking } from "react-native";
-import { parseInviteLink } from "./platform.js";
 import { RegisteredAccount } from "./provider.js";
 
 export { useCoState, experimental_useInboxSender } from "jazz-react-core";

--- a/packages/jazz-react-native/src/index.ts
+++ b/packages/jazz-react-native/src/index.ts
@@ -4,4 +4,5 @@ export * from "./storage/kv-store-context.js";
 export * from "./hooks.js";
 export * from "./media.js";
 
-export { parseInviteLink, createInviteLink, setupKvStore } from "./platform.js";
+export { parseInviteLink } from "jazz-tools";
+export { createInviteLink, setupKvStore } from "./platform.js";

--- a/packages/jazz-react-native/src/platform.ts
+++ b/packages/jazz-react-native/src/platform.ts
@@ -8,9 +8,8 @@ import {
   CoValueClass,
   CryptoProvider,
   ID,
-  InviteSecret,
   SessionID,
-  cojsonInternals,
+  createInviteLink as baseCreateInviteLink,
   createJazzContext,
 } from "jazz-tools";
 
@@ -155,58 +154,7 @@ export function createInviteLink<C extends CoValue>(
   role: "reader" | "writer" | "admin",
   { baseURL, valueHint }: { baseURL?: string; valueHint?: string } = {},
 ): string {
-  const coValueCore = value._raw.core;
-  let currentCoValue = coValueCore;
-
-  while (currentCoValue.header.ruleset.type === "ownedByGroup") {
-    currentCoValue = currentCoValue.getGroup().core;
-  }
-
-  if (currentCoValue.header.ruleset.type !== "group") {
-    throw new Error("Can't create invite link for object without group");
-  }
-
-  const group = cojsonInternals.expectGroup(currentCoValue.getCurrentContent());
-  const inviteSecret = group.createInvite(role);
-
-  return `${baseURL}/invite/${valueHint ? valueHint + "/" : ""}${
-    value.id
-  }/${inviteSecret}`;
-}
-
-/** @category Invite Links */
-// TODO: copied from jazz-browser, should be shared
-export function parseInviteLink<C extends CoValue>(
-  inviteURL: string,
-):
-  | {
-      valueID: ID<C>;
-      valueHint?: string;
-      inviteSecret: InviteSecret;
-    }
-  | undefined {
-  const url = new URL(inviteURL);
-  const parts = url.hash.split("/");
-
-  let valueHint: string | undefined;
-  let valueID: ID<C> | undefined;
-  let inviteSecret: InviteSecret | undefined;
-
-  if (parts[0] === "#" && parts[1] === "invite") {
-    if (parts.length === 5) {
-      valueHint = parts[2];
-      valueID = parts[3] as ID<C>;
-      inviteSecret = parts[4] as InviteSecret;
-    } else if (parts.length === 4) {
-      valueID = parts[2] as ID<C>;
-      inviteSecret = parts[3] as InviteSecret;
-    }
-
-    if (!valueID || !inviteSecret) {
-      return undefined;
-    }
-    return { valueID, inviteSecret, valueHint };
-  }
+  return baseCreateInviteLink(value, role, baseURL ?? "", valueHint);
 }
 
 export function setupKvStore(kvStore = new ExpoSecureStoreAdapter()) {

--- a/packages/jazz-tools/src/exports.ts
+++ b/packages/jazz-tools/src/exports.ts
@@ -50,6 +50,12 @@ export {
 } from "./internal.js";
 
 export {
+  createInviteLink,
+  parseInviteLink,
+  consumeInviteLink,
+} from "./implementation/invites.js";
+
+export {
   AnonymousJazzAgent,
   createAnonymousJazzContext,
   createJazzContext,

--- a/packages/jazz-tools/src/implementation/invites.ts
+++ b/packages/jazz-tools/src/implementation/invites.ts
@@ -1,0 +1,99 @@
+import { type InviteSecret, cojsonInternals } from "cojson";
+import { Account } from "../coValues/account.js";
+import type { CoValue, CoValueClass, ID } from "../internal.js";
+
+/** @category Invite Links */
+export function createInviteLink<C extends CoValue>(
+  value: C,
+  role: "reader" | "writer" | "admin" | "writeOnly",
+  baseURL: string,
+  valueHint?: string,
+): string {
+  const coValueCore = value._raw.core;
+  let currentCoValue = coValueCore;
+
+  while (currentCoValue.header.ruleset.type === "ownedByGroup") {
+    currentCoValue = currentCoValue.getGroup().core;
+  }
+
+  const { ruleset, meta } = currentCoValue.header;
+
+  if (ruleset.type !== "group" || meta?.type === "account") {
+    throw new Error("Can't create invite link for object without group");
+  }
+
+  const group = cojsonInternals.expectGroup(currentCoValue.getCurrentContent());
+  const inviteSecret = group.createInvite(role);
+
+  return `${baseURL}#/invite/${valueHint ? valueHint + "/" : ""}${
+    value.id
+  }/${inviteSecret}`;
+}
+
+/** @category Invite Links */
+export function parseInviteLink<C extends CoValue>(
+  inviteURL: string,
+):
+  | {
+      valueID: ID<C>;
+      valueHint?: string;
+      inviteSecret: InviteSecret;
+    }
+  | undefined {
+  const url = new URL(inviteURL);
+  const parts = url.hash.split("/");
+
+  let valueHint: string | undefined;
+  let valueID: ID<C> | undefined;
+  let inviteSecret: InviteSecret | undefined;
+
+  if (parts[0] === "#" && parts[1] === "invite") {
+    if (parts.length === 5) {
+      valueHint = parts[2];
+      valueID = parts[3] as ID<C>;
+      inviteSecret = parts[4] as InviteSecret;
+    } else if (parts.length === 4) {
+      valueID = parts[2] as ID<C>;
+      inviteSecret = parts[3] as InviteSecret;
+    }
+
+    if (!valueID || !inviteSecret) {
+      return undefined;
+    }
+    return { valueID, inviteSecret, valueHint };
+  }
+}
+
+/** @category Invite Links */
+export function consumeInviteLink<V extends CoValue>({
+  inviteURL,
+  as = Account.getMe(),
+  forValueHint,
+  invitedObjectSchema,
+}: {
+  inviteURL: string;
+  as?: Account;
+  forValueHint?: string;
+  invitedObjectSchema: CoValueClass<V>;
+}): Promise<
+  | {
+      valueID: ID<V>;
+      valueHint?: string;
+      inviteSecret: InviteSecret;
+    }
+  | undefined
+> {
+  return new Promise((resolve, reject) => {
+    const result = parseInviteLink<V>(inviteURL);
+
+    if (result && result.valueHint === forValueHint) {
+      as.acceptInvite(result.valueID, result.inviteSecret, invitedObjectSchema)
+        .then(() => {
+          resolve(result);
+        })
+        .catch(reject);
+    } else {
+      resolve(undefined);
+    }
+  });
+}

--- a/packages/jazz-tools/src/tests/invites.test.ts
+++ b/packages/jazz-tools/src/tests/invites.test.ts
@@ -1,0 +1,85 @@
+import { beforeEach, describe, expect, test } from "vitest";
+import { Account, Group } from "../exports";
+import {
+  consumeInviteLink,
+  createInviteLink,
+  parseInviteLink,
+} from "../implementation/invites";
+import { createJazzTestAccount, setupJazzTestSync } from "../testing";
+
+describe("Invite Links", () => {
+  let account: Account;
+  let group: Group;
+  const baseURL = "https://example.com";
+
+  beforeEach(async () => {
+    await setupJazzTestSync(); // Required to sync the invite between accounts
+    account = await createJazzTestAccount({
+      isCurrentActiveAccount: true,
+    });
+    group = Group.create({ owner: account });
+  });
+
+  test("createInviteLink generates correct format", () => {
+    const inviteLink = createInviteLink(group, "writer", baseURL);
+
+    expect(inviteLink).toMatch(
+      new RegExp(`^${baseURL}#/invite/${group.id}/[A-Za-z0-9_-]+$`),
+    );
+  });
+
+  test("createInviteLink with valueHint", () => {
+    const inviteLink = createInviteLink(group, "writer", baseURL, "myGroup");
+
+    expect(inviteLink).toMatch(
+      new RegExp(`^${baseURL}#/invite/myGroup/${group.id}/[A-Za-z0-9_-]+$`),
+    );
+  });
+
+  test("parseInviteLink correctly parses valid link", () => {
+    const inviteLink = createInviteLink(group, "writer", baseURL, "myGroup");
+    const result = parseInviteLink(inviteLink);
+
+    expect(result).toBeDefined();
+    expect(result?.valueID).toBe(group.id);
+    expect(result?.valueHint).toBe("myGroup");
+    expect(result?.inviteSecret).toBeDefined();
+  });
+
+  test("parseInviteLink returns undefined for invalid link", () => {
+    const invalidLink = "https://example.com/not-an-invite";
+    const result = parseInviteLink(invalidLink);
+
+    expect(result).toBeUndefined();
+  });
+
+  test("consumeInviteLink accepts valid invite", async () => {
+    const inviteLink = createInviteLink(group, "writer", baseURL, "myGroup");
+    const newAccount = await createJazzTestAccount();
+
+    const result = await consumeInviteLink({
+      inviteURL: inviteLink,
+      as: newAccount,
+      forValueHint: "myGroup",
+      invitedObjectSchema: Group,
+    });
+
+    expect(result).toBeDefined();
+    expect(result?.valueID).toBe(group.id);
+    expect(result?.valueHint).toBe("myGroup");
+  });
+
+  test("consumeInviteLink returns undefined for mismatched valueHint", async () => {
+    const inviteLink = createInviteLink(group, "writer", baseURL, "myGroup");
+    const newAccount = await createJazzTestAccount();
+
+    const result = await consumeInviteLink({
+      inviteURL: inviteLink,
+      as: newAccount,
+      forValueHint: "wrongHint",
+      invitedObjectSchema: Group,
+    });
+
+    expect(result).toBeUndefined();
+  });
+});


### PR DESCRIPTION
Moving the invite API into jazz-tools to make them usable by workers.