### PR TITLE
Remove npm create jazz-app from instructions

### DIFF
--- a/homepage/homepage/components/docs/docs-intro.mdx
+++ b/homepage/homepage/components/docs/docs-intro.mdx
@@ -10,14 +10,6 @@ Run the following command to create a new Jazz project from one of our example a
 
 <CodeGroup>
 ```sh
-npm create jazz-app@latest
-```
-</CodeGroup>
-
-or
-
-<CodeGroup>
-```sh
 npx create-jazz-app@latest
 ```
 </CodeGroup>

--- a/packages/create-jazz-app/README.md
+++ b/packages/create-jazz-app/README.md
@@ -17,13 +17,6 @@ You can create a new Jazz app in two ways:
 ### Interactive mode
 
 Simply run:
-
-```bash
-npm create jazz-app@latest
-```
-
-or
-
 ```bash
 npx create-jazz-app@latest
 ```
@@ -38,7 +31,7 @@ Then follow the interactive prompts to select your:
 Or specify all options directly:
 
 ```bash
-npm create jazz-app@latest -- --starter react-demo-auth --project-name my-app --package-manager npm
+npx create-jazz-app@latest --starter react-demo-auth --project-name my-app --package-manager npm
 ```
 
 ### Start with an example app


### PR DESCRIPTION
Removing this because it doesn't work as mentioned in https://github.com/garden-co/jazz/pull/1271