### PR TITLE
feat(PasskeyAuth): support random passphrase generation

### DIFF
--- a/.changeset/khaki-rockets-sort.md
+++ b/.changeset/khaki-rockets-sort.md
@@ -1,0 +1,5 @@
+---
+"jazz-tools": patch
+---
+
+Add registerNewUser and generateRandomPassphrase methods to PasskeyAuth and accept the username param on the signUp function

--- a/examples/passphrase/src/index.css
+++ b/examples/passphrase/src/index.css
@@ -66,3 +66,71 @@ main {
   margin: 0 auto;
   text-align: center;
 }
+
+.auth-container {
+  min-height: 100vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background-color: #f3f4f6;
+}
+
+.auth-card {
+  background-color: white;
+  padding: 2rem;
+  border-radius: 0.5rem;
+  box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1), 0 2px 4px -1px rgba(0, 0, 0, 0.06);
+  width: 28rem;
+}
+
+.auth-button-primary,
+.auth-button-secondary {
+  width: 100%;
+  padding: 0.5rem 1rem;
+  border-radius: 0.25rem;
+  font-weight: bold;
+  cursor: pointer;
+  margin-bottom: 1rem;
+}
+
+.auth-button-primary {
+  background-color: black;
+  color: white;
+  border: none;
+}
+
+.auth-button-secondary {
+  background-color: white;
+  color: black;
+  border: 1px solid black;
+}
+
+.auth-heading {
+  color: black;
+  font-size: 1.5rem;
+  font-weight: bold;
+  text-align: center;
+  margin-bottom: 1rem;
+}
+
+.auth-textarea {
+  width: 100%;
+  padding: 0.5rem;
+  border: 1px solid #d1d5db;
+  border-radius: 0.25rem;
+  margin-bottom: 1rem;
+  box-sizing: border-box;
+}
+
+.auth-description {
+  font-size: 0.875rem;
+  color: #4b5563;
+  text-align: center;
+  margin-bottom: 1rem;
+}
+
+.auth-button-group {
+  display: flex;
+  justify-content: space-between;
+  gap: 1rem;
+}

--- a/examples/passphrase/src/index.css
+++ b/examples/passphrase/src/index.css
@@ -79,7 +79,8 @@ main {
   background-color: white;
   padding: 2rem;
   border-radius: 0.5rem;
-  box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1), 0 2px 4px -1px rgba(0, 0, 0, 0.06);
+  box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1), 0 2px 4px -1px
+    rgba(0, 0, 0, 0.06);
   width: 28rem;
 }
 

--- a/examples/passphrase/src/main.tsx
+++ b/examples/passphrase/src/main.tsx
@@ -1,9 +1,141 @@
-import { JazzProvider, PassphraseAuthBasicUI } from "jazz-react";
-import { StrictMode } from "react";
+import { JazzProvider, usePassphraseAuth } from "jazz-react";
+import { StrictMode, useState } from "react";
 import { createRoot } from "react-dom/client";
 import App from "./App.tsx";
 import "./index.css";
 import { wordlist } from "./wordlist.ts";
