### PR TITLE
feat: remove the ws dependency and use native WebSocket

### DIFF
--- a/.changeset/purple-eagles-cover.md
+++ b/.changeset/purple-eagles-cover.md
@@ -1,0 +1,15 @@
+---
+"jazz-nodejs": minor
+---
+
+Remove ws dependency to use native WebSocket. 
+
+NodeJS versions prior to v22 will need to provide a WebSocket constructor from ws:
+
+```ts
+import { WebSocket } from "ws"
+
+const { worker } = await startWorker({ WebSocket, synServer });
+```
+
+This makes it easier to run workers on every JS runtime.

--- a/packages/jazz-nodejs/package.json
+++ b/packages/jazz-nodejs/package.json
@@ -9,11 +9,9 @@
   "dependencies": {
     "cojson": "workspace:0.9.19",
     "cojson-transport-ws": "workspace:0.9.22",
-    "jazz-tools": "workspace:0.9.21",
-    "ws": "^8.14.2"
+    "jazz-tools": "workspace:0.9.21"
   },
   "devDependencies": {
-    "@types/ws": "8.5.10",
     "jazz-run": "workspace:*",
     "typescript": "~5.6.2"
   },

--- a/packages/jazz-nodejs/src/index.ts
+++ b/packages/jazz-nodejs/src/index.ts
@@ -14,6 +14,7 @@ type WorkerOptions<Acc extends Account> = {
   accountID?: string;
   accountSecret?: string;
   syncServer?: string;
+  WebSocket?: typeof WebSocket;
   AccountSchema?: AccountClass<Acc>;
 };
 
@@ -29,9 +30,13 @@ export async function startWorker<Acc extends Account>(
   } = options;
 
   let node: LocalNode | undefined = undefined;
-  const wsPeer = webSocketWithReconnection(syncServer, (peer) => {
-    node?.syncManager.addPeer(peer);
-  });
+  const wsPeer = webSocketWithReconnection(
+    syncServer,
+    (peer) => {
+      node?.syncManager.addPeer(peer);
+    },
+    options.WebSocket,
+  );
 
   if (!accountID) {
     throw new Error("No accountID provided");

--- a/packages/jazz-nodejs/src/webSocketWithReconnection.ts
+++ b/packages/jazz-nodejs/src/webSocketWithReconnection.ts
@@ -1,14 +1,17 @@
 import { Peer } from "cojson";
 import { createWebSocketPeer } from "cojson-transport-ws";
-import { WebSocket } from "ws";
 
 export function webSocketWithReconnection(
   peer: string,
   addPeer: (peer: Peer) => void,
+  ws?: typeof WebSocket,
 ) {
   let done = false;
+
+  const WebSocketConstructor = ws ?? WebSocket;
+
   const wsPeer = createWebSocketPeer({
-    websocket: new WebSocket(peer),
+    websocket: new WebSocketConstructor(peer),
     id: "upstream",
     role: "server",
     onClose: handleClose,
@@ -20,11 +23,9 @@ export function webSocketWithReconnection(
 
     clearTimeout(timer);
     timer = setTimeout(() => {
-      console.log(new Date(), "Reconnecting to upstream " + peer);
-
       const wsPeer: Peer = createWebSocketPeer({
         id: "upstream",
-        websocket: new WebSocket(peer) as any,
+        websocket: new WebSocketConstructor(peer) as any,
         role: "server",
         onClose: handleClose,
       });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1684,13 +1684,7 @@ importers:
       jazz-tools:
         specifier: workspace:0.9.21
         version: link:../jazz-tools
-      ws:
-        specifier: ^8.14.2
-        version: 8.18.0
     devDependencies:
-      '@types/ws':
-        specifier: 8.5.10
-        version: 8.5.10
       jazz-run:
         specifier: workspace:*
         version: link:../jazz-run


### PR DESCRIPTION
Remove ws dependency and use native WebSocket. 

NodeJS versions prior to v22 will need to provide a WebSocket constructor from ws:

```ts
import { WebSocket } from "ws"

const { worker } = await startWorker({ WebSocket, synServer });
```

This makes it easier to run workers on every JS runtime.