### PR TITLE
fix: throw when auth hooks are used in guest mode

### DIFF
--- a/packages/jazz-react-auth-clerk/src/index.tsx
+++ b/packages/jazz-react-auth-clerk/src/index.tsx
@@ -11,6 +11,10 @@ function useJazzClerkAuth(clerk: MinimalClerkClient) {
   const context = useJazzContext();
   const authSecretStorage = useAuthSecretStorage();
 
+  if ("guest" in context) {
+    throw new Error("Clerk auth is not supported in guest mode");
+  }
+
   const authMethod = useMemo(() => {
     return new JazzClerkAuth(context.authenticate, authSecretStorage);
   }, []);

--- a/packages/jazz-react-core/src/auth/DemoAuth.tsx
+++ b/packages/jazz-react-core/src/auth/DemoAuth.tsx
@@ -17,6 +17,10 @@ export function useDemoAuth() {
   const context = useJazzContext();
   const authSecretStorage = useAuthSecretStorage();
 
+  if ("guest" in context) {
+    throw new Error("Demo auth is not supported in guest mode");
+  }
+
   const authMethod = useMemo(() => {
     return new DemoAuth(context.authenticate, authSecretStorage);
   }, []);

--- a/packages/jazz-react-core/src/auth/PassphraseAuth.tsx
+++ b/packages/jazz-react-core/src/auth/PassphraseAuth.tsx
@@ -21,6 +21,10 @@ export function usePassphraseAuth({
   const context = useJazzContext();
   const authSecretStorage = useAuthSecretStorage();
 
+  if ("guest" in context) {
+    throw new Error("Passphrase auth is not supported in guest mode");
+  }
+
   const authMethod = useMemo(() => {
     return new PassphraseAuth(
       context.node.crypto,

--- a/packages/jazz-react-core/src/tests/useDemoAuth.test.tsx
+++ b/packages/jazz-react-core/src/tests/useDemoAuth.test.tsx
@@ -32,22 +32,17 @@ describe("useDemoAuth", () => {
     });
   });
 
-  it("should initialize with anonymous state when using guest account", async () => {
+  it("throws error when using guest account", async () => {
     const guestAccount = await createJazzTestGuest();
 
-    const { result } = renderHook(() => useDemoAuth(), {
-      account: guestAccount,
-    });
-
-    expect(result.current.state).toBe("anonymous");
-    expect(result.current.existingUsers).toEqual([]);
-    expect(typeof result.current.logIn).toBe("function");
-    expect(typeof result.current.signUp).toBe("function");
+    expect(() =>
+      renderHook(() => useDemoAuth(), {
+        account: guestAccount,
+      }),
+    ).toThrow();
   });
 
   it("should show signed in state with authenticated account", async () => {
-    const account = Account.getMe();
-
     const { result } = renderHook(() => useDemoAuth(), {
       isAuthenticated: true,
     });

--- a/packages/jazz-react-core/src/tests/usePassPhraseAuth.test.ts
+++ b/packages/jazz-react-core/src/tests/usePassPhraseAuth.test.ts
@@ -24,20 +24,14 @@ describe("usePassphraseAuth", () => {
     });
   });
 
-  it("should initialize with anonymous state when using guest account", async () => {
+  it("throws error when using guest account", async () => {
     const guestAccount = await createJazzTestGuest();
 
-    const { result } = renderHook(
-      () => usePassphraseAuth({ wordlist: testWordlist }),
-      {
+    expect(() =>
+      renderHook(() => usePassphraseAuth({ wordlist: testWordlist }), {
         account: guestAccount,
-      },
-    );
-
-    expect(result.current.state).toBe("anonymous");
-    expect(typeof result.current.logIn).toBe("function");
-    expect(typeof result.current.signUp).toBe("function");
-    expect(typeof result.current.getCurrentUserPassphrase).toBe("function");
+      }),
+    ).toThrow();
   });
 
   it("should show signed in state with authenticated account", async () => {

--- a/packages/jazz-react-native-auth-clerk/src/index.tsx
+++ b/packages/jazz-react-native-auth-clerk/src/index.tsx
@@ -11,6 +11,10 @@ function useJazzClerkAuth(clerk: MinimalClerkClient) {
   const context = useJazzContext();
   const authSecretStorage = useAuthSecretStorage();
 
+  if ("guest" in context) {
+    throw new Error("Clerk auth is not supported in guest mode");
+  }
+
   const authMethod = useMemo(() => {
     return new JazzClerkAuth(context.authenticate, authSecretStorage);
   }, []);

--- a/packages/jazz-react/src/auth/PasskeyAuth.tsx
+++ b/packages/jazz-react/src/auth/PasskeyAuth.tsx
@@ -26,6 +26,10 @@ export function usePasskeyAuth({
   const context = useJazzContext();
   const authSecretStorage = useAuthSecretStorage();
 
+  if ("guest" in context) {
+    throw new Error("Passkey auth is not supported in guest mode");
+  }
+
   const authMethod = useMemo(() => {
     return new BrowserPasskeyAuth(
       context.node.crypto,

--- a/packages/jazz-svelte/src/lib/auth/PasskeyAuth.svelte.ts
+++ b/packages/jazz-svelte/src/lib/auth/PasskeyAuth.svelte.ts
@@ -24,9 +24,13 @@ export function usePasskeyAuth({
     appName,
     appHostname
   );
-  
+
+  if ("guest" in context.current) {
+    throw new Error("Passkey auth is not supported in guest mode");
+  }
+
   const isAuthenticated = useIsAuthenticated();
-  
+
   const state = $derived(isAuthenticated.value ? "signedIn" : "anonymous");
 
   return {

--- a/packages/jazz-vue/src/auth/useDemoAuth.ts
+++ b/packages/jazz-vue/src/auth/useDemoAuth.ts
@@ -7,6 +7,10 @@ export function useDemoAuth() {
   const context = useJazzContext();
   const authSecretStorage = useAuthSecretStorage();
 
+  if ("guest" in context.value) {
+    throw new Error("Demo auth is not supported in guest mode");
+  }
+
   const authMethod = computed(
     () => new DemoAuth(context.value.authenticate, authSecretStorage),
   );

--- a/packages/jazz-vue/src/auth/usePasskeyAuth.ts
+++ b/packages/jazz-vue/src/auth/usePasskeyAuth.ts
@@ -24,6 +24,10 @@ export function usePasskeyAuth({
   const authSecretStorage = useAuthSecretStorage();
   const isAuthenticated = useIsAuthenticated();
 
+  if ("guest" in context.value) {
+    throw new Error("Passkey auth is not supported in guest mode");
+  }
+
   const authMethod = computed(() => {
     return new BrowserPasskeyAuth(
       context.value.node.crypto,

--- a/packages/jazz-vue/src/auth/usePassphraseAuth.ts
+++ b/packages/jazz-vue/src/auth/usePassphraseAuth.ts
@@ -22,6 +22,10 @@ export function usePassphraseAuth({
   const authSecretStorage = useAuthSecretStorage();
   const isAuthenticated = useIsAuthenticated();
 
+  if ("guest" in context.value) {
+    throw new Error("Passphrase auth is not supported in guest mode");
+  }
+
   const authMethod = computed(() => {
     return new PassphraseAuth(
       context.value.node.crypto,


### PR DESCRIPTION
To avoid a bump in complexity and ship the authV2 sooner I'm adding a throw error that flags that the guest mode isn't supported by auth hooks.

