### PR TITLE
fix: type inference on `useCoState`

### DIFF
--- a/.changeset/odd-rules-fetch.md
+++ b/.changeset/odd-rules-fetch.md
@@ -1,0 +1,8 @@
+---
+"jazz-react-core": patch
+"jazz-svelte": patch
+"jazz-tools": patch
+"jazz-vue": patch
+---
+
+Fix type inference on `useCoState`

--- a/packages/jazz-react-core/src/hooks.ts
+++ b/packages/jazz-react-core/src/hooks.ts
@@ -102,7 +102,7 @@ function useCoValueObservable<V extends CoValue, D>() {
 export function useCoState<V extends CoValue, D>(
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   Schema: CoValueClass<V>,
-  id: ID<V> | undefined,
+  id: ID<CoValue> | undefined,
   depth: D & DepthsIn<V> = [] as D & DepthsIn<V>,
 ): DeeplyLoaded<V, D> | undefined | null {
   const contextManager = useJazzContextManager();

--- a/packages/jazz-react-core/src/tests/useCoState.test.ts
+++ b/packages/jazz-react-core/src/tests/useCoState.test.ts
@@ -1,8 +1,8 @@
 // @vitest-environment happy-dom
 
 import { cojsonInternals } from "cojson";
-import { CoMap, co } from "jazz-tools";
-import { beforeEach, describe, expect, it } from "vitest";
+import { CoMap, CoValue, ID, co } from "jazz-tools";
+import { beforeEach, describe, expect, expectTypeOf, it } from "vitest";
 import { useCoState } from "../index.js";
 import { createJazzTestAccount, setupJazzTestSync } from "../testing.js";
 import { act, renderHook, waitFor } from "./testUtils.js";
@@ -156,5 +156,22 @@ describe("useCoState", () => {
     await waitFor(() => {
       expect(result.current).toBeNull();
     });
+  });
+
+  it("should return the same type as Schema", () => {
+    class TestMap extends CoMap {
+      value = co.string;
+    }
+
+    const map = TestMap.create({
+      value: "123",
+    });
+
+    const { result } = renderHook(() =>
+      useCoState(TestMap, map.id as ID<CoValue>, []),
+    );
+    expectTypeOf(result).toEqualTypeOf<{
+      current: TestMap | null | undefined;
+    }>();
   });
 });

