### PR TITLE
fix: move access revoke after key rotation

### DIFF
--- a/.changeset/happy-pears-hug.md
+++ b/.changeset/happy-pears-hug.md
@@ -1,0 +1,5 @@
+---
+"cojson": patch
+---
+
+Rotate keys before revoking access, so when admins remove themselves the keys are successfully rotated

--- a/packages/cojson/src/coValues/group.ts
+++ b/packages/cojson/src/coValues/group.ts
@@ -383,8 +383,10 @@ export class RawGroup<
   }
 
   /** @internal */
-  rotateReadKey() {
-    const memberKeys = this.getMemberKeys();
+  rotateReadKey(removedMemberKey?: RawAccountID | AgentID | "everyone") {
+    const memberKeys = this.getMemberKeys().filter(
+      (key) => key !== removedMemberKey,
+    );
 
     const currentlyPermittedReaders = memberKeys.filter((key) => {
       const role = this.get(key);
@@ -522,7 +524,7 @@ export class RawGroup<
         continue;
       }
 
-      child.rotateReadKey();
+      child.rotateReadKey(removedMemberKey);
     }
   }
 
@@ -617,8 +619,9 @@ export class RawGroup<
     account: RawAccount | ControlledAccountOrAgent | AgentID | Everyone,
   ) {
     const memberKey = typeof account === "string" ? account : account.id;
+
+    this.rotateReadKey(memberKey);
     this.set(memberKey, "revoked", "trusting");
-    this.rotateReadKey();
   }
 
   /**


### PR DESCRIPTION
Switch to rotate keys before revoking access, so when admins remove themselves the keys are successfully rotated