### PR TITLE
fix(jazz-inspector): export typescript types and remove unneeded vite build step

### DIFF
--- a/packages/cojson/src/exports.ts
+++ b/packages/cojson/src/exports.ts
@@ -17,6 +17,8 @@ import { OpID, RawCoList } from "./coValues/coList.js";
 import { RawCoMap } from "./coValues/coMap.js";
 import { RawCoPlainText, stringifyOpID } from "./coValues/coPlainText.js";
 import {
+  BinaryStreamItem,
+  BinaryStreamStart,
   CoStreamItem,
   RawBinaryCoStream,
   RawCoStream,
@@ -57,7 +59,7 @@ import type {
 import type { InviteSecret } from "./coValues/group.js";
 import type { AgentSecret } from "./crypto/crypto.js";
 import type { AgentID, RawCoID, SessionID } from "./ids.js";
-import type { JsonValue } from "./jsonValue.js";
+import type { JsonObject, JsonValue } from "./jsonValue.js";
 import type * as Media from "./media.js";
 import { disablePermissionErrors } from "./permissions.js";
 import type {
@@ -128,6 +130,7 @@ export {
   ControlledAgent,
   RawControlledAccount,
   MAX_RECOMMENDED_TX_SIZE,
+  JsonObject,
   JsonValue,
   Peer,
   BinaryStreamInfo,
@@ -143,6 +146,8 @@ export {
   RawCoPlainText,
   stringifyOpID,
   logger,
+  base64URLtoBytes,
+  bytesToBase64url,
 };
 
 export type {
@@ -157,6 +162,8 @@ export type {
   CoValueUniqueness,
   Stringified,
   CoStreamItem,
+  BinaryStreamItem,
+  BinaryStreamStart,
   OpID,
   AccountRole,
 };

--- a/packages/jazz-inspector/package.json
+++ b/packages/jazz-inspector/package.json
@@ -4,6 +4,7 @@
   "type": "module",
   "main": "./dist/jazz-inspector.js",
   "types": "./src/app.tsx",
+  "files": ["dist/**", "src"],
   "scripts": {
     "dev": "vite build --watch",
     "build": "tsc && vite build",

--- a/packages/jazz-inspector/package.json
+++ b/packages/jazz-inspector/package.json
@@ -2,12 +2,12 @@
   "name": "jazz-inspector",
   "version": "0.9.18",
   "type": "module",
-  "main": "./dist/jazz-inspector.js",
-  "types": "./src/app.tsx",
+  "main": "./dist/app.js",
+  "types": "./dist/app.d.ts",
   "files": ["dist/**", "src"],
   "scripts": {
     "dev": "vite build --watch",
-    "build": "tsc && vite build",
+    "build": "rm -rf ./dist && tsc --sourceMap --outDir dist",
     "format-and-lint": "biome check .",
     "format-and-lint:fix": "biome check . --write",
     "preview": "vite preview"

--- a/packages/jazz-inspector/src/app.tsx
+++ b/packages/jazz-inspector/src/app.tsx
@@ -1,1 +1,1 @@
-export { JazzInspector } from "./viewer/new-app.tsx";
+export { JazzInspector } from "./viewer/new-app.js";

--- a/packages/jazz-inspector/src/viewer/breadcrumbs.tsx
+++ b/packages/jazz-inspector/src/viewer/breadcrumbs.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { PageInfo } from "./types.ts";
+import { PageInfo } from "./types.js";
 
 interface BreadcrumbsProps {
   path: PageInfo[];

--- a/packages/jazz-inspector/src/viewer/co-stream-view.tsx
+++ b/packages/jazz-inspector/src/viewer/co-stream-view.tsx
@@ -5,16 +5,16 @@ import {
   RawCoStream,
   RawCoValue,
 } from "cojson";
-import { base64URLtoBytes } from "cojson/src/base64url.ts";
+import { base64URLtoBytes } from "cojson/src/base64url.js";
 import {
   BinaryStreamItem,
   BinaryStreamStart,
   CoStreamItem,
-} from "cojson/src/coValues/coStream.ts";
-import type { JsonObject, JsonValue } from "cojson/src/jsonValue.ts";
+} from "cojson/src/coValues/coStream.js";
+import type { JsonObject, JsonValue } from "cojson/src/jsonValue.js";
 import { useEffect, useState } from "react";
-import { PageInfo } from "./types.ts";
-import { AccountOrGroupPreview } from "./value-renderer.tsx";
+import { PageInfo } from "./types.js";
+import { AccountOrGroupPreview } from "./value-renderer.js";
 
 // typeguard for BinaryStreamStart
 function isBinaryStreamStart(item: unknown): item is BinaryStreamStart {

--- a/packages/jazz-inspector/src/viewer/grid-view.tsx
+++ b/packages/jazz-inspector/src/viewer/grid-view.tsx
@@ -1,8 +1,8 @@
 import { CoID, LocalNode, RawCoValue } from "cojson";
-import { JsonObject } from "cojson/src/jsonValue.ts";
-import { ResolveIcon } from "./type-icon.tsx";
-import { PageInfo, isCoId } from "./types.ts";
-import { CoMapPreview, ValueRenderer } from "./value-renderer.tsx";
+import { JsonObject } from "cojson/src/jsonValue.js";
+import { ResolveIcon } from "./type-icon.js";
+import { PageInfo, isCoId } from "./types.js";
+import { CoMapPreview, ValueRenderer } from "./value-renderer.js";
 
 export function GridView({
   data,

--- a/packages/jazz-inspector/src/viewer/new-app.tsx
+++ b/packages/jazz-inspector/src/viewer/new-app.tsx
@@ -1,9 +1,9 @@
 import { CoID, RawCoValue } from "cojson";
 import { createUseAccountHooks } from "jazz-react-core";
 import React, { useState } from "react";
-import { Breadcrumbs } from "./breadcrumbs.tsx";
-import { PageStack } from "./page-stack.tsx";
-import { usePagePath } from "./use-page-path.ts";
+import { Breadcrumbs } from "./breadcrumbs.js";
+import { PageStack } from "./page-stack.js";
+import { usePagePath } from "./use-page-path.js";
 
 const { useAccount } = createUseAccountHooks();
 

--- a/packages/jazz-inspector/src/viewer/page-stack.tsx
+++ b/packages/jazz-inspector/src/viewer/page-stack.tsx
@@ -1,5 +1,5 @@
 import { CoID, LocalNode, RawCoValue } from "cojson";
-import { Page } from "./page.tsx"; // Assuming you have a Page component
+import { Page } from "./page.js"; // Assuming you have a Page component
 
 // Define the structure of a page in the path
 interface PageInfo {

--- a/packages/jazz-inspector/src/viewer/page.tsx
+++ b/packages/jazz-inspector/src/viewer/page.tsx
@@ -1,12 +1,12 @@
 import { CoID, LocalNode, RawCoStream, RawCoValue } from "cojson";
 import { useEffect, useState } from "react";
-import { CoStreamView } from "./co-stream-view.tsx";
-import { GridView } from "./grid-view.tsx";
-import { TableView } from "./table-viewer.tsx";
-import { TypeIcon } from "./type-icon.tsx";
-import { PageInfo } from "./types.ts";
-import { useResolvedCoValue } from "./use-resolve-covalue.ts";
-import { AccountOrGroupPreview } from "./value-renderer.tsx";
+import { CoStreamView } from "./co-stream-view.js";
+import { GridView } from "./grid-view.js";
+import { TableView } from "./table-viewer.js";
+import { TypeIcon } from "./type-icon.js";
+import { PageInfo } from "./types.js";
+import { useResolvedCoValue } from "./use-resolve-covalue.js";
+import { AccountOrGroupPreview } from "./value-renderer.js";
 
 type PageProps = {
   coId: CoID<RawCoValue>;

--- a/packages/jazz-inspector/src/viewer/table-viewer.tsx
+++ b/packages/jazz-inspector/src/viewer/table-viewer.tsx
@@ -1,10 +1,10 @@
 import { CoID, LocalNode, RawCoValue } from "cojson";
-import type { JsonObject } from "cojson/src/jsonValue.ts";
+import type { JsonObject } from "cojson/src/jsonValue.js";
 import { useMemo, useState } from "react";
-import { LinkIcon } from "../link-icon.tsx";
-import { PageInfo } from "./types.ts";
-import { useResolvedCoValues } from "./use-resolve-covalue.ts";
-import { ValueRenderer } from "./value-renderer.tsx";
+import { LinkIcon } from "../link-icon.js";
+import { PageInfo } from "./types.js";
+import { useResolvedCoValues } from "./use-resolve-covalue.js";
+import { ValueRenderer } from "./value-renderer.js";
 
 export function TableView({
   data,

--- a/packages/jazz-inspector/src/viewer/type-icon.tsx
+++ b/packages/jazz-inspector/src/viewer/type-icon.tsx
@@ -3,7 +3,7 @@ import {
   CoJsonType,
   ExtendedCoJsonType,
   useResolvedCoValue,
-} from "./use-resolve-covalue.ts";
+} from "./use-resolve-covalue.js";
 
 export const TypeIcon = ({
   type,

--- a/packages/jazz-inspector/src/viewer/use-page-path.ts
+++ b/packages/jazz-inspector/src/viewer/use-page-path.ts
@@ -1,6 +1,6 @@
 import { CoID, RawCoValue } from "cojson";
 import { useCallback, useEffect, useState } from "react";
-import { PageInfo } from "./types.ts";
+import { PageInfo } from "./types.js";
 
 export function usePagePath(defaultPath?: PageInfo[]) {
   const [path, setPath] = useState<PageInfo[]>([]);

--- a/packages/jazz-inspector/src/viewer/value-renderer.tsx
+++ b/packages/jazz-inspector/src/viewer/value-renderer.tsx
@@ -1,11 +1,11 @@
 import { CoID, JsonValue, LocalNode, RawCoValue } from "cojson";
 import React, { useEffect, useState } from "react";
-import { LinkIcon } from "../link-icon.tsx";
+import { LinkIcon } from "../link-icon.js";
 import {
   isBrowserImage,
   resolveCoValue,
   useResolvedCoValue,
-} from "./use-resolve-covalue.ts";
+} from "./use-resolve-covalue.js";
 
 // Is there a chance we can pass the actual CoValue here?
 export function ValueRenderer({

--- a/packages/jazz-inspector/tsconfig.json
+++ b/packages/jazz-inspector/tsconfig.json
@@ -8,10 +8,8 @@
 
     /* Bundler mode */
     "moduleResolution": "bundler",
-    "allowImportingTsExtensions": true,
     "resolveJsonModule": true,
     "isolatedModules": true,
-    "noEmit": true,
     "jsx": "react-jsx",
 
     /* Linting */
@@ -22,7 +20,9 @@
     "baseUrl": ".",
     "paths": {
       "@/*": ["./src/*"]
-    }
+    },
+    "declaration": true,
+    "declarationDir": "./dist"
   },
   "include": ["src"],
   "references": [{ "path": "./tsconfig.node.json" }]


### PR DESCRIPTION
Note: This PR also contains the changes from #1275. I broke it into two PRs because I was less sure about this part.

## Problem
Jazz-inspector's build setup has two issues:

1. The build command is `"build": "tsc && vite build"`, but `vite build` is not typically used for npm packages. In this repo, vite is only used for building examples, not published packages (jazz-inspector being the exception).

2. TypeScript type declarations are missing from the dist folder because:
   - `tsc` isn't generating them due to `"noEmit": true` in tsconfig.json
   - Even if generated, they would be deleted by `vite build`

## Solution
1. Remove `"noEmit": true` from `tsconfig.json`
   - This also requires removing `"allowImportingTsExtensions": true`

2. Update imports to use `.js` extensions, even for `.ts` or `.tsx` files
   - This matches the convention used in the rest of the `packages` folder

3. Fix imports from `cojson`:
   - Previously, jazz-inspector imported from subdirectories (e.g. `import { JsonObject } from "cojson/src/jsonValue.js"`)
   - These subdirectory imports aren't supported by TypeScript
   - Exported needed types from `cojson`'s top level to enable direct imports