### PR TITLE
fix(PasskeyAuth): set name iff username given

### DIFF
--- a/.changeset/six-lizards-sip.md
+++ b/.changeset/six-lizards-sip.md
@@ -3,4 +3,4 @@
 "form": minor
 ---
 
-Sets `profile.name` only if a non-empty username is passed to `signUp`
+PasskeyAuth: Sets `profile.name` only if a non-empty username is passed to `signUp`

--- a/.changeset/six-lizards-sip.md
+++ b/.changeset/six-lizards-sip.md
@@ -1,0 +1,6 @@
+---
+"jazz-browser": minor
+"form": minor
+---
+
+Sets `profile.name` only if a non-empty username is passed to `signUp`

--- a/packages/jazz-browser/src/auth/PasskeyAuth.ts
+++ b/packages/jazz-browser/src/auth/PasskeyAuth.ts
@@ -86,7 +86,9 @@ export class BrowserPasskeyAuth {
       profile: {},
     });
 
-    currentAccount.profile.name = username;
+    if (username.trim().length !== 0) {
+      currentAccount.profile.name = username;
+    }
 
     await this.authSecretStorage.set({
       accountID: credentials.accountID,

--- a/packages/jazz-browser/src/tests/PasskeyAuth.test.ts
+++ b/packages/jazz-browser/src/tests/PasskeyAuth.test.ts
@@ -174,5 +174,64 @@ describe("BrowserPasskeyAuth", () => {
         "Passkey creation aborted",
       );
     });
+
+    it("should leave the account profile name unchanged if username is empty", async () => {
+      const auth = new BrowserPasskeyAuth(
+        mockCrypto,
+        mockAuthenticate,
+        authSecretStorage,
+        "Test App",
+      );
+
+      mockNavigator.credentials.create.mockResolvedValue({
+        type: "public-key",
+        id: new Uint8Array([1, 2, 3, 4]),
+      });
+
+      await authSecretStorage.set({
+        accountID: "test123" as ID<Account>,
+        secretSeed: new Uint8Array([1, 2, 3]),
+        accountSecret: "mock-secret" as AgentSecret,
+        provider: "anonymous",
+      });
+
+      await auth.signUp("");
+
+      const currentAccount = await Account.getMe().ensureLoaded({
+        profile: {},
+      });
+
+      // 'Test Account' is the name provided during account creation (see: `jazz-tools/src/testing.ts`)
+      expect(currentAccount.profile.name).toEqual("Test Account");
+    });
+
+    it("should update the account profile name if username is provided", async () => {
+      const auth = new BrowserPasskeyAuth(
+        mockCrypto,
+        mockAuthenticate,
+        authSecretStorage,
+        "Test App",
+      );
+
+      mockNavigator.credentials.create.mockResolvedValue({
+        type: "public-key",
+        id: new Uint8Array([1, 2, 3, 4]),
+      });
+
+      await authSecretStorage.set({
+        accountID: "test123" as ID<Account>,
+        secretSeed: new Uint8Array([1, 2, 3]),
+        accountSecret: "mock-secret" as AgentSecret,
+        provider: "anonymous",
+      });
+
+      await auth.signUp("testuser");
+
+      const currentAccount = await Account.getMe().ensureLoaded({
+        profile: {},
+      });
+
+      expect(currentAccount.profile.name).toEqual("testuser");
+    });
   });
 });


### PR DESCRIPTION
If an empty username is passed to `signUp`, the `profile.name` of the user is not updated.

Fixes: #1433