### PR TITLE
feat: return inherited members and add getRoleOf and hasPermissions methods to Group

### DIFF
--- a/.changeset/cuddly-paws-kiss.md
+++ b/.changeset/cuddly-paws-kiss.md
@@ -1,0 +1,6 @@
+---
+"cojson": patch
+---
+
+Added getAllMemberKeysSet method on RawGroup
+Add everyone to the possible inputs of Group.roleOf

--- a/.changeset/eight-dingos-retire.md
+++ b/.changeset/eight-dingos-retire.md
@@ -1,0 +1,6 @@
+---
+"jazz-tools": minor
+---
+
+Make members return inherited members
+Added hasPermissions and getRoleOf methods to Account and Group

--- a/packages/cojson/src/coValues/group.ts
+++ b/packages/cojson/src/coValues/group.ts
@@ -77,7 +77,7 @@ export class RawGroup<
    *
    * @category 1. Role reading
    */
-  roleOf(accountID: RawAccountID): Role | undefined {
+  roleOf(accountID: RawAccountID | typeof EVERYONE): Role | undefined {
     return this.roleOfInternal(accountID)?.role;
   }
 
@@ -385,6 +385,18 @@ export class RawGroup<
     return this.keys().filter((key): key is RawAccountID | AgentID => {
       return key.startsWith("co_") || isAgentID(key);
     });
+  }
+
+  getAllMemberKeysSet() {
+    const memberKeys = new Set(this.getMemberKeys());
+
+    for (const { group } of this.getParentGroups()) {
+      for (const key of group.getAllMemberKeysSet()) {
+        memberKeys.add(key);
+      }
+    }
+
+    return memberKeys;
   }
 
   /** @internal */

--- a/packages/jazz-tools/src/coValues/account.ts
+++ b/packages/jazz-tools/src/coValues/account.ts
@@ -1,7 +1,9 @@
 import {
+  AccountRole,
   AgentSecret,
   CoID,
   CryptoProvider,
+  Everyone,
   InviteSecret,
   LocalNode,
   Peer,
@@ -166,6 +168,30 @@ export class Account extends CoValueBase implements CoValue {
     if (this.isLocalNodeOwner) {
       return "admin";
     }
+  }
+
+  getRoleOf(member: Everyone | ID<Account> | "me") {
+    if (member === "me") {
+      return this.isMe ? "admin" : undefined;
+    }
+
+    if (member === this.id) {
+      return "admin";
+    }
+
+    return undefined;
+  }
+
+  get members() {
+    return [{ id: this.id, role: "admin", account: this }];
+  }
+
+  hasPermissions(
+    member: Everyone | ID<Account> | "me",
+    permissions: AccountRole,
+  ) {
+    permissions;
+    return this.getRoleOf(member) === "admin";
   }
 
   async acceptInvite<V extends CoValue>(


### PR DESCRIPTION
Breaking Changes: 
- `members` getter now returns inherited members from parent groups (previously only returned direct members)

Added two new methods:
- `getRoleOf(member)`: Gets role for an account, "everyone", or "me" (current user)  
- `hasPermissions(member, permissions)`: Checks if member has specific permissions, following hierarchy (admin > writer > reader/writeOnly)

To make it possible to access this methods through the `._owner` attribute I've also added these methods to Account.