### PR TITLE
Remove instructions to use `npm create` for examples as it doesn't work

### DIFF
--- a/examples/chat-vue/README.md
+++ b/examples/chat-vue/README.md
@@ -11,10 +11,6 @@ You can either
 
 Create a new Jazz project, and use this example as a template.
 ```bash
-npm create jazz-app@latest --example chat-vue --project-name chat-vue
-```
-or
-```bash
 npx create-jazz-app@latest --example chat-vue --project-name chat-vue
 ```
 

--- a/examples/chat/README.md
+++ b/examples/chat/README.md
@@ -13,10 +13,6 @@ You can either
 
 Create a new Jazz project, and use this example as a template.
 ```bash
-npm create jazz-app@latest --example chat --project-name chat
-```
-or
-```bash
 npx create-jazz-app@latest --example chat --project-name chat
 ```
 

--- a/examples/clerk/README.md
+++ b/examples/clerk/README.md
@@ -15,10 +15,6 @@ You can either
 
 Create a new Jazz project, and use this example as a template.
 ```bash
-npm create jazz-app@latest --example clerk --project-name clerk
-```
-or
-```bash
 npx create-jazz-app@latest --example clerk --project-name clerk
 ```
 

--- a/examples/form/README.md
+++ b/examples/form/README.md
@@ -28,10 +28,6 @@ You can either
 
 Create a new Jazz project, and use this example as a template.
 ```bash
-npm create jazz-app@latest --example form --project-name form
-```
-or
-```bash
 npx create-jazz-app@latest --example form --project-name form
 ```
 

--- a/examples/image-upload/README.md
+++ b/examples/image-upload/README.md
@@ -15,10 +15,6 @@ You can either
 
 Create a new Jazz project, and use this example as a template.
 ```bash
-npm create jazz-app@latest --example image-upload --project-name image-upload
-```
-or
-```bash
 npx create-jazz-app@latest --example image-upload --project-name image-upload
 ```
 

--- a/examples/music-player/README.md
+++ b/examples/music-player/README.md
@@ -13,10 +13,6 @@ You can either
 
 Create a new Jazz project, and use this example as a template.
 ```bash
-npm create jazz-app@latest --example music-player --project-name music-player
-```
-or
-```bash
 npx create-jazz-app@latest --example music-player --project-name music-player
 ```
 

--- a/examples/onboarding/README.md
+++ b/examples/onboarding/README.md
@@ -11,10 +11,6 @@ You can either
 
 Create a new Jazz project, and use this example as a template.
 ```bash
-npm create jazz-app@latest --example onboarding --project-name onboarding
-```
-or
-```bash
 npx create-jazz-app@latest --example onboarding --project-name onboarding
 ```
 

--- a/examples/organization/README.md
+++ b/examples/organization/README.md
@@ -16,10 +16,6 @@ You can either
 
 Create a new Jazz project, and use this example as a template.
 ```bash
-npm create jazz-app@latest --example organization --project-name organization
-```
-or
-```bash
 npx create-jazz-app@latest --example organization --project-name organization
 ```
 

--- a/examples/passkey-svelte/README.md
+++ b/examples/passkey-svelte/README.md
@@ -21,10 +21,6 @@ You can either
 
 Create a new Jazz project, and use this example as a template.
 ```bash
-npm create jazz-app@latest --example passkey-svelte --project-name passkey-svelte
-```
-or
-```bash
 npx create-jazz-app@latest --example passkey-svelte --project-name passkey-svelte
 ```
 

--- a/examples/passkey/README.md
+++ b/examples/passkey/README.md
@@ -15,10 +15,6 @@ You can either
 
 Create a new Jazz project, and use this example as a template.
 ```bash
-npm create jazz-app@latest --example passkey --project-name passkey
-```
-or
-```bash
 npx create-jazz-app@latest --example passkey --project-name passkey
 ```
 

--- a/examples/password-manager/README.md
+++ b/examples/password-manager/README.md
@@ -15,10 +15,6 @@ You can either
 
 Create a new Jazz project, and use this example as a template.
 ```bash
-npm create jazz-app@latest --example password-manager --project-name password-manager
-```
-or
-```bash
 npx create-jazz-app@latest --example password-manager --project-name password-manager
 ```
 

--- a/examples/pets/README.md
+++ b/examples/pets/README.md
@@ -13,10 +13,6 @@ You can either
 
 Create a new Jazz project, and use this example as a template.
 ```bash
-npm create jazz-app@latest --example pets --project-name pets
-```
-or
-```bash
 npx create-jazz-app@latest --example pets --project-name pets
 ```
 

--- a/examples/reactions/README.md
+++ b/examples/reactions/README.md
@@ -13,10 +13,6 @@ You can either
 
 Create a new Jazz project, and use this example as a template.
 ```bash
-npm create jazz-app@latest --example reactions --project-name reactions
-```
-or
-```bash
 npx create-jazz-app@latest --example reactions --project-name reactions
 ```
 

--- a/examples/todo-vue/README.md
+++ b/examples/todo-vue/README.md
@@ -11,10 +11,6 @@ You can either
 
 Create a new Jazz project, and use this example as a template.
 ```bash
-npm create jazz-app@latest --example todo-vue --project-name todo-vue
-```
-or
-```bash
 npx create-jazz-app@latest --example todo-vue --project-name todo-vue
 ```
 

--- a/examples/todo/README.md
+++ b/examples/todo/README.md
@@ -13,10 +13,6 @@ You can either
 
 Create a new Jazz project, and use this example as a template.
 ```bash
-npm create jazz-app@latest --example todo --project-name todo
-```
-or
-```bash
 npx create-jazz-app@latest --example todo --project-name todo
 ```
 

--- a/examples/version-history/README.md
+++ b/examples/version-history/README.md
@@ -13,10 +13,6 @@ You can either
 
 Create a new Jazz project, and use this example as a template.
 ```bash
-npm create jazz-app@latest --example version-history --project-name version-history
-```
-or
-```bash
 npx create-jazz-app@latest --example version-history --project-name version-history
 ```
 


### PR DESCRIPTION
`npm create` doesn't seem to respect the `--example` parameter. Here is the output on my machine:

```
❯ npm create jazz-app@latest --example chat --project-name chat

Jazz App Creator

Let's create your Jazz app! 🎷

? Choose a starter: (Use arrow keys)
❯ React + Jazz + Demo Auth + Tailwind 
  React + Jazz + Passkey Auth 
  React + Jazz + Clerk Auth 
  Vue + Jazz + Demo Auth 
  Svelte + Jazz + Passkey Auth 
  React Native Expo + Jazz + Clerk Auth 
```

Meanwhile `npx create-jazz-app@latest` seems to work fine:

```
❯ npx create-jazz-app@latest --example chat --project-name chat2

Jazz App Creator

Let's create your Jazz app! 🎷

? Choose a package manager: (Use arrow keys)
❯ npm 
  yarn 
  pnpm 
  bun 
  deno 
```