+
+function PassphraseAuthBasicUI(props: {
+  appName: string;
+  wordlist: string[];
+  children?: React.ReactNode;
+}) {
+  const auth = usePassphraseAuth({
+    wordlist: props.wordlist,
+  });
+
+  const [step, setStep] = useState<"initial" | "create" | "login">("initial");
+  const [loginPassphrase, setLoginPassphrase] = useState("");
+  const [isCopied, setIsCopied] = useState(false);
+  const [currentPassphrase, setCurrentPassphrase] = useState(() =>
+    auth.generateRandomPassphrase(),
+  );
+
+  if (auth.state === "signedIn") {
+    return props.children ?? null;
+  }
+
+  const handleCreateAccount = async () => {
+    setStep("create");
+  };
+
+  const handleLogin = () => {
+    setStep("login");
+  };
+
+  const handleReroll = () => {
+    const newPassphrase = auth.generateRandomPassphrase();
+    setCurrentPassphrase(newPassphrase);
+    setIsCopied(false);
+  };
+
+  const handleBack = () => {
+    setStep("initial");
+    setLoginPassphrase("");
+  };
+
+  const handleCopy = async () => {
+    await navigator.clipboard.writeText(auth.passphrase);
+    setIsCopied(true);
+  };
+
+  const handleLoginSubmit = async () => {
+    await auth.logIn(loginPassphrase);
+    setStep("initial");
+    setLoginPassphrase("");
+  };
+
+  const handleNext = async () => {
+    await auth.registerNewAccount(currentPassphrase, "My Account");
+    setStep("initial");
+    setLoginPassphrase("");
+  };
+
+  return (
+    <div className="auth-container">
+      <div className="auth-card">
+        {step === "initial" && (
+          <div>
+            <h1 className="auth-heading">{props.appName}</h1>
+            <button
+              onClick={handleCreateAccount}
+              className="auth-button-primary"
+            >
+              Create new account
+            </button>
+            <button onClick={handleLogin} className="auth-button-secondary">
+              Log in
+            </button>
+          </div>
+        )}
+
+        {step === "create" && (
+          <>
+            <h1 className="auth-heading">Your Passphrase</h1>
+            <p className="auth-description">
+              Please copy and store this passphrase somewhere safe. You'll need
+              it to log in.
+            </p>
+            <textarea
+              readOnly
+              value={currentPassphrase}
+              className="auth-textarea"
+              rows={5}
+            />
+            <button onClick={handleCopy} className="auth-button-primary">
+              {isCopied ? "Copied!" : "Copy"}
+            </button>
+            <div className="auth-button-group">
+              <button onClick={handleBack} className="auth-button-secondary">
+                Back
+              </button>
+              <button onClick={handleReroll} className="auth-button-secondary">
+                Generate New Passphrase
+              </button>
+              <button onClick={handleNext} className="auth-button-primary">
+                Register
+              </button>
+            </div>
+          </>
+        )}
+
+        {step === "login" && (
+          <div>
+            <h1 className="auth-heading">Log In</h1>
+            <textarea
+              value={loginPassphrase}
+              onChange={(e) => setLoginPassphrase(e.target.value)}
+              placeholder="Enter your passphrase"
+              className="auth-textarea"
+              rows={5}
+            />
+            <div className="auth-button-group">
+              <button onClick={handleBack} className="auth-button-secondary">
+                Back
+              </button>
+              <button
+                onClick={handleLoginSubmit}
+                className="auth-button-primary"
+              >
+                Log In
+              </button>
+            </div>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
 
 function JazzAndAuth({ children }: { children: React.ReactNode }) {
   return (

--- a/packages/jazz-react-core/src/auth/PassphraseAuth.tsx
+++ b/packages/jazz-react-core/src/auth/PassphraseAuth.tsx
@@ -29,6 +29,7 @@ export function usePassphraseAuth({
     return new PassphraseAuth(
       context.node.crypto,
       context.authenticate,
+      context.register,
       authSecretStorage,
       wordlist,
     );
@@ -50,6 +51,8 @@ export function usePassphraseAuth({
     state: isAuthenticated ? "signedIn" : "anonymous",
     logIn: authMethod.logIn,
     signUp: authMethod.signUp,
+    registerNewAccount: authMethod.registerNewAccount,
+    generateRandomPassphrase: authMethod.generateRandomPassphrase,
     passphrase,
   } as const;
 }

--- a/packages/jazz-svelte/src/lib/auth/PassphraseAuth.svelte.ts
+++ b/packages/jazz-svelte/src/lib/auth/PassphraseAuth.svelte.ts
@@ -14,6 +14,7 @@ export function usePassphraseAuth({
   const auth = new PassphraseAuth(
     context.current.node.crypto,
     context.current.authenticate,
+    context.current.register,
     authSecretStorage,
     wordlist
   );
@@ -35,6 +36,8 @@ export function usePassphraseAuth({
   return {
     logIn: auth.logIn,
     signUp: auth.signUp,
+    registerNewAccount: auth.registerNewAccount,
+    generateRandomPassphrase: auth.generateRandomPassphrase,
     get passphrase() {
       return passphrase;
     },

--- a/packages/jazz-tools/src/auth/PassphraseAuth.ts
+++ b/packages/jazz-tools/src/auth/PassphraseAuth.ts
@@ -23,25 +23,13 @@ import { AuthSecretStorage } from "./AuthSecretStorage.js";
 export class PassphraseAuth {
   passphrase: string = "";
 
-  private crypto: CryptoProvider;
-  private authenticate: AuthenticateAccountFunction;
-  private register: RegisterAccountFunction;
-  private authSecretStorage: AuthSecretStorage;
-  public wordlist: string[];
-
   constructor(
-    crypto: CryptoProvider,
-    authenticate: AuthenticateAccountFunction,
-    register: RegisterAccountFunction,
-    authSecretStorage: AuthSecretStorage,
-    wordlist: string[],
-  ) {
-    this.crypto = crypto;
-    this.authenticate = authenticate;
-    this.register = register;
-    this.authSecretStorage = authSecretStorage;
-    this.wordlist = wordlist;
-  }
+    private crypto: CryptoProvider,
+    private authenticate: AuthenticateAccountFunction,
+    private register: RegisterAccountFunction,
+    private authSecretStorage: AuthSecretStorage,
+    public wordlist: string[],
+  ) {}
 
   logIn = async (passphrase: string) => {
     const { crypto, authenticate } = this;

--- a/packages/jazz-tools/src/tests/PassphraseAuth.test.ts
+++ b/packages/jazz-tools/src/tests/PassphraseAuth.test.ts
@@ -316,8 +316,9 @@ describe("PassphraseAuth with TestJazzContextManager", () => {
       expect(authSecretStorage.isAuthenticated).toBe(true);
 
       const credentials = await authSecretStorage.get();
-      expect(credentials?.accountID).toBe(accountId);
-      expect(credentials?.provider).toBe("passphrase");
+      assert(credentials);
+      expect(credentials.accountID).toBe(accountId);
+      expect(credentials.provider).toBe("passphrase");
     });
 
     it("should throw error with invalid passphrase during registration", async () => {

--- a/packages/jazz-tools/src/tests/PassphraseAuth.test.ts
+++ b/packages/jazz-tools/src/tests/PassphraseAuth.test.ts
@@ -2,6 +2,7 @@
 
 import { mnemonicToEntropy } from "@scure/bip39";
 import { AgentSecret } from "cojson";
+import { PureJSCrypto } from "cojson/src/crypto/PureJSCrypto";
 import {
   Account,
   AuthSecretStorage,
@@ -9,31 +10,41 @@ import {
   InMemoryKVStore,
   KvStoreContext,
 } from "jazz-tools";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { assert, beforeEach, describe, expect, it, vi } from "vitest";
 import { PassphraseAuth } from "../auth/PassphraseAuth";
-import { createJazzTestAccount } from "../testing";
-import { TestJSCrypto } from "../testing";
+import {
+  TestJazzContextManager,
+  createJazzTestAccount,
+  setupJazzTestSync,
+} from "../testing";
 import { testWordlist } from "./fixtures";
 
 // Initialize KV store for tests
 KvStoreContext.getInstance().initialize(new InMemoryKVStore());
 
+beforeEach(async () => {
+  await setupJazzTestSync();
+});
+
 describe("PassphraseAuth", () => {
-  let crypto: TestJSCrypto;
+  let crypto: PureJSCrypto;
   let mockAuthenticate: any;
+  let mockRegister: any;
   let authSecretStorage: AuthSecretStorage;
   let passphraseAuth: PassphraseAuth;
+  let account: Account;
 
   beforeEach(async () => {
     // Reset storage
     KvStoreContext.getInstance().getStorage().clearAll();
 
     // Set up crypto and mocks
-    crypto = await TestJSCrypto.create();
+    crypto = await PureJSCrypto.create();
     mockAuthenticate = vi.fn();
+    mockRegister = vi.fn();
     authSecretStorage = new AuthSecretStorage();
 
-    await createJazzTestAccount({
+    account = await createJazzTestAccount({
       isCurrentActiveAccount: true,
     });
 
@@ -41,6 +52,7 @@ describe("PassphraseAuth", () => {
     passphraseAuth = new PassphraseAuth(
       crypto,
       mockAuthenticate,
+      mockRegister,
       authSecretStorage,
       testWordlist,
     );
@@ -121,6 +133,39 @@ describe("PassphraseAuth", () => {
         "No credentials found",
       );
     });
+
+    it("should set account name when provided during signup", async () => {
+      const storageData = {
+        accountID: "test-account-id" as ID<Account>,
+        accountSecret: "test-secret" as AgentSecret,
+        secretSeed: new Uint8Array([
+          173, 58, 235, 40, 67, 188, 236, 11, 107, 237, 97, 23, 182, 49, 188,
+          63, 237, 52, 27, 84, 142, 66, 244, 149, 243, 114, 203, 164, 115, 239,
+          175, 194,
+        ]),
+        provider: "anonymous",
+      };
+
+      await authSecretStorage.set(storageData);
+
+      const testName = "Test User";
+      await passphraseAuth.signUp(testName);
+
+      // Verify the account name was set
+      const { profile } = await account.ensureLoaded({
+        profile: {},
+      });
+      expect(profile.name).toBe(testName);
+
+      // Verify storage was updated correctly
+      const storedData = await authSecretStorage.get();
+      expect(storedData).toEqual({
+        accountID: storageData.accountID,
+        accountSecret: storageData.accountSecret,
+        secretSeed: storageData.secretSeed,
+        provider: "passphrase",
+      });
+    });
   });
 
   describe("getCurrentAccountPassphrase", () => {
@@ -144,6 +189,155 @@ describe("PassphraseAuth", () => {
     });
 
     it("should throw error when no credentials found", async () => {
+      await expect(
+        passphraseAuth.getCurrentAccountPassphrase(),
+      ).rejects.toThrow("No credentials found");
+    });
+  });
+});
+
+// Initialize KV store for tests
+KvStoreContext.getInstance().initialize(new InMemoryKVStore());
+
+describe("PassphraseAuth with TestJazzContextManager", () => {
+  let crypto: PureJSCrypto;
+  let contextManager: TestJazzContextManager<any>;
+  let authSecretStorage: AuthSecretStorage;
+  let passphraseAuth: PassphraseAuth;
+
+  beforeEach(async () => {
+    // Reset storage
+    KvStoreContext.getInstance().getStorage().clearAll();
+
+    const account = await createJazzTestAccount({
+      isCurrentActiveAccount: true,
+    });
+
+    // Set up crypto and context manager
+    crypto = await PureJSCrypto.create();
+    contextManager = TestJazzContextManager.fromAccountOrGuest(account);
+    authSecretStorage = contextManager.getAuthSecretStorage();
+
+    // Create initial context
+    await contextManager.createContext({});
+
+    // Create PassphraseAuth instance
+    passphraseAuth = new PassphraseAuth(
+      crypto,
+      contextManager.authenticate,
+      contextManager.register,
+      authSecretStorage,
+      testWordlist,
+    );
+  });
+
+  describe("logIn", () => {
+    it("should successfully log in with valid passphrase", async () => {
+      // First sign up to create initial credentials
+      const passphrase = await passphraseAuth.signUp();
+
+      // Log out
+      await contextManager.logOut();
+
+      // Log back in with passphrase
+      await passphraseAuth.logIn(passphrase);
+
+      // Verify we're logged in
+      const context = contextManager.getCurrentValue();
+
+      assert(context && "me" in context);
+
+      // Verify storage was updated
+      const storedData = await authSecretStorage.get();
+      expect(storedData?.provider).toBe("passphrase");
+    });
+
+    it("should throw error with invalid passphrase", async () => {
+      await expect(passphraseAuth.logIn("invalid words here")).rejects.toThrow(
+        "Invalid passphrase",
+      );
+    });
+  });
+
+  describe("signUp", () => {
+    it("should successfully sign up new user", async () => {
+      expect(authSecretStorage.isAuthenticated).toBe(false);
+
+      const passphrase = await passphraseAuth.signUp();
+
+      expect(authSecretStorage.isAuthenticated).toBe(true);
+
+      // Verify passphrase format
+      expect(passphrase.split(" ").length).toBeGreaterThan(0);
+
+      // Verify storage was updated
+      const storedData = await authSecretStorage.get();
+      expect(storedData?.provider).toBe("passphrase");
+
+      // Verify we can log in with the passphrase
+      await contextManager.logOut();
+      await passphraseAuth.logIn(passphrase);
+      const context = contextManager.getCurrentValue();
+      assert(context && "me" in context);
+      expect(context.me).toBeDefined();
+    });
+
+    it("should throw error when no credentials found", async () => {
+      await authSecretStorage.clear();
+      await expect(passphraseAuth.signUp()).rejects.toThrow(
+        "No credentials found",
+      );
+    });
+  });
+
+  describe("registerNewAccount", () => {
+    it("should successfully register new account with passphrase", async () => {
+      expect(authSecretStorage.isAuthenticated).toBe(false);
+
+      const passphrase = passphraseAuth.generateRandomPassphrase();
+      const accountId = await passphraseAuth.registerNewAccount(
+        passphrase,
+        "Test User",
+      );
+
+      // Verify account was created
+      expect(accountId).toBeDefined();
+
+      // Verify we can log in with the passphrase
+      await contextManager.logOut();
+      await passphraseAuth.logIn(passphrase);
+
+      const context = contextManager.getCurrentValue();
+
+      assert(context && "me" in context);
+      expect(context.me.id).toBe(accountId);
+      expect(context.me.profile?.name).toBe("Test User");
+
+      expect(authSecretStorage.isAuthenticated).toBe(true);
+
+      const credentials = await authSecretStorage.get();
+      expect(credentials?.accountID).toBe(accountId);
+      expect(credentials?.provider).toBe("passphrase");
+    });
+
+    it("should throw error with invalid passphrase during registration", async () => {
+      await expect(
+        passphraseAuth.registerNewAccount("invalid words", "Test User"),
+      ).rejects.toThrow();
+    });
+  });
+
+  describe("getCurrentAccountPassphrase", () => {
+    it("should return current user passphrase when credentials exist", async () => {
+      const originalPassphrase = await passphraseAuth.signUp();
+      const retrievedPassphrase =
+        await passphraseAuth.getCurrentAccountPassphrase();
+
+      expect(retrievedPassphrase).toBe(originalPassphrase);
+    });
+
+    it("should throw error when no credentials found", async () => {
+      await authSecretStorage.clear();
       await expect(
         passphraseAuth.getCurrentAccountPassphrase(),
       ).rejects.toThrow("No credentials found");

--- a/packages/jazz-tools/src/types.ts
+++ b/packages/jazz-tools/src/types.ts
@@ -12,6 +12,7 @@ export type AuthCredentials = {
 export type AuthenticateAccountFunction = (
   credentials: AuthCredentials,
 ) => Promise<void>;
+
 export type RegisterAccountFunction = (
   accountSecret: AgentSecret,
   creationProps: { name: string },
@@ -22,6 +23,7 @@ export type JazzAuthContext<Acc extends Account> = {
   me: Acc;
   node: LocalNode;
   authenticate: AuthenticateAccountFunction;
+  register: RegisterAccountFunction;
   logOut: () => Promise<void>;
   done: () => void;
   isAuthenticated?: boolean;
@@ -31,6 +33,7 @@ export type JazzGuestContext = {
   guest: AnonymousJazzAgent;
   node: LocalNode;
   authenticate: AuthenticateAccountFunction;
+  register: RegisterAccountFunction;
   logOut: () => void;
   done: () => void;
   isAuthenticated?: boolean;

--- a/packages/jazz-vue/src/auth/usePassphraseAuth.ts
+++ b/packages/jazz-vue/src/auth/usePassphraseAuth.ts
@@ -30,6 +30,7 @@ export function usePassphraseAuth({
     return new PassphraseAuth(
       context.value.node.crypto,
       context.value.authenticate,
+      context.value.register,
       authSecretStorage,
       wordlist,
     );
@@ -51,6 +52,8 @@ export function usePassphraseAuth({
     state: isAuthenticated.value ? "signedIn" : "anonymous",
     logIn: authMethod.value.logIn,
     signUp: authMethod.value.signUp,
+    registerNewAccount: authMethod.value.registerNewAccount,
+    generateRandomPassphrase: authMethod.value.generateRandomPassphrase,
     passphrase: passphrase.value,
   }));
 }


### PR DESCRIPTION
Added registerNewUser and generateRandomPassphrase methods to PasskeyAuth to make it possible to build a "reroll passphrase" kind-of UI.

`registerNewUser` accepts a random passphrase that can be generated with `generateRandomPassphrase`, creates a new account and does the authentication.

Data can be migrated from the anonymous user with the `onAnonymousAccountDiscarded` 