### PR TITLE
Maintain docs side nav scroll state on navigation

### DIFF
--- a/homepage/homepage/app/(docs)/api-reference/layout.tsx
+++ b/homepage/homepage/app/(docs)/api-reference/layout.tsx
@@ -1,3 +1,4 @@
+import { TocProvider } from "@/components/TocProvider";
 import { ApiNav } from "@/components/docs/ApiNav";
 import DocsLayout from "@/components/docs/DocsLayout";
 import { Prose } from "gcmp-design-system/src/app/components/molecules/Prose";
@@ -8,8 +9,10 @@ export default function RootLayout({
   children: React.ReactNode;
 }) {
   return (
-    <DocsLayout nav={<ApiNav />} navIcon="package" navName="API Ref">
-      <Prose className="overflow-x-hidden lg:flex-1 py-10">{children}</Prose>
-    </DocsLayout>
+    <TocProvider>
+      <DocsLayout nav={<ApiNav />} navIcon="package" navName="API Ref">
+        <Prose className="overflow-x-hidden lg:flex-1 py-10">{children}</Prose>
+      </DocsLayout>
+    </TocProvider>
   );
 }

--- a/homepage/homepage/app/(docs)/docs/[framework]/[...slug]/page.tsx
+++ b/homepage/homepage/app/(docs)/docs/[framework]/[...slug]/page.tsx
@@ -1,17 +1,13 @@
-import DocsLayout from "@/components/docs/DocsLayout";
 import { TocItemsSetter } from "@/components/docs/TocItemsSetter";
 import ComingSoonPage from "@/components/docs/coming-soon.mdx";
-import { DocNav } from "@/components/docs/nav";
 import { docNavigationItems } from "@/lib/docNavigationItems.js";
 import { Framework, frameworks } from "@/lib/framework";
 import type { Toc } from "@stefanprobst/rehype-extract-toc";