--- a/packages/jazz-svelte/src/lib/jazz.svelte.ts
+++ b/packages/jazz-svelte/src/lib/jazz.svelte.ts
@@ -1,6 +1,4 @@
-import {
-  consumeInviteLinkFromWindowLocation
-} from 'jazz-browser';
+import { consumeInviteLinkFromWindowLocation } from 'jazz-browser';
 import type {
   AnonymousJazzAgent,
   AuthSecretStorage,
@@ -63,11 +61,9 @@ export function getAuthSecretStorage() {
 }
 
 // eslint-disable-next-line @typescript-eslint/no-empty-object-type
-export interface Register { }
+export interface Register {}
 
-export type RegisteredAccount = Register extends { Account: infer Acc }
-  ? Acc
-  : Account;
+export type RegisteredAccount = Register extends { Account: infer Acc } ? Acc : Account;
 
 export function useAccount(): { me: RegisteredAccount; logOut: () => void };
 export function useAccount<D extends DepthsIn<RegisteredAccount>>(
@@ -80,7 +76,10 @@ export function useAccount<D extends DepthsIn<RegisteredAccount>>(
  */
 export function useAccount<D extends DepthsIn<RegisteredAccount>>(
   depth?: D
-): { me: RegisteredAccount | DeeplyLoaded<RegisteredAccount, D> | undefined | null; logOut: () => void } {
+): {
+  me: RegisteredAccount | DeeplyLoaded<RegisteredAccount, D> | undefined | null;
+  logOut: () => void;
+} {
   const ctx = getJazzContext<RegisteredAccount>();
   if (!ctx?.current) {
     throw new Error('useAccount must be used within a JazzProvider');
@@ -131,7 +130,14 @@ export function useAccountOrGuest<D extends DepthsIn<RegisteredAccount>>(
  */
 export function useAccountOrGuest<D extends DepthsIn<RegisteredAccount>>(
   depth?: D
-): { me: RegisteredAccount | DeeplyLoaded<RegisteredAccount, D> | undefined | null | AnonymousJazzAgent } {
+): {
+  me:
+    | RegisteredAccount
+    | DeeplyLoaded<RegisteredAccount, D>
+    | undefined
+    | null
+    | AnonymousJazzAgent;
+} {
   const ctx = getJazzContext<RegisteredAccount>();
 
   if (!ctx?.current) {
@@ -175,7 +181,7 @@ export function useAccountOrGuest<D extends DepthsIn<RegisteredAccount>>(
  */
 export function useCoState<V extends CoValue, D extends DepthsIn<V> = []>(
   Schema: CoValueClass<V>,
-  id: ID<V> | undefined,
+  id: ID<CoValue> | undefined,
   depth: D = [] as D
 ): {
   current?: DeeplyLoaded<V, D> | null;
@@ -267,4 +273,3 @@ export function useAcceptInvite<V extends CoValue>({
     });
   });
 }
-

--- a/packages/jazz-svelte/src/lib/tests/useCoState.svelte.test.ts
+++ b/packages/jazz-svelte/src/lib/tests/useCoState.svelte.test.ts
@@ -1,8 +1,16 @@
-import { render, waitFor } from "@testing-library/svelte";
-import { Account, CoMap, co, cojsonInternals, type CoValue, type CoValueClass, type DepthsIn } from "jazz-tools";
-import { describe, expect, it } from "vitest";
-import { createJazzTestAccount, createJazzTestContext, setupJazzTestSync } from "../testing.js";
-import UseCoState from "./components/useCoState.svelte";
+import { render, waitFor } from '@testing-library/svelte';
+import {
+  Account,
+  CoMap,
+  co,
+  cojsonInternals,
+  type CoValue,
+  type CoValueClass,
+  type DepthsIn
+} from 'jazz-tools';
+import { describe, expect, it, expectTypeOf } from 'vitest';
+import { createJazzTestAccount, createJazzTestContext, setupJazzTestSync } from '../testing.js';
+import UseCoState from './components/useCoState.svelte';
 
 beforeEach(async () => {
   await setupJazzTestSync();
@@ -13,30 +21,26 @@ beforeEach(() => {
   cojsonInternals.CO_VALUE_LOADING_CONFIG.TIMEOUT = 1;
 });
 
-function setup<T extends CoValue>(options: {
-  account: Account;
-  map: T;
-  depth?: DepthsIn<T>;
-}) {
+function setup<T extends CoValue>(options: { account: Account; map: T; depth?: DepthsIn<T> }) {
   const result = { current: undefined } as { current: T | undefined };
 
-    render(UseCoState, {
-      context: createJazzTestContext({ account: options.account }),
-      props: {
-        Schema: options.map.constructor as CoValueClass<T>,
-        id: options.map.id,
-        depth: options.depth ?? [],
-        setResult: (value: T | undefined) => {
-          result.current = value
-        },
-      },
-    });
+  render(UseCoState, {
+    context: createJazzTestContext({ account: options.account }),
+    props: {
+      Schema: options.map.constructor as CoValueClass<T>,
+      id: options.map.id,
+      depth: options.depth ?? [],
+      setResult: (value: T | undefined) => {
+        result.current = value;
+      }
+    }
+  });
 
   return result;
 }
 
-describe("useCoState", () => {
-  it("should return the correct value", async () => {
+describe('useCoState', () => {
+  it('should return the correct value', async () => {
     class TestMap extends CoMap {
       value = co.string;
     }
@@ -45,20 +49,20 @@ describe("useCoState", () => {
 
     const map = TestMap.create(
       {
-        value: "123",
+        value: '123'
       },
-      { owner: account },
+      { owner: account }
     );
 
     const result = setup({
       account,
-      map,
+      map
     });
 
-    expect(result.current?.value).toBe("123");
+    expect(result.current?.value).toBe('123');
   });
 
-  it("should update the value when the coValue changes", async () => {
+  it('should update the value when the coValue changes', async () => {
     class TestMap extends CoMap {
       value = co.string;
     }
@@ -67,24 +71,24 @@ describe("useCoState", () => {
 
     const map = TestMap.create(
       {
-        value: "123",
+        value: '123'
       },
-      { owner: account },
+      { owner: account }
     );
 
     const result = setup({
       account,
-      map,
+      map
     });
 
-    expect(result.current?.value).toBe("123");
+    expect(result.current?.value).toBe('123');
 
-    map.value = "456";
+    map.value = '456';
 
-    expect(result.current?.value).toBe("456");
+    expect(result.current?.value).toBe('456');
   });
 
-  it("should load nested values if requested", async () => {
+  it('should load nested values if requested', async () => {
     class TestNestedMap extends CoMap {
       value = co.string;
     }
@@ -98,30 +102,30 @@ describe("useCoState", () => {
 
     const map = TestMap.create(
       {
-        value: "123",
+        value: '123',
         nested: TestNestedMap.create(
           {
-            value: "456",
+            value: '456'
           },
-          { owner: account },
-        ),
+          { owner: account }
+        )
       },
-      { owner: account },
+      { owner: account }
     );
-   
+
     const result = setup({
       account,
       map,
       depth: {
-        nested: {},
-      },
+        nested: {}
+      }
     });
 
-    expect(result.current?.value).toBe("123");
-    expect(result.current?.nested?.value).toBe("456");
+    expect(result.current?.value).toBe('123');
+    expect(result.current?.nested?.value).toBe('456');
   });
 
-  it("should load nested values on access even if not requested", async () => {
+  it('should load nested values on access even if not requested', async () => {
     class TestNestedMap extends CoMap {
       value = co.string;
     }
@@ -135,50 +139,52 @@ describe("useCoState", () => {
 
     const map = TestMap.create(
       {
-        value: "123",
+        value: '123',
         nested: TestNestedMap.create(
           {
-            value: "456",
+            value: '456'
           },
-          { owner: account },
-        ),
+          { owner: account }
+        )
       },
-      { owner: account },
+      { owner: account }
     );
 
     const result = setup({
       account,
       map,
       depth: {
-        nested: {},
-      },
+        nested: {}
+      }
     });
 
-    expect(result.current?.value).toBe("123");
-    expect(result.current?.nested?.value).toBe("456");
+    expect(result.current?.value).toBe('123');
+    expect(result.current?.nested?.value).toBe('456');
   });
 
-  it("should return null if the coValue is not found", async () => {
+  it('should return null if the coValue is not found', async () => {
     class TestMap extends CoMap {
       value = co.string;
     }
 
-    const unreachableAccount = await createJazzTestAccount({
-    });
+    const unreachableAccount = await createJazzTestAccount({});
 
-    const map = TestMap.create({
-      value: "123",
-    }, unreachableAccount);
+    const map = TestMap.create(
+      {
+        value: '123'
+      },
+      unreachableAccount
+    );
 
     unreachableAccount._raw.core.node.gracefulShutdown();
 
     const account = await createJazzTestAccount({
-      isCurrentActiveAccount: true,
+      isCurrentActiveAccount: true
     });
 
     const result = setup({
       account,
-      map,
+      map
     });
 
     expect(result.current).toBeUndefined();
@@ -186,5 +192,29 @@ describe("useCoState", () => {
     await waitFor(() => {
       expect(result.current).toBeNull();
     });
+  });
+
+  it('should return the same type as Schema', async () => {
+    class TestMap extends CoMap {
+      value = co.string;
+    }
+
+    const account = await createJazzTestAccount();
+
+    const map = TestMap.create(
+      {
+        value: '123'
+      },
+      { owner: account }
+    );
+
+    const result = setup({
+      account,
+      map
+    });
+
+    expectTypeOf(result).toEqualTypeOf<{
+      current: TestMap | undefined;
+    }>();
   });
 });

--- a/packages/jazz-tools/src/coValues/interfaces.ts
+++ b/packages/jazz-tools/src/coValues/interfaces.ts
@@ -157,7 +157,7 @@ export class CoValueBase implements CoValue {
 
 export function loadCoValueWithoutMe<V extends CoValue, Depth>(
   cls: CoValueClass<V>,
-  id: ID<V>,
+  id: ID<CoValue>,
   asOrDepth: Account | AnonymousJazzAgent | (Depth & DepthsIn<V>),
   depth?: Depth & DepthsIn<V>,
 ) {
@@ -175,7 +175,7 @@ export function loadCoValueWithoutMe<V extends CoValue, Depth>(
 
 export function loadCoValue<V extends CoValue, Depth>(
   cls: CoValueClass<V>,
-  id: ID<V>,
+  id: ID<CoValue>,
   as: Account | AnonymousJazzAgent,
   depth: Depth & DepthsIn<V>,
 ): Promise<DeeplyLoaded<V, Depth> | undefined> {
@@ -216,7 +216,7 @@ export async function ensureCoValueLoaded<V extends CoValue, Depth>(
 
 export function subscribeToCoValueWithoutMe<V extends CoValue, Depth>(
   cls: CoValueClass<V>,
-  id: ID<V>,
+  id: ID<CoValue>,
   asOrDepth: Account | AnonymousJazzAgent | (Depth & DepthsIn<V>),
   depthOrListener:
     | (Depth & DepthsIn<V>)
@@ -251,7 +251,7 @@ export function subscribeToCoValueWithoutMe<V extends CoValue, Depth>(
 
 export function subscribeToCoValue<V extends CoValue, Depth>(
   cls: CoValueClass<V>,
-  id: ID<V>,
+  id: ID<CoValue>,
   as: Account | AnonymousJazzAgent,
   depth: Depth & DepthsIn<V>,
   listener: (value: DeeplyLoaded<V, Depth>, unsubscribe: () => void) => void,
@@ -263,7 +263,7 @@ export function subscribeToCoValue<V extends CoValue, Depth>(
   let unsubscribed = false;
   let unsubscribe: (() => void) | undefined;
 
-  function subscribe(value: V | undefined) {
+  function subscribe(value: CoValue | undefined) {
     if (!value) {
       onUnavailable && onUnavailable();
       return;
@@ -313,7 +313,7 @@ export function createCoValueObservable<V extends CoValue, Depth>(options?: {
 
   function subscribe(
     cls: CoValueClass<V>,
-    id: ID<V>,
+    id: ID<CoValue>,
     as: Account | AnonymousJazzAgent,
     depth: Depth & DepthsIn<V>,
     listener: () => void,

--- a/packages/jazz-vue/src/composables.ts
+++ b/packages/jazz-vue/src/composables.ts
@@ -165,7 +165,7 @@ export { useAccount, useAccountOrGuest };
 
 export function useCoState<V extends CoValue, D>(
   Schema: CoValueClass<V>,
-  id: MaybeRef<ID<V> | undefined>,
+  id: MaybeRef<ID<CoValue> | undefined>,
   depth: D & DepthsIn<V> = [] as D & DepthsIn<V>,
 ): Ref<DeeplyLoaded<V, D> | undefined | null> {
   const state: ShallowRef<DeeplyLoaded<V, D> | undefined | null> =

--- a/packages/jazz-vue/src/tests/useCoState.test.ts
+++ b/packages/jazz-vue/src/tests/useCoState.test.ts
@@ -1,8 +1,9 @@
 // @vitest-environment happy-dom
 
-import { CoMap, ID, co, cojsonInternals } from "jazz-tools";
+import { CoMap, CoValue, ID, co, cojsonInternals } from "jazz-tools";
 import { createJazzTestAccount, setupJazzTestSync } from "jazz-tools/testing";
-import { beforeEach, describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, expectTypeOf, it } from "vitest";
+import { Ref } from "vue";
 import { useCoState } from "../index.js";
 import { waitFor, withJazzTestSetup } from "./testUtils.js";
 
@@ -152,5 +153,22 @@ describe("useCoState", () => {
     await waitFor(() => {
       expect(result.value).toBeNull();
     });
+  });
+
+  it("should return the same type as Schema", () => {
+    class TestMap extends CoMap {
+      value = co.string;
+    }
+
+    const map = TestMap.create({
+      value: "123",
+    });
+
+    const [result] = withJazzTestSetup(() =>
+      useCoState(TestMap, map.id as ID<CoValue>, []),
+    );
+    expectTypeOf(result).toEqualTypeOf<
+      Ref<TestMap | null | undefined, TestMap | null | undefined>
+    >();
   });
 });


### PR DESCRIPTION
The `id` parameter should be `ID<CoValue>` so the type inference picks up the CoValue type only from the `Schema` parameter.

See: #1476