### PR TITLE
Jazz 675 explicitly assigning undefined to a cooptionaldate on create

### DIFF
--- a/.changeset/clean-flies-sell.md
+++ b/.changeset/clean-flies-sell.md
@@ -1,0 +1,5 @@
+---
+"jazz-tools": patch
+---
+
+Fixes co.optional.Date throwing when assigned undefined

--- a/packages/jazz-tools/src/implementation/schema.ts
+++ b/packages/jazz-tools/src/implementation/schema.ts
@@ -14,6 +14,10 @@ import {
 /** @category Schema definition */
 export const Encoders = {
   Date: {
+    encode: (value: Date) => value.toISOString(),
+    decode: (value: JsonValue) => new Date(value as string),
+  },
+  OptionalDate: {
     encode: (value: Date | undefined) => value?.toISOString() || null,
     decode: (value: JsonValue) =>
       value === null ? undefined : new Date(value as string),
@@ -55,7 +59,7 @@ const optional = {
     [SchemaInit]: "json" satisfies Schema,
   } as unknown as co<null | undefined>,
   Date: {
-    [SchemaInit]: { encoded: Encoders.Date } satisfies Schema,
+    [SchemaInit]: { encoded: Encoders.OptionalDate } satisfies Schema,
   } as unknown as co<Date | undefined>,
   literal<T extends (string | number | boolean)[]>(
     ..._lit: T

--- a/packages/jazz-tools/src/implementation/schema.ts
+++ b/packages/jazz-tools/src/implementation/schema.ts
@@ -14,8 +14,9 @@ import {
 /** @category Schema definition */
 export const Encoders = {
   Date: {
-    encode: (value: Date) => value.toISOString(),
-    decode: (value: JsonValue) => new Date(value as string),
+    encode: (value: Date | undefined) => value?.toISOString() || null,
+    decode: (value: JsonValue) =>
+      value === null ? undefined : new Date(value as string),
   },
 };
 

--- a/packages/jazz-tools/src/tests/coMap.test.ts
+++ b/packages/jazz-tools/src/tests/coMap.test.ts
@@ -106,12 +106,25 @@ describe("Simple CoMap operations", async () => {
     expect(emptyMap.color).toEqual(undefined);
   });
 
+  test("setting date as undefined should throw", () => {
+    expect(() =>
+      TestMap.create(
+        {
+          color: "red",
+          _height: 10,
+          birthday: undefined!,
+        },
+        { owner: me },
+      ),
+    ).toThrow();
+  });
+
   test("setting optional date as undefined should not throw", () => {
     const map = TestMap.create(
       {
         color: "red",
         _height: 10,
-        birthday: birthday,
+        birthday,
         optionalDate: undefined,
       },
       { owner: me },

--- a/packages/jazz-tools/src/tests/coMap.test.ts
+++ b/packages/jazz-tools/src/tests/coMap.test.ts
@@ -106,7 +106,7 @@ describe("Simple CoMap operations", async () => {
     expect(emptyMap.color).toEqual(undefined);
   });
 
-  test("optional date as undefined doesn't throw", () => {
+  test("setting optional date as undefined should not throw", () => {
     const map = TestMap.create(
       {
         color: "red",

--- a/packages/jazz-tools/src/tests/coMap.test.ts
+++ b/packages/jazz-tools/src/tests/coMap.test.ts
@@ -25,7 +25,7 @@ class TestMap extends CoMap {
     encode: (value: string | undefined) => value || null,
     decode: (value: unknown) => (value as string) || undefined,
   });
-  optionalDate = co.optional.encoded(Encoders.Date);
+  optionalDate = co.optional.Date;
 
   get roughColor() {
     return this.color + "ish";
@@ -104,6 +104,19 @@ describe("Simple CoMap operations", async () => {
 
     // @ts-expect-error
     expect(emptyMap.color).toEqual(undefined);
+  });
+
+  test("optional date as undefined doesn't throw", () => {
+    const map = TestMap.create(
+      {
+        color: "red",
+        _height: 10,
+        birthday: birthday,
+        optionalDate: undefined,
+      },
+      { owner: me },
+    );
+    expect(map.optionalDate).toBeUndefined();
   });
 
   describe("Mutation", () => {


### PR DESCRIPTION
Explicitly allows assigning `undefined` to a `co.optional.Date` field on create. 