### PR TITLE
Prevent duplicate accounts from being added in inspector

### DIFF
--- a/examples/inspector/src/viewer/new-app.tsx
+++ b/examples/inspector/src/viewer/new-app.tsx
@@ -83,7 +83,10 @@ export default function CoJsonViewerApp() {
 
   const addAccount = (id: RawAccountID, secret: AgentSecret) => {
     const newAccount = { id, secret };
-    setAccounts([...accounts, newAccount]);
+    const accountExists = accounts.some((account) => account.id === id);
+    if (!accountExists) {
+      setAccounts([...accounts, newAccount]);
+    }
     setCurrentAccount(newAccount);
   };
 


### PR DESCRIPTION
Closes #1434

This prevents duplicate accounts from being added.

https://github.com/user-attachments/assets/2876e1df-a76c-41af-926f-cb6c9d3d2d4d

