### PR TITLE
fix: allow profile migrations, enforce profile ownership

### DIFF
--- a/.changeset/gorgeous-dragons-hug.md
+++ b/.changeset/gorgeous-dragons-hug.md
@@ -1,0 +1,5 @@
+---
+"cojson": minor
+---
+
+Fix roleOf resolution for "everyone"

--- a/.changeset/three-cycles-rush.md
+++ b/.changeset/three-cycles-rush.md
@@ -1,0 +1,5 @@
+---
+"jazz-tools": minor
+---
+
+Fix profile migrations

--- a/packages/cojson/src/coValues/group.ts
+++ b/packages/cojson/src/coValues/group.ts
@@ -114,6 +114,12 @@ export class RawGroup<
       }
     }
 
+    if (!roleInfo && accountID !== "everyone") {
+      const everyoneRole = this.get("everyone");
+
+      if (everyoneRole) return { role: everyoneRole, via: undefined };
+    }
+
     return roleInfo;
   }
 

--- a/packages/cojson/src/coValues/group.ts
+++ b/packages/cojson/src/coValues/group.ts
@@ -85,10 +85,10 @@ export class RawGroup<
   roleOfInternal(
     accountID: RawAccountID | AgentID | typeof EVERYONE,
   ): { role: Role; via: CoID<RawGroup> | undefined } | undefined {
-    const roleHere = this.get(accountID);
+    let roleHere = this.get(accountID);
 
     if (roleHere === "revoked") {
-      return undefined;
+      roleHere = undefined;
     }
 
     let roleInfo:

--- a/packages/cojson/src/permissions.ts
+++ b/packages/cojson/src/permissions.ts
@@ -101,8 +101,7 @@ export function determineValidTransactions(
         }
 
         const transactorRoleAtTxTime =
-          groupAtTime.roleOfInternal(effectiveTransactor)?.role ||
-          groupAtTime.roleOfInternal(EVERYONE)?.role;
+          groupAtTime.roleOfInternal(effectiveTransactor)?.role;
 
         if (
           transactorRoleAtTxTime !== "admin" &&
@@ -135,8 +134,8 @@ export function determineValidTransactions(
 }
 
 function isHigherRole(a: Role, b: Role | undefined) {
-  if (a === undefined) return false;
-  if (b === undefined) return true;
+  if (a === undefined || a === "revoked") return false;
+  if (b === undefined || b === "revoked") return true;
   if (b === "admin") return false;
   if (a === "admin") return true;
 

--- a/packages/cojson/src/tests/group.test.ts
+++ b/packages/cojson/src/tests/group.test.ts
@@ -842,3 +842,110 @@ describe("extend with role mapping", () => {
     expect(mapOnNode2.get("test")).toEqual("Written from the admin");
   });
 });
+test("roleOf should prioritize explicit account role over everyone role in same group", async () => {
+  const { node1, node2 } = await createTwoConnectedNodes("server", "server");
+
+  const group = node1.node.createGroup();
+  const account2 = await loadCoValueOrFail(node1.node, node2.accountID);
+
+  // Add both everyone and specific account
+  group.addMember("everyone", "reader");
+  group.addMember(account2, "writer");
+
+  // Should return the explicit role, not everyone's role
+  expect(group.roleOf(node2.accountID)).toEqual("writer");
+
+  // Change everyone's role
+  group.addMember("everyone", "writer");
+
+  // Should still return the explicit role
+  expect(group.roleOf(node2.accountID)).toEqual("writer");
+});
+
+test("roleOf should prioritize inherited everyone role over explicit account role", async () => {
+  const { node1, node2 } = await createTwoConnectedNodes("server", "server");
+
+  const parentGroup = node1.node.createGroup();
+  const childGroup = node1.node.createGroup();
+  const account2 = await loadCoValueOrFail(node1.node, node2.accountID);
+
+  // Set up inheritance
+  childGroup.extend(parentGroup);
+
+  // Add everyone to parent and account to child
+  parentGroup.addMember("everyone", "writer");
+  childGroup.addMember(account2, "reader");
+
+  // Should return the explicit role from child, not inherited everyone role
+  expect(childGroup.roleOf(node2.accountID)).toEqual("writer");
+});
+
+test("roleOf should use everyone role when no explicit role exists", async () => {
+  const { node1, node2 } = await createTwoConnectedNodes("server", "server");
+
+  const group = node1.node.createGroup();
+
+  // Add only everyone role
+  group.addMember("everyone", "reader");
+
+  // Should return everyone's role when no explicit role exists
+  expect(group.roleOf(node2.accountID)).toEqual("reader");
+});
+
+test("roleOf should inherit everyone role from parent when no explicit roles exist", async () => {
+  const { node1, node2 } = await createTwoConnectedNodes("server", "server");
+
+  const parentGroup = node1.node.createGroup();
+  const childGroup = node1.node.createGroup();
+
+  // Set up inheritance
+  childGroup.extend(parentGroup);
+
+  // Add everyone to parent only
+  parentGroup.addMember("everyone", "reader");
+
+  // Should inherit everyone's role from parent
+  expect(childGroup.roleOf(node2.accountID)).toEqual("reader");
+});
+
+test("roleOf should handle everyone role inheritance through multiple levels", async () => {
+  const { node1, node2 } = await createTwoConnectedNodes("server", "server");
+
+  const grandParentGroup = node1.node.createGroup();
+  const parentGroup = node1.node.createGroup();
+  const childGroup = node1.node.createGroup();
+
+  const childGroupOnNode2 = await loadCoValueOrFail(node2.node, childGroup.id);
+
+  const account2 = await loadCoValueOrFail(node1.node, node2.accountID);
+
+  // Set up inheritance chain
+  parentGroup.extend(grandParentGroup);
+  childGroup.extend(parentGroup);
+
+  // Add everyone to grandparent
+  grandParentGroup.addMember("everyone", "writer");
+
+  // Should inherit everyone's role from grandparent
+  expect(childGroup.roleOf(node2.accountID)).toEqual("writer");
+
+  // Add explicit role in parent
+  parentGroup.addMember(account2, "reader");
+
+  // Should use parent's explicit role instead of grandparent's everyone role
+  expect(childGroup.roleOf(node2.accountID)).toEqual("writer");
+
+  // Add explicit role in child
+  childGroup.addMember(account2, "admin");
+  await childGroup.core.waitForSync();
+
+  // Should use child's explicit role
+  expect(childGroup.roleOf(node2.accountID)).toEqual("admin");
+
+  // Remove child's explicit role
+  await childGroupOnNode2.removeMember(account2);
+  await childGroupOnNode2.core.waitForSync();
+
+  // access should be revoked
+  expect(childGroup.roleOf(node2.accountID)).toEqual(undefined);
+});

--- a/packages/cojson/src/tests/group.test.ts
+++ b/packages/cojson/src/tests/group.test.ts
@@ -946,6 +946,13 @@ test("roleOf should handle everyone role inheritance through multiple levels", a
   await childGroupOnNode2.removeMember(account2);
   await childGroupOnNode2.core.waitForSync();
 
-  // access should be revoked
-  expect(childGroup.roleOf(node2.accountID)).toEqual(undefined);
+  // Should fall back to parent's explicit role
+  expect(childGroup.roleOf(node2.accountID)).toEqual("writer");
+
+  // Remove parent's explicit role
+  await parentGroup.removeMember(account2);
+  await childGroup.core.waitForSync();
+
+  // Should fall back to grandparent's everyone role
+  expect(childGroup.roleOf(node2.accountID)).toEqual("writer");
 });

