### PR TITLE
docs: update the upgrade guide & authentication docs for the other frameworks

### DIFF
--- a/homepage/homepage/app/docs/[framework]/[...slug]/authentication/overview.mdx
+++ b/homepage/homepage/app/docs/[framework]/[...slug]/authentication/overview.mdx
@@ -1,6 +1,6 @@
 export const metadata = { title: "Authentication methods" };
 
-import { CodeGroup } from "@/components/forMdx";
+import { CodeGroup, ContentByFramework } from "@/components/forMdx";
 
 # Authentication in Jazz
 
@@ -10,14 +10,16 @@ When a user loads a Jazz application for the first time, we generate those keys 
 
 Without any additional steps the user can use Jazz normally, but they would be limited to use on only one device.
 
-For an account to use multiple devices, and back up their credentials, you can set up a you can setup an authentication method using one of the Jazz providers.
+For an account to use multiple devices, and back up their credentials, you can set up an authentication method using one of the Jazz providers.
 
+<ContentByFramework framework={["react", "vue", "svelte"]}>
 ## Authentication with passkeys
 
 Passkey authentication is fully local-first and the most secure of the auth methods that Jazz provides.
 
 It is based on the [Web Authentication API](https://developer.mozilla.org/en-US/docs/Web/API/Web_Authentication_API) and is both very easy to use and widely supported.
 
+<ContentByFramework framework="react">
 Using passkeys in Jazz is as easy as this:
 <CodeGroup>
 {/* prettier-ignore */}
@@ -53,8 +55,12 @@ export function AuthModal({ open, onOpenChange }: AuthModalProps) {
 }
 ```
 </CodeGroup>
+</ContentByFramework>
+
 
 You can try our passkey authentication using our [passkey example](https://passkey-demo.jazz.tools/) or the [music player demo](https://music-demo.jazz.tools/).
+
+</ContentByFramework>
 
 ## Passphrase-based authentication
 
@@ -64,6 +70,7 @@ The passphrase is generated from the local account certificate using a wordlist 
 
 You can find a set of ready-to-use wordlists in the [bip39](https://github.com/bitcoinjs/bip39/tree/a7ecbfe2e60d0214ce17163d610cad9f7b23140c/src/wordlists) repository.
 
+<ContentByFramework framework="react">
 For example:
 <CodeGroup>
 {/* prettier-ignore */}
@@ -118,9 +125,79 @@ export function AuthModal({ open, onOpenChange }: AuthModalProps) {
 }
 ```
 </CodeGroup>
+</ContentByFramework>
+
+<ContentByFramework framework="react-native">
+For example:
+<CodeGroup>
+{/* prettier-ignore */}
+```tsx
+import { View, TextInput, Button, Text } from 'react-native';
+
+export function AuthModal({ open, onOpenChange }: AuthModalProps) {
+  const [loginPassphrase, setLoginPassphrase] = useState("");
+
+  const auth = usePassphraseAuth({
+    wordlist: englishWordlist,
+  });
+
+  if (auth.state === "signedIn") {
+    return <Text>You are already signed in</Text>;
+  }
+
+  const handleSignUp = async () => {
+    await auth.signUp();
+    onOpenChange(false);
+  };
+
+  const handleLogIn = async () => {
+    await auth.logIn(loginPassphrase);
+    onOpenChange(false);
+  };
+
+  return (
+    <View>
+      <View>
+        <Text>Your current passphrase</Text>
+        <TextInput
+          editable={false}
+          value={auth.passphrase}
+          multiline
+          numberOfLines={5}
+        />
+      </View>
+
+      <Button
+        title="I have stored my passphrase"
+        onPress={handleSignUp}
+      />
+
+      <View>
+        <Text>Log in with your passphrase</Text>
+        <TextInput
+          value={loginPassphrase}
+          onChangeText={setLoginPassphrase}
+          placeholder="Enter your passphrase"
+          multiline
+          numberOfLines={5}
+          required
+        />
+      </View>
+
+      <Button
+        title="Log in"
+        onPress={handleLogIn}
+      />
+    </View>
+  );
+}
+```
+</CodeGroup>
+</ContentByFramework>
 
 You can try our passphrase authentication using our [passphrase example](https://passphrase-demo.jazz.tools/) or the [todo list demo](https://todo-demo.jazz.tools/).
 
+<ContentByFramework framework={["react", "react-native"]}>
 ## Integration with Clerk
 
 Jazz can be used with [Clerk](https://clerk.com/) to authenticate users.
@@ -129,9 +206,16 @@ This authentication method is not fully local-first, because the login and signu
 
 However, once authenticated, your users won't need to interact with Clerk anymore, and are able to use all of Jazz's features without needing to be online.
 
+<ContentByFramework framework="react">
 The clerk provider is not built into `jazz-react` and needs the `jazz-react-auth-clerk` package to be installed.
+</ContentByFramework>
+
+<ContentByFramework framework="react-native">
+The clerk provider is not built into `jazz-react-native` and needs the `jazz-react-native-auth-clerk` package to be installed.
+</ContentByFramework>
 
 After installing the package you can use the `JazzProviderWithClerk` component to wrap your app:
+<ContentByFramework framework="react">
 <CodeGroup>
 ```tsx
 import { JazzProviderWithClerk } from "jazz-react-auth-clerk";
@@ -160,7 +244,51 @@ createRoot(document.getElementById("root")!).render(
 );
 ```
 </CodeGroup>
+</ContentByFramework>
+<ContentByFramework framework="react-native">
+<CodeGroup>
+```tsx
+import { JazzProviderWithClerk } from "jazz-react-native-auth-clerk";
 
+function JazzAndAuth({ children }: { children: React.ReactNode }) {
+  const clerk = useClerk();
+
+  return (
+    <JazzProviderWithClerk
+      clerk={clerk}
+      sync={{
+        peer: `wss://cloud.jazz.tools/?key=${apiKey}`,
+      }}
+    >
+      {children}
+    </JazzProviderWithClerk>
+  );
+}
+
+export default function RootLayout() {
+  const publishableKey = process.env.EXPO_PUBLIC_CLERK_PUBLISHABLE_KEY;
+
+  if (!publishableKey) {
+    throw new Error(
+      "Missing Publishable Key. Please set EXPO_PUBLIC_CLERK_PUBLISHABLE_KEY in your .env",
+    );
+  }
+
+  return (
+    <ClerkProvider tokenCache={tokenCache} publishableKey={publishableKey}>
+      <ClerkLoaded>
+        <JazzAndAuth>
+          <Slot />
+        </JazzAndAuth>
+      </ClerkLoaded>
+    </ClerkProvider>
+  );
+}
+```
+</CodeGroup>
+</ContentByFramework>
+
+<ContentByFramework framework="react">
 Then you can use the [Clerk auth methods](https://clerk.com/docs/references/react/overview) to log in and sign up:
 <CodeGroup>
 {/* prettier-ignore */}
@@ -181,6 +309,32 @@ export function AuthButton() {
 }
 ```
 </CodeGroup>