-import { Prose } from "gcmp-design-system/src/app/components/molecules/Prose";
 
 export default async function Page({
   params: { slug, framework },
 }: { params: { slug: string[]; framework: string } }) {
   const slugPath = slug.join("/");
-  const bodyClassName = "overflow-x-hidden lg:flex-1 py-10  max-w-3xl mx-auto";
 
   try {
     let mdxSource;

--- a/homepage/homepage/app/(docs)/docs/[framework]/[...slug]/page.tsx
+++ b/homepage/homepage/app/(docs)/docs/[framework]/[...slug]/page.tsx
@@ -25,21 +25,9 @@ export default async function Page({
     // Exclude h1 from table of contents
     const tocItems = (tableOfContents as Toc)?.[0]?.children;
 
-    return (
-      <DocsLayout toc={tocItems} nav={<DocNav />}>
-        <Prose className={bodyClassName}>
-          <Content />
-        </Prose>
-      </DocsLayout>
-    );
+    return <Content />;
   } catch (error) {
-    return (
-      <DocsLayout nav={<DocNav />}>
-        <Prose className={bodyClassName}>
-          <ComingSoonPage />
-        </Prose>
-      </DocsLayout>
-    );
+    return <ComingSoonPage />;
   }
 }
 

--- a/homepage/homepage/app/(docs)/docs/[framework]/[...slug]/page.tsx
+++ b/homepage/homepage/app/(docs)/docs/[framework]/[...slug]/page.tsx
@@ -1,4 +1,5 @@
 import DocsLayout from "@/components/docs/DocsLayout";
+import { TocItemsSetter } from "@/components/docs/TocItemsSetter";
 import ComingSoonPage from "@/components/docs/coming-soon.mdx";
 import { DocNav } from "@/components/docs/nav";
 import { docNavigationItems } from "@/lib/docNavigationItems.js";
@@ -25,9 +26,19 @@ export default async function Page({
     // Exclude h1 from table of contents
     const tocItems = (tableOfContents as Toc)?.[0]?.children;
 
-    return <Content />;
+    return (
+      <>
+        <TocItemsSetter items={tocItems} />
+        <Content />
+      </>
+    );
   } catch (error) {
-    return <ComingSoonPage />;
+    return (
+      <>
+        <TocItemsSetter items={[]} />
+        <ComingSoonPage />
+      </>
+    );
   }
 }
 

--- a/homepage/homepage/app/(docs)/docs/layout.tsx
+++ b/homepage/homepage/app/(docs)/docs/layout.tsx
@@ -9,7 +9,9 @@ export default function Layout({
 }) {
   return (
     <DocsLayout nav={<DocNav />}>
-      <Prose className="max-w-3xl mx-auto lg:flex-1 py-10">{children}</Prose>
+      <Prose className="overflow-x-hidden lg:flex-1 py-10  max-w-3xl mx-auto">
+        {children}
+      </Prose>
     </DocsLayout>
   );
 }

--- a/homepage/homepage/app/(docs)/docs/layout.tsx
+++ b/homepage/homepage/app/(docs)/docs/layout.tsx
@@ -1,3 +1,4 @@
+import { TocProvider } from "@/components/TocProvider";
 import DocsLayout from "@/components/docs/DocsLayout";
 import { DocNav } from "@/components/docs/nav";
 import { Prose } from "gcmp-design-system/src/app/components/molecules/Prose";
@@ -8,10 +9,12 @@ export default function Layout({
   children: React.ReactNode;
 }) {
   return (
-    <DocsLayout nav={<DocNav />}>
-      <Prose className="overflow-x-hidden lg:flex-1 py-10  max-w-3xl mx-auto">
-        {children}
-      </Prose>
-    </DocsLayout>
+    <TocProvider>
+      <DocsLayout nav={<DocNav />}>
+        <Prose className="overflow-x-hidden lg:flex-1 py-10  max-w-3xl mx-auto">
+          {children}
+        </Prose>
+      </DocsLayout>
+    </TocProvider>
   );
 }

--- a/homepage/homepage/components/TocProvider.tsx
+++ b/homepage/homepage/components/TocProvider.tsx
@@ -1,11 +1,11 @@
 "use client";
 
 import { TocContext } from "@/lib/TocContext";
-import type { Toc } from "@stefanprobst/rehype-extract-toc";
+import type { Toc, TocEntry } from "@stefanprobst/rehype-extract-toc";
 import { useState } from "react";
 
 export function TocProvider({ children }: { children: React.ReactNode }) {
-  const [tocItems, setTocItems] = useState<Toc[0]["children"]>();
+  const [tocItems, setTocItems] = useState<Toc>();
 
   return (
     <TocContext.Provider value={{ tocItems, setTocItems }}>

--- a/homepage/homepage/components/TocProvider.tsx
+++ b/homepage/homepage/components/TocProvider.tsx
@@ -1,0 +1,15 @@
+"use client";
+
+import { TocContext } from "@/lib/TocContext";
+import type { Toc } from "@stefanprobst/rehype-extract-toc";
+import { useState } from "react";
+
+export function TocProvider({ children }: { children: React.ReactNode }) {
+  const [tocItems, setTocItems] = useState<Toc[0]["children"]>();
+
+  return (
+    <TocContext.Provider value={{ tocItems, setTocItems }}>
+      {children}
+    </TocContext.Provider>
+  );
+}

--- a/homepage/homepage/components/docs/DocsLayout.tsx
+++ b/homepage/homepage/components/docs/DocsLayout.tsx
@@ -1,5 +1,8 @@
+"use client";
+
 import { TableOfContents } from "@/components/docs/TableOfContents";
 import { JazzNav } from "@/components/nav";
+import { useTocItems } from "@/lib/TocContext";
 import { Toc } from "@stefanprobst/rehype-extract-toc";
 import { clsx } from "clsx";
 
@@ -8,7 +11,7 @@ export default function DocsLayout({
   nav,
   navName,
   navIcon,
-  toc,
+  toc: oldtoc,
 }: {
   children: React.ReactNode;
   nav?: React.ReactNode;
@@ -16,6 +19,9 @@ export default function DocsLayout({
   navIcon?: string;
   toc?: Toc;
 }) {
+  const { tocItems: toc } = useTocItems();
+  console.log({ toc });
+
   const navSections = [
     {
       name: navName || "Docs",

--- a/homepage/homepage/components/docs/DocsLayout.tsx
+++ b/homepage/homepage/components/docs/DocsLayout.tsx
@@ -11,16 +11,13 @@ export default function DocsLayout({
   nav,
   navName,
   navIcon,
-  toc: oldtoc,
 }: {
   children: React.ReactNode;
   nav?: React.ReactNode;
   navName?: string;
   navIcon?: string;
-  toc?: Toc;
 }) {
-  const { tocItems: toc } = useTocItems();
-  console.log({ toc });
+  const { tocItems } = useTocItems();
 
   const navSections = [
     {
@@ -30,8 +27,8 @@ export default function DocsLayout({
     },
     {
       name: "Outline",
-      content: toc && (
-        <TableOfContents className="text-sm" items={toc as Toc} />
+      content: tocItems?.length && (
+        <TableOfContents className="text-sm" items={tocItems as Toc} />
       ),
       icon: "tableOfContents",
     },
@@ -54,11 +51,11 @@ export default function DocsLayout({
           </div>
           <div className={clsx("md:col-span-8 lg:col-span-9 flex gap-12")}>
             {children}
-            {toc && (
+            {tocItems?.length && (
               <>
                 <TableOfContents
                   className="pl-3 py-6 shrink-0 text-sm sticky align-start top-[72px] w-[16rem] h-[calc(100vh-72px)] overflow-y-auto hidden lg:block"
-                  items={toc as Toc}
+                  items={tocItems as Toc}
                 />
               </>
             )}

--- a/homepage/homepage/components/docs/DocsLayout.tsx
+++ b/homepage/homepage/components/docs/DocsLayout.tsx
@@ -3,7 +3,6 @@
 import { TableOfContents } from "@/components/docs/TableOfContents";
 import { JazzNav } from "@/components/nav";
 import { useTocItems } from "@/lib/TocContext";
-import { Toc } from "@stefanprobst/rehype-extract-toc";
 import { clsx } from "clsx";
 
 export default function DocsLayout({
@@ -28,7 +27,7 @@ export default function DocsLayout({
     {
       name: "Outline",
       content: tocItems?.length && (
-        <TableOfContents className="text-sm" items={tocItems as Toc} />
+        <TableOfContents className="text-sm" items={tocItems} />
       ),
       icon: "tableOfContents",
     },
@@ -55,7 +54,7 @@ export default function DocsLayout({
               <>
                 <TableOfContents
                   className="pl-3 py-6 shrink-0 text-sm sticky align-start top-[72px] w-[16rem] h-[calc(100vh-72px)] overflow-y-auto hidden lg:block"
-                  items={tocItems as Toc}
+                  items={tocItems}
                 />
               </>
             )}

--- a/homepage/homepage/components/docs/TableOfContents.tsx
+++ b/homepage/homepage/components/docs/TableOfContents.tsx
@@ -9,7 +9,7 @@ const TocList = ({
   items,
   level,
   currentId,
-}: { items: TocEntry[]; level: number; currentId: string }) => {
+}: { items: Toc; level: number; currentId: string }) => {
   const isActive = (item: TocEntry) => {
     if (!item.id) return false;
     if (item.id === currentId) return true;
@@ -20,7 +20,7 @@ const TocList = ({
   };
 
   return (
-    <ul className="space-y-3" style={{ paddingLeft: `${level * 1}rem` }}>
+    <ul className="space-y-3" style={{ paddingLeft: `${level}rem` }}>
       {items.map((item) => (
         <li key={item.id} className="space-y-3">
           {item.id && (

--- a/homepage/homepage/components/docs/TocItemsSetter.tsx
+++ b/homepage/homepage/components/docs/TocItemsSetter.tsx
@@ -1,0 +1,17 @@
+"use client";
+
+import { useTocItems } from "@/lib/TocContext";
+import type { Toc } from "@stefanprobst/rehype-extract-toc";
+import { useEffect } from "react";
+
+export function TocItemsSetter({
+  items,
+}: { items: Toc[0]["children"] | undefined }) {
+  const { setTocItems } = useTocItems();
+
+  useEffect(() => {
+    setTocItems(items);
+  }, [items, setTocItems]);
+
+  return null;
+}

--- a/homepage/homepage/components/docs/TocItemsSetter.tsx
+++ b/homepage/homepage/components/docs/TocItemsSetter.tsx
@@ -1,10 +1,10 @@
 "use client";
 
 import { useTocItems } from "@/lib/TocContext";
-import type { TocEntry } from "@stefanprobst/rehype-extract-toc";
+import type { Toc } from "@stefanprobst/rehype-extract-toc";
 import { useEffect } from "react";
 
-export function TocItemsSetter({ items }: { items: TocEntry[] | undefined }) {
+export function TocItemsSetter({ items }: { items: Toc | undefined }) {
   const { setTocItems } = useTocItems();
 
   useEffect(() => {

--- a/homepage/homepage/components/docs/TocItemsSetter.tsx
+++ b/homepage/homepage/components/docs/TocItemsSetter.tsx
@@ -1,12 +1,10 @@
 "use client";
 
 import { useTocItems } from "@/lib/TocContext";
-import type { Toc } from "@stefanprobst/rehype-extract-toc";
+import type { TocEntry } from "@stefanprobst/rehype-extract-toc";
 import { useEffect } from "react";
 
-export function TocItemsSetter({
-  items,
-}: { items: Toc[0]["children"] | undefined }) {
+export function TocItemsSetter({ items }: { items: TocEntry[] | undefined }) {
   const { setTocItems } = useTocItems();
 
   useEffect(() => {

--- a/homepage/homepage/lib/TocContext.tsx
+++ b/homepage/homepage/lib/TocContext.tsx
@@ -1,9 +1,9 @@
-import type { TocEntry } from "@stefanprobst/rehype-extract-toc";
+import type { Toc } from "@stefanprobst/rehype-extract-toc";
 import { createContext, useContext } from "react";
 
 type TocContextType = {
-  tocItems: TocEntry[] | undefined;
-  setTocItems: (items: TocEntry[] | undefined) => void;
+  tocItems: Toc | undefined;
+  setTocItems: (items: Toc | undefined) => void;
 };
 
 export const TocContext = createContext<TocContextType | undefined>(undefined);

--- a/homepage/homepage/lib/TocContext.tsx
+++ b/homepage/homepage/lib/TocContext.tsx
@@ -1,9 +1,9 @@
-import type { Toc } from "@stefanprobst/rehype-extract-toc";
+import type { TocEntry } from "@stefanprobst/rehype-extract-toc";
 import { createContext, useContext } from "react";
 
 type TocContextType = {
-  tocItems: Toc[0]["children"] | undefined;
-  setTocItems: (items: Toc[0]["children"] | undefined) => void;
+  tocItems: TocEntry[] | undefined;
+  setTocItems: (items: TocEntry[] | undefined) => void;
 };
 
 export const TocContext = createContext<TocContextType | undefined>(undefined);

--- a/homepage/homepage/lib/TocContext.tsx
+++ b/homepage/homepage/lib/TocContext.tsx
@@ -1,0 +1,17 @@
+import type { Toc } from "@stefanprobst/rehype-extract-toc";
+import { createContext, useContext } from "react";
+
+type TocContextType = {
+  tocItems: Toc[0]["children"] | undefined;
+  setTocItems: (items: Toc[0]["children"] | undefined) => void;
+};
+
+export const TocContext = createContext<TocContextType | undefined>(undefined);
+
+export function useTocItems() {
+  const context = useContext(TocContext);
+  if (context === undefined) {
+    throw new Error("useTocItems must be used within a TocProvider");
+  }
+  return context;
+}


### PR DESCRIPTION
Scroll state was resetting on navigation because of how I was rendering the layout. I've moved it to `layout.tsx`. Then I needed to store the table of contents items in a context so that I can set the state from within the child.