### PR TITLE
fix: reduce the retries on coValue not found to two

### DIFF
--- a/.changeset/thick-bags-glow.md
+++ b/.changeset/thick-bags-glow.md
@@ -1,0 +1,5 @@
+---
+"cojson": patch
+---
+
+Reduce the retries on coValue not found to two

--- a/packages/cojson/src/coValueState.ts
+++ b/packages/cojson/src/coValueState.ts
@@ -5,7 +5,7 @@ import { logger } from "./logger.js";
 import { PeerID } from "./sync.js";
 
 export const CO_VALUE_LOADING_CONFIG = {
-  MAX_RETRIES: 5,
+  MAX_RETRIES: 2,
   TIMEOUT: 30_000,
 };
 


### PR DESCRIPTION
We found that 5 retires are too many to give the user a "not found" response, so we are bringing it down to two.