+</ContentByFramework>
+
+<ContentByFramework framework="react-native">
+Then you can use the [Clerk auth methods](https://clerk.com/docs/references/expo/overview) to log in and sign up:
+<CodeGroup>
+{/* prettier-ignore */}
+```tsx
+import { SignInButton } from "@clerk/clerk-expo";
+import { useAccount, useIsAuthenticated } from "jazz-react-native";
+
+export function AuthButton() {
+  const { logOut } = useAccount();
+  const { signIn, setActive, isLoaded } = useSignIn();
+
+  const isAuthenticated = useIsAuthenticated();
+
+  if (isAuthenticated) {
+    return <button onClick={() => logOut()}>Logout</button>;
+  }
+
+  // Login code with Clerk Expo
+}
+```
+</CodeGroup>
+</ContentByFramework>
+</ContentByFramework>
 
 ## Migrating data from anonymous to authenticated account
 

--- a/homepage/homepage/app/docs/[framework]/[...slug]/upgrade/0-10-0.mdx
+++ b/homepage/homepage/app/docs/[framework]/[...slug]/upgrade/0-10-0.mdx
@@ -25,32 +25,28 @@ export const metadata = { title: "Jazz 0.10.0 is out!" };
   - Bugfix: Group.removeMember now returns a promise
 </div>
 
-<ContentByFramework framework="react">
   <h3 id="new-authentication-flow">New authentication flow</h3>
   <div>
     Until now authentication has been the first part to figure out when building a Jazz app, and this was a stumbling block for many.
 
-    Now is no more required and setting up a Jazz app is as easy as writing this:
+    Now it is no longer required and setting up a Jazz app is as easy as writing this:
 <CodeGroup>
 {/* prettier-ignore */}
 ```tsx
-import { JazzProvider } from "jazz-react";
-
-ReactDOM.createRoot(document.getElementById("root")!).render(
-    <JazzProvider
-        auth={passkeyAuth} // removed  // *bin*
-        peer="wss://cloud.jazz.tools/?key=you@example.com"  // moved into sync // *bin*
-        sync={{ peer: "wss://cloud.jazz.tools/?key=you@example.com" }}  // *add*
-    >
-        <App />
-    </JazzProvider>
-);
+<JazzProvider
+    auth={authMethod} // removed  // *bin*
+    peer="wss://cloud.jazz.tools/?key=you@example.com"  // moved into sync // *bin*
+    sync={{ peer: "wss://cloud.jazz.tools/?key=you@example.com" }}  // *add*
+>
+    <App />
+</JazzProvider>
 ```
 </CodeGroup>
 
 New users are initially authenticated as "anonymous" and you can sign them up with one of the Jazz providers.
 
 Your auth code can now blend into your component tree:
+<ContentByFramework framework="react">
 <CodeGroup>
 {/* prettier-ignore */}
 ```tsx
@@ -75,12 +71,113 @@ export function AuthModal({ open, onOpenChange }: AuthModalProps) {
       await auth.logIn();
     }
     onOpenChange(false);
-  };
+};
 ```
 </CodeGroup>
+</ContentByFramework>
+<ContentByFramework framework="react-native">
+<CodeGroup>
+{/* prettier-ignore */}
+```tsx
+export function AuthModal({ open, onOpenChange }: AuthModalProps) {
+  const [username, setUsername] = useState("");
+  const [isSignUp, setIsSignUp] = useState(true);
+  const [loginPassphrase, setLoginPassphrase] = useState("");
+
+  const auth = usePassphraseAuth({ // Must be inside the JazzProvider!
+    wordlist,
+  });
+
+  const handleViewChange = () => {
+    setIsSignUp(!isSignUp);
+  };
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+
+    if (isSignUp) {
+      await auth.signUp();
+    } else {
+      await auth.logIn(loginPassphrase);
+    }
+    onOpenChange(false);
+};
+```
+</CodeGroup>
+</ContentByFramework>
+<ContentByFramework framework="svelte">
+<CodeGroup>
+{/* prettier-ignore */}
+```tsx
+import { usePasskeyAuth } from 'jazz-svelte';
+
+const auth = usePasskeyAuth({ appName: "My super-cool web app" });
+
+let error = $state<string | undefined>(undefined);
+
+function signUp(e: Event) {
+  const formData = new FormData(e.currentTarget as HTMLFormElement);
+  const name = formData.get('name') as string;
+
+  if (!name) {
+    error = 'Name is required';
+    return;
+  }
+  e.preventDefault();
+  error = undefined;
+  auth.current.signUp(name).catch((e) => {
+    error = e.message;
+  });
+}
+
+function logIn() {
+  error = undefined;
+  auth.current.logIn().catch((e) => {
+    error = e.message;
+  });
+}
+```
+</CodeGroup>
+</ContentByFramework>
+<ContentByFramework framework="vue">
+<CodeGroup>
+{/* prettier-ignore */}
+```tsx
+import { usePasskeyAuth } from 'jazz-vue';
+import { ref } from 'vue';
+
+const auth = usePasskeyAuth({ appName: "My super-cool web app" });
+const error = ref<string | undefined>(undefined);
+
+function signUp(e: Event) {
+  const formData = new FormData(e.currentTarget as HTMLFormElement);
+  const name = formData.get('name') as string;
+
+  if (!name) {
+    error.value = 'Name is required';
+    return;
+  }
+  e.preventDefault();
+  error.value = undefined;
+  auth.value.signUp(name).catch((e) => {
+    error.value = e.message;
+  });
+}
+
+function logIn(e: Event) {
+  error.value = undefined;
+  e.preventDefault();
+  auth.value.logIn().catch((e) => {
+    error.value = e.message;
+  });
+}
+```
+</CodeGroup>
+</ContentByFramework>
 
 When a user signs up with one of the providers we register the current anonymous account into it.
 
+<ContentByFramework framework={["react"]}>
 To check if the user has registered you can use the new `useIsAuthenticated` hook:
 <CodeGroup>
 {/* prettier-ignore */}
@@ -88,16 +185,14 @@ To check if the user has registered you can use the new `useIsAuthenticated` hoo
 export function AuthButton() {
   const isAuthenticated = useIsAuthenticated();
   const { logOut } = useAccount();
-  const [isModalOpen, setIsModalOpen] = useState(false);
-
-  function handleSignOut() {
-    logOut();
-    location.href = "/";
-  }
+  const [open, setOpen] = useState(false);
 
   if (isAuthenticated) {
     return (
-      <Button variant="outline" onClick={handleSignOut}>
+      <Button 
+        variant="outline" 
+        onClick={logOut}
+      >
         Sign out
       </Button>
     );
@@ -114,7 +209,42 @@ export function AuthButton() {
 }
 ```
 </CodeGroup>
+</ContentByFramework>
+<ContentByFramework framework={["react-native"]}>
+To check if the user has registered you can use the new `useIsAuthenticated` hook:
+<CodeGroup>
+{/* prettier-ignore */}
+```tsx
+export function AuthButton() {
+  const isAuthenticated = useIsAuthenticated();
+  const { logOut } = useAccount();
+  const [open, setOpen] = useState(false);
 
+  if (isAuthenticated) {
+    return (
+      <Button 
+        variant="outline" 
+        onPress={logOut}
+      >
+        Sign out
+      </Button>
+    );
+  }
+
+  return (
+    <>
+      <Button onPress={() => setOpen(true)}>
+        Sign up
+      </Button>
+      <AuthModal open={open} onOpenChange={setOpen} />
+    </>
+  );
+}
+```
+</CodeGroup>
+</ContentByFramework>
+
+<ContentByFramework framework={["react"]}>
 If you do want to require your users to register before using your app, you can do it by just moving the auth code inside the `JazzProvider` component like this:
 <CodeGroup>
 {/* prettier-ignore */}
@@ -125,17 +255,16 @@ ReactDOM.createRoot(document.getElementById("root")!).render(
     <JazzProvider
       sync={{ peer: "wss://cloud.jazz.tools/?key=you@example.com" }}
     >
-      <PasskeyAuthBasicUI appName="My super-fast web app">
+      <PasskeyAuthBasicUI appName="My super-cool web app">
         <App />
       </PasskeyAuthBasicUI>
     </JazzProvider>
 );
 ```
 </CodeGroup>
-
-For the changes related to the specific auth providers see the updated [authentication docs](/docs/authentication).
-  </div>
 </ContentByFramework>
+For the changes related to the specific auth providers see the updated [authentication docs](/docs/authentication/overview).
+  </div>
 
 <h3 id="local-only-mode">Local-only mode</h3>
 <div>

--- a/homepage/homepage/lib/docNavigationItems.js
+++ b/homepage/homepage/lib/docNavigationItems.js
@@ -152,12 +152,12 @@ export const docNavigationItems = [
     items: [
       {
         name: "Overview",
-        href: "/docs/authentication/",
+        href: "/docs/authentication/overview",
         done: {
-          react: 50,
-          vue: 0,
-          "react-native": 0,
-          svelte: 0,
+          react: 100,
+          vue: 50,
+          "react-native": 100,
+          svelte: 50,
         },
       },
       {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -24,10 +24,10 @@ importers:
         version: 1.50.1
       '@vitejs/plugin-react':
         specifier: ^4.3.3
-        version: 4.3.4(vite@6.0.11(@types/node@22.10.2)(jiti@1.21.7)(lightningcss@1.28.2)(terser@5.37.0)(yaml@2.6.1))
+        version: 4.3.4(vite@6.0.11(@types/node@22.10.2)(jiti@2.4.2)(lightningcss@1.29.1)(terser@5.37.0)(yaml@2.6.1))
       '@vitest/browser':
         specifier: ^3.0.5
-        version: 3.0.5(@types/node@22.10.2)(playwright@1.50.1)(typescript@5.6.3)(vite@6.0.11(@types/node@22.10.2)(jiti@1.21.7)(lightningcss@1.28.2)(terser@5.37.0)(yaml@2.6.1))(vitest@3.0.5)(webdriverio@8.41.0)
+        version: 3.0.5(@types/node@22.10.2)(playwright@1.50.1)(typescript@5.6.3)(vite@6.0.11(@types/node@22.10.2)(jiti@2.4.2)(lightningcss@1.29.1)(terser@5.37.0)(yaml@2.6.1))(vitest@3.0.5)(webdriverio@8.41.0)
       '@vitest/coverage-istanbul':
         specifier: 3.0.5
         version: 3.0.5(vitest@3.0.5)
@@ -57,7 +57,7 @@ importers:
         version: 0.25.13(typescript@5.6.3)
       vitest:
         specifier: 3.0.5
-        version: 3.0.5(@types/node@22.10.2)(@vitest/browser@3.0.5)(@vitest/ui@3.0.5)(happy-dom@16.8.1)(jiti@1.21.7)(jsdom@25.0.1)(lightningcss@1.28.2)(msw@2.7.0(@types/node@22.10.2)(typescript@5.6.3))(terser@5.37.0)(yaml@2.6.1)
+        version: 3.0.5(@types/node@22.10.2)(@vitest/browser@3.0.5)(@vitest/ui@3.0.5)(happy-dom@16.8.1)(jiti@2.4.2)(jsdom@25.0.1)(lightningcss@1.29.1)(msw@2.7.0(@types/node@22.10.2)(typescript@5.6.3))(terser@5.37.0)(yaml@2.6.1)
 
   examples/chat:
     dependencies:
@@ -97,7 +97,7 @@ importers:
         version: 18.3.5(@types/react@18.3.18)
       '@vitejs/plugin-react-swc':
         specifier: ^3.3.2
-        version: 3.7.2(@swc/helpers@0.5.15)(vite@6.0.11(@types/node@22.10.2)(jiti@1.21.7)(lightningcss@1.28.2)(terser@5.37.0)(yaml@2.6.1))
+        version: 3.7.2(@swc/helpers@0.5.15)(vite@6.0.11(@types/node@22.10.2)(jiti@2.4.2)(lightningcss@1.29.1)(terser@5.37.0)(yaml@2.6.1))
       autoprefixer:
         specifier: ^10.4.20
         version: 10.4.20(postcss@8.4.49)
@@ -115,7 +115,7 @@ importers:
         version: 5.6.3
       vite:
         specifier: ^6.0.11
-        version: 6.0.11(@types/node@22.10.2)(jiti@1.21.7)(lightningcss@1.28.2)(terser@5.37.0)(yaml@2.6.1)
+        version: 6.0.11(@types/node@22.10.2)(jiti@2.4.2)(lightningcss@1.29.1)(terser@5.37.0)(yaml@2.6.1)
 
   examples/chat-rn:
     dependencies:
@@ -421,10 +421,10 @@ importers:
         version: 22.10.2
       '@vitejs/plugin-vue':
         specifier: ^5.1.4
-        version: 5.2.1(vite@6.0.11(@types/node@22.10.2)(jiti@1.21.7)(lightningcss@1.28.2)(terser@5.37.0)(yaml@2.6.1))(vue@3.5.13(typescript@5.6.3))
+        version: 5.2.1(vite@6.0.11(@types/node@22.10.2)(jiti@2.4.2)(lightningcss@1.29.1)(terser@5.37.0)(yaml@2.6.1))(vue@3.5.13(typescript@5.6.3))
       '@vitejs/plugin-vue-jsx':
         specifier: ^4.0.1
-        version: 4.1.1(vite@6.0.11(@types/node@22.10.2)(jiti@1.21.7)(lightningcss@1.28.2)(terser@5.37.0)(yaml@2.6.1))(vue@3.5.13(typescript@5.6.3))
+        version: 4.1.1(vite@6.0.11(@types/node@22.10.2)(jiti@2.4.2)(lightningcss@1.29.1)(terser@5.37.0)(yaml@2.6.1))(vue@3.5.13(typescript@5.6.3))
       '@vue/tsconfig':
         specifier: ^0.5.1
         version: 0.5.1
@@ -433,10 +433,10 @@ importers:
         version: 10.4.20(postcss@8.4.49)
       eslint:
         specifier: ^9.7.0
-        version: 9.17.0(jiti@1.21.7)
+        version: 9.17.0(jiti@2.4.2)
       eslint-plugin-vue:
         specifier: ^9.28.0
-        version: 9.32.0(eslint@9.17.0(jiti@1.21.7))
+        version: 9.32.0(eslint@9.17.0(jiti@2.4.2))
       npm-run-all2:
         specifier: ^6.2.3
         version: 6.2.6
@@ -451,10 +451,10 @@ importers:
         version: 5.6.3
       vite:
         specifier: ^6.0.11
-        version: 6.0.11(@types/node@22.10.2)(jiti@1.21.7)(lightningcss@1.28.2)(terser@5.37.0)(yaml@2.6.1)
+        version: 6.0.11(@types/node@22.10.2)(jiti@2.4.2)(lightningcss@1.29.1)(terser@5.37.0)(yaml@2.6.1)
       vite-plugin-vue-devtools:
         specifier: ^7.4.6
-        version: 7.6.8(rollup@4.28.1)(vite@6.0.11(@types/node@22.10.2)(jiti@1.21.7)(lightningcss@1.28.2)(terser@5.37.0)(yaml@2.6.1))(vue@3.5.13(typescript@5.6.3))
+        version: 7.6.8(rollup@4.28.1)(vite@6.0.11(@types/node@22.10.2)(jiti@2.4.2)(lightningcss@1.29.1)(terser@5.37.0)(yaml@2.6.1))(vue@3.5.13(typescript@5.6.3))
       vue-tsc:
         specifier: ^2.1.6
         version: 2.1.10(typescript@5.6.3)
@@ -491,7 +491,7 @@ importers:
         version: 18.3.5(@types/react@18.3.18)
       '@vitejs/plugin-react':
         specifier: ^4.3.3
-        version: 4.3.4(vite@6.0.11(@types/node@22.10.2)(jiti@1.21.7)(lightningcss@1.28.2)(terser@5.37.0)(yaml@2.6.1))
+        version: 4.3.4(vite@6.0.11(@types/node@22.10.2)(jiti@2.4.2)(lightningcss@1.29.1)(terser@5.37.0)(yaml@2.6.1))
       globals:
         specifier: ^15.11.0
         version: 15.14.0
@@ -500,7 +500,7 @@ importers:
         version: 5.6.3
       vite:
         specifier: ^6.0.11
-        version: 6.0.11(@types/node@22.10.2)(jiti@1.21.7)(lightningcss@1.28.2)(terser@5.37.0)(yaml@2.6.1)
+        version: 6.0.11(@types/node@22.10.2)(jiti@2.4.2)(lightningcss@1.29.1)(terser@5.37.0)(yaml@2.6.1)
 
   examples/file-share-svelte:
     dependencies:
@@ -522,13 +522,13 @@ importers:
     devDependencies:
       '@sveltejs/adapter-vercel':
         specifier: ^5.5.0
-        version: 5.5.2(@sveltejs/kit@2.13.0(@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.15.0)(vite@6.0.11(@types/node@22.10.2)(jiti@1.21.7)(lightningcss@1.28.2)(terser@5.37.0)(yaml@2.6.1)))(svelte@5.15.0)(vite@6.0.11(@types/node@22.10.2)(jiti@1.21.7)(lightningcss@1.28.2)(terser@5.37.0)(yaml@2.6.1)))(rollup@4.28.1)
+        version: 5.5.2(@sveltejs/kit@2.13.0(@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.15.0)(vite@6.0.11(@types/node@22.10.2)(jiti@2.4.2)(lightningcss@1.29.1)(terser@5.37.0)(yaml@2.6.1)))(svelte@5.15.0)(vite@6.0.11(@types/node@22.10.2)(jiti@2.4.2)(lightningcss@1.29.1)(terser@5.37.0)(yaml@2.6.1)))(rollup@4.28.1)
       '@sveltejs/kit':
         specifier: ^2.0.0
-        version: 2.13.0(@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.15.0)(vite@6.0.11(@types/node@22.10.2)(jiti@1.21.7)(lightningcss@1.28.2)(terser@5.37.0)(yaml@2.6.1)))(svelte@5.15.0)(vite@6.0.11(@types/node@22.10.2)(jiti@1.21.7)(lightningcss@1.28.2)(terser@5.37.0)(yaml@2.6.1))
+        version: 2.13.0(@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.15.0)(vite@6.0.11(@types/node@22.10.2)(jiti@2.4.2)(lightningcss@1.29.1)(terser@5.37.0)(yaml@2.6.1)))(svelte@5.15.0)(vite@6.0.11(@types/node@22.10.2)(jiti@2.4.2)(lightningcss@1.29.1)(terser@5.37.0)(yaml@2.6.1))
       '@sveltejs/vite-plugin-svelte':
         specifier: ^5.0.0
-        version: 5.0.3(svelte@5.15.0)(vite@6.0.11(@types/node@22.10.2)(jiti@1.21.7)(lightningcss@1.28.2)(terser@5.37.0)(yaml@2.6.1))
+        version: 5.0.3(svelte@5.15.0)(vite@6.0.11(@types/node@22.10.2)(jiti@2.4.2)(lightningcss@1.29.1)(terser@5.37.0)(yaml@2.6.1))
       '@types/is-ci':
         specifier: ^3.0.4
         version: 3.0.4
@@ -537,13 +537,13 @@ importers:
         version: 10.4.20(postcss@8.4.49)
       eslint:
         specifier: ^9.7.0
-        version: 9.17.0(jiti@1.21.7)
+        version: 9.17.0(jiti@2.4.2)
       eslint-config-prettier:
         specifier: ^9.1.0
-        version: 9.1.0(eslint@9.17.0(jiti@1.21.7))
+        version: 9.1.0(eslint@9.17.0(jiti@2.4.2))
       eslint-plugin-svelte:
         specifier: ^2.36.0
-        version: 2.46.1(eslint@9.17.0(jiti@1.21.7))(svelte@5.15.0)(ts-node@10.9.2(@swc/core@1.10.1(@swc/helpers@0.5.15))(@types/node@22.10.2)(typescript@5.6.3))
+        version: 2.46.1(eslint@9.17.0(jiti@2.4.2))(svelte@5.15.0)(ts-node@10.9.2(@swc/core@1.10.1(@swc/helpers@0.5.15))(@types/node@22.10.2)(typescript@5.6.3))
       globals:
         specifier: ^15.11.0
         version: 15.14.0
@@ -573,10 +573,10 @@ importers:
         version: 5.6.3
       typescript-eslint:
         specifier: ^8.0.0
-        version: 8.18.1(eslint@9.17.0(jiti@1.21.7))(typescript@5.6.3)
+        version: 8.18.1(eslint@9.17.0(jiti@2.4.2))(typescript@5.6.3)
       vite:
         specifier: ^6.0.11
-        version: 6.0.11(@types/node@22.10.2)(jiti@1.21.7)(lightningcss@1.28.2)(terser@5.37.0)(yaml@2.6.1)
+        version: 6.0.11(@types/node@22.10.2)(jiti@2.4.2)(lightningcss@1.29.1)(terser@5.37.0)(yaml@2.6.1)
 
   examples/form:
     dependencies:
@@ -616,7 +616,7 @@ importers:
         version: 18.3.5(@types/react@18.3.18)
       '@vitejs/plugin-react':
         specifier: ^4.3.3
-        version: 4.3.4(vite@6.0.11(@types/node@22.10.2)(jiti@1.21.7)(lightningcss@1.28.2)(terser@5.37.0)(yaml@2.6.1))
+        version: 4.3.4(vite@6.0.11(@types/node@22.10.2)(jiti@2.4.2)(lightningcss@1.29.1)(terser@5.37.0)(yaml@2.6.1))
       autoprefixer:
         specifier: ^10.4.20
         version: 10.4.20(postcss@8.4.49)
@@ -637,7 +637,7 @@ importers:
         version: 5.6.3
       vite:
         specifier: ^6.0.11
-        version: 6.0.11(@types/node@22.10.2)(jiti@1.21.7)(lightningcss@1.28.2)(terser@5.37.0)(yaml@2.6.1)
+        version: 6.0.11(@types/node@22.10.2)(jiti@2.4.2)(lightningcss@1.29.1)(terser@5.37.0)(yaml@2.6.1)
 
   examples/image-upload:
     dependencies:
@@ -668,7 +668,7 @@ importers:
         version: 18.3.5(@types/react@18.3.18)
       '@vitejs/plugin-react':
         specifier: ^4.3.3
-        version: 4.3.4(vite@6.0.11(@types/node@22.10.2)(jiti@1.21.7)(lightningcss@1.28.2)(terser@5.37.0)(yaml@2.6.1))
+        version: 4.3.4(vite@6.0.11(@types/node@22.10.2)(jiti@2.4.2)(lightningcss@1.29.1)(terser@5.37.0)(yaml@2.6.1))
       globals:
         specifier: ^15.11.0
         version: 15.14.0
@@ -677,7 +677,7 @@ importers:
         version: 5.6.3
       vite:
         specifier: ^6.0.11
-        version: 6.0.11(@types/node@22.10.2)(jiti@1.21.7)(lightningcss@1.28.2)(terser@5.37.0)(yaml@2.6.1)
+        version: 6.0.11(@types/node@22.10.2)(jiti@2.4.2)(lightningcss@1.29.1)(terser@5.37.0)(yaml@2.6.1)
 
   examples/inspector:
     dependencies:
@@ -747,7 +747,7 @@ importers:
         version: 18.3.5(@types/react@18.3.18)
       '@vitejs/plugin-react-swc':
         specifier: ^3.3.2
-        version: 3.7.2(@swc/helpers@0.5.15)(vite@6.0.11(@types/node@22.10.2)(jiti@1.21.7)(lightningcss@1.28.2)(terser@5.37.0)(yaml@2.6.1))
+        version: 3.7.2(@swc/helpers@0.5.15)(vite@6.0.11(@types/node@22.10.2)(jiti@2.4.2)(lightningcss@1.29.1)(terser@5.37.0)(yaml@2.6.1))
       autoprefixer:
         specifier: ^10.4.20
         version: 10.4.20(postcss@8.4.49)
@@ -762,7 +762,7 @@ importers:
         version: 5.6.3
       vite:
         specifier: ^6.0.11
-        version: 6.0.11(@types/node@22.10.2)(jiti@1.21.7)(lightningcss@1.28.2)(terser@5.37.0)(yaml@2.6.1)
+        version: 6.0.11(@types/node@22.10.2)(jiti@2.4.2)(lightningcss@1.29.1)(terser@5.37.0)(yaml@2.6.1)
 
   examples/music-player:
     dependencies:
@@ -832,7 +832,7 @@ importers:
         version: 18.3.5(@types/react@18.3.18)
       '@vitejs/plugin-react-swc':
         specifier: ^3.3.2
-        version: 3.7.2(@swc/helpers@0.5.15)(vite@6.0.11(@types/node@22.10.2)(jiti@1.21.7)(lightningcss@1.28.2)(terser@5.37.0)(yaml@2.6.1))
+        version: 3.7.2(@swc/helpers@0.5.15)(vite@6.0.11(@types/node@22.10.2)(jiti@2.4.2)(lightningcss@1.29.1)(terser@5.37.0)(yaml@2.6.1))
       autoprefixer:
         specifier: ^10.4.20
         version: 10.4.20(postcss@8.4.49)
@@ -847,7 +847,7 @@ importers:
         version: 5.6.3
       vite:
         specifier: ^6.0.11
-        version: 6.0.11(@types/node@22.10.2)(jiti@1.21.7)(lightningcss@1.28.2)(terser@5.37.0)(yaml@2.6.1)
+        version: 6.0.11(@types/node@22.10.2)(jiti@2.4.2)(lightningcss@1.29.1)(terser@5.37.0)(yaml@2.6.1)
 
   examples/onboarding:
     dependencies:
@@ -878,7 +878,7 @@ importers:
         version: 18.3.5(@types/react@18.3.18)
       '@vitejs/plugin-react':
         specifier: ^4.3.3
-        version: 4.3.4(vite@6.0.11(@types/node@22.10.2)(jiti@1.21.7)(lightningcss@1.28.2)(terser@5.37.0)(yaml@2.6.1))
+        version: 4.3.4(vite@6.0.11(@types/node@22.10.2)(jiti@2.4.2)(lightningcss@1.29.1)(terser@5.37.0)(yaml@2.6.1))
       autoprefixer:
         specifier: ^10.4.20
         version: 10.4.20(postcss@8.4.49)
@@ -899,7 +899,7 @@ importers:
         version: 5.6.3
       vite:
         specifier: ^6.0.11
-        version: 6.0.11(@types/node@22.10.2)(jiti@1.21.7)(lightningcss@1.28.2)(terser@5.37.0)(yaml@2.6.1)
+        version: 6.0.11(@types/node@22.10.2)(jiti@2.4.2)(lightningcss@1.29.1)(terser@5.37.0)(yaml@2.6.1)
 
   examples/organization:
     dependencies:
@@ -939,7 +939,7 @@ importers:
         version: 18.3.5(@types/react@18.3.18)
       '@vitejs/plugin-react':
         specifier: ^4.3.3
-        version: 4.3.4(vite@6.0.11(@types/node@22.10.2)(jiti@1.21.7)(lightningcss@1.28.2)(terser@5.37.0)(yaml@2.6.1))
+        version: 4.3.4(vite@6.0.11(@types/node@22.10.2)(jiti@2.4.2)(lightningcss@1.29.1)(terser@5.37.0)(yaml@2.6.1))
       autoprefixer:
         specifier: ^10.4.20
         version: 10.4.20(postcss@8.4.49)
@@ -957,7 +957,7 @@ importers:
         version: 5.6.3
       vite:
         specifier: ^6.0.11
-        version: 6.0.11(@types/node@22.10.2)(jiti@1.21.7)(lightningcss@1.28.2)(terser@5.37.0)(yaml@2.6.1)
+        version: 6.0.11(@types/node@22.10.2)(jiti@2.4.2)(lightningcss@1.29.1)(terser@5.37.0)(yaml@2.6.1)
 
   examples/passkey:
     dependencies:
@@ -985,7 +985,7 @@ importers:
         version: 18.3.5(@types/react@18.3.18)
       '@vitejs/plugin-react':
         specifier: ^4.3.3
-        version: 4.3.4(vite@6.0.11(@types/node@22.10.2)(jiti@1.21.7)(lightningcss@1.28.2)(terser@5.37.0)(yaml@2.6.1))
+        version: 4.3.4(vite@6.0.11(@types/node@22.10.2)(jiti@2.4.2)(lightningcss@1.29.1)(terser@5.37.0)(yaml@2.6.1))
       globals:
         specifier: ^15.11.0
         version: 15.14.0
@@ -994,7 +994,7 @@ importers:
         version: 5.6.3
       vite:
         specifier: ^6.0.11
-        version: 6.0.11(@types/node@22.10.2)(jiti@1.21.7)(lightningcss@1.28.2)(terser@5.37.0)(yaml@2.6.1)
+        version: 6.0.11(@types/node@22.10.2)(jiti@2.4.2)(lightningcss@1.29.1)(terser@5.37.0)(yaml@2.6.1)
 
   examples/passkey-svelte:
     dependencies:
@@ -1004,25 +1004,25 @@ importers:
     devDependencies:
       '@sveltejs/adapter-auto':
         specifier: ^3.0.0
-        version: 3.3.1(@sveltejs/kit@2.13.0(@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.15.0)(vite@6.0.11(@types/node@22.10.2)(jiti@1.21.7)(lightningcss@1.28.2)(terser@5.37.0)(yaml@2.6.1)))(svelte@5.15.0)(vite@6.0.11(@types/node@22.10.2)(jiti@1.21.7)(lightningcss@1.28.2)(terser@5.37.0)(yaml@2.6.1)))
+        version: 3.3.1(@sveltejs/kit@2.13.0(@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.15.0)(vite@6.0.11(@types/node@22.10.2)(jiti@2.4.2)(lightningcss@1.29.1)(terser@5.37.0)(yaml@2.6.1)))(svelte@5.15.0)(vite@6.0.11(@types/node@22.10.2)(jiti@2.4.2)(lightningcss@1.29.1)(terser@5.37.0)(yaml@2.6.1)))
       '@sveltejs/kit':
         specifier: ^2.0.0