--- a/packages/cojson/src/tests/testUtils.ts
+++ b/packages/cojson/src/tests/testUtils.ts
@@ -5,7 +5,7 @@ import {
   MeterProvider,
   MetricReader,
 } from "@opentelemetry/sdk-metrics";
-import { expect, vi } from "vitest";
+import { expect, onTestFinished, vi } from "vitest";
 import { ControlledAgent } from "../coValues/account.js";
 import { WasmCrypto } from "../crypto/WasmCrypto.js";
 import type { CoID, RawCoValue } from "../exports.js";
@@ -200,6 +200,9 @@ export function newGroupHighLevel() {
 
   const group = node.createGroup();
 
+  onTestFinished(() => {
+    node.gracefulShutdown();
+  });
   return { admin, node, group };
 }
 

--- a/packages/jazz-tools/src/coValues/account.ts
+++ b/packages/jazz-tools/src/coValues/account.ts
@@ -294,6 +294,12 @@ export class Account extends CoValueBase implements CoValue {
       this.profile = Profile.create({ name: creationProps.name }, profileGroup);
       this.profile._owner.addMember("everyone", "reader");
     } else if (this.profile && creationProps) {
+      if (this.profile._owner._type !== "Group") {
+        throw new Error("Profile must be owned by a Group", {
+          cause: `The profile of the account "${this.id}" was created with an Account as owner, which is not allowed.`,
+        });
+      }
+
       // We enforce the name to be set to the creationProps.name, as the user may have created the profile with a different name
       this.profile.name = creationProps.name;
 

--- a/packages/jazz-tools/src/coValues/account.ts
+++ b/packages/jazz-tools/src/coValues/account.ts
@@ -299,8 +299,6 @@ export class Account extends CoValueBase implements CoValue {
           cause: `The profile of the account "${this.id}" was created with an Account as owner, which is not allowed.`,
         });
       }
