### PR TITLE
feat(llms-txt): add the music player example code

### DIFF
--- a/homepage/homepage/generate-docs/llms-full.mjs
+++ b/homepage/homepage/generate-docs/llms-full.mjs
@@ -1,12 +1,10 @@
 import { promises as fs } from "fs";
 import path from "path";
-import { Deserializer, ReflectionKind } from "typedoc";
-import { DOC_SECTIONS, PACKAGES } from "./utils/config.mjs";
-import {
-  getPackageDescription,
-  loadTypedocFiles,
-  writeDocsFile,
-} from "./utils/index.mjs";
+import { join } from "path";
+import { readFile, readdir } from "fs/promises";
+import { Deserializer } from "typedoc";
+import { DOC_SECTIONS } from "./utils/config.mjs";
+import { loadTypedocFiles, writeDocsFile } from "./utils/index.mjs";
 
 function formatType(type) {
   if (!type) return "unknown";
@@ -500,9 +498,90 @@ async function generateDetailedDocs(docs) {
     "- [Examples](https://jazz.tools/examples): Code examples and tutorials\n",
   );
 
-  const content = output.join("\n");
-  await writeDocsFile("llms.txt", content);
-  await writeDocsFile("llms-full.txt", content);
+  const outputWithExamples = [...output];
+  await readMusicExample(outputWithExamples);
+
+  await writeDocsFile("llms.txt", output.join("\n"));
+  await writeDocsFile("llms-full.txt", outputWithExamples.join("\n"));
+}
+
+/**
+ * @typedef {Object} FileContent
+ * @property {string} filepath - The relative path to the file
+ * @property {string} content - The content of the file
+ */
+
+/**
+ * Recursively loads all files from a directory and its subdirectories
+ * @param {string} directoryPath - The path to the directory to load
+ * @param {Object} options - Optional configuration
+ * @param {string[]} options.exclude - File patterns to exclude (e.g., ['*.md', '*.git'])
+ * @param {string} options.encoding - File encoding (default: 'utf-8')
+ * @returns {Promise<FileContent[]>} Array of filepath/content pairs
+ */
+async function loadDirectoryContent(directoryPath, options = {}) {
+  const { exclude = [], encoding = "utf-8" } = options;
+
+  async function processDirectory(currentPath) {
+    const results = [];
+
+    try {
+      const entries = await readdir(currentPath, { withFileTypes: true });
+
+      for (const entry of entries) {
+        const fullPath = join(currentPath, entry.name);
+
+        if (entry.isDirectory()) {
+          // Recursively process subdirectories
+          const subDirResults = await processDirectory(fullPath);
+          results.push(...subDirResults);
+        } else if (entry.isFile()) {
+          // Check if file should be excluded
+          const shouldExclude = exclude.some((pattern) => {
+            if (pattern.startsWith("*.")) {
+              const extension = pattern.slice(1);
+              return entry.name.endsWith(extension);
+            }
+            return entry.name === pattern;
+          });
+
+          if (!shouldExclude) {
+            try {
+              const content = await readFile(fullPath, { encoding });
+              results.push({
+                filepath: fullPath,
+                content: content,
+              });
+            } catch (error) {
+              console.error(`Error reading file ${fullPath}:`, error);
+            }
+          }
+        }
+      }
+    } catch (error) {
+      console.error(`Error reading directory ${currentPath}:`, error);
+    }
+
+    return results;
+  }
+
+  try {
+    return await processDirectory(directoryPath);
+  } catch (error) {
+    throw new Error(`Failed to load directory content: ${error.message}`);
+  }
+}
+
+async function readMusicExample(output) {
+  const files = await loadDirectoryContent(
+    path.join(process.cwd(), "../../examples/music-player/src"),
+  );
+
+  output.push("## Music Example\n\n");
+  for (const file of files) {
+    output.push(`### ${file.filepath}\n`);
+    output.push(`\`\`\`ts\n${file.content}\n\`\`\`\n`);
+  }
 }
 
 // Main execution


### PR DESCRIPTION
Over the weekend I tried to create a v0 app asking to use Jazz via the llms-txt.

The results weren't great, so I've tried adding a full example code and the results were way better.

Used the music player because it uses FileStream, it's based on React and has the structure I wanted (schema+actions+optional auth)

