### PR TITLE
fix: check CoValue permissions when loading/subscribing

### DIFF
--- a/.changeset/breezy-boxes-unite.md
+++ b/.changeset/breezy-boxes-unite.md
@@ -1,0 +1,6 @@
+---
+"jazz-tools": minor
+"cojson": minor
+---
+
+Check CoValue access permissions when loading

--- a/.changeset/funny-birds-flash.md
+++ b/.changeset/funny-birds-flash.md
@@ -1,0 +1,5 @@
+---
+"cojson": minor
+---
+
+Return the EVERYONE role if the account is not direct a member of the group

--- a/packages/cojson/src/coValues/coMap.ts
+++ b/packages/cojson/src/coValues/coMap.ts
@@ -238,7 +238,7 @@ export class RawCoMapView<
   get<K extends keyof Shape & string>(key: K): Shape[K] | undefined {
     const entry = this.getRaw(key);
 
-    if (entry === undefined) {
+    if (entry?.change === undefined) {
       return undefined;
     }
 

--- a/packages/cojson/src/coValues/group.ts
+++ b/packages/cojson/src/coValues/group.ts
@@ -85,7 +85,15 @@ export class RawGroup<
   roleOfInternal(
     accountID: RawAccountID | AgentID | typeof EVERYONE,
   ): { role: Role; via: CoID<RawGroup> | undefined } | undefined {
-    const roleHere = this.get(accountID);
+    let roleHere = this.get(accountID);
+
+    if (!roleHere) {
+      const everyoneRole = this.get(EVERYONE);
+
+      if (everyoneRole && everyoneRole !== "revoked") {
+        roleHere = everyoneRole;
+      }
+    }
 
     if (roleHere === "revoked") {
       return undefined;

--- a/packages/cojson/src/permissions.ts
+++ b/packages/cojson/src/permissions.ts
@@ -101,8 +101,7 @@ export function determineValidTransactions(
         }
 
         const transactorRoleAtTxTime =
-          groupAtTime.roleOfInternal(effectiveTransactor)?.role ||
-          groupAtTime.roleOfInternal(EVERYONE)?.role;
+          groupAtTime.roleOfInternal(effectiveTransactor)?.role;
 
         if (
           transactorRoleAtTxTime !== "admin" &&

--- a/packages/jazz-nodejs/src/test/startWorker.test.ts
+++ b/packages/jazz-nodejs/src/test/startWorker.test.ts
@@ -64,7 +64,7 @@ describe("startWorker integration", () => {
 
     await map.waitForSync();
 
-    const mapOnWorker2 = await TestMap.load(map.id, worker2.worker);
+    const mapOnWorker2 = await TestMap.load(map.id, { loadAs: worker2.worker });
 
     expect(mapOnWorker2?.value).toBe("test");
 
@@ -89,7 +89,7 @@ describe("startWorker integration", () => {
 
     const worker2 = await setupWorker(worker1.syncServer);
 
-    const mapOnWorker2 = await TestMap.load(map.id, worker2.worker);
+    const mapOnWorker2 = await TestMap.load(map.id, { loadAs: worker2.worker });
 
     expect(mapOnWorker2?.value).toBe("test");
 
@@ -124,7 +124,7 @@ describe("startWorker integration", () => {
 
     const resultId = await sender.sendMessage(map);
 
-    const result = await TestMap.load(resultId, worker2.worker, {});
+    const result = await TestMap.load(resultId, { loadAs: worker2.worker });
 
     expect(result?.value).toEqual("Hello! Responded from the inbox");
 
@@ -170,8 +170,10 @@ describe("startWorker integration", () => {
     await map2.waitForSync();
 
     // Verify both old and new values are synced
-    const mapOnWorker2 = await TestMap.load(map.id, worker2.worker, {});
-    const map2OnWorker2 = await TestMap.load(map2.id, worker2.worker, {});
+    const mapOnWorker2 = await TestMap.load(map.id, { loadAs: worker2.worker });
+    const map2OnWorker2 = await TestMap.load(map2.id, {
+      loadAs: worker2.worker,
+    });
 
     expect(mapOnWorker2?.value).toBe("initial value");
     expect(map2OnWorker2?.value).toBe("created while offline");

--- a/packages/jazz-react-core/src/hooks.ts
+++ b/packages/jazz-react-core/src/hooks.ts
@@ -50,11 +50,7 @@ export function useCoState<
 ): Resolved<V, R> | undefined | null {
   const context = useJazzContext();
 
-  const [observable] = React.useState(() =>
-    createCoValueObservable<V, R>({
-      syncResolution: true,
-    }),
-  );
+  const [observable] = React.useState(() => createCoValueObservable<V, R>());
 
   const value = React.useSyncExternalStore<Resolved<V, R> | undefined | null>(
     React.useCallback(
@@ -69,8 +65,10 @@ export function useCoState<
           {
             loadAs: agent,
             resolve: options?.resolve,
+            onUnauthorized: callback,
+            onUnavailable: callback,
+            syncResolution: true,
           },
-          callback,
           callback,
         );
       },

--- a/packages/jazz-svelte/src/lib/jazz.svelte.ts
+++ b/packages/jazz-svelte/src/lib/jazz.svelte.ts
@@ -182,15 +182,21 @@ export function useCoState<V extends CoValue, R extends RefsToResolve<V>>(
     return subscribeToCoValue<V, R>(
       Schema,
       id,
-      { resolve: options?.resolve, loadAs: agent },
+      {
+        resolve: options?.resolve,
+        loadAs: agent,
+        onUnavailable: () => {
+          state = null;
+        },
+        onUnauthorized: () => {
+          state = null;
+        },
+        syncResolution: true,
+      },
       (value) => {
         // Get current value from our stable observable
         state = value;
       },
-      () => {
-        state = null;
-      },
-      true
     );
   });
 

--- a/packages/jazz-tools/src/coValues/account.ts
+++ b/packages/jazz-tools/src/coValues/account.ts
@@ -28,6 +28,7 @@ import {
   Resolved,
   type Schema,
   SchemaInit,
+  SubscribeListenerOptions,
   SubscribeRestArgs,
   ensureCoValueLoaded,
   inspect,
@@ -313,10 +314,7 @@ export class Account extends CoValueBase implements CoValue {
   static subscribe<A extends Account, const R extends RefsToResolve<A> = true>(
     this: CoValueClass<A>,
     id: ID<A>,
-    options: {
-      resolve?: RefsToResolveStrict<A, R>;
-      loadAs?: Account | AnonymousJazzAgent;
-    },
+    options: SubscribeListenerOptions<A, R>,
     listener: (value: Resolved<A, R>, unsubscribe: () => void) => void,
   ): () => void;
   static subscribe<A extends Account, const R extends RefsToResolve<A>>(

--- a/packages/jazz-tools/src/coValues/coFeed.ts
+++ b/packages/jazz-tools/src/coValues/coFeed.ts
@@ -21,6 +21,7 @@ import type {
   Resolved,
   Schema,
   SchemaFor,
+  SubscribeListenerOptions,
   SubscribeRestArgs,
   UnCo,
 } from "../internal.js";
@@ -349,10 +350,7 @@ export class CoFeed<Item = any> extends CoValueBase implements CoValue {
   static subscribe<F extends CoFeed, const R extends RefsToResolve<F> = true>(
     this: CoValueClass<F>,
     id: ID<F>,
-    options: {
-      resolve?: RefsToResolveStrict<F, R>;
-      loadAs?: Account | AnonymousJazzAgent;
-    },
+    options: SubscribeListenerOptions<F, R>,
     listener: (value: Resolved<F, R>, unsubscribe: () => void) => void,
   ): () => void;
   static subscribe<F extends CoFeed, const R extends RefsToResolve<F>>(

--- a/packages/jazz-tools/src/coValues/coList.ts
+++ b/packages/jazz-tools/src/coValues/coList.ts
@@ -11,6 +11,7 @@ import type {
   Resolved,
   Schema,
   SchemaFor,
+  SubscribeListenerOptions,
   SubscribeRestArgs,
   UnCo,
 } from "../internal.js";
@@ -410,10 +411,7 @@ export class CoList<Item = any> extends Array<Item> implements CoValue {
   static subscribe<L extends CoList, const R extends RefsToResolve<L> = true>(
     this: CoValueClass<L>,
     id: ID<L>,
-    options: {
-      resolve?: RefsToResolveStrict<L, R>;
-      loadAs?: Account | AnonymousJazzAgent;
-    },
+    options: SubscribeListenerOptions<L, R>,
     listener: (value: Resolved<L, R>, unsubscribe: () => void) => void,
   ): () => void;
   static subscribe<L extends CoList, const R extends RefsToResolve<L>>(

--- a/packages/jazz-tools/src/coValues/coMap.ts
+++ b/packages/jazz-tools/src/coValues/coMap.ts
@@ -20,6 +20,7 @@ import type {
   RefsToResolveStrict,
   Resolved,
   Schema,
+  SubscribeListenerOptions,
   SubscribeRestArgs,
   co,
 } from "../internal.js";
@@ -481,10 +482,7 @@ export class CoMap extends CoValueBase implements CoValue {
   static subscribe<M extends CoMap, const R extends RefsToResolve<M> = true>(
     this: CoValueClass<M>,
     id: ID<M>,
-    options: {
-      resolve?: RefsToResolveStrict<M, R>;
-      loadAs?: Account | AnonymousJazzAgent;
-    },
+    options: SubscribeListenerOptions<M, R>,
     listener: (value: Resolved<M, R>, unsubscribe: () => void) => void,
   ): () => void;
   static subscribe<M extends CoMap, const R extends RefsToResolve<M>>(

--- a/packages/jazz-tools/src/coValues/coPlainText.ts
+++ b/packages/jazz-tools/src/coValues/coPlainText.ts
@@ -10,6 +10,7 @@ import type {
   CoValueClass,
   ID,
   Resolved,
+  SubscribeListenerOptions,
   SubscribeRestArgs,
 } from "../internal.js";
 import {
@@ -168,7 +169,7 @@ export class CoPlainText extends String implements CoValue {
   static subscribe<T extends CoPlainText>(
     this: CoValueClass<T>,
     id: ID<T>,
-    options: { loadAs?: Account | AnonymousJazzAgent },
+    options: Omit<SubscribeListenerOptions<T, true>, "resolve">,
     listener: (value: Resolved<T, true>, unsubscribe: () => void) => void,
   ): () => void;
   static subscribe<T extends CoPlainText>(

--- a/packages/jazz-tools/src/coValues/group.ts
+++ b/packages/jazz-tools/src/coValues/group.ts
@@ -14,6 +14,7 @@ import type {
   RefsToResolveStrict,
   Resolved,
   Schema,
+  SubscribeListenerOptions,
   SubscribeRestArgs,
 } from "../internal.js";
 import {
@@ -208,7 +209,7 @@ export class Group extends CoValueBase implements CoValue {
   static subscribe<G extends Group, const R extends RefsToResolve<G>>(
     this: CoValueClass<G>,
     id: ID<G>,
-    options: { resolve?: RefsToResolveStrict<G, R>; loadAs?: Account },
+    options: SubscribeListenerOptions<G, R>,
     listener: (value: Resolved<G, R>, unsubscribe: () => void) => void,
   ): () => void;
   static subscribe<G extends Group, const R extends RefsToResolve<G>>(

--- a/packages/jazz-tools/src/tests/coMap.test.ts
+++ b/packages/jazz-tools/src/tests/coMap.test.ts
@@ -491,7 +491,7 @@ describe("CoMap resolution", async () => {
     expect(loadedMap?.nested?._refs.twiceNested?.value).toBeDefined();
   });
 
-  test("Subscription & auto-resolution", async () => {
+  async function setupTest() {
     const { me, map } = await initNodeAndMap();
 
     const [initialAsPeer, secondAsPeer] = connectedPeers("initial", "second", {
@@ -516,28 +516,53 @@ describe("CoMap resolution", async () => {
 
     const queue = new cojsonInternals.Channel<TestMap>();
 
+    await meOnSecondPeer.waitForAllCoValuesSync();
+
     TestMap.subscribe(map.id, { loadAs: meOnSecondPeer }, (subscribedMap) => {
       // Read to property to trigger loading
       subscribedMap.nested?.twiceNested?.taste;
       void queue.push(subscribedMap);
     });
 
+    return { me, map, meOnSecondPeer, queue };
+  }
+
+  test("initial subscription loads nested data progressively", async () => {
+    const { queue } = await setupTest();
+
     const update1 = (await queue.next()).value;
     expect(update1.nested).toEqual(null);
 
     const update2 = (await queue.next()).value;
     expect(update2.nested?.name).toEqual("nested");
+  });
+
+  test("updates to nested properties are received", async () => {
+    const { map, queue } = await setupTest();
+
+    // Skip initial updates
+    await queue.next();
+    await queue.next();
 
     map.nested!.name = "nestedUpdated";
 
-    const _ = (await queue.next()).value;
+    await queue.next(); // Skip intermediate update
     const update3 = (await queue.next()).value;
     expect(update3.nested?.name).toEqual("nestedUpdated");
 
     const oldTwiceNested = update3.nested!.twiceNested;
     expect(oldTwiceNested?.taste).toEqual("sour");
+  });
 
-    // When assigning a new nested value, we get an update
+  test("replacing nested object triggers updates", async () => {
+    const { meOnSecondPeer, queue } = await setupTest();
+
+    // Skip initial updates
+    await queue.next();
+    await queue.next();
+
+    const update3 = (await queue.next()).value;
+
     const newTwiceNested = TwiceNestedMap.create(
       {
         taste: "sweet",
@@ -555,14 +580,40 @@ describe("CoMap resolution", async () => {
 
     update3.nested = newNested;
 
-    (await queue.next()).value;
-    // const update4 = (await queue.next()).value;
-    const update4b = (await queue.next()).value;
+    await queue.next(); // Skip intermediate update
+    const update4 = (await queue.next()).value;
 
-    expect(update4b.nested?.name).toEqual("newNested");
-    expect(update4b.nested?.twiceNested?.taste).toEqual("sweet");
+    expect(update4.nested?.name).toEqual("newNested");
+    expect(update4.nested?.twiceNested?.taste).toEqual("sweet");
+  });
 
-    // we get updates when the new nested value changes
+  test("updates to deeply nested properties are received", async () => {
+    const { queue } = await setupTest();
+
+    // Skip to the point where we have the nested object
+    await queue.next();
+    await queue.next();
+    const update3 = (await queue.next()).value;
+
+    const newTwiceNested = TwiceNestedMap.create(
+      { taste: "sweet" },
+      { owner: update3.nested!._raw.owner },
+    );
+
+    const newNested = NestedMap.create(
+      {
+        name: "newNested",
+        twiceNested: newTwiceNested,
+      },
+      { owner: update3.nested!._raw.owner },
+    );
+
+    update3.nested = newNested;
+
+    // Skip intermediate updates
+    await queue.next();
+    await queue.next();
+
     newTwiceNested.taste = "salty";
     const update5 = (await queue.next()).value;
     expect(update5.nested?.twiceNested?.taste).toEqual("salty");

--- a/packages/jazz-tools/src/tests/schemaUnion.test.ts
+++ b/packages/jazz-tools/src/tests/schemaUnion.test.ts
@@ -114,7 +114,7 @@ describe("SchemaUnion", () => {
     const unsubscribe = subscribeToCoValue(
       WidgetUnion,
       buttonWidget.id,
-      { loadAs: me },
+      { loadAs: me, syncResolution: true },
       (value: BaseWidget) => {
         if (value instanceof BlueButtonWidget) {
           expect(value.label).toBe(currentValue);
@@ -122,8 +122,6 @@ describe("SchemaUnion", () => {
           throw new Error("Unexpected widget type");
         }
       },
-      () => {},
-      true,
     );
     currentValue = "Changed";
     buttonWidget.label = "Changed";

--- a/packages/jazz-vue/src/composables.ts
+++ b/packages/jazz-vue/src/composables.ts
@@ -194,14 +194,17 @@ export function useCoState<V extends CoValue, const R extends RefsToResolve<V>>(
             "me" in context.value
               ? toRaw(context.value.me)
               : toRaw(context.value.guest),
+          onUnavailable: () => {
+            state.value = null;
+          },
+          onUnauthorized: () => {
+            state.value = null;
+          },
+          syncResolution: true,
         },
         (value) => {
           state.value = value;
         },
-        () => {
-          state.value = null;
-        },
-        true,
       );
     },
     { deep: true, immediate: true },

--- a/tests/e2e/src/lib/waitForCoValue.ts
+++ b/tests/e2e/src/lib/waitForCoValue.ts
@@ -17,20 +17,26 @@ export function waitForCoValue<
   predicate: (value: T) => boolean,
   options: { loadAs: Account; resolve?: RefsToResolveStrict<T, R> },
 ) {
-  return new Promise<T>((resolve) => {
+  return new Promise<T>((resolve, reject) => {
     function subscribe() {
       subscribeToCoValue(
         coMap,
         valueId,
-        options,
+        {
+          loadAs: options.loadAs,
+          resolve: options.resolve,
+          onUnavailable: () => {
+            setTimeout(subscribe, 100);
+          },
+          onUnauthorized: () => {
+            reject(new Error("Unauthorized"));
+          },
+        },
         (value, unsubscribe) => {
           if (predicate(value)) {
             resolve(value);
             unsubscribe();
           }
-        },
-        () => {
-          setTimeout(subscribe, 100);
         },
       );
     }


### PR DESCRIPTION
Changes:
- Consider "everyone" role when computing "roleOf". This is helpful especially when the role is inherited
- Add an onUnauthorized callback to subscribeToCoValue
- Add permissions checks on fulfillDepth
- Update useCoState to return null when the current account lacks access rights
- Return undefined on the load APIs when the current account lacks access rights