-      // We enforce the name to be set to the creationProps.name, as the user may have created the profile with a different name
-      this.profile.name = creationProps.name;
     }
 
     const node = this._raw.core.node;

--- a/packages/jazz-tools/src/coValues/account.ts
+++ b/packages/jazz-tools/src/coValues/account.ts
@@ -299,21 +299,8 @@ export class Account extends CoValueBase implements CoValue {
           cause: `The profile of the account "${this.id}" was created with an Account as owner, which is not allowed.`,
         });
       }
-
       // We enforce the name to be set to the creationProps.name, as the user may have created the profile with a different name
       this.profile.name = creationProps.name;
-
-      // by convention, the profile must be owned by a publicly readable group, in case the user
-      // created the profile themselves and has not set the owner group to be (at least) publicly readable,
-      // we add the everyone as a reader.
-      if (
-        !this.profile._owner.members.some(
-          (m) =>
-            m.id === "everyone" && (m.role === "reader" || m.role === "writer"),
-        )
-      ) {
-        this.profile._owner.addMember("everyone", "reader");
-      }
     }
 
     const node = this._raw.core.node;

--- a/packages/jazz-tools/src/coValues/account.ts
+++ b/packages/jazz-tools/src/coValues/account.ts
@@ -285,13 +285,29 @@ export class Account extends CoValueBase implements CoValue {
   }
 
   async applyMigration(creationProps?: AccountCreationProps) {
-    if (creationProps) {
+    await this.migrate(creationProps);
+
+    // if the user has not defined a profile themselves, we create one
+    if (this.profile === undefined && creationProps) {
       const profileGroup = RegisteredSchemas["Group"].create({ owner: this });
-      profileGroup.addMember("everyone", "reader");
-      this.profile = Profile.create(
-        { name: creationProps.name },
-        { owner: profileGroup },
-      );
+
+      this.profile = Profile.create({ name: creationProps.name }, profileGroup);
+      this.profile._owner.addMember("everyone", "reader");
+    } else if (this.profile && creationProps) {
+      // We enforce the name to be set to the creationProps.name, as the user may have created the profile with a different name
+      this.profile.name = creationProps.name;
+
+      // by convention, the profile must be owned by a publicly readable group, in case the user
+      // created the profile themselves and has not set the owner group to be (at least) publicly readable,
+      // we add the everyone as a reader.
+      if (
+        !this.profile._owner.members.some(
+          (m) =>
+            m.id === "everyone" && (m.role === "reader" || m.role === "writer"),
+        )
+      ) {
+        this.profile._owner.addMember("everyone", "reader");
+      }
     }
 
     const node = this._raw.core.node;
@@ -304,8 +320,6 @@ export class Account extends CoValueBase implements CoValue {
       profile.set("inbox", inboxRoot.id);
       profile.set("inboxInvite", inboxRoot.inviteLink);
     }
-
-    await this.migrate(creationProps);
   }
 
   // Placeholder method for subclasses to override

--- a/packages/jazz-tools/src/coValues/inbox.ts
+++ b/packages/jazz-tools/src/coValues/inbox.ts
@@ -332,6 +332,16 @@ export class InboxSender<I extends CoValue, O extends CoValue | undefined> {
       throw new Error("Failed to load the inbox owner profile");
     }
 
+    if (
+      inboxOwnerProfileRaw.group.myRole() !== "reader" &&
+      inboxOwnerProfileRaw.group.myRole() !== "writer" &&
+      inboxOwnerProfileRaw.group.myRole() !== "admin"
+    ) {
+      throw new Error(
+        "Insufficient permissions to access the inbox, make sure its user profile is publicly readable.",
+      );
+    }
+
     const inboxInvite = inboxOwnerProfileRaw.get("inboxInvite");
 
     if (!inboxInvite) {

--- a/packages/jazz-tools/src/coValues/inbox.ts
+++ b/packages/jazz-tools/src/coValues/inbox.ts
@@ -333,9 +333,9 @@ export class InboxSender<I extends CoValue, O extends CoValue | undefined> {
     }
 
     if (
-      inboxOwnerProfileRaw.group.myRole() !== "reader" &&
-      inboxOwnerProfileRaw.group.myRole() !== "writer" &&
-      inboxOwnerProfileRaw.group.myRole() !== "admin"
+      inboxOwnerProfileRaw.group.roleOf(currentAccount._raw.id) !== "reader" &&
+      inboxOwnerProfileRaw.group.roleOf(currentAccount._raw.id) !== "writer" &&
+      inboxOwnerProfileRaw.group.roleOf(currentAccount._raw.id) !== "admin"
     ) {
       throw new Error(
         "Insufficient permissions to access the inbox, make sure its user profile is publicly readable.",

--- a/packages/jazz-tools/src/coValues/profile.ts
+++ b/packages/jazz-tools/src/coValues/profile.ts
@@ -1,6 +1,8 @@
 import { CoID } from "cojson";
-import { co } from "../internal.js";
-import { CoMap } from "./coMap.js";
+import { CoValueClass, co } from "../internal.js";
+import { Account } from "./account.js";
+import { CoMap, CoMapInit, Simplify } from "./coMap.js";
+import { Group } from "./group.js";
 import { InboxInvite, InboxRoot } from "./inbox.js";
 
 /** @category Identity & Permissions */
@@ -8,4 +10,35 @@ export class Profile extends CoMap {
   name = co.string;
   inbox = co.optional.json<CoID<InboxRoot>>();
   inboxInvite = co.optional.json<InboxInvite>();
+
+  override get _owner(): Group {
+    return super._owner as Group;
+  }
+
+  /**
+   * Creates a new profile with the given initial values and owner.
+   *
+   * The owner (a Group) determines access rights to the Profile.
+   *
+   * @category Creation
+   */
+  static override create<M extends CoMap>(
+    this: CoValueClass<M>,
+    init: Simplify<CoMapInit<M>>,
+    options?:
+      | {
+          owner: Group;
+        }
+      | Group,
+  ) {
+    const owner =
+      options !== undefined && "owner" in options ? options.owner : options;
+
+    // We add some guardrails to ensure that the owner of a profile is a group
+    if ((owner as Group | Account | undefined)?._type === "Account") {
+      throw new Error("Profiles should be owned by a group");
+    }
+
+    return super.create<M>(init, options);
+  }
 }

--- a/packages/jazz-tools/src/tests/deepLoading.test.ts
+++ b/packages/jazz-tools/src/tests/deepLoading.test.ts
@@ -187,13 +187,10 @@ class CustomAccount extends Account {
     creationProps?: { name: string } | undefined,
   ) {
     if (creationProps) {
-      this.profile = CustomProfile.create(
-        {
-          name: creationProps.name,
-          stream: TestStream.create([], { owner: this }),
-        },
-        { owner: this },
-      );
+      this.profile = CustomProfile.create({
+        name: creationProps.name,
+        stream: TestStream.create([], { owner: this }),
+      });
       this.root = TestMap.create(
         { list: TestList.create([], { owner: this }) },
         { owner: this },

--- a/packages/jazz-tools/src/tests/deepLoading.test.ts
+++ b/packages/jazz-tools/src/tests/deepLoading.test.ts
@@ -6,6 +6,7 @@ import {
   CoFeed,
   CoList,
   CoMap,
+  Group,
   ID,
   Profile,
   SessionID,
@@ -187,14 +188,15 @@ class CustomAccount extends Account {
     creationProps?: { name: string } | undefined,
   ) {
     if (creationProps) {
-      this.profile = CustomProfile.create({
-        name: creationProps.name,
-        stream: TestStream.create([], { owner: this }),
-      });
-      this.root = TestMap.create(
-        { list: TestList.create([], { owner: this }) },
-        { owner: this },
+      const profileGroup = Group.create(this);
+      this.profile = CustomProfile.create(
+        {
+          name: creationProps.name,
+          stream: TestStream.create([], this),
+        },
+        profileGroup,
       );
+      this.root = TestMap.create({ list: TestList.create([], this) }, this);
     }
 
     const thisLoaded = await this.ensureLoaded({
@@ -309,18 +311,10 @@ test("doesn't break on Map.Record key deletion when the key is referenced in the
 
   class JazzySnapStore extends CoMap.Record(co.ref(JazzProfile)) {}
 
-  const me = await Account.create({
-    creationProps: { name: "Tester McTesterson" },
-    crypto: Crypto,
+  const snapStore = JazzySnapStore.create({
+    profile1: JazzProfile.create({ firstName: "John" }),
+    profile2: JazzProfile.create({ firstName: "John" }),
   });
-
-  const snapStore = JazzySnapStore.create(
-    {
-      profile1: JazzProfile.create({ firstName: "John" }, { owner: me }),
-      profile2: JazzProfile.create({ firstName: "John" }, { owner: me }),
-    },
-    { owner: me },
-  );
 
   const spy = vi.fn();
   const unsub = snapStore.subscribe({ profile1: {}, profile2: {} }, spy);

--- a/packages/jazz-tools/src/tests/groupsAndAccounts.test.ts
+++ b/packages/jazz-tools/src/tests/groupsAndAccounts.test.ts
@@ -114,28 +114,6 @@ describe("Custom accounts and groups", async () => {
       }),
     ).rejects.toThrowError("Profiles should be owned by a group");
   });
-
-  test("Should enforce 'name' to be set to the creationProps.name if it exists", async () => {
-    class CustomAccount extends Account {
-      migrate(this: CustomAccount, creationProps?: { name: string }) {
-        if (creationProps) {
-          const profileGroup = Group.create({ owner: this });
-
-          this.profile = Profile.create(
-            { name: "Stephen Hawking" },
-            profileGroup,
-          );
-        }
-      }
-    }
-
-    const me = await CustomAccount.create({
-      creationProps: { name: "Hermes Puggington" },
-      crypto: Crypto,
-    });
-
-    expect(me.profile?.name).toBe("Hermes Puggington");
-  });
 });
 
 describe("Group inheritance", () => {

--- a/packages/jazz-tools/src/tests/groupsAndAccounts.test.ts
+++ b/packages/jazz-tools/src/tests/groupsAndAccounts.test.ts
@@ -14,38 +14,37 @@ beforeEach(async () => {
 });
 
 describe("Custom accounts and groups", async () => {
-  class CustomProfile extends Profile {
-    name = co.string;
-    color = co.string;
-  }
+  test("Custom account and group", async () => {
+    class CustomProfile extends Profile {
+      name = co.string;
+      color = co.string;
+    }
 
-  class CustomAccount extends Account {
-    profile = co.ref(CustomProfile);
-    root = co.ref(CoMap);
+    class CustomAccount extends Account {
+      profile = co.ref(CustomProfile);
+      root = co.ref(CoMap);
 
-    migrate(this: CustomAccount, creationProps?: { name: string }) {
-      if (creationProps) {
-        const profileGroup = Group.create({ owner: this });
-        profileGroup.addMember("everyone", "reader");
-        this.profile = CustomProfile.create(
-          { name: creationProps.name, color: "blue" },
-          { owner: this },
-        );
+      migrate(this: CustomAccount, creationProps?: { name: string }) {
+        if (creationProps) {
+          const profileGroup = Group.create({ owner: this });
+          profileGroup.addMember("everyone", "reader");
+          this.profile = CustomProfile.create(
+            { name: creationProps.name, color: "blue" },
+            profileGroup,
+          );
+        }
       }
     }
-  }
 
-  class CustomGroup extends Group {
-    profile = co.null;
-    root = co.null;
-    [co.members] = co.ref(CustomAccount);
+    class CustomGroup extends Group {
+      profile = co.null;
+      root = co.null;
+      [co.members] = co.ref(CustomAccount);
 
-    get nMembers() {
-      return this.members.length;
+      get nMembers() {
+        return this.members.length;
+      }
     }
-  }
-
-  test("Custom account and group", async () => {
     const me = await CustomAccount.create({
       creationProps: { name: "Hermes Puggington" },
       crypto: Crypto,
@@ -55,7 +54,7 @@ describe("Custom accounts and groups", async () => {
     expect(me.profile?.name).toBe("Hermes Puggington");
     expect(me.profile?.color).toBe("blue");
 
-    const group = new CustomGroup({ owner: me });
+    const group = CustomGroup.create({ owner: me });
     group.addMember("everyone", "reader");
 
     expect(group.members).toMatchObject([
@@ -93,6 +92,74 @@ describe("Custom accounts and groups", async () => {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     expect((map._owner as any).nMembers).toBeUndefined();
     expect(map._owner.castAs(CustomGroup).nMembers).toBe(2);
+  });
+
+  test("Should throw when creating a profile with an account as owner", async () => {
+    class CustomAccount extends Account {
+      migrate(this: CustomAccount, creationProps?: { name: string }) {
+        if (creationProps) {
+          this.profile = Profile.create(
+            { name: creationProps.name },
+            // @ts-expect-error - only groups can own profiles, but we want to also perform a runtime check
+            this,
+          );
+        }
+      }
+    }
+
+    expect(() =>
+      CustomAccount.create({
+        creationProps: { name: "Hermes Puggington" },
+        crypto: Crypto,
+      }),
+    ).rejects.toThrowError("Profiles should be owned by a group");
+  });
+
+  test("Should enforce 'everyone' to be reader of profile groups", async () => {
+    class CustomAccount extends Account {
+      migrate(this: CustomAccount, creationProps?: { name: string }) {
+        if (creationProps) {
+          const profileGroup = Group.create({ owner: this });
+
+          this.profile = Profile.create(
+            { name: creationProps.name },
+            profileGroup,
+          );
+        }
+      }
+    }
+
+    const me = await CustomAccount.create({
+      creationProps: { name: "Hermes Puggington" },
+      crypto: Crypto,
+    });
+
+    expect(me.profile?._owner.members).toContainEqual({
+      id: "everyone",
+      role: "reader",
+    });
+  });
+
+  test("Should enforce 'name' to be set to the creationProps.name if it exists", async () => {
+    class CustomAccount extends Account {
+      migrate(this: CustomAccount, creationProps?: { name: string }) {
+        if (creationProps) {
+          const profileGroup = Group.create({ owner: this });
+
+          this.profile = Profile.create(
+            { name: "Stephen Hawking" },
+            profileGroup,
+          );
+        }
+      }
+    }
+
+    const me = await CustomAccount.create({
+      creationProps: { name: "Hermes Puggington" },
+      crypto: Crypto,
+    });
+
+    expect(me.profile?.name).toBe("Hermes Puggington");
   });
 });
 

--- a/packages/jazz-tools/src/tests/groupsAndAccounts.test.ts
+++ b/packages/jazz-tools/src/tests/groupsAndAccounts.test.ts
@@ -115,31 +115,6 @@ describe("Custom accounts and groups", async () => {
     ).rejects.toThrowError("Profiles should be owned by a group");
   });
 
-  test("Should enforce 'everyone' to be reader of profile groups", async () => {
-    class CustomAccount extends Account {
-      migrate(this: CustomAccount, creationProps?: { name: string }) {
-        if (creationProps) {
-          const profileGroup = Group.create({ owner: this });
-
-          this.profile = Profile.create(
-            { name: creationProps.name },
-            profileGroup,
-          );
-        }
-      }
-    }
-
-    const me = await CustomAccount.create({
-      creationProps: { name: "Hermes Puggington" },
-      crypto: Crypto,
-    });
-
-    expect(me.profile?._owner.members).toContainEqual({
-      id: "everyone",
-      role: "reader",
-    });
-  });
-
   test("Should enforce 'name' to be set to the creationProps.name if it exists", async () => {
     class CustomAccount extends Account {
       migrate(this: CustomAccount, creationProps?: { name: string }) {

--- a/packages/jazz-tools/src/tests/inbox.test.ts
+++ b/packages/jazz-tools/src/tests/inbox.test.ts
@@ -1,7 +1,9 @@
 import { describe, expect, it } from "vitest";
+import { Account } from "../coValues/account";
 import { CoMap } from "../coValues/coMap";
 import { Group } from "../coValues/group";
 import { Inbox, InboxSender } from "../coValues/inbox";
+import { Profile } from "../exports";
 import { co } from "../internal";
 import { setupTwoNodes, waitFor } from "./utils";
 
@@ -10,6 +12,28 @@ class Message extends CoMap {
 }
 
 describe("Inbox", () => {
+  describe("Private profile", () => {
+    it("Should throw if the inbox owner profile is private", async () => {
+      class WorkerAccount extends Account {
+        migrate() {
+          this.profile = Profile.create(
+            { name: "Worker" },
+            Group.create({ owner: this }),
+          );
+        }
+      }
+
+      const { clientAccount: sender, serverAccount: receiver } =
+        await setupTwoNodes({
+          serverAccountClass: WorkerAccount,
+        });
+
+      await expect(() => InboxSender.load(receiver.id, sender)).rejects.toThrow(
+        "Insufficient permissions to access the inbox, make sure its user profile is publicly readable.",
+      );
+    });
+  });
+
   it("should create inbox and allow message exchange between accounts", async () => {
     const { clientAccount: sender, serverAccount: receiver } =
       await setupTwoNodes();

--- a/packages/jazz-tools/src/tests/inbox.test.ts
+++ b/packages/jazz-tools/src/tests/inbox.test.ts
@@ -25,7 +25,7 @@ describe("Inbox", () => {
 
       const { clientAccount: sender, serverAccount: receiver } =
         await setupTwoNodes({
-          serverAccountClass: WorkerAccount,
+          ServerAccountSchema: WorkerAccount,
         });
 
       await expect(() => InboxSender.load(receiver.id, sender)).rejects.toThrow(

--- a/packages/jazz-tools/src/tests/utils.ts
+++ b/packages/jazz-tools/src/tests/utils.ts
@@ -44,7 +44,11 @@ export async function setupAccount() {
   return { me, meOnSecondPeer };
 }
 
-export async function setupTwoNodes() {
+export async function setupTwoNodes(options?: {
+  serverAccountClass?: typeof Account;
+}) {
+  const serverAccountClass = options?.serverAccountClass || Account;
+
   const [serverAsPeer, clientAsPeer] = cojsonInternals.connectedPeers(
     "clientToServer",
     "serverToClient",
@@ -72,7 +76,7 @@ export async function setupTwoNodes() {
     crypto: Crypto,
     creationProps: { name: "Server" },
     migration: async (rawAccount, _node, creationProps) => {
-      const account = new Account({
+      const account = new serverAccountClass({
         fromRaw: rawAccount,
       });
 

--- a/packages/jazz-tools/src/tests/utils.ts
+++ b/packages/jazz-tools/src/tests/utils.ts
@@ -45,9 +45,9 @@ export async function setupAccount() {
 }
 
 export async function setupTwoNodes(options?: {
-  serverAccountClass?: typeof Account;
+  ServerAccountSchema?: typeof Account;
 }) {
-  const serverAccountClass = options?.serverAccountClass || Account;
+  const ServerAccountSchema = options?.ServerAccountSchema ?? Account;
 
   const [serverAsPeer, clientAsPeer] = cojsonInternals.connectedPeers(
     "clientToServer",
@@ -76,7 +76,7 @@ export async function setupTwoNodes(options?: {
     crypto: Crypto,
     creationProps: { name: "Server" },
     migration: async (rawAccount, _node, creationProps) => {
-      const account = new serverAccountClass({
+      const account = new ServerAccountSchema({
         fromRaw: rawAccount,
       });
 
@@ -90,7 +90,7 @@ export async function setupTwoNodes(options?: {
     clientAccount: Account.fromRaw(
       await loadCoValueOrFail(client.node, client.accountID),
     ),
-    serverAccount: Account.fromRaw(
+    serverAccount: ServerAccountSchema.fromRaw(
       await loadCoValueOrFail(server.node, server.accountID),
     ),
   };


### PR DESCRIPTION
Allows Profile migrations while enforcing profiles group ownership with (at least) public readable permissions.