### PR TITLE
feat: support external authenticators on passkey authentication

### DIFF
--- a/.changeset/poor-bats-applaud.md
+++ b/.changeset/poor-bats-applaud.md
@@ -1,0 +1,5 @@
+---
+"jazz-browser": patch
+---
+
+Support external authenticators on passkey auth

--- a/packages/jazz-browser/src/auth/PasskeyAuth.ts
+++ b/packages/jazz-browser/src/auth/PasskeyAuth.ts
@@ -128,11 +128,17 @@ export class BrowserPasskeyAuth {
             name: username + ` (${new Date().toLocaleString()})`,
             displayName: username,
           },
-          pubKeyCredParams: [{ alg: -7, type: "public-key" }],
+          pubKeyCredParams: [
+            { alg: -7, type: "public-key" },
+            { alg: -8, type: "public-key" },
+            { alg: -37, type: "public-key" },
+            { alg: -257, type: "public-key" },
+          ],
           authenticatorSelection: {
-            authenticatorAttachment: "platform",
+            authenticatorAttachment: "cross-platform",
             requireResidentKey: true,
             residentKey: "required",
+            userVerification: "preferred",
           },
           timeout: 60000,
           attestation: "direct",
@@ -151,7 +157,9 @@ export class BrowserPasskeyAuth {
           rpId: this.appHostname,
           allowCredentials: [],
           timeout: 60000,
+          userVerification: "preferred",
         },
+        mediation: "optional",
       });
 
       return value as


### PR DESCRIPTION
Tested with a Yubikey on Safari, Chrome and Firefox on MacOS.

I have two Yubikeys (a 7 years old Yubikey 4 and a 6 years old Yubikey 5 NFC)

Got it working only on the Yubikey 5 NFC, but I think it's good enough 😄 