### PR TITLE
feat: add onAuthChange lifecycle hook to Account

### DIFF
--- a/.changeset/slimy-ducks-shout.md
+++ b/.changeset/slimy-ducks-shout.md
@@ -1,0 +1,5 @@
+---
+"jazz-tools": patch
+---
+
+Add onAuthChange lifecycle hook to Account

--- a/examples/music-player/src/1_schema.ts
+++ b/examples/music-player/src/1_schema.ts
@@ -104,6 +104,10 @@ export class MusicaAccount extends Account {
       });
     }
   }
+
+  onAuthChange(isAuthenticated: boolean) {
+    console.log("onAuthChange", isAuthenticated, this.id);
+  }
 }
 
 /** Walkthrough: Continue with ./2_main.tsx */

--- a/packages/jazz-tools/src/auth/AuthSecretStorage.ts
+++ b/packages/jazz-tools/src/auth/AuthSecretStorage.ts
@@ -117,7 +117,7 @@ export class AuthSecretStorage {
 
       const currentAccount = activeAccountContext.maybeGet();
       if (currentAccount && authStateChanged) {
-        await currentAccount.onAuthChange(this.isAuthenticated);
+        await currentAccount.onSignUp(this.isAuthenticated);
       }
     }
   }

--- a/packages/jazz-tools/src/coValues/account.ts
+++ b/packages/jazz-tools/src/coValues/account.ts
@@ -341,7 +341,7 @@ export class Account extends CoValueBase implements CoValue {
     creationProps; // To avoid unused parameter warning
   }
 
-  onAuthChange(isAuthenticated: boolean) {
+  onSignUp(isAuthenticated: boolean) {
     isAuthenticated; // To avoid unused parameter warning
   }
 

--- a/packages/jazz-tools/src/coValues/account.ts
+++ b/packages/jazz-tools/src/coValues/account.ts
@@ -341,6 +341,10 @@ export class Account extends CoValueBase implements CoValue {
     creationProps; // To avoid unused parameter warning
   }
 
+  onAuthChange(isAuthenticated: boolean) {
+    isAuthenticated; // To avoid unused parameter warning
+  }
+
   /** @category Subscription & Loading */
   static load<A extends Account, Depth>(
     this: CoValueClass<A>,

--- a/packages/jazz-tools/src/implementation/ContextManager.ts
+++ b/packages/jazz-tools/src/implementation/ContextManager.ts
@@ -91,12 +91,6 @@ export class JazzContextManager<
     }
 
     this.notify();
-
-    if (this.context && "me" in this.context) {
-      await this.context.me.onAuthChange(
-        this.authSecretStorage.isAuthenticated,
-      );
-    }
   }
 
   propsChanged(props: P) {

--- a/packages/jazz-tools/src/implementation/ContextManager.ts
+++ b/packages/jazz-tools/src/implementation/ContextManager.ts
@@ -91,6 +91,12 @@ export class JazzContextManager<
     }
 
     this.notify();
+
+    if (this.context && "me" in this.context) {
+      await this.context.me.onAuthChange(
+        this.authSecretStorage.isAuthenticated,
+      );
+    }
   }
 
   propsChanged(props: P) {


### PR DESCRIPTION
This PR introduces a new onAuthChange (the exact name is TBD) lifecycle hook on account to make it possible to run migrations when the user signs up.

Fixes #1473 

TODO:
- [ ] Try to spec when this runs. It would be great to have it run only on signUp.
- [ ] Add tests
- [ ] Write some minimal docs and mark it as experimental
- [ ] Use the feature in one of our example apps