### PR TITLE
Fix monospace font in safari

### DIFF
--- a/homepage/design-system/tailwind.config.js
+++ b/homepage/design-system/tailwind.config.js
@@ -136,6 +136,7 @@ const config = {
               padding: "0.15rem 0.25rem",
               borderRadius: "2px",
               whiteSpace: "nowrap",
+              fontWeight: 400,
             },
             p: {
               marginBottom: theme("spacing.3"),


### PR DESCRIPTION
before
<img width="471" alt="image" src="https://github.com/user-attachments/assets/831e9839-06dc-4a43-bcc4-48398111d49a" />

after
<img width="563" alt="image" src="https://github.com/user-attachments/assets/85c3d9d8-6187-48b9-aae9-071fac752c78" />
