### PR TITLE
Update README.md

### DIFF
--- a/packages/jazz-vue/README.md
+++ b/packages/jazz-vue/README.md
@@ -1,3 +1,3 @@
-# `jazz-react`
+# `jazz-vue`
 
-React bindings for Jazz (see [jazz.tools](https://jazz.tools)), a framework for distributed state.
+Vue bindings for Jazz (see [jazz.tools](https://jazz.tools)), a framework for distributed state.


### PR DESCRIPTION
The current jazz-vue package describes itself as bindings for React. 

Update to fix this.