### PR TITLE
fix(ContextManager): avoid race conditions on context creation

### DIFF
--- a/.changeset/quiet-rats-fix.md
+++ b/.changeset/quiet-rats-fix.md
@@ -1,0 +1,6 @@
+---
+"jazz-tools": patch
+---
+
+Avoid race conditions on context creation and run the anonymous migration only when the hook is provided
+

--- a/packages/jazz-browser/src/BrowserContextManager.ts
+++ b/packages/jazz-browser/src/BrowserContextManager.ts
@@ -36,24 +36,18 @@ export class JazzBrowserContextManager<
     }
   }
 
-  async createContext(
+  async getNewContext(
     props: JazzContextManagerProps<Acc>,
     authProps?: JazzContextManagerAuthProps,
   ) {
-    let currentContext;
-
-    // We need to store the props here to block the double effect execution
-    // on React. Otherwise when calling propsChanged this.props is undefined.
-    this.props = props;
-
     if (props.guestMode) {
-      currentContext = await createJazzBrowserGuestContext({
+      return createJazzBrowserGuestContext({
         sync: props.sync,
         storage: props.storage,
         authSecretStorage: this.authSecretStorage,
       });
     } else {
-      currentContext = await createJazzBrowserContext<Acc>({
+      return createJazzBrowserContext<Acc>({
         sync: props.sync,
         storage: props.storage,
         AccountSchema: props.AccountSchema,
@@ -63,8 +57,6 @@ export class JazzBrowserContextManager<
         authSecretStorage: this.authSecretStorage,
       });
     }
-
-    await this.updateContext(props, currentContext, authProps);
   }
 
   propsChanged(props: JazzContextManagerProps<Acc>) {

--- a/packages/jazz-react-native/src/ReactNativeContextManager.ts
+++ b/packages/jazz-react-native/src/ReactNativeContextManager.ts
@@ -27,25 +27,19 @@ export type JazzContextManagerProps<Acc extends Account> = {
 export class ReactNativeContextManager<
   Acc extends Account,
 > extends JazzContextManager<Acc, JazzContextManagerProps<Acc>> {
-  async createContext(
+  async getNewContext(
     props: JazzContextManagerProps<Acc>,
     authProps?: JazzContextManagerAuthProps,
   ) {
-    let currentContext;
-
-    // We need to store the props here to block the double effect execution
-    // on React. Otherwise when calling propsChanged this.props is undefined.
-    this.props = props;
-
     if (props.guestMode) {
-      currentContext = await createJazzReactNativeGuestContext({
+      return createJazzReactNativeGuestContext({
         sync: props.sync,
         storage: props.storage,
         authSecretStorage: this.authSecretStorage,
         CryptoProvider: props.CryptoProvider,
       });
     } else {
-      currentContext = await createJazzReactNativeContext<Acc>({
+      return createJazzReactNativeContext<Acc>({
         sync: props.sync,
         storage: props.storage,
         AccountSchema: props.AccountSchema,
@@ -56,8 +50,6 @@ export class ReactNativeContextManager<
         CryptoProvider: props.CryptoProvider,
       });
     }
-
-    await this.updateContext(props, currentContext, authProps);
   }
 
   getKvStore(): KvStore {

--- a/packages/jazz-tools/src/implementation/ContextManager.ts
+++ b/packages/jazz-tools/src/implementation/ContextManager.ts
@@ -43,7 +43,8 @@ export class JazzContextManager<
   protected context: PlatformSpecificContext<Acc> | undefined;
   protected props: P | undefined;
   protected authSecretStorage = new AuthSecretStorage();
-  protected authenticating = false;
+  protected keepContextOpen = false;
+  protected contextPromise: Promise<void> | undefined;
 
   constructor() {
     KvStoreContext.getInstance().initialize(this.getKvStore());
@@ -54,6 +55,33 @@ export class JazzContextManager<
   }
 
   async createContext(props: P, authProps?: JazzContextManagerAuthProps) {
+    // We need to store the props here to block the double effect execution
+    // on React. Otherwise when calling propsChanged this.props is undefined.
+    this.props = props;
+
+    // Avoid race condition between the previous context and the new one
+    const { promise, resolve } = createResolvablePromise<void>();
+
+    const prevPromise = this.contextPromise;
+    this.contextPromise = promise;
+
+    await prevPromise;
+
+    try {
+      const result = await this.getNewContext(props, authProps);
+      await this.updateContext(props, result, authProps);
+
+      resolve();
+    } catch (error) {
+      resolve();
+      throw error;
+    }
+  }
+
+  async getNewContext(
+    props: P,
+    authProps?: JazzContextManagerAuthProps,
+  ): Promise<PlatformSpecificContext<Acc>> {
     props;
     authProps;
     throw new Error("Not implemented");
@@ -64,9 +92,9 @@ export class JazzContextManager<
     context: PlatformSpecificContext<Acc>,
     authProps?: JazzContextManagerAuthProps,
   ) {
-    // When authenticating we don't want to close the previous context
+    // When keepContextOpen we don't want to close the previous context
     // because we might need to handle the onAnonymousAccountDiscarded callback
-    if (!this.authenticating) {
+    if (!this.keepContextOpen) {
       this.context?.done();
     }
 
@@ -120,6 +148,18 @@ export class JazzContextManager<
     this.context.done();
   };
 
+  shouldMigrateAnonymousAccount = async () => {
+    if (!this.props?.onAnonymousAccountDiscarded) {
+      return false;
+    }
+
+    const prevCredentials = await this.authSecretStorage.get();
+    const wasAnonymous =
+      this.authSecretStorage.getIsAuthenticated(prevCredentials) === false;
+
+    return wasAnonymous;
+  };
+
   /**
    * Authenticates the user with the given credentials
    */
@@ -129,16 +169,15 @@ export class JazzContextManager<
     }
 
     const prevContext = this.context;
-    const prevCredentials = await this.authSecretStorage.get();
-    const wasAnonymous =
-      this.authSecretStorage.getIsAuthenticated(prevCredentials) === false;
+    const migratingAnonymousAccount =
+      await this.shouldMigrateAnonymousAccount();
 
-    this.authenticating = true;
+    this.keepContextOpen = migratingAnonymousAccount;
     await this.createContext(this.props, { credentials }).finally(() => {
-      this.authenticating = false;
+      this.keepContextOpen = false;
     });
 
-    if (wasAnonymous) {
+    if (migratingAnonymousAccount) {
       await this.handleAnonymousAccountMigration(prevContext);
     }
   };
@@ -152,21 +191,20 @@ export class JazzContextManager<
     }
 
     const prevContext = this.context;
-    const prevCredentials = await this.authSecretStorage.get();
-    const wasAnonymous =
-      this.authSecretStorage.getIsAuthenticated(prevCredentials) === false;
+    const migratingAnonymousAccount =
+      await this.shouldMigrateAnonymousAccount();
 
-    this.authenticating = true;
+    this.keepContextOpen = migratingAnonymousAccount;
     await this.createContext(this.props, {
       newAccountProps: {
         secret: accountSecret,
         creationProps,
       },
     }).finally(() => {
-      this.authenticating = false;
+      this.keepContextOpen = false;
     });
 
-    if (wasAnonymous) {
+    if (migratingAnonymousAccount) {
       await this.handleAnonymousAccountMigration(prevContext);
     }
 
@@ -234,4 +272,14 @@ export class JazzContextManager<
       listener();
     }
   }
+}
+
+function createResolvablePromise<T>() {
+  let resolve!: (value: T) => void;
+
+  const promise = new Promise<T>((res) => {
+    resolve = res;
+  });
+
+  return { promise, resolve };
 }

--- a/packages/jazz-tools/src/testing.ts
+++ b/packages/jazz-tools/src/testing.ts
@@ -237,12 +237,10 @@ export class TestJazzContextManager<
     return context;
   }
 
-  async createContext(
+  async getNewContext(
     props: TestJazzContextManagerProps<Acc>,
     authProps?: JazzContextManagerAuthProps,
   ) {
-    this.props = props;
-
     if (!syncServer.current) {
       throw new Error(
         "You need to setup a test sync server with setupJazzTestSync to use the Auth functions",
@@ -260,20 +258,16 @@ export class TestJazzContextManager<
       AccountSchema: props.AccountSchema,
     });
 
-    await this.updateContext(
-      props,
-      {
-        me: context.account,
-        node: context.node,
-        done: () => {
-          context.done();
-        },
-        logOut: () => {
-          return context.logOut();
-        },
+    return {
+      me: context.account,
+      node: context.node,
+      done: () => {
+        context.done();
       },
-      authProps,
-    );
+      logOut: () => {
+        return context.logOut();
+      },
+    };
   }
 }
 

--- a/packages/jazz-tools/src/tests/ContextManager.test.ts
+++ b/packages/jazz-tools/src/tests/ContextManager.test.ts
@@ -35,7 +35,7 @@ class TestJazzContextManager<Acc extends Account> extends JazzContextManager<
     AccountSchema?: AccountClass<Acc>;
   }
 > {
-  async createContext(
+  async getNewContext(
     props: JazzContextManagerBaseProps<Acc> & {
       defaultProfileName?: string;
       AccountSchema?: AccountClass<Acc>;
@@ -53,20 +53,16 @@ class TestJazzContextManager<Acc extends Account> extends JazzContextManager<
       AccountSchema: props.AccountSchema,
     });
 
-    await this.updateContext(
-      props,
-      {
-        me: context.account,
-        node: context.node,
-        done: () => {
-          context.done();
-        },
-        logOut: async () => {
-          await context.logOut();
-        },
+    return {
+      me: context.account,
+      node: context.node,
+      done: () => {
+        context.done();
       },
-      authProps,
-    );
+      logOut: async () => {
+        await context.logOut();
+      },
+    };
   }
 }
 
@@ -122,6 +118,23 @@ describe("ContextManager", () => {
     };
 
     // Authenticate with those credentials
+    await manager.authenticate(credentials);
+
+    expect(getCurrentValue().me.id).toBe(credentials.accountID);
+  });
+
+  test("handles race conditions on the context creation", async () => {
+    const account = await createJazzTestAccount();
+
+    manager.createContext({});
+
+    const credentials = {
+      accountID: account.id,
+      accountSecret: account._raw.core.node.account.agentSecret,
+      provider: "test",
+    };
+
+    // Authenticate without waiting for the previous context to be created
     await manager.authenticate(credentials);
 
     expect(getCurrentValue().me.id).toBe(credentials.accountID);

--- a/packages/jazz-tools/src/tests/PassphraseAuth.test.ts
+++ b/packages/jazz-tools/src/tests/PassphraseAuth.test.ts
@@ -302,6 +302,10 @@ describe("PassphraseAuth with TestJazzContextManager", () => {
       // Verify account was created
       expect(accountId).toBeDefined();
 
+      await contextManager
+        .getCurrentValue()
+        ?.node.syncManager.waitForAllCoValuesSync();
+
       // Verify we can log in with the passphrase
       await contextManager.logOut();
       await passphraseAuth.logIn(passphrase);


### PR DESCRIPTION
Avoid race conditions on context creation and run the anonymous migration only when the hook is provided