-        version: 2.13.0(@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.15.0)(vite@6.0.11(@types/node@22.10.2)(jiti@1.21.7)(lightningcss@1.28.2)(terser@5.37.0)(yaml@2.6.1)))(svelte@5.15.0)(vite@6.0.11(@types/node@22.10.2)(jiti@1.21.7)(lightningcss@1.28.2)(terser@5.37.0)(yaml@2.6.1))
+        version: 2.13.0(@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.15.0)(vite@6.0.11(@types/node@22.10.2)(jiti@2.4.2)(lightningcss@1.29.1)(terser@5.37.0)(yaml@2.6.1)))(svelte@5.15.0)(vite@6.0.11(@types/node@22.10.2)(jiti@2.4.2)(lightningcss@1.29.1)(terser@5.37.0)(yaml@2.6.1))
       '@sveltejs/vite-plugin-svelte':
         specifier: ^5.0.0
-        version: 5.0.3(svelte@5.15.0)(vite@6.0.11(@types/node@22.10.2)(jiti@1.21.7)(lightningcss@1.28.2)(terser@5.37.0)(yaml@2.6.1))
+        version: 5.0.3(svelte@5.15.0)(vite@6.0.11(@types/node@22.10.2)(jiti@2.4.2)(lightningcss@1.29.1)(terser@5.37.0)(yaml@2.6.1))
       '@types/eslint':
         specifier: ^9.6.0
         version: 9.6.1
       eslint:
         specifier: ^9.7.0
-        version: 9.17.0(jiti@1.21.7)
+        version: 9.17.0(jiti@2.4.2)
       eslint-config-prettier:
         specifier: ^9.1.0
-        version: 9.1.0(eslint@9.17.0(jiti@1.21.7))
+        version: 9.1.0(eslint@9.17.0(jiti@2.4.2))
       eslint-plugin-svelte:
         specifier: ^2.36.0
-        version: 2.46.1(eslint@9.17.0(jiti@1.21.7))(svelte@5.15.0)(ts-node@10.9.2(@swc/core@1.10.1(@swc/helpers@0.5.15))(@types/node@22.10.2)(typescript@5.6.3))
+        version: 2.46.1(eslint@9.17.0(jiti@2.4.2))(svelte@5.15.0)(ts-node@10.9.2(@swc/core@1.10.1(@swc/helpers@0.5.15))(@types/node@22.10.2)(typescript@5.6.3))
       globals:
         specifier: ^15.11.0
         version: 15.14.0
@@ -1043,10 +1043,10 @@ importers:
         version: 5.6.3
       typescript-eslint:
         specifier: ^8.0.0
-        version: 8.18.1(eslint@9.17.0(jiti@1.21.7))(typescript@5.6.3)
+        version: 8.18.1(eslint@9.17.0(jiti@2.4.2))(typescript@5.6.3)
       vite:
         specifier: ^6.0.11
-        version: 6.0.11(@types/node@22.10.2)(jiti@1.21.7)(lightningcss@1.28.2)(terser@5.37.0)(yaml@2.6.1)
+        version: 6.0.11(@types/node@22.10.2)(jiti@2.4.2)(lightningcss@1.29.1)(terser@5.37.0)(yaml@2.6.1)
 
   examples/passphrase:
     dependencies:
@@ -1074,7 +1074,7 @@ importers:
         version: 18.3.5(@types/react@18.3.18)
       '@vitejs/plugin-react':
         specifier: ^4.3.3
-        version: 4.3.4(vite@6.0.11(@types/node@22.10.2)(jiti@1.21.7)(lightningcss@1.28.2)(terser@5.37.0)(yaml@2.6.1))
+        version: 4.3.4(vite@6.0.11(@types/node@22.10.2)(jiti@2.4.2)(lightningcss@1.29.1)(terser@5.37.0)(yaml@2.6.1))
       globals:
         specifier: ^15.11.0
         version: 15.14.0
@@ -1083,7 +1083,7 @@ importers:
         version: 5.6.3
       vite:
         specifier: ^6.0.11
-        version: 6.0.11(@types/node@22.10.2)(jiti@1.21.7)(lightningcss@1.28.2)(terser@5.37.0)(yaml@2.6.1)
+        version: 6.0.11(@types/node@22.10.2)(jiti@2.4.2)(lightningcss@1.29.1)(terser@5.37.0)(yaml@2.6.1)
 
   examples/password-manager:
     dependencies:
@@ -1114,10 +1114,10 @@ importers:
         version: 18.3.5(@types/react@18.3.18)
       '@vitejs/plugin-react':
         specifier: ^4.3.3
-        version: 4.3.4(vite@6.0.11(@types/node@22.10.2)(jiti@1.21.7)(lightningcss@1.28.2)(terser@5.37.0)(yaml@2.6.1))
+        version: 4.3.4(vite@6.0.11(@types/node@22.10.2)(jiti@2.4.2)(lightningcss@1.29.1)(terser@5.37.0)(yaml@2.6.1))
       '@vitejs/plugin-react-swc':
         specifier: ^3.3.2
-        version: 3.7.2(@swc/helpers@0.5.15)(vite@6.0.11(@types/node@22.10.2)(jiti@1.21.7)(lightningcss@1.28.2)(terser@5.37.0)(yaml@2.6.1))
+        version: 3.7.2(@swc/helpers@0.5.15)(vite@6.0.11(@types/node@22.10.2)(jiti@2.4.2)(lightningcss@1.29.1)(terser@5.37.0)(yaml@2.6.1))
       autoprefixer:
         specifier: ^10.4.20
         version: 10.4.20(postcss@8.4.49)
@@ -1132,7 +1132,7 @@ importers:
         version: 5.6.3
       vite:
         specifier: ^6.0.11
-        version: 6.0.11(@types/node@22.10.2)(jiti@1.21.7)(lightningcss@1.28.2)(terser@5.37.0)(yaml@2.6.1)
+        version: 6.0.11(@types/node@22.10.2)(jiti@2.4.2)(lightningcss@1.29.1)(terser@5.37.0)(yaml@2.6.1)
 
   examples/pets:
     dependencies:
@@ -1205,7 +1205,7 @@ importers:
         version: 18.3.5(@types/react@18.3.18)
       '@vitejs/plugin-react-swc':
         specifier: ^3.3.2
-        version: 3.7.2(@swc/helpers@0.5.15)(vite@6.0.11(@types/node@22.10.2)(jiti@1.21.7)(lightningcss@1.28.2)(terser@5.37.0)(yaml@2.6.1))
+        version: 3.7.2(@swc/helpers@0.5.15)(vite@6.0.11(@types/node@22.10.2)(jiti@2.4.2)(lightningcss@1.29.1)(terser@5.37.0)(yaml@2.6.1))
       autoprefixer:
         specifier: ^10.4.20
         version: 10.4.20(postcss@8.4.49)
@@ -1226,10 +1226,10 @@ importers:
         version: 5.6.3
       vite:
         specifier: ^6.0.11
-        version: 6.0.11(@types/node@22.10.2)(jiti@1.21.7)(lightningcss@1.28.2)(terser@5.37.0)(yaml@2.6.1)
+        version: 6.0.11(@types/node@22.10.2)(jiti@2.4.2)(lightningcss@1.29.1)(terser@5.37.0)(yaml@2.6.1)
       vite-plugin-top-level-await:
         specifier: ^1.4.4
-        version: 1.4.4(@swc/helpers@0.5.15)(rollup@4.28.1)(vite@6.0.11(@types/node@22.10.2)(jiti@1.21.7)(lightningcss@1.28.2)(terser@5.37.0)(yaml@2.6.1))
+        version: 1.4.4(@swc/helpers@0.5.15)(rollup@4.28.1)(vite@6.0.11(@types/node@22.10.2)(jiti@2.4.2)(lightningcss@1.29.1)(terser@5.37.0)(yaml@2.6.1))
 
   examples/reactions:
     dependencies:
@@ -1263,7 +1263,7 @@ importers:
         version: 18.3.5(@types/react@18.3.18)
       '@vitejs/plugin-react':
         specifier: ^4.3.3
-        version: 4.3.4(vite@6.0.11(@types/node@22.10.2)(jiti@1.21.7)(lightningcss@1.28.2)(terser@5.37.0)(yaml@2.6.1))
+        version: 4.3.4(vite@6.0.11(@types/node@22.10.2)(jiti@2.4.2)(lightningcss@1.29.1)(terser@5.37.0)(yaml@2.6.1))
       globals:
         specifier: ^15.11.0
         version: 15.14.0
@@ -1272,7 +1272,7 @@ importers:
         version: 5.6.3
       vite:
         specifier: ^6.0.11
-        version: 6.0.11(@types/node@22.10.2)(jiti@1.21.7)(lightningcss@1.28.2)(terser@5.37.0)(yaml@2.6.1)
+        version: 6.0.11(@types/node@22.10.2)(jiti@2.4.2)(lightningcss@1.29.1)(terser@5.37.0)(yaml@2.6.1)
 
   examples/todo:
     dependencies:
@@ -1336,7 +1336,7 @@ importers:
         version: 18.3.5(@types/react@18.3.18)
       '@vitejs/plugin-react-swc':
         specifier: ^3.3.2
-        version: 3.7.2(@swc/helpers@0.5.15)(vite@6.0.11(@types/node@22.10.2)(jiti@1.21.7)(lightningcss@1.28.2)(terser@5.37.0)(yaml@2.6.1))
+        version: 3.7.2(@swc/helpers@0.5.15)(vite@6.0.11(@types/node@22.10.2)(jiti@2.4.2)(lightningcss@1.29.1)(terser@5.37.0)(yaml@2.6.1))
       autoprefixer:
         specifier: ^10.4.20
         version: 10.4.20(postcss@8.4.49)
@@ -1351,7 +1351,7 @@ importers:
         version: 5.6.3
       vite:
         specifier: ^6.0.11
-        version: 6.0.11(@types/node@22.10.2)(jiti@1.21.7)(lightningcss@1.28.2)(terser@5.37.0)(yaml@2.6.1)
+        version: 6.0.11(@types/node@22.10.2)(jiti@2.4.2)(lightningcss@1.29.1)(terser@5.37.0)(yaml@2.6.1)
 
   examples/todo-vue:
     dependencies:
@@ -1379,10 +1379,10 @@ importers:
         version: 22.10.2
       '@vitejs/plugin-vue':
         specifier: ^5.1.4
-        version: 5.2.1(vite@6.0.11(@types/node@22.10.2)(jiti@1.21.7)(lightningcss@1.28.2)(terser@5.37.0)(yaml@2.6.1))(vue@3.5.13(typescript@5.6.3))
+        version: 5.2.1(vite@6.0.11(@types/node@22.10.2)(jiti@2.4.2)(lightningcss@1.29.1)(terser@5.37.0)(yaml@2.6.1))(vue@3.5.13(typescript@5.6.3))
       '@vitejs/plugin-vue-jsx':
         specifier: ^4.0.1
-        version: 4.1.1(vite@6.0.11(@types/node@22.10.2)(jiti@1.21.7)(lightningcss@1.28.2)(terser@5.37.0)(yaml@2.6.1))(vue@3.5.13(typescript@5.6.3))
+        version: 4.1.1(vite@6.0.11(@types/node@22.10.2)(jiti@2.4.2)(lightningcss@1.29.1)(terser@5.37.0)(yaml@2.6.1))(vue@3.5.13(typescript@5.6.3))
       '@vue/tsconfig':
         specifier: ^0.5.1
         version: 0.5.1
@@ -1391,10 +1391,10 @@ importers:
         version: 10.4.20(postcss@8.4.49)
       eslint:
         specifier: ^9.7.0
-        version: 9.17.0(jiti@1.21.7)
+        version: 9.17.0(jiti@2.4.2)
       eslint-plugin-vue:
         specifier: ^9.28.0
-        version: 9.32.0(eslint@9.17.0(jiti@1.21.7))
+        version: 9.32.0(eslint@9.17.0(jiti@2.4.2))
       npm-run-all2:
         specifier: ^6.2.3
         version: 6.2.6
@@ -1409,10 +1409,10 @@ importers:
         version: 5.6.3
       vite:
         specifier: ^6.0.11
-        version: 6.0.11(@types/node@22.10.2)(jiti@1.21.7)(lightningcss@1.28.2)(terser@5.37.0)(yaml@2.6.1)
+        version: 6.0.11(@types/node@22.10.2)(jiti@2.4.2)(lightningcss@1.29.1)(terser@5.37.0)(yaml@2.6.1)
       vite-plugin-vue-devtools:
         specifier: ^7.4.6
-        version: 7.6.8(rollup@4.28.1)(vite@6.0.11(@types/node@22.10.2)(jiti@1.21.7)(lightningcss@1.28.2)(terser@5.37.0)(yaml@2.6.1))(vue@3.5.13(typescript@5.6.3))
+        version: 7.6.8(rollup@4.28.1)(vite@6.0.11(@types/node@22.10.2)(jiti@2.4.2)(lightningcss@1.29.1)(terser@5.37.0)(yaml@2.6.1))(vue@3.5.13(typescript@5.6.3))
       vue-tsc:
         specifier: ^2.1.6
         version: 2.1.10(typescript@5.6.3)
@@ -1449,7 +1449,7 @@ importers:
         version: 18.3.5(@types/react@18.3.18)
       '@vitejs/plugin-react':
         specifier: ^4.3.3
-        version: 4.3.4(vite@6.0.11(@types/node@22.10.2)(jiti@1.21.7)(lightningcss@1.28.2)(terser@5.37.0)(yaml@2.6.1))
+        version: 4.3.4(vite@6.0.11(@types/node@22.10.2)(jiti@2.4.2)(lightningcss@1.29.1)(terser@5.37.0)(yaml@2.6.1))
       globals:
         specifier: ^15.11.0
         version: 15.14.0
@@ -1458,7 +1458,7 @@ importers:
         version: 5.6.3
       vite:
         specifier: ^6.0.11
-        version: 6.0.11(@types/node@22.10.2)(jiti@1.21.7)(lightningcss@1.28.2)(terser@5.37.0)(yaml@2.6.1)
+        version: 6.0.11(@types/node@22.10.2)(jiti@2.4.2)(lightningcss@1.29.1)(terser@5.37.0)(yaml@2.6.1)
 
   packages/cojson:
     dependencies:
@@ -1498,7 +1498,7 @@ importers:
         version: 5.6.3
       vitest:
         specifier: 3.0.5
-        version: 3.0.5(@types/node@22.10.2)(@vitest/browser@3.0.5)(@vitest/ui@3.0.5)(happy-dom@16.8.1)(jiti@1.21.7)(jsdom@25.0.1)(lightningcss@1.28.2)(msw@2.7.0(@types/node@22.10.2)(typescript@5.6.3))(terser@5.37.0)(yaml@2.6.1)
+        version: 3.0.5(@types/node@22.10.2)(@vitest/browser@3.0.5)(@vitest/ui@3.0.5)(happy-dom@16.8.1)(jiti@2.4.2)(jsdom@25.0.1)(lightningcss@1.29.1)(msw@2.7.0(@types/node@22.10.2)(typescript@5.6.3))(terser@5.37.0)(yaml@2.6.1)
 
   packages/cojson-storage:
     dependencies:
@@ -1511,7 +1511,7 @@ importers:
         version: 5.6.3
       vitest:
         specifier: 3.0.5
-        version: 3.0.5(@types/node@22.10.2)(@vitest/browser@3.0.5)(@vitest/ui@3.0.5)(happy-dom@16.8.1)(jiti@1.21.7)(jsdom@25.0.1)(lightningcss@1.28.2)(msw@2.7.0(@types/node@22.10.2)(typescript@5.6.3))(terser@5.37.0)(yaml@2.6.1)
+        version: 3.0.5(@types/node@22.10.2)(@vitest/browser@3.0.5)(@vitest/ui@3.0.5)(happy-dom@16.8.1)(jiti@2.4.2)(jsdom@25.0.1)(lightningcss@1.29.1)(msw@2.7.0(@types/node@22.10.2)(typescript@5.6.3))(terser@5.37.0)(yaml@2.6.1)
 
   packages/cojson-storage-indexeddb:
     dependencies:
