### PR TITLE
[jazz-react-native] override Context#getKvStore to actually use the declared kvStore in the provider

### DIFF
--- a/.changeset/witty-points-shop.md
+++ b/.changeset/witty-points-shop.md
@@ -1,0 +1,5 @@
+---
+"jazz-react-native": patch
+---
+
+read provided kvStore instead of falling back to the default in-memory store

--- a/packages/jazz-react-native/src/ReactNativeContextManager.ts
+++ b/packages/jazz-react-native/src/ReactNativeContextManager.ts
@@ -11,6 +11,7 @@ import {
   createJazzReactNativeContext,
   createJazzReactNativeGuestContext,
 } from "./platform.js";
+import { KvStoreContext } from "./storage/kv-store-context.js";
 
 export type JazzContextManagerProps<Acc extends Account> = {
   guestMode?: boolean;
@@ -57,6 +58,10 @@ export class ReactNativeContextManager<
     }
 
     await this.updateContext(props, currentContext, authProps);
+  }
+
+  getKvStore(): KvStore {
+    return KvStoreContext.getInstance().getStorage();
   }
 
   propsChanged(props: JazzContextManagerProps<Acc>) {


### PR DESCRIPTION
jazz-react-native doesn't store auth credentials in the kvStore provided.
This PR makes sure that the context is using the right kv store (instead of in-memory store by default).
