### PR TITLE
fix: fixes the clerk credentials migration

### DIFF
--- a/.changeset/wet-chefs-dress.md
+++ b/.changeset/wet-chefs-dress.md
@@ -1,0 +1,5 @@
+---
+"jazz-tools": patch
+---
+
+Fix Clerk credentials migration

--- a/packages/jazz-tools/src/auth/AuthSecretStorage.ts
+++ b/packages/jazz-tools/src/auth/AuthSecretStorage.ts
@@ -28,14 +28,48 @@ export class AuthSecretStorage {
     if (!(await kvStore.get(STORAGE_KEY))) {
       const demoAuthSecret = await kvStore.get("demo-auth-logged-in-secret");
       if (demoAuthSecret) {
-        await kvStore.set(STORAGE_KEY, demoAuthSecret);
+        const parsed = JSON.parse(demoAuthSecret);
+        await kvStore.set(
+          STORAGE_KEY,
+          JSON.stringify({
+            accountID: parsed.accountID,
+            accountSecret: parsed.accountSecret,
+            provider: "demo",
+          }),
+        );
         await kvStore.delete("demo-auth-logged-in-secret");
       }
 
       const clerkAuthSecret = await kvStore.get("jazz-clerk-auth");
       if (clerkAuthSecret) {
-        await kvStore.set(STORAGE_KEY, clerkAuthSecret);
+        const parsed = JSON.parse(clerkAuthSecret);
+        await kvStore.set(
+          STORAGE_KEY,
+          JSON.stringify({
+            accountID: parsed.accountID,
+            accountSecret: parsed.secret,
+            provider: "clerk",
+          }),
+        );
         await kvStore.delete("jazz-clerk-auth");
+      }
+    }
+
+    const value = await kvStore.get(STORAGE_KEY);
+
+    if (value) {
+      const parsed = JSON.parse(value);
+
+      if ("secret" in parsed) {
+        await kvStore.set(
+          STORAGE_KEY,
+          JSON.stringify({
+            accountID: parsed.accountID,
+            secretSeed: parsed.secretSeed,
+            accountSecret: parsed.secret,
+            provider: parsed.provider,
+          }),
+        );
       }
     }
   }

--- a/packages/jazz-tools/src/tests/AuthSecretStorage.test.ts
+++ b/packages/jazz-tools/src/tests/AuthSecretStorage.test.ts
@@ -28,20 +28,52 @@ describe("AuthSecretStorage", () => {
 
       await authSecretStorage.migrate();
 
-      expect(await kvStore.get("jazz-logged-in-secret")).toBe(demoSecret);
+      expect(await kvStore.get("jazz-logged-in-secret")).toBe(
+        JSON.stringify({
+          accountID: "demo123",
+          accountSecret: "secret123",
+          provider: "demo",
+        }),
+      );
       expect(await kvStore.get("demo-auth-logged-in-secret")).toBeNull();
     });
 
     it("should migrate clerk auth secret", async () => {
       const clerkSecret = JSON.stringify({
         accountID: "clerk123",
-        accountSecret: "secret123",
+        secret: "secret123",
       });
       await kvStore.set("jazz-clerk-auth", clerkSecret);
 
       await authSecretStorage.migrate();
 
-      expect(await kvStore.get("jazz-logged-in-secret")).toBe(clerkSecret);
+      expect(await kvStore.get("jazz-logged-in-secret")).toBe(
+        JSON.stringify({
+          accountID: "clerk123",
+          accountSecret: "secret123",
+          provider: "clerk",
+        }),
+      );
+      expect(await kvStore.get("jazz-clerk-auth")).toBeNull();
+    });
+
+    it("should migrate auth wrong secret key to accountSecret", async () => {
+      const clerkSecret = JSON.stringify({
+        accountID: "clerk123",
+        secret: "secret123",
+        provider: "clerk",
+      });
+      await kvStore.set("jazz-logged-in-secret", clerkSecret);
+
+      await authSecretStorage.migrate();
+
+      expect(await kvStore.get("jazz-logged-in-secret")).toBe(
+        JSON.stringify({
+          accountID: "clerk123",
+          accountSecret: "secret123",
+          provider: "clerk",
+        }),
+      );
       expect(await kvStore.get("jazz-clerk-auth")).toBeNull();
     });
   });


### PR DESCRIPTION
Fixing the credentials migration for Clerk, which was using the `secret` attribute instead of `accountSecret` 