@@ -1524,13 +1524,13 @@ importers:
     devDependencies:
       '@vitest/browser':
         specifier: ^3.0.5
-        version: 3.0.5(@types/node@22.10.2)(playwright@1.50.1)(typescript@5.6.3)(vite@6.0.11(@types/node@22.10.2)(jiti@1.21.7)(lightningcss@1.28.2)(terser@5.37.0)(yaml@2.6.1))(vitest@3.0.5)(webdriverio@8.41.0)
+        version: 3.0.5(@types/node@22.10.2)(playwright@1.50.1)(typescript@5.6.3)(vite@6.0.11(@types/node@22.10.2)(jiti@2.4.2)(lightningcss@1.29.1)(terser@5.37.0)(yaml@2.6.1))(vitest@3.0.5)(webdriverio@8.41.0)
       typescript:
         specifier: ~5.6.2
         version: 5.6.3
       vitest:
         specifier: 3.0.5
-        version: 3.0.5(@types/node@22.10.2)(@vitest/browser@3.0.5)(@vitest/ui@3.0.5)(happy-dom@16.8.1)(jiti@1.21.7)(jsdom@25.0.1)(lightningcss@1.28.2)(msw@2.7.0(@types/node@22.10.2)(typescript@5.6.3))(terser@5.37.0)(yaml@2.6.1)
+        version: 3.0.5(@types/node@22.10.2)(@vitest/browser@3.0.5)(@vitest/ui@3.0.5)(happy-dom@16.8.1)(jiti@2.4.2)(jsdom@25.0.1)(lightningcss@1.29.1)(msw@2.7.0(@types/node@22.10.2)(typescript@5.6.3))(terser@5.37.0)(yaml@2.6.1)
       webdriverio:
         specifier: ^8.15.0
         version: 8.41.0
@@ -1718,7 +1718,7 @@ importers:
         version: 18.3.5(@types/react@18.3.18)
       '@vitejs/plugin-react-swc':
         specifier: ^3.3.2
-        version: 3.7.2(@swc/helpers@0.5.15)(vite@6.0.11(@types/node@22.10.2)(jiti@1.21.7)(lightningcss@1.28.2)(terser@5.37.0)(yaml@2.6.1))
+        version: 3.7.2(@swc/helpers@0.5.15)(vite@6.0.11(@types/node@22.10.2)(jiti@2.4.2)(lightningcss@1.29.1)(terser@5.37.0)(yaml@2.6.1))
       rollup-plugin-node-externals:
         specifier: ^8.0.0
         version: 8.0.0(rollup@4.28.1)
@@ -1727,7 +1727,7 @@ importers:
         version: 5.6.3
       vite:
         specifier: ^6.0.11
-        version: 6.0.11(@types/node@22.10.2)(jiti@1.21.7)(lightningcss@1.28.2)(terser@5.37.0)(yaml@2.6.1)
+        version: 6.0.11(@types/node@22.10.2)(jiti@2.4.2)(lightningcss@1.29.1)(terser@5.37.0)(yaml@2.6.1)
 
   packages/jazz-nodejs:
     dependencies:
@@ -1985,22 +1985,22 @@ importers:
     devDependencies:
       '@sveltejs/adapter-vercel':
         specifier: ^5.5.0
-        version: 5.5.2(@sveltejs/kit@2.17.1(@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.15.0)(vite@6.0.11(@types/node@22.10.2)(jiti@1.21.7)(lightningcss@1.28.2)(terser@5.37.0)(yaml@2.6.1)))(svelte@5.15.0)(vite@6.0.11(@types/node@22.10.2)(jiti@1.21.7)(lightningcss@1.28.2)(terser@5.37.0)(yaml@2.6.1)))(rollup@4.28.1)
+        version: 5.5.2(@sveltejs/kit@2.17.1(@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.15.0)(vite@6.0.11(@types/node@22.10.2)(jiti@2.4.2)(lightningcss@1.29.1)(terser@5.37.0)(yaml@2.6.1)))(svelte@5.15.0)(vite@6.0.11(@types/node@22.10.2)(jiti@2.4.2)(lightningcss@1.29.1)(terser@5.37.0)(yaml@2.6.1)))(rollup@4.28.1)
       '@sveltejs/kit':
         specifier: ^2.16.0
-        version: 2.17.1(@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.15.0)(vite@6.0.11(@types/node@22.10.2)(jiti@1.21.7)(lightningcss@1.28.2)(terser@5.37.0)(yaml@2.6.1)))(svelte@5.15.0)(vite@6.0.11(@types/node@22.10.2)(jiti@1.21.7)(lightningcss@1.28.2)(terser@5.37.0)(yaml@2.6.1))
+        version: 2.17.1(@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.15.0)(vite@6.0.11(@types/node@22.10.2)(jiti@2.4.2)(lightningcss@1.29.1)(terser@5.37.0)(yaml@2.6.1)))(svelte@5.15.0)(vite@6.0.11(@types/node@22.10.2)(jiti@2.4.2)(lightningcss@1.29.1)(terser@5.37.0)(yaml@2.6.1))
       '@sveltejs/package':
         specifier: ^2.0.0
         version: 2.3.7(svelte@5.15.0)(typescript@5.6.3)
       '@sveltejs/vite-plugin-svelte':
         specifier: ^5.0.0
-        version: 5.0.3(svelte@5.15.0)(vite@6.0.11(@types/node@22.10.2)(jiti@1.21.7)(lightningcss@1.28.2)(terser@5.37.0)(yaml@2.6.1))
+        version: 5.0.3(svelte@5.15.0)(vite@6.0.11(@types/node@22.10.2)(jiti@2.4.2)(lightningcss@1.29.1)(terser@5.37.0)(yaml@2.6.1))
       '@testing-library/jest-dom':
         specifier: ^6.6.3
         version: 6.6.3
       '@testing-library/svelte':
         specifier: ^5.2.6
-        version: 5.2.6(svelte@5.15.0)(vite@6.0.11(@types/node@22.10.2)(jiti@1.21.7)(lightningcss@1.28.2)(terser@5.37.0)(yaml@2.6.1))(vitest@3.0.5)
+        version: 5.2.6(svelte@5.15.0)(vite@6.0.11(@types/node@22.10.2)(jiti@2.4.2)(lightningcss@1.29.1)(terser@5.37.0)(yaml@2.6.1))(vitest@3.0.5)
       '@testing-library/user-event':
         specifier: ^14.6.1
         version: 14.6.1(@testing-library/dom@10.4.0)
@@ -2012,13 +2012,13 @@ importers:
         version: 3.0.5(@vitest/browser@3.0.5)(vitest@3.0.5)
       eslint:
         specifier: ^9.7.0
-        version: 9.17.0(jiti@1.21.7)
+        version: 9.17.0(jiti@2.4.2)
       eslint-config-prettier:
         specifier: ^9.1.0
-        version: 9.1.0(eslint@9.17.0(jiti@1.21.7))
+        version: 9.1.0(eslint@9.17.0(jiti@2.4.2))
       eslint-plugin-svelte:
         specifier: ^2.36.0
-        version: 2.46.1(eslint@9.17.0(jiti@1.21.7))(svelte@5.15.0)(ts-node@10.9.2(@swc/core@1.10.1(@swc/helpers@0.5.15))(@types/node@22.10.2)(typescript@5.6.3))
+        version: 2.46.1(eslint@9.17.0(jiti@2.4.2))(svelte@5.15.0)(ts-node@10.9.2(@swc/core@1.10.1(@swc/helpers@0.5.15))(@types/node@22.10.2)(typescript@5.6.3))
       globals:
         specifier: ^15.11.0
         version: 15.14.0
@@ -2045,13 +2045,13 @@ importers:
         version: 5.6.3
       typescript-eslint:
         specifier: ^8.0.0
-        version: 8.18.1(eslint@9.17.0(jiti@1.21.7))(typescript@5.6.3)
+        version: 8.18.1(eslint@9.17.0(jiti@2.4.2))(typescript@5.6.3)
       vite:
         specifier: ^6.0.11
-        version: 6.0.11(@types/node@22.10.2)(jiti@1.21.7)(lightningcss@1.28.2)(terser@5.37.0)(yaml@2.6.1)
+        version: 6.0.11(@types/node@22.10.2)(jiti@2.4.2)(lightningcss@1.29.1)(terser@5.37.0)(yaml@2.6.1)
       vitest:
         specifier: 3.0.5
-        version: 3.0.5(@types/node@22.10.2)(@vitest/browser@3.0.5)(@vitest/ui@3.0.5)(happy-dom@16.8.1)(jiti@1.21.7)(jsdom@25.0.1)(lightningcss@1.28.2)(msw@2.7.0(@types/node@22.10.2)(typescript@5.6.3))(terser@5.37.0)(yaml@2.6.1)
+        version: 3.0.5(@types/node@22.10.2)(@vitest/browser@3.0.5)(@vitest/ui@3.0.5)(happy-dom@16.8.1)(jiti@2.4.2)(jsdom@25.0.1)(lightningcss@1.29.1)(msw@2.7.0(@types/node@22.10.2)(typescript@5.6.3))(terser@5.37.0)(yaml@2.6.1)
 
   packages/jazz-tools:
     dependencies:
@@ -2064,13 +2064,13 @@ importers:
     devDependencies:
       tsup:
         specifier: 8.3.5
-        version: 8.3.5(@microsoft/api-extractor@7.48.1(@types/node@22.10.2))(@swc/core@1.10.1(@swc/helpers@0.5.15))(jiti@1.21.7)(postcss@8.4.49)(typescript@5.6.3)(yaml@2.6.1)
+        version: 8.3.5(@microsoft/api-extractor@7.48.1(@types/node@22.10.2))(@swc/core@1.10.1(@swc/helpers@0.5.15))(jiti@2.4.2)(postcss@8.4.49)(typescript@5.6.3)(yaml@2.6.1)
       typescript:
         specifier: ~5.6.2
         version: 5.6.3
       vitest:
         specifier: 3.0.5
-        version: 3.0.5(@types/node@22.10.2)(@vitest/browser@3.0.5)(@vitest/ui@3.0.5)(happy-dom@16.8.1)(jiti@1.21.7)(jsdom@25.0.1)(lightningcss@1.28.2)(msw@2.7.0(@types/node@22.10.2)(typescript@5.6.3))(terser@5.37.0)(yaml@2.6.1)
+        version: 3.0.5(@types/node@22.10.2)(@vitest/browser@3.0.5)(@vitest/ui@3.0.5)(happy-dom@16.8.1)(jiti@2.4.2)(jsdom@25.0.1)(lightningcss@1.29.1)(msw@2.7.0(@types/node@22.10.2)(typescript@5.6.3))(terser@5.37.0)(yaml@2.6.1)
       ws:
         specifier: ^8.14.2
         version: 8.18.0
@@ -2092,7 +2092,7 @@ importers:
         version: 1.5.0
       '@vitejs/plugin-vue':
         specifier: ^5.1.4
-        version: 5.2.1(vite@6.0.11(@types/node@22.10.2)(jiti@1.21.7)(lightningcss@1.28.2)(terser@5.37.0)(yaml@2.6.1))(vue@3.5.13(typescript@5.6.3))
+        version: 5.2.1(vite@6.0.11(@types/node@22.10.2)(jiti@2.4.2)(lightningcss@1.29.1)(terser@5.37.0)(yaml@2.6.1))(vue@3.5.13(typescript@5.6.3))
       rollup-plugin-node-externals:
         specifier: ^8.0.0
         version: 8.0.0(rollup@4.28.1)
@@ -2101,10 +2101,10 @@ importers:
         version: 5.6.3
       vite:
         specifier: ^6.0.11
-        version: 6.0.11(@types/node@22.10.2)(jiti@1.21.7)(lightningcss@1.28.2)(terser@5.37.0)(yaml@2.6.1)
+        version: 6.0.11(@types/node@22.10.2)(jiti@2.4.2)(lightningcss@1.29.1)(terser@5.37.0)(yaml@2.6.1)
       vite-plugin-dts:
         specifier: ^4.2.4
-        version: 4.4.0(@types/node@22.10.2)(rollup@4.28.1)(typescript@5.6.3)(vite@6.0.11(@types/node@22.10.2)(jiti@1.21.7)(lightningcss@1.28.2)(terser@5.37.0)(yaml@2.6.1))
+        version: 4.4.0(@types/node@22.10.2)(rollup@4.28.1)(typescript@5.6.3)(vite@6.0.11(@types/node@22.10.2)(jiti@2.4.2)(lightningcss@1.29.1)(terser@5.37.0)(yaml@2.6.1))
       vue:
         specifier: ^3.5.11
         version: 3.5.13(typescript@5.6.3)
@@ -2141,7 +2141,7 @@ importers:
         version: 18.3.5(@types/react@18.3.18)
       '@vitejs/plugin-react':
         specifier: ^4.3.3
-        version: 4.3.4(vite@6.0.11(@types/node@22.10.2)(jiti@1.21.7)(lightningcss@1.28.2)(terser@5.37.0)(yaml@2.6.1))
+        version: 4.3.4(vite@6.0.11(@types/node@22.10.2)(jiti@2.4.2)(lightningcss@1.29.1)(terser@5.37.0)(yaml@2.6.1))
       autoprefixer:
         specifier: ^10.4.20
         version: 10.4.20(postcss@8.4.49)
@@ -2162,7 +2162,7 @@ importers:
         version: 5.6.3
       vite:
         specifier: ^6.0.11
-        version: 6.0.11(@types/node@22.10.2)(jiti@1.21.7)(lightningcss@1.28.2)(terser@5.37.0)(yaml@2.6.1)
+        version: 6.0.11(@types/node@22.10.2)(jiti@2.4.2)(lightningcss@1.29.1)(terser@5.37.0)(yaml@2.6.1)
 
   tests/browser-integration:
     dependencies:
@@ -2187,7 +2187,7 @@ importers:
         version: 5.6.3
       vitest:
         specifier: 3.0.5
-        version: 3.0.5(@types/node@22.10.2)(@vitest/browser@3.0.5)(@vitest/ui@3.0.5)(happy-dom@16.8.1)(jiti@1.21.7)(jsdom@25.0.1)(lightningcss@1.28.2)(msw@2.7.0(@types/node@22.10.2)(typescript@5.6.3))(terser@5.37.0)(yaml@2.6.1)
+        version: 3.0.5(@types/node@22.10.2)(@vitest/browser@3.0.5)(@vitest/ui@3.0.5)(happy-dom@16.8.1)(jiti@2.4.2)(jsdom@25.0.1)(lightningcss@1.29.1)(msw@2.7.0(@types/node@22.10.2)(typescript@5.6.3))(terser@5.37.0)(yaml@2.6.1)
 
   tests/e2e:
     dependencies:
@@ -2233,7 +2233,7 @@ importers:
         version: 18.3.5(@types/react@18.3.18)
       '@vitejs/plugin-react-swc':
         specifier: ^3.3.2
-        version: 3.7.2(@swc/helpers@0.5.15)(vite@5.4.11(@types/node@22.10.2)(lightningcss@1.28.2)(terser@5.37.0))
+        version: 3.7.2(@swc/helpers@0.5.15)(vite@5.4.11(@types/node@22.10.2)(lightningcss@1.29.1)(terser@5.37.0))
       jazz-run:
         specifier: workspace:*
         version: link:../../packages/jazz-run
@@ -2245,7 +2245,7 @@ importers:
         version: 5.6.3
       vite:
         specifier: ^5.0.10
-        version: 5.4.11(@types/node@22.10.2)(lightningcss@1.28.2)(terser@5.37.0)
+        version: 5.4.11(@types/node@22.10.2)(lightningcss@1.29.1)(terser@5.37.0)
 
   tests/e2e-react-native:
     dependencies:
@@ -6718,8 +6718,8 @@ packages:
   end-of-stream@1.4.4:
     resolution: {integrity: sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==}
 
-  enhanced-resolve@5.17.1:
-    resolution: {integrity: sha512-LMHl3dXhTcfv8gM4kEzIUeTQ+7fpdA0l2tUf34BddXPkz2A5xJ5L/Pchd5BL6rdccM9QGvu0sWZzK1Z1t4wwyg==}
+  enhanced-resolve@5.18.1:
+    resolution: {integrity: sha512-ZSW3ma5GkcQBIpwZTSRAI8N71Uuwgs93IezB7mf7R60tC8ZbJideoDNKjHn2O9KIlx6rkGTTEk1xUCK2E1Y2Yg==}
     engines: {node: '>=10.13.0'}
 
   enquirer@2.4.1:
@@ -8112,6 +8112,10 @@ packages:
     resolution: {integrity: sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==}
     hasBin: true
 
+  jiti@2.4.2:
+    resolution: {integrity: sha512-rg9zJN+G4n2nfJl5MW3BMygZX56zKPNVEYYqq7adpmMh4Jn2QNEwhvQlFy6jPVdcod7txZtKHWnyZiA3a0zP7A==}
+    hasBin: true
+
   jju@1.4.0:
     resolution: {integrity: sha512-8wb9Yw966OSxApiCt0K3yNJL8pnNeIv+OEq2YMidz4FKP6nonSRoOXc80iXY4JaN2FC11B9qsNmDsm+ZOfMROA==}
 
@@ -8338,6 +8342,12 @@ packages:
     cpu: [arm64]
     os: [darwin]
 
