### PR TITLE
fix: handle websocket errors and add onSuccess callback

### DIFF
--- a/.changeset/selfish-points-teach.md
+++ b/.changeset/selfish-points-teach.md
@@ -1,0 +1,5 @@
+---
+"cojson-transport-ws": patch
+---
+
+Handle websocket errors and add an onSuccess callback

--- a/packages/cojson-transport-ws/package.json
+++ b/packages/cojson-transport-ws/package.json
@@ -6,7 +6,7 @@
   "types": "src/index.ts",
   "license": "MIT",
   "dependencies": {
-    "cojson": "workspace:0.9.19",
+    "cojson": "workspace:*",
     "typescript": "~5.6.2"
   },
   "scripts": {
@@ -19,6 +19,7 @@
     "prepublishOnly": "npm run build"
   },
   "devDependencies": {
-    "@types/ws": "8.5.10"
+    "@types/ws": "8.5.10",
+    "ws": "^8.14.2"
   }
 }

--- a/packages/cojson-transport-ws/src/index.ts
+++ b/packages/cojson-transport-ws/src/index.ts
@@ -21,6 +21,7 @@ export type CreateWebSocketPeerOpts = {
   batchingByDefault?: boolean;
   deletePeerStateOnClose?: boolean;
   onClose?: () => void;
+  onSuccess?: () => void;
 };
 
 function createPingTimeoutListener(enabled: boolean, callback: () => void) {
@@ -127,6 +128,7 @@ export function createWebSocketPeer({
   expectPings = true,
   batchingByDefault = true,
   deletePeerStateOnClose = false,
+  onSuccess,
   onClose,
 }: CreateWebSocketPeerOpts): Peer {
   const incoming = new cojsonInternals.Channel<
@@ -142,6 +144,13 @@ export function createWebSocketPeer({
   }
 
   websocket.addEventListener("close", handleClose);
+  websocket.addEventListener("error" as any, (err) => {
+    logger.warn(err.message);
+
+    if (err.message.includes("ECONNREFUSED")) {
+      websocket.close();
+    }
+  });
 
   const pingTimeout = createPingTimeoutListener(expectPings, () => {
     incoming
@@ -154,6 +163,7 @@ export function createWebSocketPeer({
     websocket,
     batchingByDefault,
   );
+  let isFirstMessage = true;
 
   function handleIncomingMsg(event: { data: unknown }) {
     if (event.data === "") {
@@ -167,6 +177,13 @@ export function createWebSocketPeer({
         "Error while deserializing messages: " + getErrorMessage(result.error),
       );
       return;
+    }
+
+    if (isFirstMessage) {
+      // The only way to know that the connection has been correctly established with our sync server
+      // is to track that we got a message from the server.
+      onSuccess?.();
+      isFirstMessage = false;
     }
 
     const { messages } = result;

--- a/packages/cojson-transport-ws/src/tests/createWebSocketPeer.test.ts
+++ b/packages/cojson-transport-ws/src/tests/createWebSocketPeer.test.ts
@@ -170,6 +170,31 @@ describe("createWebSocketPeer", () => {
     );
   });
 
+  test("should call onSuccess handler after receiving first message", () => {
+    const onSuccess = vi.fn();
+    const { listeners } = setup({ onSuccess });
+
+    const messageHandler = listeners.get("message");
+    const message: SyncMessage = {
+      action: "known",
+      id: "co_ztest",
+      header: false,
+      sessions: {},
+    };
+
+    // First message should trigger onSuccess
+    messageHandler?.(
+      new MessageEvent("message", { data: JSON.stringify(message) }),
+    );
+    expect(onSuccess).toHaveBeenCalledTimes(1);
+
+    // Subsequent messages should not trigger onSuccess again
+    messageHandler?.(
+      new MessageEvent("message", { data: JSON.stringify(message) }),
+    );
+    expect(onSuccess).toHaveBeenCalledTimes(1);
+  });
+
   describe("batchingByDefault = true", () => {
     test("should batch outgoing messages", async () => {
       const { peer, mockWebSocket } = setup();

--- a/packages/cojson-transport-ws/src/tests/integration.test.ts
+++ b/packages/cojson-transport-ws/src/tests/integration.test.ts
@@ -1,0 +1,132 @@
+import { ControlledAgent, LocalNode, WasmCrypto } from "cojson";
+import { afterEach, beforeEach, describe, expect, test } from "vitest";
+import { WebSocket } from "ws";
+import { createWebSocketPeer } from "../index";
+import { startSyncServer } from "./syncServer";
+
+describe("WebSocket Peer Integration", () => {
+  let server: any;
+  let syncServerUrl: string;
+  let crypto: WasmCrypto;
+
+  beforeEach(async () => {
+    crypto = await WasmCrypto.create();
+    const result = await startSyncServer();
+    server = result;
+    syncServerUrl = result.syncServer;
+  });
+
+  afterEach(() => {
+    server.close();
+  });
+
+  test("should establish connection between client and server nodes", async () => {
+    // Create client node
+    const clientAgent = crypto.newRandomAgentSecret();
+    const clientNode = new LocalNode(
+      new ControlledAgent(clientAgent, crypto),
+      crypto.newRandomSessionID(crypto.getAgentID(clientAgent)),
+      crypto,
+    );
+
+    // Create WebSocket connection
+    const ws = new WebSocket(syncServerUrl);
+
+    // Track connection success
+    let connectionEstablished = false;
+
+    // Create peer and add to client node
+    const peer = createWebSocketPeer({
+      id: "test-client",
+      websocket: ws,
+      role: "server",
+      onSuccess: () => {
+        connectionEstablished = true;
+      },
+    });
+
+    clientNode.syncManager.addPeer(peer);
+
+    // Wait for connection to establish
+    await new Promise<void>((resolve) => {
+      const checkConnection = setInterval(() => {
+        if (connectionEstablished) {
+          clearInterval(checkConnection);
+          resolve();
+        }
+      }, 100);
+    });
+
+    expect(connectionEstablished).toBe(true);
+    expect(clientNode.syncManager.getPeers()).toHaveLength(1);
+  });
+
+  test("should sync data between nodes through WebSocket connection", async () => {
+    const clientAgent = crypto.newRandomAgentSecret();
+    const clientNode = new LocalNode(
+      new ControlledAgent(clientAgent, crypto),
+      crypto.newRandomSessionID(crypto.getAgentID(clientAgent)),
+      crypto,
+    );
+
+    const ws = new WebSocket(syncServerUrl);
+
+    const peer = createWebSocketPeer({
+      id: "test-client",
+      websocket: ws,
+      role: "server",
+    });
+
+    clientNode.syncManager.addPeer(peer);
+
+    // Create a test group
+    const group = clientNode.createGroup();
+    const map = group.createMap();
+    map.set("testKey", "testValue", "trusting");
+
+    // Wait for sync
+    await map.core.waitForSync();
+    console.log("synced");
+
+    // Verify data reached the server
+    const serverNode = server.localNode;
+    const serverMap = await serverNode.load(map.id);
+
+    expect(serverMap.get("testKey")).toBe("testValue");
+  });
+
+  test("should handle disconnection and cleanup", async () => {
+    const clientAgent = crypto.newRandomAgentSecret();
+    const clientNode = new LocalNode(
+      new ControlledAgent(clientAgent, crypto),
+      crypto.newRandomSessionID(crypto.getAgentID(clientAgent)),
+      crypto,
+    );
+
+    const ws = new WebSocket(syncServerUrl);
+    let disconnectCalled = false;
+
+    const peer = createWebSocketPeer({
+      id: "test-client",
+      websocket: ws,
+      role: "server",
+      onClose: () => {
+        disconnectCalled = true;
+      },
+    });
+
+    clientNode.syncManager.addPeer(peer);
+
+    // Wait for connection to establish
+    await new Promise((resolve) => setTimeout(resolve, 200));
+
+    // Close the server
+    server.close();
+
+    // Wait for disconnect handling
+    await new Promise((resolve) => setTimeout(resolve, 200));
+
+    expect(disconnectCalled).toBe(true);
+    expect(ws.readyState).toBe(WebSocket.CLOSED);
+  });
+});

--- a/packages/cojson-transport-ws/src/tests/syncServer.ts
+++ b/packages/cojson-transport-ws/src/tests/syncServer.ts
@@ -1,0 +1,89 @@
+import { createServer } from "http";
+import { ControlledAgent, LocalNode, WasmCrypto } from "cojson";
+import { WebSocket, WebSocketServer } from "ws";
+import { createWebSocketPeer } from "../index";
+
+export const startSyncServer = async (port?: number) => {
+  const crypto = await WasmCrypto.create();
+
+  const server = createServer((req, res) => {
+    if (req.url === "/health") {
+      res.writeHead(200);
+      res.end("ok");
+    }
+  });
+  const wss = new WebSocketServer({ noServer: true });
+
+  const agentSecret = crypto.newRandomAgentSecret();
+  const agentID = crypto.getAgentID(agentSecret);
+
+  const localNode = new LocalNode(
+    new ControlledAgent(agentSecret, crypto),
+    crypto.newRandomSessionID(agentID),
+    crypto,
+  );
+
+  const connections = new Set<WebSocket>();
+
+  wss.on("connection", function connection(ws, req) {
+    connections.add(ws);
+
+    const sendPing = () => {
+      ws.send(
+        JSON.stringify({
+          type: "ping",
+          time: Date.now(),
+          dc: "unknown",
+        }),
+      );
+    };
+
+    // ping/pong for the connection liveness
+    const pinging = setInterval(sendPing, 100);
+
+    sendPing(); // Immediately send a ping to the client to signal that the connection is established
+
+    ws.on("close", () => {
+      clearInterval(pinging);
+      connections.delete(ws);
+    });
+
+    const clientId = new Date().toISOString();
+
+    localNode.syncManager.addPeer(
+      createWebSocketPeer({
+        id: clientId,
+        role: "client",
+        websocket: ws,
+        expectPings: false,
+        batchingByDefault: false,
+        deletePeerStateOnClose: true,
+      }),
+    );
+
+    ws.on("error", (e) => console.error(`Error on connection ${clientId}:`, e));
+  });
+
+  server.on("upgrade", function upgrade(req, socket, head) {
+    if (req.url !== "/health") {
+      wss.handleUpgrade(req, socket, head, function done(ws) {
+        wss.emit("connection", ws, req);
+      });
+    }
+  });
+
+  server.listen(port ?? 0);
+
+  port = (server.address() as { port: number }).port;
+  const syncServer = `ws://localhost:${port}`;
+
+  return {
+    close: () => {
+      connections.forEach((ws) => ws.close());
+      server.close();
+    },
+    syncServer,
+    port,
+    localNode,
+  };
+};

--- a/packages/jazz-nodejs/src/test/startWorker.test.ts
+++ b/packages/jazz-nodejs/src/test/startWorker.test.ts
@@ -131,4 +131,53 @@ describe("startWorker integration", () => {
     await worker1.done();
     await worker2.done();
   });
+
+  test("worker reconnects when sync server is closed and reopened", async () => {
+    const worker1 = await setup();
+    const worker2 = await setupWorker(worker1.syncServer);
+
+    const group = Group.create({ owner: worker1.worker });
+    group.addMember("everyone", "reader");
+
+    const map = TestMap.create(
+      {
+        value: "initial value",
+      },
+      { owner: group },
+    );
+
+    await map.waitForSync();
+
+    // Close the sync server
+    worker1.server.close();
+
+    // Create a new value while server is down
+    const map2 = TestMap.create(
+      {
+        value: "created while offline",
+      },
+      { owner: group },
+    );
+
+    // Start a new sync server on the same port
+    const newServer = await startSyncServer({
+      port: worker1.port,
+      inMemory: true,
+      db: "",
+    });
+
+    // Wait for reconnection and sync
+    await map2.waitForSync();
+
+    // Verify both old and new values are synced
+    const mapOnWorker2 = await TestMap.load(map.id, worker2.worker, {});
+    const map2OnWorker2 = await TestMap.load(map2.id, worker2.worker, {});
+
+    expect(mapOnWorker2?.value).toBe("initial value");
+    expect(map2OnWorker2?.value).toBe("created while offline");
+
+    // Cleanup
+    await worker2.done();
+    newServer.close();
+  });
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1518,7 +1518,7 @@ importers:
   packages/cojson-transport-ws:
     dependencies:
       cojson:
-        specifier: workspace:0.9.19
+        specifier: workspace:*
         version: link:../cojson
       typescript:
         specifier: ~5.6.2
@@ -1527,6 +1527,9 @@ importers:
       '@types/ws':
         specifier: 8.5.10
         version: 8.5.10
+      ws:
+        specifier: ^8.14.2
+        version: 8.18.0
 
   packages/create-jazz-app:
     dependencies:


### PR DESCRIPTION
Adding an error handler to make the WebSocket restart correctly when the server connection goes down on workers.

Added an onSuccess callback for future use on managing the client reconnections (part of AuthV2)