### PR TITLE
fix: make Group.removeMember return the promise from CoJSON

### DIFF
--- a/.changeset/proud-scissors-double.md
+++ b/.changeset/proud-scissors-double.md
@@ -1,0 +1,6 @@
+---
+"jazz-tools": minor
+---
+
+Group.addMember and Group.removeMember are not chainable anymore.
+Group.removeMember now returns the internal promise.

--- a/packages/jazz-tools/src/coValues/group.ts
+++ b/packages/jazz-tools/src/coValues/group.ts
@@ -139,16 +139,14 @@ export class Group extends CoValueBase implements CoValue {
     return this._raw.myRole();
   }
 
-  addMember(member: Everyone, role: "writer" | "reader"): Group;
-  addMember(member: Account, role: AccountRole): Group;
+  addMember(member: Everyone, role: "writer" | "reader"): void;
+  addMember(member: Account, role: AccountRole): void;
   addMember(member: Everyone | Account, role: AccountRole) {
     this._raw.addMember(member === "everyone" ? member : member._raw, role);
-    return this;
   }
 
   removeMember(member: Everyone | Account) {
-    this._raw.removeMember(member === "everyone" ? member : member._raw);
-    return this;
+    return this._raw.removeMember(member === "everyone" ? member : member._raw);
   }
 
   get members() {

--- a/packages/jazz-tools/src/tests/groupsAndAccounts.test.ts
+++ b/packages/jazz-tools/src/tests/groupsAndAccounts.test.ts
@@ -122,7 +122,7 @@ describe("Group inheritance", () => {
     const mapAsReader = await TestMap.load(mapInChild.id, reader, {});
     expect(mapAsReader?.title).toBe("In Child");
 
-    parentGroup.removeMember(reader);
+    await parentGroup.removeMember(reader);
 
     mapInChild.title = "In Child (updated)";
 
@@ -161,7 +161,7 @@ describe("Group inheritance", () => {
     const mapAsReader = await TestMap.load(mapInGrandChild.id, reader, {});
     expect(mapAsReader?.title).toBe("In Grand Child");
 
-    grandParentGroup.removeMember(reader);
+    await grandParentGroup.removeMember(reader);
 
     mapInGrandChild.title = "In Grand Child (updated)";
 


### PR DESCRIPTION
Make Group.removeMember return the promise from CoJSON so it can be correctly awaited.

For consistency now both Group.addMember and Group.removeMember are not chainable anymore.