### PR TITLE
fix: improve typescript types for group.addMember

### DIFF
--- a/.changeset/three-beers-repeat.md
+++ b/.changeset/three-beers-repeat.md
@@ -1,0 +1,5 @@
+---
+"jazz-tools": patch
+---
+
+Improve typescript types for group.addMember

--- a/packages/cojson/src/exports.ts
+++ b/packages/cojson/src/exports.ts
@@ -38,7 +38,7 @@ import {
 } from "./ids.js";
 import { Stringified, parseJSON, stableStringify } from "./jsonStringify.js";
 import { LocalNode } from "./localNode.js";
-import type { Role } from "./permissions.js";
+import type { AccountRole, Role } from "./permissions.js";
 import { Channel, connectedPeers } from "./streamUtils.js";
 import { accountOrAgentIDfromSessionID } from "./typeUtils/accountOrAgentIDfromSessionID.js";
 import { expectGroup } from "./typeUtils/expectGroup.js";
@@ -158,6 +158,7 @@ export type {
   Stringified,
   CoStreamItem,
   OpID,
+  AccountRole,
 };
 
 // eslint-disable-next-line @typescript-eslint/no-namespace

--- a/packages/jazz-tools/src/coValues/group.ts
+++ b/packages/jazz-tools/src/coValues/group.ts
@@ -1,4 +1,10 @@
-import type { Everyone, RawAccountID, RawGroup, Role } from "cojson";
+import type {
+  AccountRole,
+  Everyone,
+  RawAccountID,
+  RawGroup,
+  Role,
+} from "cojson";
 import type {
   CoValue,
   CoValueClass,
@@ -133,7 +139,9 @@ export class Group extends CoValueBase implements CoValue {
     return this._raw.myRole();
   }
 
-  addMember(member: Everyone | Account, role: Role) {
+  addMember(member: Everyone, role: "writer" | "reader"): Group;
+  addMember(member: Account, role: AccountRole): Group;
+  addMember(member: Everyone | Account, role: AccountRole) {
     this._raw.addMember(member === "everyone" ? member : member._raw, role);
     return this;
   }


### PR DESCRIPTION
Changes:
- Allow only 'reader' and 'writer' roles for everyone to match the runtime validation
- Allow only  'reader', 'writer', 'admin' and 'writeOnly' to not create confusion by suggesting  invite-related roles