### PR TITLE
tony/fix-contributing-md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -48,7 +48,19 @@ You'll need Node.js 20.x or 22.x installed (we're working on support for 23.x), 
    pnpm install
    ```
 
-3. **Run tests** to verify everything is working:
+3. **Install homepage dependencies**:
+
+   ```bash
+   cd homepage && pnpm install
+   ```
+
+4. **Build the packages**:
+
+   ```bash
+   pnpm build
+   ```
+
+5. **Run tests** to verify everything is working:
    ```bash
    pnpm test
    ```


### PR DESCRIPTION
## Context
When cloning the repository, I encountered errors running tests immediately after installing dependencies. I concluded that workspace dependencies were not fully exposed, particularly those for the homepage. It appears that a pnpm configuration prevents the extraction of homepage dependencies during the initial installation.

## Update CONTRIBUTING.md
- Add an explicit step to install homepage dependencies.
- Include package build instructions before running tests.