+  lightningcss-darwin-arm64@1.29.1:
+    resolution: {integrity: sha512-HtR5XJ5A0lvCqYAoSv2QdZZyoHNttBpa5EP9aNuzBQeKGfbyH5+UipLWvVzpP4Uml5ej4BYs5I9Lco9u1fECqw==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [darwin]
+
   lightningcss-darwin-x64@1.27.0:
     resolution: {integrity: sha512-0+mZa54IlcNAoQS9E0+niovhyjjQWEMrwW0p2sSdLRhLDc8LMQ/b67z7+B5q4VmjYCMSfnFi3djAAQFIDuj/Tg==}
     engines: {node: '>= 12.0.0'}
@@ -8346,6 +8356,12 @@ packages:
 
   lightningcss-darwin-x64@1.28.2:
     resolution: {integrity: sha512-R7sFrXlgKjvoEG8umpVt/yutjxOL0z8KWf0bfPT3cYMOW4470xu5qSHpFdIOpRWwl3FKNMUdbKtMUjYt0h2j4g==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [darwin]
+
+  lightningcss-darwin-x64@1.29.1:
+    resolution: {integrity: sha512-k33G9IzKUpHy/J/3+9MCO4e+PzaFblsgBjSGlpAaFikeBFm8B/CkO3cKU9oI4g+fjS2KlkLM/Bza9K/aw8wsNA==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [darwin]
@@ -8362,6 +8378,12 @@ packages:
     cpu: [x64]
     os: [freebsd]
 
+  lightningcss-freebsd-x64@1.29.1:
+    resolution: {integrity: sha512-0SUW22fv/8kln2LnIdOCmSuXnxgxVC276W5KLTwoehiO0hxkacBxjHOL5EtHD8BAXg2BvuhsJPmVMasvby3LiQ==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [freebsd]
+
   lightningcss-linux-arm-gnueabihf@1.27.0:
     resolution: {integrity: sha512-MUMRmtdRkOkd5z3h986HOuNBD1c2lq2BSQA1Jg88d9I7bmPGx08bwGcnB75dvr17CwxjxD6XPi3Qh8ArmKFqCA==}
     engines: {node: '>= 12.0.0'}
@@ -8370,6 +8392,12 @@ packages:
 
   lightningcss-linux-arm-gnueabihf@1.28.2:
     resolution: {integrity: sha512-DKMzpICBEKnL53X14rF7hFDu8KKALUJtcKdFUCW5YOlGSiwRSgVoRjM97wUm/E0NMPkzrTi/rxfvt7ruNK8meg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm]
+    os: [linux]
+
+  lightningcss-linux-arm-gnueabihf@1.29.1:
+    resolution: {integrity: sha512-sD32pFvlR0kDlqsOZmYqH/68SqUMPNj+0pucGxToXZi4XZgZmqeX/NkxNKCPsswAXU3UeYgDSpGhu05eAufjDg==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm]
     os: [linux]
@@ -8386,6 +8414,12 @@ packages:
     cpu: [arm64]
     os: [linux]
 
+  lightningcss-linux-arm64-gnu@1.29.1:
+    resolution: {integrity: sha512-0+vClRIZ6mmJl/dxGuRsE197o1HDEeeRk6nzycSy2GofC2JsY4ifCRnvUWf/CUBQmlrvMzt6SMQNMSEu22csWQ==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [linux]
+
   lightningcss-linux-arm64-musl@1.27.0:
     resolution: {integrity: sha512-rCGBm2ax7kQ9pBSeITfCW9XSVF69VX+fm5DIpvDZQl4NnQoMQyRwhZQm9pd59m8leZ1IesRqWk2v/DntMo26lg==}
     engines: {node: '>= 12.0.0'}
@@ -8394,6 +8428,12 @@ packages:
 
   lightningcss-linux-arm64-musl@1.28.2:
     resolution: {integrity: sha512-1SPG1ZTNnphWvAv8RVOymlZ8BDtAg69Hbo7n4QxARvkFVCJAt0cgjAw1Fox0WEhf4PwnyoOBaVH0Z5YNgzt4dA==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [linux]
+
+  lightningcss-linux-arm64-musl@1.29.1:
+    resolution: {integrity: sha512-UKMFrG4rL/uHNgelBsDwJcBqVpzNJbzsKkbI3Ja5fg00sgQnHw/VrzUTEc4jhZ+AN2BvQYz/tkHu4vt1kLuJyw==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
@@ -8410,6 +8450,12 @@ packages:
     cpu: [x64]
     os: [linux]
 
+  lightningcss-linux-x64-gnu@1.29.1:
+    resolution: {integrity: sha512-u1S+xdODy/eEtjADqirA774y3jLcm8RPtYztwReEXoZKdzgsHYPl0s5V52Tst+GKzqjebkULT86XMSxejzfISw==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [linux]
+
   lightningcss-linux-x64-musl@1.27.0:
     resolution: {integrity: sha512-QKjTxXm8A9s6v9Tg3Fk0gscCQA1t/HMoF7Woy1u68wCk5kS4fR+q3vXa1p3++REW784cRAtkYKrPy6JKibrEZA==}
     engines: {node: '>= 12.0.0'}
@@ -8418,6 +8464,12 @@ packages:
 
   lightningcss-linux-x64-musl@1.28.2:
     resolution: {integrity: sha512-alb/j1NMrgQmSFyzTbN1/pvMPM+gdDw7YBuQ5VSgcFDypN3Ah0BzC2dTZbzwzaMdUVDszX6zH5MzjfVN1oGuww==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [linux]
+
+  lightningcss-linux-x64-musl@1.29.1:
+    resolution: {integrity: sha512-L0Tx0DtaNUTzXv0lbGCLB/c/qEADanHbu4QdcNOXLIe1i8i22rZRpbT3gpWYsCh9aSL9zFujY/WmEXIatWvXbw==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
@@ -8434,6 +8486,12 @@ packages:
     cpu: [arm64]
     os: [win32]
 
+  lightningcss-win32-arm64-msvc@1.29.1:
+    resolution: {integrity: sha512-QoOVnkIEFfbW4xPi+dpdft/zAKmgLgsRHfJalEPYuJDOWf7cLQzYg0DEh8/sn737FaeMJxHZRc1oBreiwZCjog==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [win32]
+
   lightningcss-win32-x64-msvc@1.27.0:
     resolution: {integrity: sha512-/OJLj94Zm/waZShL8nB5jsNj3CfNATLCTyFxZyouilfTmSoLDX7VlVAmhPHoZWVFp4vdmoiEbPEYC8HID3m6yw==}
     engines: {node: '>= 12.0.0'}
@@ -8446,12 +8504,22 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  lightningcss-win32-x64-msvc@1.29.1:
+    resolution: {integrity: sha512-NygcbThNBe4JElP+olyTI/doBNGJvLs3bFCRPdvuCcxZCcCZ71B858IHpdm7L1btZex0FvCmM17FK98Y9MRy1Q==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [win32]
+
   lightningcss@1.27.0:
     resolution: {integrity: sha512-8f7aNmS1+etYSLHht0fQApPc2kNO8qGRutifN5rVIc6Xo6ABsEbqOr758UwI7ALVbTt4x1fllKt0PYgzD9S3yQ==}
     engines: {node: '>= 12.0.0'}
 
   lightningcss@1.28.2:
     resolution: {integrity: sha512-ePLRrbt3fgjXI5VFZOLbvkLD5ZRuxGKm+wJ3ujCqBtL3NanDHPo/5zicR5uEKAPiIjBYF99BM4K4okvMznjkVA==}
+    engines: {node: '>= 12.0.0'}
+
+  lightningcss@1.29.1:
+    resolution: {integrity: sha512-FmGoeD4S05ewj+AkhTY+D+myDvXI6eL27FjHIjoyUkO/uw7WZD1fBVs0QxeYWa7E17CUHJaYX/RUGISCtcrG4Q==}
     engines: {node: '>= 12.0.0'}
 
   lilconfig@2.1.0:
@@ -13085,9 +13153,9 @@ snapshots:
   '@esbuild/win32-x64@0.24.0':
     optional: true
 
-  '@eslint-community/eslint-utils@4.4.1(eslint@9.17.0(jiti@1.21.7))':
+  '@eslint-community/eslint-utils@4.4.1(eslint@9.17.0(jiti@2.4.2))':
     dependencies:
-      eslint: 9.17.0(jiti@1.21.7)
+      eslint: 9.17.0(jiti@2.4.2)
       eslint-visitor-keys: 3.4.3
 
   '@eslint-community/regexpp@4.12.1': {}
@@ -14798,14 +14866,14 @@ snapshots:
     dependencies:
       '@sinonjs/commons': 3.0.1
 
-  '@sveltejs/adapter-auto@3.3.1(@sveltejs/kit@2.13.0(@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.15.0)(vite@6.0.11(@types/node@22.10.2)(jiti@1.21.7)(lightningcss@1.28.2)(terser@5.37.0)(yaml@2.6.1)))(svelte@5.15.0)(vite@6.0.11(@types/node@22.10.2)(jiti@1.21.7)(lightningcss@1.28.2)(terser@5.37.0)(yaml@2.6.1)))':
+  '@sveltejs/adapter-auto@3.3.1(@sveltejs/kit@2.13.0(@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.15.0)(vite@6.0.11(@types/node@22.10.2)(jiti@2.4.2)(lightningcss@1.29.1)(terser@5.37.0)(yaml@2.6.1)))(svelte@5.15.0)(vite@6.0.11(@types/node@22.10.2)(jiti@2.4.2)(lightningcss@1.29.1)(terser@5.37.0)(yaml@2.6.1)))':
     dependencies:
-      '@sveltejs/kit': 2.13.0(@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.15.0)(vite@6.0.11(@types/node@22.10.2)(jiti@1.21.7)(lightningcss@1.28.2)(terser@5.37.0)(yaml@2.6.1)))(svelte@5.15.0)(vite@6.0.11(@types/node@22.10.2)(jiti@1.21.7)(lightningcss@1.28.2)(terser@5.37.0)(yaml@2.6.1))
+      '@sveltejs/kit': 2.13.0(@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.15.0)(vite@6.0.11(@types/node@22.10.2)(jiti@2.4.2)(lightningcss@1.29.1)(terser@5.37.0)(yaml@2.6.1)))(svelte@5.15.0)(vite@6.0.11(@types/node@22.10.2)(jiti@2.4.2)(lightningcss@1.29.1)(terser@5.37.0)(yaml@2.6.1))
       import-meta-resolve: 4.1.0
 
-  '@sveltejs/adapter-vercel@5.5.2(@sveltejs/kit@2.13.0(@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.15.0)(vite@6.0.11(@types/node@22.10.2)(jiti@1.21.7)(lightningcss@1.28.2)(terser@5.37.0)(yaml@2.6.1)))(svelte@5.15.0)(vite@6.0.11(@types/node@22.10.2)(jiti@1.21.7)(lightningcss@1.28.2)(terser@5.37.0)(yaml@2.6.1)))(rollup@4.28.1)':
+  '@sveltejs/adapter-vercel@5.5.2(@sveltejs/kit@2.13.0(@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.15.0)(vite@6.0.11(@types/node@22.10.2)(jiti@2.4.2)(lightningcss@1.29.1)(terser@5.37.0)(yaml@2.6.1)))(svelte@5.15.0)(vite@6.0.11(@types/node@22.10.2)(jiti@2.4.2)(lightningcss@1.29.1)(terser@5.37.0)(yaml@2.6.1)))(rollup@4.28.1)':
     dependencies:
-      '@sveltejs/kit': 2.13.0(@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.15.0)(vite@6.0.11(@types/node@22.10.2)(jiti@1.21.7)(lightningcss@1.28.2)(terser@5.37.0)(yaml@2.6.1)))(svelte@5.15.0)(vite@6.0.11(@types/node@22.10.2)(jiti@1.21.7)(lightningcss@1.28.2)(terser@5.37.0)(yaml@2.6.1))
+      '@sveltejs/kit': 2.13.0(@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.15.0)(vite@6.0.11(@types/node@22.10.2)(jiti@2.4.2)(lightningcss@1.29.1)(terser@5.37.0)(yaml@2.6.1)))(svelte@5.15.0)(vite@6.0.11(@types/node@22.10.2)(jiti@2.4.2)(lightningcss@1.29.1)(terser@5.37.0)(yaml@2.6.1))
       '@vercel/nft': 0.27.10(rollup@4.28.1)
       esbuild: 0.24.0
     transitivePeerDependencies:
@@ -14813,9 +14881,9 @@ snapshots:
       - rollup
       - supports-color
 
-  '@sveltejs/adapter-vercel@5.5.2(@sveltejs/kit@2.17.1(@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.15.0)(vite@6.0.11(@types/node@22.10.2)(jiti@1.21.7)(lightningcss@1.28.2)(terser@5.37.0)(yaml@2.6.1)))(svelte@5.15.0)(vite@6.0.11(@types/node@22.10.2)(jiti@1.21.7)(lightningcss@1.28.2)(terser@5.37.0)(yaml@2.6.1)))(rollup@4.28.1)':
+  '@sveltejs/adapter-vercel@5.5.2(@sveltejs/kit@2.17.1(@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.15.0)(vite@6.0.11(@types/node@22.10.2)(jiti@2.4.2)(lightningcss@1.29.1)(terser@5.37.0)(yaml@2.6.1)))(svelte@5.15.0)(vite@6.0.11(@types/node@22.10.2)(jiti@2.4.2)(lightningcss@1.29.1)(terser@5.37.0)(yaml@2.6.1)))(rollup@4.28.1)':
     dependencies:
-      '@sveltejs/kit': 2.17.1(@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.15.0)(vite@6.0.11(@types/node@22.10.2)(jiti@1.21.7)(lightningcss@1.28.2)(terser@5.37.0)(yaml@2.6.1)))(svelte@5.15.0)(vite@6.0.11(@types/node@22.10.2)(jiti@1.21.7)(lightningcss@1.28.2)(terser@5.37.0)(yaml@2.6.1))
+      '@sveltejs/kit': 2.17.1(@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.15.0)(vite@6.0.11(@types/node@22.10.2)(jiti@2.4.2)(lightningcss@1.29.1)(terser@5.37.0)(yaml@2.6.1)))(svelte@5.15.0)(vite@6.0.11(@types/node@22.10.2)(jiti@2.4.2)(lightningcss@1.29.1)(terser@5.37.0)(yaml@2.6.1))
       '@vercel/nft': 0.27.10(rollup@4.28.1)
       esbuild: 0.24.0
     transitivePeerDependencies:
@@ -14823,9 +14891,9 @@ snapshots:
       - rollup
       - supports-color
 
-  '@sveltejs/kit@2.13.0(@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.15.0)(vite@6.0.11(@types/node@22.10.2)(jiti@1.21.7)(lightningcss@1.28.2)(terser@5.37.0)(yaml@2.6.1)))(svelte@5.15.0)(vite@6.0.11(@types/node@22.10.2)(jiti@1.21.7)(lightningcss@1.28.2)(terser@5.37.0)(yaml@2.6.1))':
+  '@sveltejs/kit@2.13.0(@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.15.0)(vite@6.0.11(@types/node@22.10.2)(jiti@2.4.2)(lightningcss@1.29.1)(terser@5.37.0)(yaml@2.6.1)))(svelte@5.15.0)(vite@6.0.11(@types/node@22.10.2)(jiti@2.4.2)(lightningcss@1.29.1)(terser@5.37.0)(yaml@2.6.1))':
     dependencies:
-      '@sveltejs/vite-plugin-svelte': 5.0.3(svelte@5.15.0)(vite@6.0.11(@types/node@22.10.2)(jiti@1.21.7)(lightningcss@1.28.2)(terser@5.37.0)(yaml@2.6.1))
+      '@sveltejs/vite-plugin-svelte': 5.0.3(svelte@5.15.0)(vite@6.0.11(@types/node@22.10.2)(jiti@2.4.2)(lightningcss@1.29.1)(terser@5.37.0)(yaml@2.6.1))
       '@types/cookie': 0.6.0
       cookie: 0.6.0
       devalue: 5.1.1
@@ -14839,11 +14907,11 @@ snapshots:
       sirv: 3.0.0
       svelte: 5.15.0
       tiny-glob: 0.2.9
-      vite: 6.0.11(@types/node@22.10.2)(jiti@1.21.7)(lightningcss@1.28.2)(terser@5.37.0)(yaml@2.6.1)
+      vite: 6.0.11(@types/node@22.10.2)(jiti@2.4.2)(lightningcss@1.29.1)(terser@5.37.0)(yaml@2.6.1)
 
-  '@sveltejs/kit@2.17.1(@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.15.0)(vite@6.0.11(@types/node@22.10.2)(jiti@1.21.7)(lightningcss@1.28.2)(terser@5.37.0)(yaml@2.6.1)))(svelte@5.15.0)(vite@6.0.11(@types/node@22.10.2)(jiti@1.21.7)(lightningcss@1.28.2)(terser@5.37.0)(yaml@2.6.1))':
+  '@sveltejs/kit@2.17.1(@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.15.0)(vite@6.0.11(@types/node@22.10.2)(jiti@2.4.2)(lightningcss@1.29.1)(terser@5.37.0)(yaml@2.6.1)))(svelte@5.15.0)(vite@6.0.11(@types/node@22.10.2)(jiti@2.4.2)(lightningcss@1.29.1)(terser@5.37.0)(yaml@2.6.1))':
     dependencies:
-      '@sveltejs/vite-plugin-svelte': 5.0.3(svelte@5.15.0)(vite@6.0.11(@types/node@22.10.2)(jiti@1.21.7)(lightningcss@1.28.2)(terser@5.37.0)(yaml@2.6.1))
+      '@sveltejs/vite-plugin-svelte': 5.0.3(svelte@5.15.0)(vite@6.0.11(@types/node@22.10.2)(jiti@2.4.2)(lightningcss@1.29.1)(terser@5.37.0)(yaml@2.6.1))
       '@types/cookie': 0.6.0
       cookie: 0.6.0
       devalue: 5.1.1
@@ -14856,7 +14924,7 @@ snapshots:
       set-cookie-parser: 2.7.1
       sirv: 3.0.0
       svelte: 5.15.0
-      vite: 6.0.11(@types/node@22.10.2)(jiti@1.21.7)(lightningcss@1.28.2)(terser@5.37.0)(yaml@2.6.1)
+      vite: 6.0.11(@types/node@22.10.2)(jiti@2.4.2)(lightningcss@1.29.1)(terser@5.37.0)(yaml@2.6.1)
 
   '@sveltejs/package@2.3.7(svelte@5.15.0)(typescript@5.6.3)':
     dependencies:
@@ -14869,25 +14937,25 @@ snapshots:
     transitivePeerDependencies:
       - typescript
 
-  '@sveltejs/vite-plugin-svelte-inspector@4.0.1(@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.15.0)(vite@6.0.11(@types/node@22.10.2)(jiti@1.21.7)(lightningcss@1.28.2)(terser@5.37.0)(yaml@2.6.1)))(svelte@5.15.0)(vite@6.0.11(@types/node@22.10.2)(jiti@1.21.7)(lightningcss@1.28.2)(terser@5.37.0)(yaml@2.6.1))':
+  '@sveltejs/vite-plugin-svelte-inspector@4.0.1(@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.15.0)(vite@6.0.11(@types/node@22.10.2)(jiti@2.4.2)(lightningcss@1.29.1)(terser@5.37.0)(yaml@2.6.1)))(svelte@5.15.0)(vite@6.0.11(@types/node@22.10.2)(jiti@2.4.2)(lightningcss@1.29.1)(terser@5.37.0)(yaml@2.6.1))':
     dependencies:
-      '@sveltejs/vite-plugin-svelte': 5.0.3(svelte@5.15.0)(vite@6.0.11(@types/node@22.10.2)(jiti@1.21.7)(lightningcss@1.28.2)(terser@5.37.0)(yaml@2.6.1))
+      '@sveltejs/vite-plugin-svelte': 5.0.3(svelte@5.15.0)(vite@6.0.11(@types/node@22.10.2)(jiti@2.4.2)(lightningcss@1.29.1)(terser@5.37.0)(yaml@2.6.1))
       debug: 4.4.0
       svelte: 5.15.0
-      vite: 6.0.11(@types/node@22.10.2)(jiti@1.21.7)(lightningcss@1.28.2)(terser@5.37.0)(yaml@2.6.1)
+      vite: 6.0.11(@types/node@22.10.2)(jiti@2.4.2)(lightningcss@1.29.1)(terser@5.37.0)(yaml@2.6.1)
     transitivePeerDependencies:
       - supports-color
 
-  '@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.15.0)(vite@6.0.11(@types/node@22.10.2)(jiti@1.21.7)(lightningcss@1.28.2)(terser@5.37.0)(yaml@2.6.1))':
+  '@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.15.0)(vite@6.0.11(@types/node@22.10.2)(jiti@2.4.2)(lightningcss@1.29.1)(terser@5.37.0)(yaml@2.6.1))':
     dependencies:
-      '@sveltejs/vite-plugin-svelte-inspector': 4.0.1(@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.15.0)(vite@6.0.11(@types/node@22.10.2)(jiti@1.21.7)(lightningcss@1.28.2)(terser@5.37.0)(yaml@2.6.1)))(svelte@5.15.0)(vite@6.0.11(@types/node@22.10.2)(jiti@1.21.7)(lightningcss@1.28.2)(terser@5.37.0)(yaml@2.6.1))
+      '@sveltejs/vite-plugin-svelte-inspector': 4.0.1(@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.15.0)(vite@6.0.11(@types/node@22.10.2)(jiti@2.4.2)(lightningcss@1.29.1)(terser@5.37.0)(yaml@2.6.1)))(svelte@5.15.0)(vite@6.0.11(@types/node@22.10.2)(jiti@2.4.2)(lightningcss@1.29.1)(terser@5.37.0)(yaml@2.6.1))
       debug: 4.4.0
       deepmerge: 4.3.1
       kleur: 4.1.5
       magic-string: 0.30.17
       svelte: 5.15.0
-      vite: 6.0.11(@types/node@22.10.2)(jiti@1.21.7)(lightningcss@1.28.2)(terser@5.37.0)(yaml@2.6.1)
-      vitefu: 1.0.4(vite@6.0.11(@types/node@22.10.2)(jiti@1.21.7)(lightningcss@1.28.2)(terser@5.37.0)(yaml@2.6.1))
+      vite: 6.0.11(@types/node@22.10.2)(jiti@2.4.2)(lightningcss@1.29.1)(terser@5.37.0)(yaml@2.6.1)
+      vitefu: 1.0.4(vite@6.0.11(@types/node@22.10.2)(jiti@2.4.2)(lightningcss@1.29.1)(terser@5.37.0)(yaml@2.6.1))
     transitivePeerDependencies:
       - supports-color
 
@@ -14996,13 +15064,13 @@ snapshots:
       '@types/react': 18.3.18
       '@types/react-dom': 18.3.5(@types/react@18.3.18)
 
-  '@testing-library/svelte@5.2.6(svelte@5.15.0)(vite@6.0.11(@types/node@22.10.2)(jiti@1.21.7)(lightningcss@1.28.2)(terser@5.37.0)(yaml@2.6.1))(vitest@3.0.5)':
+  '@testing-library/svelte@5.2.6(svelte@5.15.0)(vite@6.0.11(@types/node@22.10.2)(jiti@2.4.2)(lightningcss@1.29.1)(terser@5.37.0)(yaml@2.6.1))(vitest@3.0.5)':
     dependencies:
       '@testing-library/dom': 10.4.0
       svelte: 5.15.0
     optionalDependencies:
-      vite: 6.0.11(@types/node@22.10.2)(jiti@1.21.7)(lightningcss@1.28.2)(terser@5.37.0)(yaml@2.6.1)
-      vitest: 3.0.5(@types/node@22.10.2)(@vitest/browser@3.0.5)(@vitest/ui@3.0.5)(happy-dom@16.8.1)(jiti@1.21.7)(jsdom@25.0.1)(lightningcss@1.28.2)(msw@2.7.0(@types/node@22.10.2)(typescript@5.6.3))(terser@5.37.0)(yaml@2.6.1)
+      vite: 6.0.11(@types/node@22.10.2)(jiti@2.4.2)(lightningcss@1.29.1)(terser@5.37.0)(yaml@2.6.1)
+      vitest: 3.0.5(@types/node@22.10.2)(@vitest/browser@3.0.5)(@vitest/ui@3.0.5)(happy-dom@16.8.1)(jiti@2.4.2)(jsdom@25.0.1)(lightningcss@1.29.1)(msw@2.7.0(@types/node@22.10.2)(typescript@5.6.3))(terser@5.37.0)(yaml@2.6.1)
 
   '@testing-library/user-event@14.6.1(@testing-library/dom@10.4.0)':
     dependencies:
@@ -15181,15 +15249,15 @@ snapshots:
       '@types/node': 22.10.2
     optional: true
 
-  '@typescript-eslint/eslint-plugin@8.18.1(@typescript-eslint/parser@8.18.1(eslint@9.17.0(jiti@1.21.7))(typescript@5.6.3))(eslint@9.17.0(jiti@1.21.7))(typescript@5.6.3)':
+  '@typescript-eslint/eslint-plugin@8.18.1(@typescript-eslint/parser@8.18.1(eslint@9.17.0(jiti@2.4.2))(typescript@5.6.3))(eslint@9.17.0(jiti@2.4.2))(typescript@5.6.3)':
     dependencies:
       '@eslint-community/regexpp': 4.12.1
-      '@typescript-eslint/parser': 8.18.1(eslint@9.17.0(jiti@1.21.7))(typescript@5.6.3)
+      '@typescript-eslint/parser': 8.18.1(eslint@9.17.0(jiti@2.4.2))(typescript@5.6.3)
       '@typescript-eslint/scope-manager': 8.18.1
-      '@typescript-eslint/type-utils': 8.18.1(eslint@9.17.0(jiti@1.21.7))(typescript@5.6.3)
-      '@typescript-eslint/utils': 8.18.1(eslint@9.17.0(jiti@1.21.7))(typescript@5.6.3)
+      '@typescript-eslint/type-utils': 8.18.1(eslint@9.17.0(jiti@2.4.2))(typescript@5.6.3)
+      '@typescript-eslint/utils': 8.18.1(eslint@9.17.0(jiti@2.4.2))(typescript@5.6.3)
       '@typescript-eslint/visitor-keys': 8.18.1
-      eslint: 9.17.0(jiti@1.21.7)
+      eslint: 9.17.0(jiti@2.4.2)
       graphemer: 1.4.0
       ignore: 5.3.2
       natural-compare: 1.4.0
@@ -15198,14 +15266,14 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/parser@8.18.1(eslint@9.17.0(jiti@1.21.7))(typescript@5.6.3)':
+  '@typescript-eslint/parser@8.18.1(eslint@9.17.0(jiti@2.4.2))(typescript@5.6.3)':
     dependencies:
       '@typescript-eslint/scope-manager': 8.18.1
       '@typescript-eslint/types': 8.18.1
       '@typescript-eslint/typescript-estree': 8.18.1(typescript@5.6.3)
       '@typescript-eslint/visitor-keys': 8.18.1
       debug: 4.4.0
-      eslint: 9.17.0(jiti@1.21.7)
+      eslint: 9.17.0(jiti@2.4.2)
       typescript: 5.6.3
     transitivePeerDependencies:
       - supports-color
@@ -15215,12 +15283,12 @@ snapshots:
       '@typescript-eslint/types': 8.18.1
       '@typescript-eslint/visitor-keys': 8.18.1
 
-  '@typescript-eslint/type-utils@8.18.1(eslint@9.17.0(jiti@1.21.7))(typescript@5.6.3)':
+  '@typescript-eslint/type-utils@8.18.1(eslint@9.17.0(jiti@2.4.2))(typescript@5.6.3)':
     dependencies:
       '@typescript-eslint/typescript-estree': 8.18.1(typescript@5.6.3)
-      '@typescript-eslint/utils': 8.18.1(eslint@9.17.0(jiti@1.21.7))(typescript@5.6.3)
+      '@typescript-eslint/utils': 8.18.1(eslint@9.17.0(jiti@2.4.2))(typescript@5.6.3)
       debug: 4.4.0
-      eslint: 9.17.0(jiti@1.21.7)
+      eslint: 9.17.0(jiti@2.4.2)
       ts-api-utils: 1.4.3(typescript@5.6.3)
       typescript: 5.6.3
     transitivePeerDependencies:
@@ -15242,13 +15310,13 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/utils@8.18.1(eslint@9.17.0(jiti@1.21.7))(typescript@5.6.3)':
+  '@typescript-eslint/utils@8.18.1(eslint@9.17.0(jiti@2.4.2))(typescript@5.6.3)':
     dependencies:
-      '@eslint-community/eslint-utils': 4.4.1(eslint@9.17.0(jiti@1.21.7))
+      '@eslint-community/eslint-utils': 4.4.1(eslint@9.17.0(jiti@2.4.2))
       '@typescript-eslint/scope-manager': 8.18.1
       '@typescript-eslint/types': 8.18.1
       '@typescript-eslint/typescript-estree': 8.18.1(typescript@5.6.3)
-      eslint: 9.17.0(jiti@1.21.7)
+      eslint: 9.17.0(jiti@2.4.2)
       typescript: 5.6.3
     transitivePeerDependencies:
       - supports-color
@@ -15289,57 +15357,57 @@ snapshots:
       - rollup
       - supports-color
 
-  '@vitejs/plugin-react-swc@3.7.2(@swc/helpers@0.5.15)(vite@5.4.11(@types/node@22.10.2)(lightningcss@1.28.2)(terser@5.37.0))':
+  '@vitejs/plugin-react-swc@3.7.2(@swc/helpers@0.5.15)(vite@5.4.11(@types/node@22.10.2)(lightningcss@1.29.1)(terser@5.37.0))':
     dependencies:
       '@swc/core': 1.10.1(@swc/helpers@0.5.15)
-      vite: 5.4.11(@types/node@22.10.2)(lightningcss@1.28.2)(terser@5.37.0)
+      vite: 5.4.11(@types/node@22.10.2)(lightningcss@1.29.1)(terser@5.37.0)
     transitivePeerDependencies:
       - '@swc/helpers'
 
-  '@vitejs/plugin-react-swc@3.7.2(@swc/helpers@0.5.15)(vite@6.0.11(@types/node@22.10.2)(jiti@1.21.7)(lightningcss@1.28.2)(terser@5.37.0)(yaml@2.6.1))':
+  '@vitejs/plugin-react-swc@3.7.2(@swc/helpers@0.5.15)(vite@6.0.11(@types/node@22.10.2)(jiti@2.4.2)(lightningcss@1.29.1)(terser@5.37.0)(yaml@2.6.1))':
     dependencies:
       '@swc/core': 1.10.1(@swc/helpers@0.5.15)
-      vite: 6.0.11(@types/node@22.10.2)(jiti@1.21.7)(lightningcss@1.28.2)(terser@5.37.0)(yaml@2.6.1)
+      vite: 6.0.11(@types/node@22.10.2)(jiti@2.4.2)(lightningcss@1.29.1)(terser@5.37.0)(yaml@2.6.1)
     transitivePeerDependencies:
       - '@swc/helpers'
 
-  '@vitejs/plugin-react@4.3.4(vite@6.0.11(@types/node@22.10.2)(jiti@1.21.7)(lightningcss@1.28.2)(terser@5.37.0)(yaml@2.6.1))':
+  '@vitejs/plugin-react@4.3.4(vite@6.0.11(@types/node@22.10.2)(jiti@2.4.2)(lightningcss@1.29.1)(terser@5.37.0)(yaml@2.6.1))':
     dependencies:
       '@babel/core': 7.26.0
       '@babel/plugin-transform-react-jsx-self': 7.25.9(@babel/core@7.26.0)
       '@babel/plugin-transform-react-jsx-source': 7.25.9(@babel/core@7.26.0)
       '@types/babel__core': 7.20.5
       react-refresh: 0.14.2
-      vite: 6.0.11(@types/node@22.10.2)(jiti@1.21.7)(lightningcss@1.28.2)(terser@5.37.0)(yaml@2.6.1)
+      vite: 6.0.11(@types/node@22.10.2)(jiti@2.4.2)(lightningcss@1.29.1)(terser@5.37.0)(yaml@2.6.1)
     transitivePeerDependencies:
       - supports-color
 
-  '@vitejs/plugin-vue-jsx@4.1.1(vite@6.0.11(@types/node@22.10.2)(jiti@1.21.7)(lightningcss@1.28.2)(terser@5.37.0)(yaml@2.6.1))(vue@3.5.13(typescript@5.6.3))':
+  '@vitejs/plugin-vue-jsx@4.1.1(vite@6.0.11(@types/node@22.10.2)(jiti@2.4.2)(lightningcss@1.29.1)(terser@5.37.0)(yaml@2.6.1))(vue@3.5.13(typescript@5.6.3))':
     dependencies:
       '@babel/core': 7.26.0
       '@babel/plugin-transform-typescript': 7.26.3(@babel/core@7.26.0)
       '@vue/babel-plugin-jsx': 1.2.5(@babel/core@7.26.0)
-      vite: 6.0.11(@types/node@22.10.2)(jiti@1.21.7)(lightningcss@1.28.2)(terser@5.37.0)(yaml@2.6.1)
+      vite: 6.0.11(@types/node@22.10.2)(jiti@2.4.2)(lightningcss@1.29.1)(terser@5.37.0)(yaml@2.6.1)
       vue: 3.5.13(typescript@5.6.3)
     transitivePeerDependencies:
       - supports-color
 
-  '@vitejs/plugin-vue@5.2.1(vite@6.0.11(@types/node@22.10.2)(jiti@1.21.7)(lightningcss@1.28.2)(terser@5.37.0)(yaml@2.6.1))(vue@3.5.13(typescript@5.6.3))':
+  '@vitejs/plugin-vue@5.2.1(vite@6.0.11(@types/node@22.10.2)(jiti@2.4.2)(lightningcss@1.29.1)(terser@5.37.0)(yaml@2.6.1))(vue@3.5.13(typescript@5.6.3))':
     dependencies:
-      vite: 6.0.11(@types/node@22.10.2)(jiti@1.21.7)(lightningcss@1.28.2)(terser@5.37.0)(yaml@2.6.1)
+      vite: 6.0.11(@types/node@22.10.2)(jiti@2.4.2)(lightningcss@1.29.1)(terser@5.37.0)(yaml@2.6.1)
       vue: 3.5.13(typescript@5.6.3)
 
-  '@vitest/browser@3.0.5(@types/node@22.10.2)(playwright@1.50.1)(typescript@5.6.3)(vite@6.0.11(@types/node@22.10.2)(jiti@1.21.7)(lightningcss@1.28.2)(terser@5.37.0)(yaml@2.6.1))(vitest@3.0.5)(webdriverio@8.41.0)':
+  '@vitest/browser@3.0.5(@types/node@22.10.2)(playwright@1.50.1)(typescript@5.6.3)(vite@6.0.11(@types/node@22.10.2)(jiti@2.4.2)(lightningcss@1.29.1)(terser@5.37.0)(yaml@2.6.1))(vitest@3.0.5)(webdriverio@8.41.0)':
     dependencies:
       '@testing-library/dom': 10.4.0
       '@testing-library/user-event': 14.6.1(@testing-library/dom@10.4.0)
-      '@vitest/mocker': 3.0.5(msw@2.7.0(@types/node@22.10.2)(typescript@5.6.3))(vite@6.0.11(@types/node@22.10.2)(jiti@1.21.7)(lightningcss@1.28.2)(terser@5.37.0)(yaml@2.6.1))
+      '@vitest/mocker': 3.0.5(msw@2.7.0(@types/node@22.10.2)(typescript@5.6.3))(vite@6.0.11(@types/node@22.10.2)(jiti@2.4.2)(lightningcss@1.29.1)(terser@5.37.0)(yaml@2.6.1))
       '@vitest/utils': 3.0.5
       magic-string: 0.30.17
       msw: 2.7.0(@types/node@22.10.2)(typescript@5.6.3)
       sirv: 3.0.0
       tinyrainbow: 2.0.0
-      vitest: 3.0.5(@types/node@22.10.2)(@vitest/browser@3.0.5)(@vitest/ui@3.0.5)(happy-dom@16.8.1)(jiti@1.21.7)(jsdom@25.0.1)(lightningcss@1.28.2)(msw@2.7.0(@types/node@22.10.2)(typescript@5.6.3))(terser@5.37.0)(yaml@2.6.1)
+      vitest: 3.0.5(@types/node@22.10.2)(@vitest/browser@3.0.5)(@vitest/ui@3.0.5)(happy-dom@16.8.1)(jiti@2.4.2)(jsdom@25.0.1)(lightningcss@1.29.1)(msw@2.7.0(@types/node@22.10.2)(typescript@5.6.3))(terser@5.37.0)(yaml@2.6.1)
       ws: 8.18.0
     optionalDependencies:
       playwright: 1.50.1
@@ -15363,7 +15431,7 @@ snapshots:
       magicast: 0.3.5
       test-exclude: 7.0.1
       tinyrainbow: 2.0.0
-      vitest: 3.0.5(@types/node@22.10.2)(@vitest/browser@3.0.5)(@vitest/ui@3.0.5)(happy-dom@16.8.1)(jiti@1.21.7)(jsdom@25.0.1)(lightningcss@1.28.2)(msw@2.7.0(@types/node@22.10.2)(typescript@5.6.3))(terser@5.37.0)(yaml@2.6.1)
+      vitest: 3.0.5(@types/node@22.10.2)(@vitest/browser@3.0.5)(@vitest/ui@3.0.5)(happy-dom@16.8.1)(jiti@2.4.2)(jsdom@25.0.1)(lightningcss@1.29.1)(msw@2.7.0(@types/node@22.10.2)(typescript@5.6.3))(terser@5.37.0)(yaml@2.6.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -15381,9 +15449,9 @@ snapshots:
       std-env: 3.8.0
       test-exclude: 7.0.1
       tinyrainbow: 2.0.0
-      vitest: 3.0.5(@types/node@22.10.2)(@vitest/browser@3.0.5)(@vitest/ui@3.0.5)(happy-dom@16.8.1)(jiti@1.21.7)(jsdom@25.0.1)(lightningcss@1.28.2)(msw@2.7.0(@types/node@22.10.2)(typescript@5.6.3))(terser@5.37.0)(yaml@2.6.1)
+      vitest: 3.0.5(@types/node@22.10.2)(@vitest/browser@3.0.5)(@vitest/ui@3.0.5)(happy-dom@16.8.1)(jiti@2.4.2)(jsdom@25.0.1)(lightningcss@1.29.1)(msw@2.7.0(@types/node@22.10.2)(typescript@5.6.3))(terser@5.37.0)(yaml@2.6.1)
     optionalDependencies:
-      '@vitest/browser': 3.0.5(@types/node@22.10.2)(playwright@1.50.1)(typescript@5.6.3)(vite@6.0.11(@types/node@22.10.2)(jiti@1.21.7)(lightningcss@1.28.2)(terser@5.37.0)(yaml@2.6.1))(vitest@3.0.5)(webdriverio@8.41.0)
+      '@vitest/browser': 3.0.5(@types/node@22.10.2)(playwright@1.50.1)(typescript@5.6.3)(vite@6.0.11(@types/node@22.10.2)(jiti@2.4.2)(lightningcss@1.29.1)(terser@5.37.0)(yaml@2.6.1))(vitest@3.0.5)(webdriverio@8.41.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -15394,14 +15462,14 @@ snapshots:
       chai: 5.1.2
       tinyrainbow: 2.0.0
 
-  '@vitest/mocker@3.0.5(msw@2.7.0(@types/node@22.10.2)(typescript@5.6.3))(vite@6.0.11(@types/node@22.10.2)(jiti@1.21.7)(lightningcss@1.28.2)(terser@5.37.0)(yaml@2.6.1))':
+  '@vitest/mocker@3.0.5(msw@2.7.0(@types/node@22.10.2)(typescript@5.6.3))(vite@6.0.11(@types/node@22.10.2)(jiti@2.4.2)(lightningcss@1.29.1)(terser@5.37.0)(yaml@2.6.1))':
     dependencies:
       '@vitest/spy': 3.0.5
       estree-walker: 3.0.3
       magic-string: 0.30.17
     optionalDependencies:
       msw: 2.7.0(@types/node@22.10.2)(typescript@5.6.3)
-      vite: 6.0.11(@types/node@22.10.2)(jiti@1.21.7)(lightningcss@1.28.2)(terser@5.37.0)(yaml@2.6.1)
+      vite: 6.0.11(@types/node@22.10.2)(jiti@2.4.2)(lightningcss@1.29.1)(terser@5.37.0)(yaml@2.6.1)
 
   '@vitest/pretty-format@3.0.5':
     dependencies:
@@ -15431,7 +15499,7 @@ snapshots:
       sirv: 3.0.0
       tinyglobby: 0.2.10
       tinyrainbow: 2.0.0
-      vitest: 3.0.5(@types/node@22.10.2)(@vitest/browser@3.0.5)(@vitest/ui@3.0.5)(happy-dom@16.8.1)(jiti@1.21.7)(jsdom@25.0.1)(lightningcss@1.28.2)(msw@2.7.0(@types/node@22.10.2)(typescript@5.6.3))(terser@5.37.0)(yaml@2.6.1)
+      vitest: 3.0.5(@types/node@22.10.2)(@vitest/browser@3.0.5)(@vitest/ui@3.0.5)(happy-dom@16.8.1)(jiti@2.4.2)(jsdom@25.0.1)(lightningcss@1.29.1)(msw@2.7.0(@types/node@22.10.2)(typescript@5.6.3))(terser@5.37.0)(yaml@2.6.1)
 
   '@vitest/utils@3.0.5':
     dependencies:
@@ -15518,14 +15586,14 @@ snapshots:
 
   '@vue/devtools-api@6.6.4': {}
 
-  '@vue/devtools-core@7.6.8(vite@6.0.11(@types/node@22.10.2)(jiti@1.21.7)(lightningcss@1.28.2)(terser@5.37.0)(yaml@2.6.1))(vue@3.5.13(typescript@5.6.3))':
+  '@vue/devtools-core@7.6.8(vite@6.0.11(@types/node@22.10.2)(jiti@2.4.2)(lightningcss@1.29.1)(terser@5.37.0)(yaml@2.6.1))(vue@3.5.13(typescript@5.6.3))':
     dependencies:
       '@vue/devtools-kit': 7.6.8
       '@vue/devtools-shared': 7.6.8
       mitt: 3.0.1
       nanoid: 5.0.9
       pathe: 1.1.2
-      vite-hot-client: 0.2.4(vite@6.0.11(@types/node@22.10.2)(jiti@1.21.7)(lightningcss@1.28.2)(terser@5.37.0)(yaml@2.6.1))
+      vite-hot-client: 0.2.4(vite@6.0.11(@types/node@22.10.2)(jiti@2.4.2)(lightningcss@1.29.1)(terser@5.37.0)(yaml@2.6.1))
       vue: 3.5.13(typescript@5.6.3)
     transitivePeerDependencies:
       - vite
@@ -16907,7 +16975,7 @@ snapshots:
     dependencies:
       once: 1.4.0
 
-  enhanced-resolve@5.17.1:
+  enhanced-resolve@5.18.1:
     dependencies:
       graceful-fs: 4.2.11
       tapable: 2.2.1
@@ -16988,21 +17056,21 @@ snapshots:
     optionalDependencies:
       source-map: 0.6.1
 
-  eslint-compat-utils@0.5.1(eslint@9.17.0(jiti@1.21.7)):
+  eslint-compat-utils@0.5.1(eslint@9.17.0(jiti@2.4.2)):
     dependencies:
-      eslint: 9.17.0(jiti@1.21.7)
+      eslint: 9.17.0(jiti@2.4.2)
       semver: 7.6.3
 
-  eslint-config-prettier@9.1.0(eslint@9.17.0(jiti@1.21.7)):
+  eslint-config-prettier@9.1.0(eslint@9.17.0(jiti@2.4.2)):
     dependencies:
-      eslint: 9.17.0(jiti@1.21.7)
+      eslint: 9.17.0(jiti@2.4.2)
 
-  eslint-plugin-svelte@2.46.1(eslint@9.17.0(jiti@1.21.7))(svelte@5.15.0)(ts-node@10.9.2(@swc/core@1.10.1(@swc/helpers@0.5.15))(@types/node@22.10.2)(typescript@5.6.3)):
+  eslint-plugin-svelte@2.46.1(eslint@9.17.0(jiti@2.4.2))(svelte@5.15.0)(ts-node@10.9.2(@swc/core@1.10.1(@swc/helpers@0.5.15))(@types/node@22.10.2)(typescript@5.6.3)):
     dependencies:
-      '@eslint-community/eslint-utils': 4.4.1(eslint@9.17.0(jiti@1.21.7))
+      '@eslint-community/eslint-utils': 4.4.1(eslint@9.17.0(jiti@2.4.2))
       '@jridgewell/sourcemap-codec': 1.5.0
-      eslint: 9.17.0(jiti@1.21.7)
-      eslint-compat-utils: 0.5.1(eslint@9.17.0(jiti@1.21.7))
+      eslint: 9.17.0(jiti@2.4.2)
+      eslint-compat-utils: 0.5.1(eslint@9.17.0(jiti@2.4.2))
       esutils: 2.0.3
       known-css-properties: 0.35.0
       postcss: 8.4.49
@@ -17016,16 +17084,16 @@ snapshots:
     transitivePeerDependencies:
       - ts-node
 
-  eslint-plugin-vue@9.32.0(eslint@9.17.0(jiti@1.21.7)):
+  eslint-plugin-vue@9.32.0(eslint@9.17.0(jiti@2.4.2)):
     dependencies:
-      '@eslint-community/eslint-utils': 4.4.1(eslint@9.17.0(jiti@1.21.7))
-      eslint: 9.17.0(jiti@1.21.7)
+      '@eslint-community/eslint-utils': 4.4.1(eslint@9.17.0(jiti@2.4.2))
+      eslint: 9.17.0(jiti@2.4.2)
       globals: 13.24.0
       natural-compare: 1.4.0
       nth-check: 2.1.1
       postcss-selector-parser: 6.1.2
       semver: 7.6.3
-      vue-eslint-parser: 9.4.3(eslint@9.17.0(jiti@1.21.7))
+      vue-eslint-parser: 9.4.3(eslint@9.17.0(jiti@2.4.2))
       xml-name-validator: 4.0.0
     transitivePeerDependencies:
       - supports-color
@@ -17049,9 +17117,9 @@ snapshots:
 
   eslint-visitor-keys@4.2.0: {}
 
-  eslint@9.17.0(jiti@1.21.7):
+  eslint@9.17.0(jiti@2.4.2):
     dependencies:
-      '@eslint-community/eslint-utils': 4.4.1(eslint@9.17.0(jiti@1.21.7))
+      '@eslint-community/eslint-utils': 4.4.1(eslint@9.17.0(jiti@2.4.2))
       '@eslint-community/regexpp': 4.12.1
       '@eslint/config-array': 0.19.1
       '@eslint/core': 0.9.1
@@ -17086,7 +17154,7 @@ snapshots:
       natural-compare: 1.4.0
       optionator: 0.9.4
     optionalDependencies:
-      jiti: 1.21.7
+      jiti: 2.4.2
     transitivePeerDependencies:
       - supports-color
 
@@ -18641,6 +18709,9 @@ snapshots:
 
   jiti@1.21.7: {}
 
+  jiti@2.4.2:
+    optional: true
+
   jju@1.4.0: {}
 
   join-component@1.1.0: {}
@@ -18888,10 +18959,16 @@ snapshots:
   lightningcss-darwin-arm64@1.28.2:
     optional: true
 
+  lightningcss-darwin-arm64@1.29.1:
+    optional: true
+
   lightningcss-darwin-x64@1.27.0:
     optional: true
 
   lightningcss-darwin-x64@1.28.2:
+    optional: true
+
+  lightningcss-darwin-x64@1.29.1:
     optional: true
 
   lightningcss-freebsd-x64@1.27.0:
@@ -18900,10 +18977,16 @@ snapshots:
   lightningcss-freebsd-x64@1.28.2:
     optional: true
 
+  lightningcss-freebsd-x64@1.29.1:
+    optional: true
+
   lightningcss-linux-arm-gnueabihf@1.27.0:
     optional: true
 
   lightningcss-linux-arm-gnueabihf@1.28.2:
+    optional: true
+
+  lightningcss-linux-arm-gnueabihf@1.29.1:
     optional: true
 
   lightningcss-linux-arm64-gnu@1.27.0:
@@ -18912,10 +18995,16 @@ snapshots:
   lightningcss-linux-arm64-gnu@1.28.2:
     optional: true
 
+  lightningcss-linux-arm64-gnu@1.29.1:
+    optional: true
+
   lightningcss-linux-arm64-musl@1.27.0:
     optional: true
 
   lightningcss-linux-arm64-musl@1.28.2:
+    optional: true
+
+  lightningcss-linux-arm64-musl@1.29.1:
     optional: true
 
   lightningcss-linux-x64-gnu@1.27.0:
@@ -18924,10 +19013,16 @@ snapshots:
   lightningcss-linux-x64-gnu@1.28.2:
     optional: true
 
+  lightningcss-linux-x64-gnu@1.29.1:
+    optional: true
+
   lightningcss-linux-x64-musl@1.27.0:
     optional: true
 
   lightningcss-linux-x64-musl@1.28.2:
+    optional: true
+
+  lightningcss-linux-x64-musl@1.29.1:
     optional: true
 
   lightningcss-win32-arm64-msvc@1.27.0:
@@ -18936,10 +19031,16 @@ snapshots:
   lightningcss-win32-arm64-msvc@1.28.2:
     optional: true
 
+  lightningcss-win32-arm64-msvc@1.29.1:
+    optional: true
+
   lightningcss-win32-x64-msvc@1.27.0:
     optional: true
 
   lightningcss-win32-x64-msvc@1.28.2:
+    optional: true
+
+  lightningcss-win32-x64-msvc@1.29.1:
     optional: true
 
   lightningcss@1.27.0:
@@ -18971,6 +19072,22 @@ snapshots:
       lightningcss-linux-x64-musl: 1.28.2
       lightningcss-win32-arm64-msvc: 1.28.2
       lightningcss-win32-x64-msvc: 1.28.2
+
+  lightningcss@1.29.1:
+    dependencies:
+      detect-libc: 1.0.3
+    optionalDependencies:
+      lightningcss-darwin-arm64: 1.29.1
+      lightningcss-darwin-x64: 1.29.1
+      lightningcss-freebsd-x64: 1.29.1
+      lightningcss-linux-arm-gnueabihf: 1.29.1
+      lightningcss-linux-arm64-gnu: 1.29.1
+      lightningcss-linux-arm64-musl: 1.29.1
+      lightningcss-linux-x64-gnu: 1.29.1
+      lightningcss-linux-x64-musl: 1.29.1
+      lightningcss-win32-arm64-msvc: 1.29.1
+      lightningcss-win32-x64-msvc: 1.29.1
+    optional: true
 
   lilconfig@2.1.0: {}
 
@@ -19946,11 +20063,11 @@ snapshots:
       postcss: 8.4.49
       ts-node: 10.9.2(@swc/core@1.10.1(@swc/helpers@0.5.15))(@types/node@22.10.2)(typescript@5.6.3)
 
-  postcss-load-config@6.0.1(jiti@1.21.7)(postcss@8.4.49)(yaml@2.6.1):
+  postcss-load-config@6.0.1(jiti@2.4.2)(postcss@8.4.49)(yaml@2.6.1):
     dependencies:
       lilconfig: 3.1.3
     optionalDependencies:
-      jiti: 1.21.7
+      jiti: 2.4.2
       postcss: 8.4.49
       yaml: 2.6.1
 
@@ -21540,7 +21657,7 @@ snapshots:
 
   tslib@2.8.1: {}
 
-  tsup@8.3.5(@microsoft/api-extractor@7.48.1(@types/node@22.10.2))(@swc/core@1.10.1(@swc/helpers@0.5.15))(jiti@1.21.7)(postcss@8.4.49)(typescript@5.6.3)(yaml@2.6.1):
+  tsup@8.3.5(@microsoft/api-extractor@7.48.1(@types/node@22.10.2))(@swc/core@1.10.1(@swc/helpers@0.5.15))(jiti@2.4.2)(postcss@8.4.49)(typescript@5.6.3)(yaml@2.6.1):
     dependencies:
       bundle-require: 5.0.0(esbuild@0.24.0)
       cac: 6.7.14
@@ -21550,7 +21667,7 @@ snapshots:
       esbuild: 0.24.0
       joycon: 3.1.1
       picocolors: 1.1.1
-      postcss-load-config: 6.0.1(jiti@1.21.7)(postcss@8.4.49)(yaml@2.6.1)
+      postcss-load-config: 6.0.1(jiti@2.4.2)(postcss@8.4.49)(yaml@2.6.1)
       resolve-from: 5.0.0
       rollup: 4.28.1
       source-map: 0.8.0-beta.0
@@ -21632,12 +21749,12 @@ snapshots:
       shiki: 0.14.7
       typescript: 5.6.3
 
-  typescript-eslint@8.18.1(eslint@9.17.0(jiti@1.21.7))(typescript@5.6.3):
+  typescript-eslint@8.18.1(eslint@9.17.0(jiti@2.4.2))(typescript@5.6.3):
     dependencies:
-      '@typescript-eslint/eslint-plugin': 8.18.1(@typescript-eslint/parser@8.18.1(eslint@9.17.0(jiti@1.21.7))(typescript@5.6.3))(eslint@9.17.0(jiti@1.21.7))(typescript@5.6.3)
-      '@typescript-eslint/parser': 8.18.1(eslint@9.17.0(jiti@1.21.7))(typescript@5.6.3)
-      '@typescript-eslint/utils': 8.18.1(eslint@9.17.0(jiti@1.21.7))(typescript@5.6.3)
-      eslint: 9.17.0(jiti@1.21.7)
+      '@typescript-eslint/eslint-plugin': 8.18.1(@typescript-eslint/parser@8.18.1(eslint@9.17.0(jiti@2.4.2))(typescript@5.6.3))(eslint@9.17.0(jiti@2.4.2))(typescript@5.6.3)
+      '@typescript-eslint/parser': 8.18.1(eslint@9.17.0(jiti@2.4.2))(typescript@5.6.3)
+      '@typescript-eslint/utils': 8.18.1(eslint@9.17.0(jiti@2.4.2))(typescript@5.6.3)
+      eslint: 9.17.0(jiti@2.4.2)
       typescript: 5.6.3
     transitivePeerDependencies:
       - supports-color
@@ -21785,17 +21902,17 @@ snapshots:
 
   vary@1.1.2: {}
 
-  vite-hot-client@0.2.4(vite@6.0.11(@types/node@22.10.2)(jiti@1.21.7)(lightningcss@1.28.2)(terser@5.37.0)(yaml@2.6.1)):
+  vite-hot-client@0.2.4(vite@6.0.11(@types/node@22.10.2)(jiti@2.4.2)(lightningcss@1.29.1)(terser@5.37.0)(yaml@2.6.1)):
     dependencies:
-      vite: 6.0.11(@types/node@22.10.2)(jiti@1.21.7)(lightningcss@1.28.2)(terser@5.37.0)(yaml@2.6.1)
+      vite: 6.0.11(@types/node@22.10.2)(jiti@2.4.2)(lightningcss@1.29.1)(terser@5.37.0)(yaml@2.6.1)
 
-  vite-node@3.0.5(@types/node@22.10.2)(jiti@1.21.7)(lightningcss@1.28.2)(terser@5.37.0)(yaml@2.6.1):
+  vite-node@3.0.5(@types/node@22.10.2)(jiti@2.4.2)(lightningcss@1.29.1)(terser@5.37.0)(yaml@2.6.1):
     dependencies:
       cac: 6.7.14
       debug: 4.4.0
       es-module-lexer: 1.6.0
       pathe: 2.0.2
-      vite: 6.0.11(@types/node@22.10.2)(jiti@1.21.7)(lightningcss@1.28.2)(terser@5.37.0)(yaml@2.6.1)
+      vite: 6.0.11(@types/node@22.10.2)(jiti@2.4.2)(lightningcss@1.29.1)(terser@5.37.0)(yaml@2.6.1)
     transitivePeerDependencies:
       - '@types/node'
       - jiti
@@ -21810,7 +21927,7 @@ snapshots:
       - tsx
       - yaml
 
-  vite-plugin-dts@4.4.0(@types/node@22.10.2)(rollup@4.28.1)(typescript@5.6.3)(vite@6.0.11(@types/node@22.10.2)(jiti@1.21.7)(lightningcss@1.28.2)(terser@5.37.0)(yaml@2.6.1)):
+  vite-plugin-dts@4.4.0(@types/node@22.10.2)(rollup@4.28.1)(typescript@5.6.3)(vite@6.0.11(@types/node@22.10.2)(jiti@2.4.2)(lightningcss@1.29.1)(terser@5.37.0)(yaml@2.6.1)):
     dependencies:
       '@microsoft/api-extractor': 7.48.1(@types/node@22.10.2)
       '@rollup/pluginutils': 5.1.4(rollup@4.28.1)
@@ -21823,13 +21940,13 @@ snapshots:
       magic-string: 0.30.17
       typescript: 5.6.3
     optionalDependencies:
-      vite: 6.0.11(@types/node@22.10.2)(jiti@1.21.7)(lightningcss@1.28.2)(terser@5.37.0)(yaml@2.6.1)
+      vite: 6.0.11(@types/node@22.10.2)(jiti@2.4.2)(lightningcss@1.29.1)(terser@5.37.0)(yaml@2.6.1)
     transitivePeerDependencies:
       - '@types/node'
       - rollup
       - supports-color
 
-  vite-plugin-inspect@0.8.9(rollup@4.28.1)(vite@6.0.11(@types/node@22.10.2)(jiti@1.21.7)(lightningcss@1.28.2)(terser@5.37.0)(yaml@2.6.1)):
+  vite-plugin-inspect@0.8.9(rollup@4.28.1)(vite@6.0.11(@types/node@22.10.2)(jiti@2.4.2)(lightningcss@1.29.1)(terser@5.37.0)(yaml@2.6.1)):
     dependencies:
       '@antfu/utils': 0.7.10
       '@rollup/pluginutils': 5.1.4(rollup@4.28.1)
@@ -21840,38 +21957,38 @@ snapshots:
       perfect-debounce: 1.0.0
       picocolors: 1.1.1
       sirv: 3.0.0
-      vite: 6.0.11(@types/node@22.10.2)(jiti@1.21.7)(lightningcss@1.28.2)(terser@5.37.0)(yaml@2.6.1)
+      vite: 6.0.11(@types/node@22.10.2)(jiti@2.4.2)(lightningcss@1.29.1)(terser@5.37.0)(yaml@2.6.1)
     transitivePeerDependencies:
       - rollup
       - supports-color
 
-  vite-plugin-top-level-await@1.4.4(@swc/helpers@0.5.15)(rollup@4.28.1)(vite@6.0.11(@types/node@22.10.2)(jiti@1.21.7)(lightningcss@1.28.2)(terser@5.37.0)(yaml@2.6.1)):
+  vite-plugin-top-level-await@1.4.4(@swc/helpers@0.5.15)(rollup@4.28.1)(vite@6.0.11(@types/node@22.10.2)(jiti@2.4.2)(lightningcss@1.29.1)(terser@5.37.0)(yaml@2.6.1)):
     dependencies:
       '@rollup/plugin-virtual': 3.0.2(rollup@4.28.1)
       '@swc/core': 1.10.1(@swc/helpers@0.5.15)
       uuid: 10.0.0
-      vite: 6.0.11(@types/node@22.10.2)(jiti@1.21.7)(lightningcss@1.28.2)(terser@5.37.0)(yaml@2.6.1)
+      vite: 6.0.11(@types/node@22.10.2)(jiti@2.4.2)(lightningcss@1.29.1)(terser@5.37.0)(yaml@2.6.1)
     transitivePeerDependencies:
       - '@swc/helpers'
       - rollup
 
-  vite-plugin-vue-devtools@7.6.8(rollup@4.28.1)(vite@6.0.11(@types/node@22.10.2)(jiti@1.21.7)(lightningcss@1.28.2)(terser@5.37.0)(yaml@2.6.1))(vue@3.5.13(typescript@5.6.3)):
+  vite-plugin-vue-devtools@7.6.8(rollup@4.28.1)(vite@6.0.11(@types/node@22.10.2)(jiti@2.4.2)(lightningcss@1.29.1)(terser@5.37.0)(yaml@2.6.1))(vue@3.5.13(typescript@5.6.3)):
     dependencies:
-      '@vue/devtools-core': 7.6.8(vite@6.0.11(@types/node@22.10.2)(jiti@1.21.7)(lightningcss@1.28.2)(terser@5.37.0)(yaml@2.6.1))(vue@3.5.13(typescript@5.6.3))
+      '@vue/devtools-core': 7.6.8(vite@6.0.11(@types/node@22.10.2)(jiti@2.4.2)(lightningcss@1.29.1)(terser@5.37.0)(yaml@2.6.1))(vue@3.5.13(typescript@5.6.3))
       '@vue/devtools-kit': 7.6.8
       '@vue/devtools-shared': 7.6.8
       execa: 9.5.2
       sirv: 3.0.0
-      vite: 6.0.11(@types/node@22.10.2)(jiti@1.21.7)(lightningcss@1.28.2)(terser@5.37.0)(yaml@2.6.1)
-      vite-plugin-inspect: 0.8.9(rollup@4.28.1)(vite@6.0.11(@types/node@22.10.2)(jiti@1.21.7)(lightningcss@1.28.2)(terser@5.37.0)(yaml@2.6.1))
-      vite-plugin-vue-inspector: 5.3.1(vite@6.0.11(@types/node@22.10.2)(jiti@1.21.7)(lightningcss@1.28.2)(terser@5.37.0)(yaml@2.6.1))
+      vite: 6.0.11(@types/node@22.10.2)(jiti@2.4.2)(lightningcss@1.29.1)(terser@5.37.0)(yaml@2.6.1)
+      vite-plugin-inspect: 0.8.9(rollup@4.28.1)(vite@6.0.11(@types/node@22.10.2)(jiti@2.4.2)(lightningcss@1.29.1)(terser@5.37.0)(yaml@2.6.1))
+      vite-plugin-vue-inspector: 5.3.1(vite@6.0.11(@types/node@22.10.2)(jiti@2.4.2)(lightningcss@1.29.1)(terser@5.37.0)(yaml@2.6.1))
     transitivePeerDependencies:
       - '@nuxt/kit'
       - rollup
       - supports-color
       - vue
 
-  vite-plugin-vue-inspector@5.3.1(vite@6.0.11(@types/node@22.10.2)(jiti@1.21.7)(lightningcss@1.28.2)(terser@5.37.0)(yaml@2.6.1)):
+  vite-plugin-vue-inspector@5.3.1(vite@6.0.11(@types/node@22.10.2)(jiti@2.4.2)(lightningcss@1.29.1)(terser@5.37.0)(yaml@2.6.1)):
     dependencies:
       '@babel/core': 7.26.0
       '@babel/plugin-proposal-decorators': 7.25.9(@babel/core@7.26.0)
@@ -21882,11 +21999,11 @@ snapshots:
       '@vue/compiler-dom': 3.5.13
       kolorist: 1.8.0
       magic-string: 0.30.17
-      vite: 6.0.11(@types/node@22.10.2)(jiti@1.21.7)(lightningcss@1.28.2)(terser@5.37.0)(yaml@2.6.1)
+      vite: 6.0.11(@types/node@22.10.2)(jiti@2.4.2)(lightningcss@1.29.1)(terser@5.37.0)(yaml@2.6.1)
     transitivePeerDependencies:
       - supports-color
 
-  vite@5.4.11(@types/node@22.10.2)(lightningcss@1.28.2)(terser@5.37.0):
+  vite@5.4.11(@types/node@22.10.2)(lightningcss@1.29.1)(terser@5.37.0):
     dependencies:
       esbuild: 0.24.0
       postcss: 8.4.49
@@ -21894,10 +22011,10 @@ snapshots:
     optionalDependencies:
       '@types/node': 22.10.2
       fsevents: 2.3.3
-      lightningcss: 1.28.2
+      lightningcss: 1.29.1
       terser: 5.37.0
 
-  vite@6.0.11(@types/node@22.10.2)(jiti@1.21.7)(lightningcss@1.28.2)(terser@5.37.0)(yaml@2.6.1):
+  vite@6.0.11(@types/node@22.10.2)(jiti@2.4.2)(lightningcss@1.29.1)(terser@5.37.0)(yaml@2.6.1):
     dependencies:
       esbuild: 0.24.0
       postcss: 8.4.49
@@ -21905,19 +22022,19 @@ snapshots:
     optionalDependencies:
       '@types/node': 22.10.2
       fsevents: 2.3.3
-      jiti: 1.21.7
-      lightningcss: 1.28.2
+      jiti: 2.4.2
+      lightningcss: 1.29.1
       terser: 5.37.0
       yaml: 2.6.1
 
-  vitefu@1.0.4(vite@6.0.11(@types/node@22.10.2)(jiti@1.21.7)(lightningcss@1.28.2)(terser@5.37.0)(yaml@2.6.1)):
+  vitefu@1.0.4(vite@6.0.11(@types/node@22.10.2)(jiti@2.4.2)(lightningcss@1.29.1)(terser@5.37.0)(yaml@2.6.1)):
     optionalDependencies:
-      vite: 6.0.11(@types/node@22.10.2)(jiti@1.21.7)(lightningcss@1.28.2)(terser@5.37.0)(yaml@2.6.1)
+      vite: 6.0.11(@types/node@22.10.2)(jiti@2.4.2)(lightningcss@1.29.1)(terser@5.37.0)(yaml@2.6.1)
 
-  vitest@3.0.5(@types/node@22.10.2)(@vitest/browser@3.0.5)(@vitest/ui@3.0.5)(happy-dom@16.8.1)(jiti@1.21.7)(jsdom@25.0.1)(lightningcss@1.28.2)(msw@2.7.0(@types/node@22.10.2)(typescript@5.6.3))(terser@5.37.0)(yaml@2.6.1):
+  vitest@3.0.5(@types/node@22.10.2)(@vitest/browser@3.0.5)(@vitest/ui@3.0.5)(happy-dom@16.8.1)(jiti@2.4.2)(jsdom@25.0.1)(lightningcss@1.29.1)(msw@2.7.0(@types/node@22.10.2)(typescript@5.6.3))(terser@5.37.0)(yaml@2.6.1):
     dependencies:
       '@vitest/expect': 3.0.5
-      '@vitest/mocker': 3.0.5(msw@2.7.0(@types/node@22.10.2)(typescript@5.6.3))(vite@6.0.11(@types/node@22.10.2)(jiti@1.21.7)(lightningcss@1.28.2)(terser@5.37.0)(yaml@2.6.1))
+      '@vitest/mocker': 3.0.5(msw@2.7.0(@types/node@22.10.2)(typescript@5.6.3))(vite@6.0.11(@types/node@22.10.2)(jiti@2.4.2)(lightningcss@1.29.1)(terser@5.37.0)(yaml@2.6.1))
       '@vitest/pretty-format': 3.0.5
       '@vitest/runner': 3.0.5
       '@vitest/snapshot': 3.0.5
@@ -21933,12 +22050,12 @@ snapshots:
       tinyexec: 0.3.2
       tinypool: 1.0.2
       tinyrainbow: 2.0.0
-      vite: 6.0.11(@types/node@22.10.2)(jiti@1.21.7)(lightningcss@1.28.2)(terser@5.37.0)(yaml@2.6.1)
-      vite-node: 3.0.5(@types/node@22.10.2)(jiti@1.21.7)(lightningcss@1.28.2)(terser@5.37.0)(yaml@2.6.1)
+      vite: 6.0.11(@types/node@22.10.2)(jiti@2.4.2)(lightningcss@1.29.1)(terser@5.37.0)(yaml@2.6.1)
+      vite-node: 3.0.5(@types/node@22.10.2)(jiti@2.4.2)(lightningcss@1.29.1)(terser@5.37.0)(yaml@2.6.1)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 22.10.2
-      '@vitest/browser': 3.0.5(@types/node@22.10.2)(playwright@1.50.1)(typescript@5.6.3)(vite@6.0.11(@types/node@22.10.2)(jiti@1.21.7)(lightningcss@1.28.2)(terser@5.37.0)(yaml@2.6.1))(vitest@3.0.5)(webdriverio@8.41.0)
+      '@vitest/browser': 3.0.5(@types/node@22.10.2)(playwright@1.50.1)(typescript@5.6.3)(vite@6.0.11(@types/node@22.10.2)(jiti@2.4.2)(lightningcss@1.29.1)(terser@5.37.0)(yaml@2.6.1))(vitest@3.0.5)(webdriverio@8.41.0)
       '@vitest/ui': 3.0.5(vitest@3.0.5)
       happy-dom: 16.8.1
       jsdom: 25.0.1
@@ -21964,10 +22081,10 @@ snapshots:
 
   vscode-uri@3.0.8: {}
 
-  vue-eslint-parser@9.4.3(eslint@9.17.0(jiti@1.21.7)):
+  vue-eslint-parser@9.4.3(eslint@9.17.0(jiti@2.4.2)):
     dependencies:
       debug: 4.4.0
-      eslint: 9.17.0(jiti@1.21.7)
+      eslint: 9.17.0(jiti@2.4.2)
       eslint-scope: 7.2.2
       eslint-visitor-keys: 3.4.3
       espree: 9.6.1
@@ -22109,7 +22226,7 @@ snapshots:
       acorn: 8.14.0
       browserslist: 4.24.3
       chrome-trace-event: 1.0.4
-      enhanced-resolve: 5.17.1
+      enhanced-resolve: 5.18.1
       es-module-lexer: 1.6.0
       eslint-scope: 5.1.1
       events: 3.3.0


### PR DESCRIPTION
Ported the authentication/upgrade guide to React native, Vue and Svelte 

Focused mostly on React Native and hidden to Vue/Svelte the parts that would have required too much time.