### PR TITLE
Change isMe to indicate whether an account is the currently active account

### DIFF
--- a/.changeset/honest-melons-relate.md
+++ b/.changeset/honest-melons-relate.md
@@ -1,5 +1,5 @@
 ---
-"jazz-tools": minor
+"jazz-tools": patch
 ---
 
 Account.isMe now indicates whether an account is the currently active account. To check if an account is the owner of the local node use isLocalNodeOwner instead.

--- a/.changeset/honest-melons-relate.md
+++ b/.changeset/honest-melons-relate.md
@@ -1,0 +1,5 @@
+---
+"jazz-tools": minor
+---
+
+Account.isMe now indicates whether an account is the currently active account. To check if an account is the owner of the local node use isLocalNodeOwner instead.

--- a/packages/jazz-tools/src/coValues/account.ts
+++ b/packages/jazz-tools/src/coValues/account.ts
@@ -73,7 +73,7 @@ export class Account extends CoValueBase implements CoValue {
     return this as Account;
   }
   get _loadedAs(): Account | AnonymousJazzAgent {
-    if (this.isMe) return this;
+    if (this.isLocalNodeOwner) return this;
 
     const rawAccount = this._raw.core.node.account;
 
@@ -120,7 +120,17 @@ export class Account extends CoValueBase implements CoValue {
     };
   }
 
-  isMe: boolean;
+  /**
+   * Whether this account is the currently active account.
+   */
+  get isMe() {
+    return activeAccountContext.get().id === this.id;
+  }
+
+  /**
+   * Whether this account is the owner of the local node.
+   */
+  isLocalNodeOwner: boolean;
   sessionID: SessionID | undefined;
 
   constructor(options: { fromRaw: RawAccount | RawControlledAccount }) {
@@ -128,7 +138,8 @@ export class Account extends CoValueBase implements CoValue {
     if (!("fromRaw" in options)) {
       throw new Error("Can only construct account from raw or with .create()");
     }
-    this.isMe = options.fromRaw.id == options.fromRaw.core.node.account.id;
+    this.isLocalNodeOwner =
+      options.fromRaw.id == options.fromRaw.core.node.account.id;
 
     Object.defineProperties(this, {
       id: {
@@ -139,7 +150,7 @@ export class Account extends CoValueBase implements CoValue {
       _type: { value: "Account", enumerable: false },
     });
 
-    if (this.isMe) {
+    if (this.isLocalNodeOwner) {
       this.sessionID = options.fromRaw.core.node.currentSessionID;
     }
 
@@ -147,7 +158,7 @@ export class Account extends CoValueBase implements CoValue {
   }
 
   myRole(): "admin" | undefined {
-    if (this.isMe) {
+    if (this.isLocalNodeOwner) {
       return "admin";
     }
   }
@@ -157,7 +168,7 @@ export class Account extends CoValueBase implements CoValue {
     inviteSecret: InviteSecret,
     coValueClass: CoValueClass<V>,
   ) {
-    if (!this.isMe) {
+    if (!this.isLocalNodeOwner) {
       throw new Error("Only a controlled account can accept invites");
     }
 
@@ -433,11 +444,11 @@ export const AccountAndGroupProxyHandler: ProxyHandler<Account | Group> = {
 
 /** @category Identity & Permissions */
 export function isControlledAccount(account: Account): account is Account & {
-  isMe: true;
+  isLocalNodeOwner: true;
   sessionID: SessionID;
   _raw: RawControlledAccount;
 } {
-  return account.isMe;
+  return account.isLocalNodeOwner;
 }
 
 export type AccountClass<Acc extends Account> = CoValueClass<Acc> & {

--- a/packages/jazz-tools/src/coValues/inbox.ts
+++ b/packages/jazz-tools/src/coValues/inbox.ts
@@ -28,7 +28,7 @@ export type InboxRoot = RawCoMap<{
 }>;
 
 export function createInboxRoot(account: Account) {
-  if (!account.isMe) {
+  if (!account.isLocalNodeOwner) {
     throw new Error("Account is not controlled");
   }
 
@@ -361,7 +361,7 @@ async function acceptInvite(invite: string, account?: Account) {
     throw new Error("Invalid inbox ticket");
   }
 
-  if (!account.isMe) {
+  if (!account.isLocalNodeOwner) {
     throw new Error("Account is not controlled");
   }
 

--- a/packages/jazz-tools/src/tests/account.test.ts
+++ b/packages/jazz-tools/src/tests/account.test.ts
@@ -1,6 +1,6 @@
 import { expect, test } from "vitest";
-import { CoMap, co } from "../exports.js";
-import { createJazzTestAccount } from "../testing.js";
+import { Account, CoMap, co } from "../exports.js";
+import { createJazzTestAccount, setActiveAccount } from "../testing.js";
 import { setupTwoNodes } from "./utils.js";
 
 test("waitForAllCoValuesSync should resolve when all the values are synced", async () => {
@@ -38,4 +38,39 @@ test("waitForSync should resolve when the value is uploaded", async () => {
   const loadedAccount = await serverNode.load(clientAccount._raw.id);
 
   expect(loadedAccount).not.toBe("unavailable");
+});
+
+test("isMe gets updated correctly when switching accounts", async () => {
+  const oldMe = await createJazzTestAccount({
+    isCurrentActiveAccount: true,
+  });
+
+  expect(oldMe.isMe).toBe(true);
+
+  const newMe = await createJazzTestAccount({
+    isCurrentActiveAccount: false,
+  });
+
+  expect(newMe.isMe).toBe(false);
+  expect(oldMe.isMe).toBe(true);
+
+  setActiveAccount(newMe);
+
+  expect(newMe.isMe).toBe(true);
+  expect(oldMe.isMe).toBe(false);
+});
+
+test("Me gets updated correctly when creating a new account as active", async () => {
+  const oldMe = await createJazzTestAccount({
+    isCurrentActiveAccount: true,
+  });
+
+  expect(oldMe.isMe).toBe(true);
+
+  const newMe = await createJazzTestAccount({
+    isCurrentActiveAccount: true,
+  });
+
+  expect(newMe.isMe).toBe(true);
+  expect(oldMe.isMe).toBe(false);
 });


### PR DESCRIPTION
Also adds `isLocalNodeOwner` to replace the previous behavior to check if an account is the local node owner.