### PR TITLE
fix(jazz-inspector): ensure `dist` is included in published releases

### DIFF
--- a/packages/jazz-inspector/package.json
+++ b/packages/jazz-inspector/package.json
@@ -4,6 +4,7 @@
   "type": "module",
   "main": "./dist/jazz-inspector.js",
   "types": "./src/app.tsx",
+  "files": ["dist/**", "src"],
   "scripts": {
     "dev": "vite build --watch",
     "build": "tsc && vite build",


### PR DESCRIPTION
## Problem
The current version of `jazz-inspector` on npm is unusable due to missing files. This occurs because:
1. The package.json doesn't specify a `files` field, so `pnpm release` only includes `src`, `public`, and top-level files
2. The package's entry point is set to `"main": "./dist/jazz-inspector.js"`, but the `dist` folder isn't being published
3. As a result, build systems fail when trying to locate the missing entry point

## Solution
Add `"files": ["dist/**", "src"]` to package.json.

I've verified this fix by:
1. Building with `pnpm build`
2. Copying the result into another project's `node_modules`
3. Confirming the package works as expected

## Note
There's an unrelated issue with the `types` field being set to `"./src/app.tsx"`, which seems incorrect. This predates this PR and is left unchanged. However, I try to address it in #1276.