### PR TITLE
feat: API to handle the authenticate on top of an anonymous user

### DIFF
--- a/examples/music-player/src/1_schema.ts
+++ b/examples/music-player/src/1_schema.ts
@@ -36,6 +36,8 @@ export class MusicTrack extends CoMap {
    */
   file = co.ref(FileStream);
   waveform = co.ref(MusicTrackWaveform);
+
+  isExampleTrack = co.optional.boolean;
 }
 
 export class MusicTrackWaveform extends CoMap {
@@ -87,27 +89,19 @@ export class MusicaAccount extends Account {
    */
   migrate() {
     if (this.root === undefined) {
-      const ownership = { owner: this };
+      const tracks = ListOfTracks.create([]);
+      const rootPlaylist = Playlist.create({
+        tracks,
+        title: "",
+      });
 
-      const tracks = ListOfTracks.create([], ownership);
-      const rootPlaylist = Playlist.create(
-        {
-          tracks,
-          title: "",
-        },
-        ownership,
-      );
-
-      this.root = MusicaAccountRoot.create(
-        {
-          rootPlaylist,
-          playlists: ListOfPlaylists.create([], ownership),
-          activeTrack: null,
-          activePlaylist: rootPlaylist,
-          exampleDataLoaded: false,
-        },
-        ownership,
-      );
+      this.root = MusicaAccountRoot.create({
+        rootPlaylist,
+        playlists: ListOfPlaylists.create([]),
+        activeTrack: null,
+        activePlaylist: rootPlaylist,
+        exampleDataLoaded: false,
+      });
     }
   }
 }

--- a/examples/music-player/src/2_main.tsx
+++ b/examples/music-player/src/2_main.tsx
@@ -12,6 +12,7 @@ import "./index.css";
 
 import { MusicaAccount } from "@/1_schema";
 import { JazzProvider } from "jazz-react";
+import { onAnonymousUserDiscarded } from "./4_actions";
 import { useUploadExampleData } from "./lib/useUploadExampleData";
 
 /**
@@ -76,6 +77,7 @@ ReactDOM.createRoot(document.getElementById("root")!).render(
       storage="indexedDB"
       AccountSchema={MusicaAccount}
       defaultProfileName="Anonymous unicorn"
+      onAnonymousUserDiscarded={onAnonymousUserDiscarded}
     >
       <Main />
       <JazzInspector />

--- a/examples/music-player/src/components/AuthModal.tsx
+++ b/examples/music-player/src/components/AuthModal.tsx
@@ -8,7 +8,7 @@ import {
 } from "@/components/ui/dialog";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
-import { usePasskeyAuth } from "jazz-react";
+import { useAccount, usePasskeyAuth } from "jazz-react";
 import { useState } from "react";
 
 interface AuthModalProps {
@@ -20,6 +20,14 @@ export function AuthModal({ open, onOpenChange }: AuthModalProps) {
   const [username, setUsername] = useState("");
   const [isSignUp, setIsSignUp] = useState(true);
   const [error, setError] = useState<string | null>(null);
+
+  const { me } = useAccount({
+    root: {
+      rootPlaylist: {
+        tracks: [{}],
+      },
+    },
+  });
 
   const auth = usePasskeyAuth({
     appName: "Jazz Music Player",
@@ -44,6 +52,10 @@ export function AuthModal({ open, onOpenChange }: AuthModalProps) {
       setError(error instanceof Error ? error.message : "Unknown error");
     }
   };
+
+  const shouldShowTransferRootPlaylist =
+    !isSignUp &&
+    me?.root.rootPlaylist.tracks.some((track) => !track.isExampleTrack);
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
@@ -72,6 +84,13 @@ export function AuthModal({ open, onOpenChange }: AuthModalProps) {
             </div>
           )}
           {error && <div className="text-sm text-red-500">{error}</div>}
+          {shouldShowTransferRootPlaylist && (
+            <div className="text-sm text-red-500">
+              You have tracks in your root playlist that are not example tracks.
+              If you log in with a passkey, your playlists will be transferred
+              to your logged account.
+            </div>
+          )}
           <div className="space-y-4">
             <Button
               type="submit"

--- a/examples/music-player/src/lib/useUploadExampleData.ts
+++ b/examples/music-player/src/lib/useUploadExampleData.ts
@@ -25,7 +25,7 @@ async function uploadOnboardingData() {
   try {
     const trackFile = await (await fetch("/example.mp3")).blob();
 
-    await uploadMusicTracks([new File([trackFile], "Example song")]);
+    await uploadMusicTracks([new File([trackFile], "Example song")], true);
   } catch (error) {
     me.root.exampleDataLoaded = false;
     throw error;

--- a/packages/jazz-browser/src/BrowserContextManager.ts
+++ b/packages/jazz-browser/src/BrowserContextManager.ts
@@ -17,6 +17,7 @@ export type JazzContextManagerProps<Acc extends Account> = {
   guestMode?: boolean;
   sync: SyncConfig;
   onLogOut?: () => void;
+  onAnonymousUserDiscarded?: (anonymousAccount: Acc) => Promise<void>;
   storage?: BaseBrowserContextOptions["storage"];
   AccountSchema?: AccountClass<Acc>;
   defaultProfileName?: string;

--- a/packages/jazz-react-core/src/hooks.ts
+++ b/packages/jazz-react-core/src/hooks.ts
@@ -72,8 +72,6 @@ export function useCoState<V extends CoValue, D>(
     () => observable.getCurrentValue(),
   );
 
-  console.log("value", value);
-
   return value;
 }
 

--- a/packages/jazz-react-native/src/ReactNativeContextManager.ts
+++ b/packages/jazz-react-native/src/ReactNativeContextManager.ts
@@ -19,6 +19,7 @@ export type JazzContextManagerProps<Acc extends Account> = {
   storage?: BaseReactNativeContextOptions["storage"];
   AccountSchema?: AccountClass<Acc>;
   defaultProfileName?: string;
+  onAnonymousUserDiscarded?: (anonymousAccount: Acc) => Promise<void>;
 };
 
 export class ReactNativeContextManager<

--- a/packages/jazz-svelte/src/lib/Provider.svelte
+++ b/packages/jazz-svelte/src/lib/Provider.svelte
@@ -33,7 +33,9 @@
           storage: props.storage,
           guestMode: props.guestMode,
           AccountSchema: props.AccountSchema,
-          defaultProfileName: props.defaultProfileName
+          defaultProfileName: props.defaultProfileName,
+          onAnonymousUserDiscarded: props.onAnonymousUserDiscarded,
+          onLogOut: props.onLogOut,
         })
         .catch((error) => {
           console.error('Error creating Jazz browser context:', error);

--- a/packages/jazz-tools/src/testing.ts
+++ b/packages/jazz-tools/src/testing.ts
@@ -135,9 +135,6 @@ export function getJazzContextShape<Acc extends Account>(
       authenticate: async () => {
         throw new Error("Not implemented");
       },
-      register: async () => {
-        throw new Error("Not implemented");
-      },
       logOut: () => account.guest.node.gracefulShutdown(),
       done: () => account.guest.node.gracefulShutdown(),
     } satisfies JazzGuestContext;
@@ -147,10 +144,6 @@ export function getJazzContextShape<Acc extends Account>(
     me: account,
     node: account._raw.core.node,
     authenticate: async () => {},
-    register: async () => {
-      const account = await createJazzTestAccount();
-      return account.id;
-    },
     logOut: () => account._raw.core.node.gracefulShutdown(),
     done: () => account._raw.core.node.gracefulShutdown(),
   } satisfies JazzAuthContext<Acc>;

--- a/packages/jazz-tools/src/types.ts
+++ b/packages/jazz-tools/src/types.ts
@@ -22,7 +22,6 @@ export type JazzAuthContext<Acc extends Account> = {
   me: Acc;
   node: LocalNode;
   authenticate: AuthenticateAccountFunction;
-  register: RegisterAccountFunction;
   logOut: () => void;
   done: () => void;
 };
@@ -31,7 +30,6 @@ export type JazzGuestContext = {
   guest: AnonymousJazzAgent;
   node: LocalNode;
   authenticate: AuthenticateAccountFunction;
-  register: RegisterAccountFunction;
   logOut: () => void;
   done: () => void;
 };

--- a/packages/jazz-vue/src/provider.ts
+++ b/packages/jazz-vue/src/provider.ts
@@ -46,6 +46,16 @@ export const JazzProvider = defineComponent({
       type: String,
       required: false,
     },
+    onAnonymousUserDiscarded: {
+      type: Function as PropType<
+        (anonymousAccount: RegisteredAccount) => Promise<void>
+      >,
+      required: false,
+    },
+    onLogOut: {
+      type: Function as PropType<() => void>,
+      required: false,
+    },
   },
   setup(props, { slots }) {
     const contextManager = new JazzBrowserContextManager<RegisteredAccount>();
@@ -69,6 +79,8 @@ export const JazzProvider = defineComponent({
             guestMode: props.guestMode,
             AccountSchema: props.AccountSchema,
             defaultProfileName: props.defaultProfileName,
+            onAnonymousUserDiscarded: props.onAnonymousUserDiscarded,
+            onLogOut: props.onLogOut,
           })
           .catch((error) => {
             console.error("Error creating Jazz browser context:", error);


### PR DESCRIPTION
This PR introduces a `onAnonymousUserDiscarded` handler to pass the data to the logged user before the data on the anonymous user gets lost.

Got the idea of adding a `transferOwnership` API on Account, which would make the things way easier because it doesn't require a good permissions design/understanding.

Tried that road, but it isn't a quick win so I've decided to set for a dumb API that's hard to use but gets the job done.

Howerver once works it is wonderful:

https://github.com/user-attachments/assets/81fff4ef-43d2-4397-b30f-3630d557a7af

