### PR TITLE
1572-filestream-docs

### DIFF
--- a/homepage/homepage/app/(docs)/docs/[framework]/[...slug]/using-covalues/filestreams.mdx
+++ b/homepage/homepage/app/(docs)/docs/[framework]/[...slug]/using-covalues/filestreams.mdx
@@ -32,19 +32,6 @@ class Document extends CoMap {
 
 There are two main ways to create FileStreams: creating empty ones for manual data population or creating directly from existing files or blobs.
 
-### Creating Empty FileStreams
-
-Create an empty FileStream when you want to manually [add binary data in chunks](/docs/using-covalues/filestreams#writing-to-filestreams):
-
-<CodeGroup>
-```ts
-import { FileStream } from "jazz-tools";
-
-// Create a new empty FileStream
-const fileStream = FileStream.create();
-```
-</CodeGroup>
-
 ### Creating from Blobs and Files
 
 For files from input elements or drag-and-drop interfaces, use `createFromBlob`:
@@ -70,6 +57,19 @@ fileInput.addEventListener('change', async () => {
     });
   }
 });
+```
+</CodeGroup>
+
+### Creating Empty FileStreams
+
+Create an empty FileStream when you want to manually [add binary data in chunks](/docs/using-covalues/filestreams#writing-to-filestreams):
+
+<CodeGroup>
+```ts
+import { FileStream } from "jazz-tools";
+
+// Create a new empty FileStream
+const fileStream = FileStream.create();
 ```
 </CodeGroup>
 

--- a/homepage/homepage/app/(docs)/docs/[framework]/[...slug]/using-covalues/filestreams.mdx
+++ b/homepage/homepage/app/(docs)/docs/[framework]/[...slug]/using-covalues/filestreams.mdx
@@ -75,7 +75,7 @@ const fileStream = FileStream.create();
 
 ## Reading from FileStreams
 
-FileStreams provide several ways to access their binary content, from raw chunks to convenient Blob objects.
+`FileStream`s provide several ways to access their binary content, from raw chunks to convenient Blob objects.
 
 ### Getting Raw Data Chunks
 
@@ -101,7 +101,7 @@ if (fileData) {
 ```
 </CodeGroup>
 
-By default, `getChunks()` only returns data for completed uploads. For in-progress uploads, use the `allowUnfinished` option:
+By default, `getChunks()` only returns data for completely synced `FileStream`s. To start using chunks from a `FileStream` that's currently still being synced use the `allowUnfinished` option:
 
 <CodeGroup>
 ```ts
@@ -137,7 +137,7 @@ if (blob) {
 
 ### Loading FileStreams as Blobs
 
-You can directly load a FileStream as a Blob when you only have its ID:
+You can directly load a `FileStream` as a `Blob` when you only have its ID:
 
 <CodeGroup>
 ```ts
@@ -154,7 +154,7 @@ const partialBlob = await FileStream.loadAsBlob(fileStreamId, {
 
 ### Checking Completion Status
 
-Check if a FileStream is fully uploaded:
+Check if a `FileStream` is fully uploaded:
 
 <CodeGroup>
 ```ts
@@ -168,17 +168,17 @@ if (fileStream.isBinaryStreamEnded()) {
 
 ## Writing to FileStreams
 
-When creating a FileStream manually (not using `createFromBlob`), you need to manage the upload process yourself. This gives you more control over chunking and progress tracking.
+When creating a `FileStream` manually (not using `createFromBlob`), you need to manage the upload process yourself. This gives you more control over chunking and progress tracking.
 
 ### The Upload Lifecycle
 
-FileStream uploads follow a three-stage process:
+`FileStream` uploads follow a three-stage process:
 
 1. **Start** - Initialize with metadata
 2. **Push** - Send one or more chunks of data
 3. **End** - Mark the stream as complete
 
-### Starting a FileStream
+### Starting a `FileStream`
 
 Begin by providing metadata about the file:
 
@@ -223,7 +223,7 @@ for (let i = 0; i < data.length; i += chunkSize) {
 
 ### Completing the Upload
 
-Once all chunks are pushed, mark the FileStream as complete:
+Once all chunks are pushed, mark the `FileStream` as complete:
 
 <CodeGroup>
 ```ts
@@ -234,13 +234,13 @@ console.log('Upload complete!');
 ```
 </CodeGroup>
 
-## Subscribing to FileStreams
+## Subscribing to `FileStream`s
 
-Like other CoValues, you can subscribe to FileStreams to get notified of changes as they happen. This is especially useful for tracking upload progress when someone else is uploading a file.
+Like other CoValues, you can subscribe to `FileStream`s to get notified of changes as they happen. This is especially useful for tracking upload progress when someone else is uploading a file.
 
 ### Loading by ID
 
-Load a FileStream when you have its ID:
+Load a `FileStream` when you have its ID:
 
 <CodeGroup>
 ```ts
@@ -261,7 +261,7 @@ if (fileStream) {
 
 ### Subscribing to Changes
 
-Subscribe to a FileStream to be notified when chunks are added or when the upload is complete:
+Subscribe to a `FileStream` to be notified when chunks are added or when the upload is complete:
 
 <CodeGroup>
 ```ts
@@ -294,7 +294,7 @@ const unsubscribe = FileStream.subscribe(fileStreamId, [], (fileStream) => {
 
 ### Waiting for Upload Completion
 
-If you need to wait for a FileStream to be fully synchronized across devices:
+If you need to wait for a `FileStream` to be fully synchronized across devices:
 
 <CodeGroup>
 ```ts

--- a/homepage/homepage/app/(docs)/docs/[framework]/[...slug]/using-covalues/filestreams.mdx
+++ b/homepage/homepage/app/(docs)/docs/[framework]/[...slug]/using-covalues/filestreams.mdx
@@ -34,7 +34,7 @@ There are two main ways to create FileStreams: creating empty ones for manual da
 
 ### Creating Empty FileStreams
 
-Create an empty FileStream when you want to manually add binary data in chunks:
+Create an empty FileStream when you want to manually [add binary data in chunks](/docs/using-covalues/filestreams#writing-to-filestreams):
 
 <CodeGroup>
 ```ts

--- a/homepage/homepage/app/(docs)/docs/[framework]/[...slug]/using-covalues/filestreams.mdx
+++ b/homepage/homepage/app/(docs)/docs/[framework]/[...slug]/using-covalues/filestreams.mdx
@@ -190,7 +190,7 @@ const fileStream = FileStream.create();
 // Initialize with metadata
 fileStream.start({
   mimeType: 'application/pdf',      // MIME type (required)
-  totalSizeBytes: 1024 * 1024 * 2,  // Size in bytes (optional)
+  totalSizeBytes: 1024 * 1024 * 2,  // Size in bytes (if known)
   fileName: 'document.pdf'          // Original filename (optional)
 });
 ```

--- a/homepage/homepage/app/(docs)/docs/[framework]/[...slug]/using-covalues/filestreams.mdx
+++ b/homepage/homepage/app/(docs)/docs/[framework]/[...slug]/using-covalues/filestreams.mdx
@@ -1,0 +1,286 @@
+import { CodeGroup } from "@/components/forMdx";
+
+export const metadata = { title: "FileStreams" };
+
+# FileStreams
+
+FileStreams handle binary data in Jazz applications - think files, images, and other non-text content. They're essentially collaborative versions of `Blob`s that sync automatically across devices.
+
+Use FileStreams when you need to:
+- Share images in collaborative apps
+- Distribute documents across devices
+- Store audio or video files
+- Sync any binary data between users
+
+FileStreams chunk large files automatically, track upload progress, and handle MIME types and metadata.
+
+In your schema, reference FileStreams like any other CoValue:
+
+<CodeGroup>
+```ts
+import { CoMap, FileStream, co } from "jazz-tools";
+
+class UserProfile extends CoMap {
+  name = co.string;
+  avatar = co.ref(FileStream);  // Store profile picture
+}
+```
+</CodeGroup>
+
+## Creating FileStreams
+
+There are two main ways to create FileStreams: creating empty ones for manual data population or creating directly from existing files or blobs.
+
+### Creating Empty FileStreams
+
+Create an empty FileStream when you want to manually add binary data in chunks:
+
+```ts
+import { FileStream } from "jazz-tools";
+
+// Create a new empty FileStream
+const fileStream = FileStream.create();
+```
+
+### Creating from Blobs and Files
+
+For files from input elements or drag-and-drop interfaces, use `createFromBlob`:
+
+```ts
+// From a file input
+const fileInput = document.querySelector('input[type="file"]');
+fileInput.addEventListener('change', async () => {
+  const file = fileInput.files[0];
+  if (file) {
+    // Create FileStream from user-selected file
+    const fileStream = await FileStream.createFromBlob(file);
+    
+    // Or with progress tracking for better UX
+    const fileWithProgress = await FileStream.createFromBlob(file, {
+      onProgress: (progress) => {
+        // progress is a value between 0 and 1
+        const percent = Math.round(progress * 100);
+        console.log(`Upload progress: ${percent}%`);
+        progressBar.style.width = `${percent}%`;
+      }
+    });
+  }
+});
+```
+
+## Reading from FileStreams
+
+FileStreams provide several ways to access their binary content, from raw chunks to convenient Blob objects.
+
+### Getting Raw Data Chunks
+
+To access the raw binary data and metadata:
+
+```ts
+// Get all chunks and metadata
+const fileData = fileStream.getChunks();
+
+if (fileData) {
+  console.log(`MIME type: ${fileData.mimeType}`);
+  console.log(`Total size: ${fileData.totalSizeBytes} bytes`);
+  console.log(`File name: ${fileData.fileName}`);
+  console.log(`Is complete: ${fileData.finished}`);
+  
+  // Access raw binary chunks
+  for (const chunk of fileData.chunks) {
+    // Each chunk is a Uint8Array
+    console.log(`Chunk size: ${chunk.length} bytes`);
+  }
+}
+```
+
+By default, `getChunks()` only returns data for completed uploads. For in-progress uploads, use the `allowUnfinished` option:
+
+```ts
+// Get data even if the stream isn't complete
+const partialData = fileStream.getChunks({ allowUnfinished: true });
+```
+
+### Converting to Blobs
+
+For easier integration with web APIs, convert to a `Blob`:
+
+```ts
+// Convert to a Blob
+const blob = fileStream.toBlob();
+
+if (blob) {
+  // Use with URL.createObjectURL
+  const url = URL.createObjectURL(blob);
+  
+  // Set as image source
+  imageElement.src = url;
+  
+  // Or create a download link
+  const link = document.createElement('a');
+  link.href = url;
+  link.download = fileData?.fileName || 'download';
+  link.click();
+  
+  // Clean up when done
+  URL.revokeObjectURL(url);
+}
+```
+
+### Loading FileStreams as Blobs
+
+You can directly load a FileStream as a Blob when you only have its ID:
+
+```ts
+// Load directly as a Blob when you have an ID
+const blob = await FileStream.loadAsBlob(fileStreamId);
+
+// By default, waits for complete uploads
+// For in-progress uploads:
+const partialBlob = await FileStream.loadAsBlob(fileStreamId, {
+  allowUnfinished: true 
+});
+```
+
+### Checking Completion Status
+
+Check if a FileStream is fully uploaded:
+
+```ts
+if (fileStream.isBinaryStreamEnded()) {
+  console.log('File is completely uploaded');
+} else {
+  console.log('File upload is still in progress');
+}
+```
+
+## Writing to FileStreams
+
+When creating a FileStream manually (not using `createFromBlob`), you need to manage the upload process yourself. This gives you more control over chunking and progress tracking.
+
+### The Upload Lifecycle
+
+FileStream uploads follow a three-stage process:
+
+1. **Start** - Initialize with metadata
+2. **Push** - Send one or more chunks of data
+3. **End** - Mark the stream as complete
+
+### Starting a FileStream
+
+Begin by providing metadata about the file:
+
+```ts
+// Create an empty FileStream
+const fileStream = FileStream.create();
+
+// Initialize with metadata
+fileStream.start({
+  mimeType: 'image/jpeg',          // MIME type (required)
+  totalSizeBytes: 1024 * 1024 * 2, // Size in bytes (optional)
+  fileName: 'photo.jpg'            // Original filename (optional)
+});
+```
+
+### Pushing Data
+
+Add binary data in chunks - this helps with large files and progress tracking:
+
+```ts
+// Create a sample Uint8Array (in real apps, this would be file data)
+const data = new Uint8Array([...]);
+
+// For large files, break into chunks (e.g., 100KB each)
+const chunkSize = 1024 * 100;
+for (let i = 0; i < data.length; i += chunkSize) {
+  // Create a slice of the data
+  const chunk = data.slice(i, i + chunkSize);
+  
+  // Push chunk to the FileStream
+  fileStream.push(chunk);
+  
+  // Track progress
+  const progress = Math.min(100, Math.round((i + chunk.length) * 100 / data.length));
+  console.log(`Upload progress: ${progress}%`);
+}
+```
+
+### Completing the Upload
+
+Once all chunks are pushed, mark the FileStream as complete:
+
+```ts
+// Finalize the upload
+fileStream.end();
+
+console.log('Upload complete!');
+```
+
+## Subscribing to FileStreams
+
+Like other CoValues, you can subscribe to FileStreams to get notified of changes as they happen. This is especially useful for tracking upload progress when someone else is uploading a file.
+
+### Loading by ID
+
+Load a FileStream when you have its ID:
+
+```ts
+// Load a FileStream by ID
+const fileStream = await FileStream.load(fileStreamId, []);
+
+if (fileStream) {
+  console.log('FileStream loaded successfully');
+  
+  // Check if it's complete
+  if (fileStream.isBinaryStreamEnded()) {
+    // Process the completed file
+    const blob = fileStream.toBlob();
+  }
+}
+```
+
+### Subscribing to Changes
+
+Subscribe to a FileStream to be notified when chunks are added or when the upload is complete:
+
+```ts
+// Subscribe to a FileStream by ID
+const unsubscribe = FileStream.subscribe(fileStreamId, [], (fileStream) => {
+  // Called whenever the FileStream changes
+  console.log('FileStream updated');
+  
+  // Get current status
+  const chunks = fileStream.getChunks({ allowUnfinished: true });
+  if (chunks) {
+    const uploadedBytes = chunks.chunks.reduce((sum, chunk) => sum + chunk.length, 0);
+    const totalBytes = chunks.totalSizeBytes || 1;
+    const progress = Math.min(100, Math.round(uploadedBytes * 100 / totalBytes));
+    
+    console.log(`Upload progress: ${progress}%`);
+    
+    if (fileStream.isBinaryStreamEnded()) {
+      console.log('Upload complete!');
+      // Now safe to use the file
+      const blob = fileStream.toBlob();
+      
+      // Clean up the subscription if we're done
+      unsubscribe();
+    }
+  }
+});
+```
+
+### Waiting for Upload Completion
+
+If you need to wait for a FileStream to be fully synchronized across devices:
+
+```ts
+// Wait for the FileStream to be fully synced
+await fileStream.waitForSync({
+  timeout: 5000  // Optional timeout in ms
+});
+
+console.log('FileStream is now synced to all connected devices');
+```
+
+This is useful when you need to ensure that a file is available to other users before proceeding with an operation.

--- a/homepage/homepage/app/(docs)/docs/[framework]/[...slug]/using-covalues/filestreams.mdx
+++ b/homepage/homepage/app/(docs)/docs/[framework]/[...slug]/using-covalues/filestreams.mdx
@@ -35,17 +35,20 @@ There are two main ways to create FileStreams: creating empty ones for manual da
 
 Create an empty FileStream when you want to manually add binary data in chunks:
 
+<CodeGroup>
 ```ts
 import { FileStream } from "jazz-tools";
 
 // Create a new empty FileStream
 const fileStream = FileStream.create();
 ```
+</CodeGroup>
 
 ### Creating from Blobs and Files
 
 For files from input elements or drag-and-drop interfaces, use `createFromBlob`:
 
+<CodeGroup>
 ```ts
 // From a file input
 const fileInput = document.querySelector('input[type="file"]');
@@ -67,6 +70,7 @@ fileInput.addEventListener('change', async () => {
   }
 });
 ```
+</CodeGroup>
 
 ## Reading from FileStreams
 
@@ -76,6 +80,7 @@ FileStreams provide several ways to access their binary content, from raw chunks
 
 To access the raw binary data and metadata:
 
+<CodeGroup>
 ```ts
 // Get all chunks and metadata
 const fileData = fileStream.getChunks();
@@ -93,18 +98,22 @@ if (fileData) {
   }
 }
 ```
+</CodeGroup>
 
 By default, `getChunks()` only returns data for completed uploads. For in-progress uploads, use the `allowUnfinished` option:
 
+<CodeGroup>
 ```ts
 // Get data even if the stream isn't complete
 const partialData = fileStream.getChunks({ allowUnfinished: true });
 ```
+</CodeGroup>
 
 ### Converting to Blobs
 
 For easier integration with web APIs, convert to a `Blob`:
 
+<CodeGroup>
 ```ts
 // Convert to a Blob
 const blob = fileStream.toBlob();
@@ -126,11 +135,13 @@ if (blob) {
   URL.revokeObjectURL(url);
 }
 ```
+</CodeGroup>
 
 ### Loading FileStreams as Blobs
 
 You can directly load a FileStream as a Blob when you only have its ID:
 
+<CodeGroup>
 ```ts
 // Load directly as a Blob when you have an ID
 const blob = await FileStream.loadAsBlob(fileStreamId);
@@ -141,11 +152,13 @@ const partialBlob = await FileStream.loadAsBlob(fileStreamId, {
   allowUnfinished: true 
 });
 ```
+</CodeGroup>
 
 ### Checking Completion Status
 
 Check if a FileStream is fully uploaded:
 
+<CodeGroup>
 ```ts
 if (fileStream.isBinaryStreamEnded()) {
   console.log('File is completely uploaded');
@@ -153,6 +166,7 @@ if (fileStream.isBinaryStreamEnded()) {
   console.log('File upload is still in progress');
 }
 ```
+</CodeGroup>
 
 ## Writing to FileStreams
 
@@ -170,6 +184,7 @@ FileStream uploads follow a three-stage process:
 
 Begin by providing metadata about the file:
 
+<CodeGroup>
 ```ts
 // Create an empty FileStream
 const fileStream = FileStream.create();
@@ -181,11 +196,13 @@ fileStream.start({
   fileName: 'photo.jpg'            // Original filename (optional)
 });
 ```
+</CodeGroup>
 
 ### Pushing Data
 
 Add binary data in chunks - this helps with large files and progress tracking:
 
+<CodeGroup>
 ```ts
 // Create a sample Uint8Array (in real apps, this would be file data)
 const data = new Uint8Array([...]);
@@ -204,17 +221,20 @@ for (let i = 0; i < data.length; i += chunkSize) {
   console.log(`Upload progress: ${progress}%`);
 }
 ```
+</CodeGroup>
 
 ### Completing the Upload
 
 Once all chunks are pushed, mark the FileStream as complete:
 
+<CodeGroup>
 ```ts
 // Finalize the upload
 fileStream.end();
 
 console.log('Upload complete!');
 ```
+</CodeGroup>
 
 ## Subscribing to FileStreams
 
@@ -224,6 +244,7 @@ Like other CoValues, you can subscribe to FileStreams to get notified of changes
 
 Load a FileStream when you have its ID:
 
+<CodeGroup>
 ```ts
 // Load a FileStream by ID
 const fileStream = await FileStream.load(fileStreamId, []);
@@ -238,11 +259,13 @@ if (fileStream) {
   }
 }
 ```
+</CodeGroup>
 
 ### Subscribing to Changes
 
 Subscribe to a FileStream to be notified when chunks are added or when the upload is complete:
 
+<CodeGroup>
 ```ts
 // Subscribe to a FileStream by ID
 const unsubscribe = FileStream.subscribe(fileStreamId, [], (fileStream) => {
@@ -269,11 +292,13 @@ const unsubscribe = FileStream.subscribe(fileStreamId, [], (fileStream) => {
   }
 });
 ```
+</CodeGroup>  
 
 ### Waiting for Upload Completion
 
 If you need to wait for a FileStream to be fully synchronized across devices:
 
+<CodeGroup>
 ```ts
 // Wait for the FileStream to be fully synced
 await fileStream.waitForSync({
@@ -282,5 +307,6 @@ await fileStream.waitForSync({
 
 console.log('FileStream is now synced to all connected devices');
 ```
+</CodeGroup>
 
 This is useful when you need to ensure that a file is available to other users before proceeding with an operation.

--- a/homepage/homepage/app/(docs)/docs/[framework]/[...slug]/using-covalues/filestreams.mdx
+++ b/homepage/homepage/app/(docs)/docs/[framework]/[...slug]/using-covalues/filestreams.mdx
@@ -154,12 +154,12 @@ const partialBlob = await FileStream.loadAsBlob(fileStreamId, {
 
 ### Checking Completion Status
 
-Check if a `FileStream` is fully uploaded:
+Check if a `FileStream` is fully synced:
 
 <CodeGroup>
 ```ts
 if (fileStream.isBinaryStreamEnded()) {
-  console.log('File is completely uploaded');
+  console.log('File is completely synced');
 } else {
   console.log('File upload is still in progress');
 }

--- a/homepage/homepage/app/(docs)/docs/[framework]/[...slug]/using-covalues/filestreams.mdx
+++ b/homepage/homepage/app/(docs)/docs/[framework]/[...slug]/using-covalues/filestreams.mdx
@@ -4,15 +4,16 @@ export const metadata = { title: "FileStreams" };
 
 # FileStreams
 
-FileStreams handle binary data in Jazz applications - think files, images, and other non-text content. They're essentially collaborative versions of `Blob`s that sync automatically across devices.
+FileStreams handle binary data in Jazz applications - think documents, audio files, and other non-text content. They're essentially collaborative versions of `Blob`s that sync automatically across devices.
 
 Use FileStreams when you need to:
-- Share images in collaborative apps
 - Distribute documents across devices
 - Store audio or video files
 - Sync any binary data between users
 
-FileStreams chunk large files automatically, track upload progress, and handle MIME types and metadata.
+> **Note:** For images specifically, Jazz provides the higher-level `ImageDefinition` abstraction which manages multiple image resolutions - see the [ImageDefinition documentation](/docs/using-covalues/imagedefinition) for details.
+
+FileStreams provide automatic chunking when using the `createFromBlob` method, track upload progress, and handle MIME types and metadata.
 
 In your schema, reference FileStreams like any other CoValue:
 
@@ -20,9 +21,9 @@ In your schema, reference FileStreams like any other CoValue:
 ```ts
 import { CoMap, FileStream, co } from "jazz-tools";
 
-class UserProfile extends CoMap {
-  name = co.string;
-  avatar = co.ref(FileStream);  // Store profile picture
+class Document extends CoMap {
+  title = co.string;
+  file = co.ref(FileStream);  // Store a document file
 }
 ```
 </CodeGroup>
@@ -122,13 +123,10 @@ if (blob) {
   // Use with URL.createObjectURL
   const url = URL.createObjectURL(blob);
   
-  // Set as image source
-  imageElement.src = url;
-  
-  // Or create a download link
+  // Create a download link
   const link = document.createElement('a');
   link.href = url;
-  link.download = fileData?.fileName || 'download';
+  link.download = fileData?.fileName || 'document.pdf';
   link.click();
   
   // Clean up when done
@@ -191,9 +189,9 @@ const fileStream = FileStream.create();
 
 // Initialize with metadata
 fileStream.start({
-  mimeType: 'image/jpeg',          // MIME type (required)
-  totalSizeBytes: 1024 * 1024 * 2, // Size in bytes (optional)
-  fileName: 'photo.jpg'            // Original filename (optional)
+  mimeType: 'application/pdf',      // MIME type (required)
+  totalSizeBytes: 1024 * 1024 * 2,  // Size in bytes (optional)
+  fileName: 'document.pdf'          // Original filename (optional)
 });
 ```
 </CodeGroup>

--- a/homepage/homepage/app/(docs)/docs/[framework]/[...slug]/using-covalues/filestreams.mdx
+++ b/homepage/homepage/app/(docs)/docs/[framework]/[...slug]/using-covalues/filestreams.mdx
@@ -11,7 +11,7 @@ Use FileStreams when you need to:
 - Store audio or video files
 - Sync any binary data between users
 
-> **Note:** For images specifically, Jazz provides the higher-level `ImageDefinition` abstraction which manages multiple image resolutions - see the [ImageDefinition documentation](/docs/using-covalues/imagedefinition) for details.
+**Note:** For images specifically, Jazz provides the higher-level `ImageDefinition` abstraction which manages multiple image resolutions - see the [ImageDefinition documentation](/docs/using-covalues/imagedefinition) for details.
 
 FileStreams provide automatic chunking when using the `createFromBlob` method, track upload progress, and handle MIME types and metadata.
 

--- a/homepage/homepage/app/(docs)/docs/[framework]/[...slug]/using-covalues/imagedef.mdx
+++ b/homepage/homepage/app/(docs)/docs/[framework]/[...slug]/using-covalues/imagedef.mdx
@@ -96,7 +96,21 @@ const appropriateRes = image.highestResAvailable({ maxWidth });
 
 ### Fallback Behavior
 
-`highestResAvailable` sorts resolutions from smallest to largest but returns the largest that fits your constraints. If a resolution has incomplete data, it falls back to the next available lower resolution.
+`highestResAvailable` returns the largest resolution that fits your constraints. If a resolution has incomplete data, it falls back to the next available lower resolution.
+
+<CodeGroup>
+```ts
+const image = ImageDefinition.create({
+  originalSize: [1920, 1080],
+});
+
+image["1920x1080"] = FileStream.create(); // Empty image upload
+image["800x450"] = await FileStream.createFromBlob(mediumSizeBlob);
+
+const highestRes = image.highestResAvailable();
+console.log(highestRes.res); // 800x450
+```
+</CodeGroup>
 
 ## Progressive Loading Patterns
 

--- a/homepage/homepage/app/(docs)/docs/[framework]/[...slug]/using-covalues/imagedef.mdx
+++ b/homepage/homepage/app/(docs)/docs/[framework]/[...slug]/using-covalues/imagedef.mdx
@@ -85,6 +85,11 @@ if (highestRes) {
   if (blob) {
     const url = URL.createObjectURL(blob);
     imageElement.src = url;
+    
+    // Remember to revoke the URL when no longer needed
+    imageElement.onload = () => {
+      URL.revokeObjectURL(url);
+    };
   }
 }
 
@@ -114,7 +119,7 @@ console.log(highestRes.res); // 800x450
 
 ## Progressive Loading Patterns
 
-ImageDefinition supports simple progressive loading with placeholders and resolution selection:
+`ImageDefinition` supports simple progressive loading with placeholders and resolution selection:
 
 <CodeGroup>
 ```ts
@@ -132,7 +137,19 @@ if (bestRes) {
   if (blob) {
     const url = URL.createObjectURL(blob);
     imageElement.src = url;
+    
+    // Remember to revoke the URL when no longer needed
+    imageElement.onload = () => {
+      URL.revokeObjectURL(url);
+    };
   }
 }
 ```
 </CodeGroup>
+## Best Practices
+
+- **Generate resolutions server-side** when possible for optimal quality
+- **Use placeholders** (like LQIP - Low Quality Image Placeholders) for instant rendering
+- **Prioritize loading** the resolution appropriate for the current viewport
+- **Consider device pixel ratio** (window.devicePixelRatio) for high-DPI displays
+- **Always call URL.revokeObjectURL** after the image loads to prevent memory leaks

--- a/homepage/homepage/app/(docs)/docs/[framework]/[...slug]/using-covalues/imagedef.mdx
+++ b/homepage/homepage/app/(docs)/docs/[framework]/[...slug]/using-covalues/imagedef.mdx
@@ -1,0 +1,124 @@
+import { CodeGroup } from "@/components/forMdx";
+
+export const metadata = { title: "ImageDefinition" };
+
+# ImageDefinition
+
+`ImageDefinition` is a specialized CoValue designed specifically for managing images in Jazz applications. It extends beyond basic file storage by supporting multiple resolutions of the same image and progressive loading patterns.
+
+The [Image Upload example](https://github.com/gardencmp/jazz/tree/main/examples/image-upload) demonstrates use of `ImageDefinition`.
+
+## Creating ImageDefinitions
+
+Create an `ImageDefinition` by specifying the original dimensions and an optional placeholder:
+
+<CodeGroup>
+```ts
+import { ImageDefinition } from "jazz-tools";
+
+// Create with original dimensions
+const image = ImageDefinition.create({
+  originalSize: [1920, 1080],
+});
+
+// With a placeholder for immediate display
+const imageWithPlaceholder = ImageDefinition.create({
+  originalSize: [1920, 1080],
+  placeholderDataURL: "data:image/jpeg;base64,/9j/4AAQSkZJRgABAQEASABIAAD/2wBDAAP...",
+});
+```
+</CodeGroup>
+
+### Structure
+
+`ImageDefinition` stores:
+- The original image dimensions (`originalSize`)
+- An optional placeholder (`placeholderDataURL`, typically a tiny base64-encoded preview)
+- Multiple resolution variants of the same image as [`FileStream`s](./using-covalues/filestream)
+
+Each resolution is stored with a key in the format `"widthxheight"` (e.g., `"1920x1080"`, `"800x450"`).
+
+<CodeGroup>
+```ts
+import { CoMap, CoList, ImageDefinition, co } from "jazz-tools";
+
+class ListOfImages extends CoList.Of(co.ref(ImageDefinition)) {}
+
+class Gallery extends CoMap {
+  title = co.string;
+  images = co.ref(ListOfImages);
+}
+```
+</CodeGroup>
+
+## Adding Image Resolutions
+
+Add multiple resolutions to an `ImageDefinition` by creating `FileStream`s for each size:
+
+<CodeGroup>
+```ts
+// Create FileStreams for different resolutions
+const fullRes = await FileStream.createFromBlob(fullSizeBlob);
+const mediumRes = await FileStream.createFromBlob(mediumSizeBlob);
+const thumbnailRes = await FileStream.createFromBlob(thumbnailBlob);
+
+// Add to the ImageDefinition with appropriate resolution keys
+image["1920x1080"] = fullRes;
+image["800x450"] = mediumRes;
+image["320x180"] = thumbnailRes;
+```
+</CodeGroup>
+
+## Retrieving Images
+
+The `highestResAvailable` method helps select the best image resolution for the current context:
+
+<CodeGroup>
+```ts
+// Get the highest resolution available
+const highestRes = image.highestResAvailable();
+if (highestRes) {
+  console.log(`Found resolution: ${highestRes.res}`);
+  
+  // Convert to a usable blob
+  const blob = highestRes.stream.toBlob();
+  if (blob) {
+    const url = URL.createObjectURL(blob);
+    imageElement.src = url;
+  }
+}
+
+// Or constrain by maximum width
+const maxWidth = window.innerWidth;
+const appropriateRes = image.highestResAvailable({ maxWidth });
+```
+</CodeGroup>
+
+### Fallback Behavior
+
+`highestResAvailable` sorts resolutions from smallest to largest but returns the largest that fits your constraints. If a resolution has incomplete data, it falls back to the next available lower resolution.
+
+## Progressive Loading Patterns
+
+ImageDefinition supports simple progressive loading with placeholders and resolution selection:
+
+<CodeGroup>
+```ts
+// Start with placeholder for immediate display
+if (image.placeholderDataURL) {
+  imageElement.src = image.placeholderDataURL;
+}
+
+// Then load the best resolution for the current display
+const screenWidth = window.innerWidth;
+const bestRes = image.highestResAvailable({ maxWidth: screenWidth });
+
+if (bestRes) {
+  const blob = bestRes.stream.toBlob();
+  if (blob) {
+    const url = URL.createObjectURL(blob);
+    imageElement.src = url;
+  }
+}
+```
+</CodeGroup>

--- a/homepage/homepage/app/(docs)/docs/[framework]/[...slug]/using-covalues/imagedef.mdx
+++ b/homepage/homepage/app/(docs)/docs/[framework]/[...slug]/using-covalues/imagedef.mdx
@@ -8,6 +8,8 @@ export const metadata = { title: "ImageDefinition" };
 
 The [Image Upload example](https://github.com/gardencmp/jazz/tree/main/examples/image-upload) demonstrates use of `ImageDefinition`.
 
+If you're building with React, we recommend starting with our [React-specific image documentation](/docs/react/using-covalues/imagedef) which covers higher-level components and hooks for working with images.
+
 ## Creating ImageDefinitions
 
 Create an `ImageDefinition` by specifying the original dimensions and an optional placeholder:

--- a/homepage/homepage/app/(docs)/docs/[framework]/[...slug]/using-covalues/imagedef.mdx
+++ b/homepage/homepage/app/(docs)/docs/[framework]/[...slug]/using-covalues/imagedef.mdx
@@ -44,6 +44,28 @@ The `createImage()` function:
 - Creates multiple resolution variants of your image
 - Returns the ID of the created `ImageDefinition`
 
+### Configuration Options
+
+You can configure `createImage()` with additional options:
+
+<CodeGroup>
+```tsx
+// Configuration options
+const options = {
+  owner: me,                // Owner for access control
+  maxSize: 1024             // Maximum resolution to generate
+};
+
+// Setting maxSize controls which resolutions are generated:
+// 256: Only creates the smallest resolution (256px on longest side)
+// 1024: Creates 256px and 1024px resolutions
+// 2048: Creates 256px, 1024px, and 2048px resolutions
+// undefined: Creates all resolutions including the original size
+
+const image = await createImage(file, options);
+```
+</CodeGroup>
+
 ## Creating ImageDefinitions
 
 Create an `ImageDefinition` by specifying the original dimensions and an optional placeholder:

--- a/homepage/homepage/app/(docs)/docs/[framework]/[...slug]/using-covalues/imagedef.mdx
+++ b/homepage/homepage/app/(docs)/docs/[framework]/[...slug]/using-covalues/imagedef.mdx
@@ -6,9 +6,43 @@ export const metadata = { title: "ImageDefinition" };
 
 `ImageDefinition` is a specialized CoValue designed specifically for managing images in Jazz applications. It extends beyond basic file storage by supporting multiple resolutions of the same image and progressive loading patterns.
 
-The [Image Upload example](https://github.com/gardencmp/jazz/tree/main/examples/image-upload) demonstrates use of `ImageDefinition`.
+We also offer [`createImage()`](#creating-images), a higher-level function to create an `ImageDefinition` from a file.
 
 If you're building with React, we recommend starting with our [React-specific image documentation](/docs/react/using-covalues/imagedef) which covers higher-level components and hooks for working with images.
+
+The [Image Upload example](https://github.com/gardencmp/jazz/tree/main/examples/image-upload) demonstrates use of `ImageDefinition`.
+
+## Creating Images
+
+The easiest way to create and use images in your Jazz application is with the `createImage()` function:
+
+<CodeGroup>
+```ts
+import { createImage } from "jazz-browser-media-images";
+
+// Create an image from a file input
+async function handleFileUpload(event) {
+  const file = event.target.files[0];
+  if (file) {
+    // Creates ImageDefinition with multiple resolutions automatically
+    const image = await createImage(file, {
+      owner: me.profile._owner,
+    });
+    
+    // Store the image in your application data
+    me.profile.image = image;
+  }
+}
+```
+</CodeGroup>
+
+> Note: `createImage()` requires a browser environment as it uses browser APIs to process images.
+
+The `createImage()` function:
+- Creates an `ImageDefinition` with the right properties
+- Generates a small placeholder for immediate display
+- Creates multiple resolution variants of your image
+- Returns the ID of the created `ImageDefinition`
 
 ## Creating ImageDefinitions
 

--- a/homepage/homepage/app/(docs)/docs/[framework]/[...slug]/using-covalues/imagedef/react-native.mdx
+++ b/homepage/homepage/app/(docs)/docs/[framework]/[...slug]/using-covalues/imagedef/react-native.mdx
@@ -1,0 +1,265 @@
+import { CodeGroup } from "@/components/forMdx";
+
+export const metadata = { title: "ImageDefinition" };
+
+# ImageDefinition
+
+`ImageDefinition` is a specialized CoValue designed specifically for managing images in Jazz. It extends beyond basic file storage by supporting multiple resolutions of the same image, optimized for mobile devices.
+
+Jazz offers several tools to work with images in React Native:
+- [`createImage()`](#creating-images) - function to create an `ImageDefinition` from a base64 image data URI
+- [`ProgressiveImg`](#displaying-images-with-progressiveimg) - React component to display an image with progressive loading
+- [`useProgressiveImg`](#using-useprogressiveimg-hook) - React hook to load an image in your own component
+
+For a complete implementation example, see the [React Native Clerk Chat example](https://github.com/gardencmp/jazz/tree/main/examples/chat-rn-clerk) in the Jazz repository.
+
+## Creating Images
+
+The easiest way to create and use images in your Jazz application is with the `createImage()` function:
+
+<CodeGroup>
+```tsx
+import { createImage } from "jazz-react-native-media-images";
+import * as ImagePicker from 'expo-image-picker';
+
+async function handleImagePicker() {
+  try {
+    // Launch the image picker
+    const result = await ImagePicker.launchImageLibraryAsync({
+      mediaTypes: ImagePicker.MediaTypeOptions.Images,
+      base64: true,
+      quality: 1,
+    });
+    
+    if (!result.canceled) {
+      const base64Uri = `data:image/jpeg;base64,${result.assets[0].base64}`;
+      
+      // Creates ImageDefinition with multiple resolutions automatically
+      const image = await createImage(base64Uri, {
+        owner: me.profile._owner,
+        maxSize: 2048, // Optional: limit maximum resolution
+      });
+      
+      // Store the image
+      me.profile.image = image;
+    }
+  } catch (error) {
+    console.error("Error creating image:", error);
+  }
+}
+```
+</CodeGroup>
+
+The `createImage()` function for React Native:
+- Creates an `ImageDefinition` with the right properties
+- Generates a small placeholder for immediate display
+- Creates multiple resolution variants of your image
+- Returns the created `ImageDefinition`
+
+### Configuration Options
+
+You can configure the function with additional options:
+
+<CodeGroup>
+```tsx
+// Configuration options
+const options = {
+  owner: me.profile._owner, // Owner for access control
+  maxSize: 1024             // Maximum resolution to generate (256, 1024, 2048, or undefined)
+};
+
+// Setting maxSize controls which resolutions are generated:
+// 256: Only creates the smallest resolution (256px on longest side)
+// 1024: Creates 256px and 1024px resolutions
+// 2048: Creates 256px, 1024px, and 2048px resolutions
+// undefined: Creates all resolutions including the original size
+
+const image = await createImage(base64Uri, options);
+```
+</CodeGroup>
+
+## Displaying Images with `ProgressiveImg`
+
+For a complete progressive loading experience, use the `ProgressiveImg` component:
+
+<CodeGroup>
+```tsx
+import { ProgressiveImg } from "jazz-react-native";
+import { Image, StyleSheet } from "react-native";
+
+function GalleryView({ image }) {
+  return (
+    <ProgressiveImg image={image} maxWidth={800}>
+      {({ src }) => (
+        <Image 
+          source={{ uri: src }} 
+          style={styles.galleryImage}
+          resizeMode="cover"
+        />
+      )}
+    </ProgressiveImg>
+  );
+}
+
+const styles = StyleSheet.create({
+  galleryImage: {
+    width: '100%',
+    height: 200,
+    borderRadius: 8,
+  }
+});
+```
+</CodeGroup>
+
+The `ProgressiveImg` component handles:
+- Showing a placeholder while loading
+- Automatically selecting the appropriate resolution
+- Progressive enhancement as higher resolutions become available
+- Cleaning up resources when unmounted
+
+### Customizing Image Display
+
+You can customize the display with the render prop pattern:
+
+<CodeGroup>
+```tsx
+<ProgressiveImg image={image} maxWidth={800}>
+  {({ src, res, originalSize }) => (
+    <Image 
+      source={{ uri: src }}
+      style={{
+        width: '100%',
+        height: 300,
+        borderRadius: 4,
+      }}
+      resizeMode="cover"
+    />
+  )}
+</ProgressiveImg>
+```
+</CodeGroup>
+
+## Using `useProgressiveImg` Hook
+
+For more control over image loading, you can implement your own progressive image component:
+
+<CodeGroup>
+```tsx
+import { useProgressiveImg } from "jazz-react-native";
+import { Image, View, Text, ActivityIndicator } from "react-native";
+
+function CustomImageComponent({ image }) {
+  const {
+    src, // Data URI containing the image data as a base64 string,
+         // or a placeholder image URI
+    res, // The current resolution
+    originalSize // The original size of the image
+  } = useProgressiveImg({
+    image: image,
+    maxWidth: 800
+  });
+  
+  // When image is not available yet
+  if (!src) {
+    return (
+      <View style={{ height: 200, justifyContent: 'center', alignItems: 'center', backgroundColor: '#f0f0f0' }}>
+        <ActivityIndicator size="small" color="#0000ff" />
+        <Text style={{ marginTop: 10 }}>Loading image...</Text>
+      </View>
+    );
+  }
+  
+  // When using placeholder
+  if (res === "placeholder") {
+    return (
+      <View style={{ position: 'relative' }}>
+        <Image 
+          source={{ uri: src }} 
+          style={{ width: '100%', height: 200, opacity: 0.7 }}
+          resizeMode="cover"
+        />
+        <ActivityIndicator 
+          size="large" 
+          color="#ffffff" 
+          style={{ position: 'absolute', top: '50%', left: '50%', marginLeft: -20, marginTop: -20 }}
+        />
+      </View>
+    );
+  }
+  
+  // Full image display with custom overlay
+  return (
+    <View style={{ position: 'relative', width: '100%', height: 200 }}>
+      <Image 
+        source={{ uri: src }} 
+        style={{ width: '100%', height: '100%' }}
+        resizeMode="cover"
+      />
+      <View style={{ position: 'absolute', bottom: 0, left: 0, right: 0, backgroundColor: 'rgba(0,0,0,0.5)', padding: 8 }}>
+        <Text style={{ color: 'white' }}>Resolution: {res}</Text>
+      </View>
+    </View>
+  );
+}
+```
+</CodeGroup>
+
+### Configuration Options
+
+You can configure the hook with:
+
+<CodeGroup>
+```tsx
+const imageData = useProgressiveImg({
+  image: imageDefinition, // The image definition to load
+  maxWidth: 800, // Limit to resolutions up to 800px wide
+});
+```
+</CodeGroup>
+
+## Understanding ImageDefinition
+
+Behind the scenes, `ImageDefinition` is a specialized CoValue that stores:
+
+- The original image dimensions (`originalSize`)
+- An optional placeholder (`placeholderDataURL`) for immediate display
+- Multiple resolution variants of the same image as [`FileStream`s](../using-covalues/filestreams)
+
+Each resolution is stored with a key in the format `"widthxheight"` (e.g., `"1920x1080"`, `"800x450"`).
+
+<CodeGroup>
+```tsx
+// Structure of an ImageDefinition
+const image = ImageDefinition.create({
+  originalSize: [1920, 1080],
+  placeholderDataURL: "data:image/jpeg;base64,/9j/4AAQSkZJRg...",
+});
+
+// Accessing the highest available resolution
+const highestRes = image.highestResAvailable();
+if (highestRes) {
+  console.log(`Found resolution: ${highestRes.res}`);
+  console.log(`Stream: ${highestRes.stream}`);
+}
+```
+</CodeGroup>
+
+For more details on using `ImageDefinition` directly, see the [VanillaJS docs](/docs/vanilla/using-covalues/imagedef).
+
+### Fallback Behavior
+
+`highestResAvailable` returns the largest resolution that fits your constraints. If a resolution has incomplete data, it falls back to the next available lower resolution.
+
+<CodeGroup>
+```tsx
+const image = ImageDefinition.create({
+  originalSize: [1920, 1080],
+});
+
+image["1920x1080"] = FileStream.create(); // Empty image upload
+image["800x450"] = await FileStream.createFromBlob(mediumSizeBlob);
+
+const highestRes = image.highestResAvailable();
+console.log(highestRes.res); // 800x450
+```
+</CodeGroup>

--- a/homepage/homepage/app/(docs)/docs/[framework]/[...slug]/using-covalues/imagedef/react-native.mdx
+++ b/homepage/homepage/app/(docs)/docs/[framework]/[...slug]/using-covalues/imagedef/react-native.mdx
@@ -11,7 +11,7 @@ Jazz offers several tools to work with images in React Native:
 - [`ProgressiveImg`](#displaying-images-with-progressiveimg) - React component to display an image with progressive loading
 - [`useProgressiveImg`](#using-useprogressiveimg-hook) - React hook to load an image in your own component
 
-For a complete implementation example, see the [React Native Clerk Chat example](https://github.com/gardencmp/jazz/tree/main/examples/chat-rn-clerk) in the Jazz repository.
+For an example of use, see our [React Native Clerk Chat example](https://github.com/gardencmp/jazz/tree/main/examples/chat-rn-clerk).
 
 ## Creating Images
 
@@ -50,7 +50,7 @@ async function handleImagePicker() {
 ```
 </CodeGroup>
 
-The `createImage()` function for React Native:
+The `createImage()` function:
 - Creates an `ImageDefinition` with the right properties
 - Generates a small placeholder for immediate display
 - Creates multiple resolution variants of your image
@@ -58,14 +58,14 @@ The `createImage()` function for React Native:
 
 ### Configuration Options
 
-You can configure the function with additional options:
+You can configure `createImage()` with additional options:
 
 <CodeGroup>
 ```tsx
 // Configuration options
 const options = {
-  owner: me.profile._owner, // Owner for access control
-  maxSize: 1024             // Maximum resolution to generate (256, 1024, 2048, or undefined)
+  owner: me,                // Owner for access control
+  maxSize: 1024             // Maximum resolution to generate
 };
 
 // Setting maxSize controls which resolutions are generated:
@@ -89,7 +89,10 @@ import { Image, StyleSheet } from "react-native";
 
 function GalleryView({ image }) {
   return (
-    <ProgressiveImg image={image} maxWidth={800}>
+    <ProgressiveImg
+      image={image}  // The image definition to load
+      maxWidth={800} // Limit to resolutions up to 800px wide
+    >
       {({ src }) => (
         <Image 
           source={{ uri: src }} 
@@ -117,28 +120,6 @@ The `ProgressiveImg` component handles:
 - Progressive enhancement as higher resolutions become available
 - Cleaning up resources when unmounted
 
-### Customizing Image Display
-
-You can customize the display with the render prop pattern:
-
-<CodeGroup>
-```tsx
-<ProgressiveImg image={image} maxWidth={800}>
-  {({ src, res, originalSize }) => (
-    <Image 
-      source={{ uri: src }}
-      style={{
-        width: '100%',
-        height: 300,
-        borderRadius: 4,
-      }}
-      resizeMode="cover"
-    />
-  )}
-</ProgressiveImg>
-```
-</CodeGroup>
-
 ## Using `useProgressiveImg` Hook
 
 For more control over image loading, you can implement your own progressive image component:
@@ -150,15 +131,15 @@ import { Image, View, Text, ActivityIndicator } from "react-native";
 
 function CustomImageComponent({ image }) {
   const {
-    src, // Data URI containing the image data as a base64 string,
-         // or a placeholder image URI
-    res, // The current resolution
+    src,         // Data URI containing the image data as a base64 string,
+                 // or a placeholder image URI
+    res,         // The current resolution
     originalSize // The original size of the image
   } = useProgressiveImg({
-    image: image,
-    maxWidth: 800
+    image: image,  // The image definition to load
+    maxWidth: 800  // Limit to resolutions up to 800px wide
   });
-  
+
   // When image is not available yet
   if (!src) {
     return (
@@ -201,19 +182,6 @@ function CustomImageComponent({ image }) {
     </View>
   );
 }
-```
-</CodeGroup>
-
-### Configuration Options
-
-You can configure the hook with:
-
-<CodeGroup>
-```tsx
-const imageData = useProgressiveImg({
-  image: imageDefinition, // The image definition to load
-  maxWidth: 800, // Limit to resolutions up to 800px wide
-});
 ```
 </CodeGroup>
 

--- a/homepage/homepage/app/(docs)/docs/[framework]/[...slug]/using-covalues/imagedef/react.mdx
+++ b/homepage/homepage/app/(docs)/docs/[framework]/[...slug]/using-covalues/imagedef/react.mdx
@@ -1,0 +1,199 @@
+import { CodeGroup } from "@/components/forMdx";
+
+export const metadata = { title: "ImageDefinition" };
+
+# ImageDefinition
+
+`ImageDefinition` is a specialized CoValue designed specifically for managing images in Jazz applications. It extends beyond basic file storage by supporting multiple resolutions of the same image and progressive loading patterns.
+
+Beyond [`ImageDefinition`](#understanding-imagedefinition), Jazz offers higher-level functions and components that make it easier to use images:
+- [`createImage()`](#creating-images) - function to create an `ImageDefinition` from a file
+- [`ProgressiveImg`](#displaying-images-with-progressiveimg) - React component to display an image with progressive loading
+- [`useProgressiveImg`](#using-useprogressiveimg-hook) - React hook to load an image in your own component
+
+The [Image Upload example](https://github.com/gardencmp/jazz/tree/main/examples/image-upload) demonstrates use of `ProgressiveImg` and `ImageDefinition`.
+
+## Creating Images
+
+The easiest way to create and use images in your Jazz application is with the `createImage()` function:
+
+<CodeGroup>
+```ts
+import { createImage } from "jazz-browser-media-images";
+
+// Create an image from a file input
+async function handleFileUpload(event) {
+  const file = event.target.files[0];
+  if (file) {
+    // Creates ImageDefinition with multiple resolutions automatically
+    const image = await createImage(file, {
+      owner: me.profile._owner,
+    });
+    
+    // Store the image in your application data
+    me.profile.image = image;
+  }
+}
+```
+</CodeGroup>
+
+> Note: `createImage()` requires a browser environment as it uses browser APIs to process images.
+
+The `createImage()` function:
+- Creates an `ImageDefinition` with the right properties
+- Generates a small placeholder for immediate display
+- Creates multiple resolution variants of your image
+- Returns the ID of the created `ImageDefinition`
+
+## Displaying Images with `ProgressiveImg`
+
+For a complete progressive loading experience, use the `ProgressiveImg` component:
+
+<CodeGroup>
+```tsx
+import { ProgressiveImg } from "jazz-react";
+
+function GalleryView({ image }) {
+  return (
+    <div className="image-container">
+      <ProgressiveImg image={image}>
+        {({ src }) => (
+          <img 
+            src={src} 
+            alt="Gallery image" 
+            className="gallery-image"
+          />
+        )}
+      </ProgressiveImg>
+    </div>
+  );
+}
+```
+</CodeGroup>
+
+The `ProgressiveImg` component handles:
+- Showing a placeholder while loading
+- Automatically selecting the appropriate resolution
+- Progressive enhancement as higher resolutions become available
+- Cleaning up resources when unmounted
+
+### Customizing Image Display
+
+You can customize the display with the render prop pattern:
+
+<CodeGroup>
+```tsx
+<ProgressiveImg image={image}>
+  {({ src }) => (
+    <img 
+      src={src}
+      alt="Description of image" 
+      className="my-custom-class"
+      style={{ objectFit: "cover" }}
+      width={400} 
+      height={300}
+    />
+  )}
+</ProgressiveImg>
+```
+</CodeGroup>
+
+## Using `useProgressiveImg` Hook
+
+For more control over image loading, you can implement your own progressive image component:
+
+<CodeGroup>
+```tsx
+import { useProgressiveImg } from "jazz-react";
+
+function CustomImageComponent({ image }) {
+  const { src, isLoading, placeholderSrc } = useProgressiveImg(image);
+  
+  if (isLoading && placeholderSrc) {
+    return <img src={placeholderSrc} alt="Loading..." className="blur-effect" />;
+  }
+  
+  if (!src) {
+    return <div className="image-loading-fallback">Loading image...</div>;
+  }
+  
+  return (
+    <div className="custom-image-wrapper">
+      <img 
+        src={src} 
+        alt="Custom image" 
+        className="custom-image"
+      />
+      <div className="image-overlay">
+        <span className="image-caption">Custom UI elements</span>
+      </div>
+    </div>
+  );
+}
+```
+</CodeGroup>
+
+The hook returns an object with:
+- `src`: URL for the highest available resolution that fits the current screen
+- `isLoading`: Boolean indicating if a higher resolution is still loading
+- `placeholderSrc`: Base64 data URL for immediate display (if available)
+- `dimensions`: Original image dimensions as [width, height]
+- `error`: Any error that occurred during loading
+
+### Configuration Options
+
+You can configure the hook with options:
+
+<CodeGroup>
+```tsx
+const imageData = useProgressiveImg(imageId, {
+  maxWidth: 800, // Limit to resolutions up to 800px wide
+  devicePixelRatio: true, // Account for high-DPI displays
+});
+```
+</CodeGroup>
+
+## Understanding ImageDefinition
+
+Behind the scenes, `ImageDefinition` is a specialized CoValue that stores:
+
+- The original image dimensions (`originalSize`)
+- An optional placeholder (`placeholderDataURL`) for immediate display
+- Multiple resolution variants of the same image as [`FileStream`s](./using-covalues/filestream)
+
+Each resolution is stored with a key in the format `"widthxheight"` (e.g., `"1920x1080"`, `"800x450"`).
+
+<CodeGroup>
+```ts
+// Structure of an ImageDefinition
+const image = ImageDefinition.create({
+  originalSize: [1920, 1080],
+  placeholderDataURL: "data:image/jpeg;base64,/9j/4AAQSkZJRg...",
+});
+
+// Accessing the highest available resolution
+const highestRes = image.highestResAvailable();
+if (highestRes) {
+  console.log(`Found resolution: ${highestRes.res}`);
+  console.log(`Stream: ${highestRes.stream}`);
+}
+```
+</CodeGroup>
+
+### Fallback Behavior
+
+`highestResAvailable` returns the largest resolution that fits your constraints. If a resolution has incomplete data, it falls back to the next available lower resolution.
+
+<CodeGroup>
+```ts
+const image = ImageDefinition.create({
+  originalSize: [1920, 1080],
+});
+
+image["1920x1080"] = FileStream.create(); // Empty image upload
+image["800x450"] = await FileStream.createFromBlob(mediumSizeBlob);
+
+const highestRes = image.highestResAvailable();
+console.log(highestRes.res); // 800x450
+```
+</CodeGroup>

--- a/homepage/homepage/app/(docs)/docs/[framework]/[...slug]/using-covalues/imagedef/react.mdx
+++ b/homepage/homepage/app/(docs)/docs/[framework]/[...slug]/using-covalues/imagedef/react.mdx
@@ -180,6 +180,8 @@ if (highestRes) {
 ```
 </CodeGroup>
 
+For more details on using `ImageDefinition` directly, see the [VanillaJS docs](/docs/vanilla/using-covalues/imagedef).
+
 ### Fallback Behavior
 
 `highestResAvailable` returns the largest resolution that fits your constraints. If a resolution has incomplete data, it falls back to the next available lower resolution.

--- a/homepage/homepage/app/(docs)/docs/[framework]/[...slug]/using-covalues/imagedef/react.mdx
+++ b/homepage/homepage/app/(docs)/docs/[framework]/[...slug]/using-covalues/imagedef/react.mdx
@@ -45,6 +45,28 @@ The `createImage()` function:
 - Creates multiple resolution variants of your image
 - Returns the created `ImageDefinition`
 
+### Configuration Options
+
+You can configure `createImage()` with additional options:
+
+<CodeGroup>
+```tsx
+// Configuration options
+const options = {
+  owner: me,                // Owner for access control
+  maxSize: 1024             // Maximum resolution to generate
+};
+
+// Setting maxSize controls which resolutions are generated:
+// 256: Only creates the smallest resolution (256px on longest side)
+// 1024: Creates 256px and 1024px resolutions
+// 2048: Creates 256px, 1024px, and 2048px resolutions
+// undefined: Creates all resolutions including the original size
+
+const image = await createImage(file, options);
+```
+</CodeGroup>
+
 ## Displaying Images with `ProgressiveImg`
 
 For a complete progressive loading experience, use the `ProgressiveImg` component:
@@ -56,7 +78,10 @@ import { ProgressiveImg } from "jazz-react";
 function GalleryView({ image }) {
   return (
     <div className="image-container">
-      <ProgressiveImg image={image}>
+      <ProgressiveImg
+        image={image}  // The image definition to load
+        maxWidth={800} // Limit to resolutions up to 800px wide
+      >
         {({ src }) => (
           <img 
             src={src} 
@@ -77,27 +102,6 @@ The `ProgressiveImg` component handles:
 - Progressive enhancement as higher resolutions become available
 - Cleaning up resources when unmounted
 
-### Customizing Image Display
-
-You can customize the display with the render prop pattern:
-
-<CodeGroup>
-```tsx
-<ProgressiveImg image={image}>
-  {({ src }) => (
-    <img 
-      src={src}
-      alt="Description of image" 
-      className="my-custom-class"
-      style={{ objectFit: "cover" }}
-      width={400} 
-      height={300}
-    />
-  )}
-</ProgressiveImg>
-```
-</CodeGroup>
-
 ## Using `useProgressiveImg` Hook
 
 For more control over image loading, you can implement your own progressive image component:
@@ -107,18 +111,26 @@ For more control over image loading, you can implement your own progressive imag
 import { useProgressiveImg } from "jazz-react";
 
 function CustomImageComponent({ image }) {
-  const { src, isLoading, placeholderSrc } = useProgressiveImg(image);
-  
-  // When image is loading, show a placeholder
-  if (isLoading && placeholderSrc) {
-    return <img src={placeholderSrc} alt="Loading..." className="blur-effect" />;
-  }
+  const {
+    src,         // Data URI containing the image data as a base64 string,
+                 // or a placeholder image URI
+    res,         // The current resolution
+    originalSize // The original size of the image
+  } = useProgressiveImg({
+    image: image,  // The image definition to load
+    maxWidth: 800  // Limit to resolutions up to 800px wide
+  });
 
   // When image is not available yet
   if (!src) {
     return <div className="image-loading-fallback">Loading image...</div>;
   }
   
+  // When image is loading, show a placeholder
+  if (res === "placeholder") {
+    return <img src={src} alt="Loading..." className="blur-effect" />;
+  }
+
   // Full image display with custom overlay
   return (
     <div className="custom-image-wrapper">
@@ -128,31 +140,11 @@ function CustomImageComponent({ image }) {
         className="custom-image"
       />
       <div className="image-overlay">
-        <span className="image-caption">Custom UI elements</span>
+        <span className="image-caption">Resolution: {res}</span>
       </div>
     </div>
   );
 }
-```
-</CodeGroup>
-
-The hook returns an object with:
-- `src`: URL for the highest available resolution that fits the current screen
-- `isLoading`: Boolean indicating if a higher resolution is still loading
-- `placeholderSrc`: Base64 data URL for immediate display (if available)
-- `dimensions`: Original image dimensions as [width, height]
-- `error`: Any error that occurred during loading
-
-### Configuration Options
-
-You can configure the hook with options:
-
-<CodeGroup>
-```tsx
-const imageData = useProgressiveImg(imageId, {
-  maxWidth: 800, // Limit to resolutions up to 800px wide
-  devicePixelRatio: true, // Account for high-DPI displays
-});
 ```
 </CodeGroup>
 

--- a/homepage/homepage/app/(docs)/docs/[framework]/[...slug]/using-covalues/imagedef/react.mdx
+++ b/homepage/homepage/app/(docs)/docs/[framework]/[...slug]/using-covalues/imagedef/react.mdx
@@ -43,7 +43,7 @@ The `createImage()` function:
 - Creates an `ImageDefinition` with the right properties
 - Generates a small placeholder for immediate display
 - Creates multiple resolution variants of your image
-- Returns the ID of the created `ImageDefinition`
+- Returns the created `ImageDefinition`
 
 ## Displaying Images with `ProgressiveImg`
 
@@ -109,14 +109,17 @@ import { useProgressiveImg } from "jazz-react";
 function CustomImageComponent({ image }) {
   const { src, isLoading, placeholderSrc } = useProgressiveImg(image);
   
+  // When image is loading, show a placeholder
   if (isLoading && placeholderSrc) {
     return <img src={placeholderSrc} alt="Loading..." className="blur-effect" />;
   }
-  
+
+  // When image is not available yet
   if (!src) {
     return <div className="image-loading-fallback">Loading image...</div>;
   }
   
+  // Full image display with custom overlay
   return (
     <div className="custom-image-wrapper">
       <img 
@@ -159,7 +162,7 @@ Behind the scenes, `ImageDefinition` is a specialized CoValue that stores:
 
 - The original image dimensions (`originalSize`)
 - An optional placeholder (`placeholderDataURL`) for immediate display
-- Multiple resolution variants of the same image as [`FileStream`s](./using-covalues/filestream)
+- Multiple resolution variants of the same image as [`FileStream`s](../using-covalues/filestreams)
 
 Each resolution is stored with a key in the format `"widthxheight"` (e.g., `"1920x1080"`, `"800x450"`).
 

--- a/homepage/homepage/lib/docNavigationItems.js
+++ b/homepage/homepage/lib/docNavigationItems.js
@@ -14,9 +14,6 @@ export const docNavigationItems = [
         href: "/docs/guide",
         done: {
           react: 100,
-          "react-native": 0,
-          vue: 0,
-          svelte: 0,
         },
       },
       {

--- a/homepage/homepage/lib/docNavigationItems.js
+++ b/homepage/homepage/lib/docNavigationItems.js
@@ -152,11 +152,6 @@ export const docNavigationItems = [
         href: "/docs/using-covalues/history-and-time-travel",
         done: 0,
       },
-      {
-        name: "Access control",
-        href: "/docs/using-covalues/access-control",
-        done: 0,
-      },
     ],
   },
   {

--- a/homepage/homepage/lib/docNavigationItems.js
+++ b/homepage/homepage/lib/docNavigationItems.js
@@ -137,7 +137,11 @@ export const docNavigationItems = [
       {
         name: "ImageDefinition",
         href: "/docs/using-covalues/imagedef",
-        done: 100,
+        done: {
+          react: 100,
+          "react-native": 100,
+          vanilla: 100,
+        },
       },
       {
         name: "SchemaUnions",

--- a/homepage/homepage/lib/docNavigationItems.js
+++ b/homepage/homepage/lib/docNavigationItems.js
@@ -120,22 +120,22 @@ export const docNavigationItems = [
       {
         name: "CoMaps",
         href: "/docs/using-covalues/comaps",
-        done: 80,
+        done: 100,
       },
       {
         name: "CoLists",
         href: "/docs/using-covalues/colists",
-        done: 80,
+        done: 100,
       },
       {
         name: "CoFeeds",
         href: "/docs/using-covalues/cofeeds",
-        done: 80,
+        done: 100,
       },
       {
         name: "FileStreams",
         href: "/docs/using-covalues/filestreams",
-        done: 0,
+        done: 80,
       },
       {
         name: "SchemaUnions",

--- a/homepage/homepage/lib/docNavigationItems.js
+++ b/homepage/homepage/lib/docNavigationItems.js
@@ -138,6 +138,11 @@ export const docNavigationItems = [
         done: 80,
       },
       {
+        name: "ImageDefinition",
+        href: "/docs/using-covalues/imagedef",
+        done: 100,
+      },
+      {
         name: "SchemaUnions",
         href: "/docs/using-covalues/schemaunions",
         done: 0,

--- a/packages/jazz-tools/src/coValues/extensions/imageDef.ts
+++ b/packages/jazz-tools/src/coValues/extensions/imageDef.ts
@@ -26,10 +26,11 @@ export class ImageDefinition extends CoMap {
           Number(key.split("x")[0]) <= options.maxWidth),
     ) as `${number}x${number}`[];
 
+    // Sort the resolutions by width, smallest to largest
     resolutions.sort((a, b) => {
       const aWidth = Number(a.split("x")[0]);
       const bWidth = Number(b.split("x")[0]);
-      return aWidth - bWidth;
+      return aWidth - bWidth; // Sort smallest to largest
     });
 
     let highestAvailableResolution: `${number}x${number}` | undefined;
@@ -37,15 +38,10 @@ export class ImageDefinition extends CoMap {
     for (const resolution of resolutions) {
       if (this[resolution] && this[resolution]?.getChunks()) {
         highestAvailableResolution = resolution;
-      } else {
-        return (
-          highestAvailableResolution && {
-            res: highestAvailableResolution,
-            stream: this[highestAvailableResolution]!,
-          }
-        );
       }
     }
+
+    // Return the highest complete resolution if we found one
     return (
       highestAvailableResolution && {
         res: highestAvailableResolution,

--- a/packages/jazz-tools/src/tests/coFeed.test.ts
+++ b/packages/jazz-tools/src/tests/coFeed.test.ts
@@ -470,6 +470,38 @@ describe("FileStream.loadAsBlob", async () => {
   });
 });
 
+describe("FileStream progress tracking", async () => {
+  test("createFromBlob should report upload progress correctly", async () => {
+    // Create 5MB test blob
+    const testData = new Uint8Array(5 * 1024 * 1024); // 5MB instead of 500KB
+    for (let i = 0; i < testData.length; i++) testData[i] = i % 256;
+    const testBlob = new Blob([testData]);
+
+    // Collect progress updates
+    const progressUpdates: number[] = [];
+    await FileStream.createFromBlob(testBlob, {
+      onProgress: (progress) => progressUpdates.push(progress),
+    });
+
+    // Verify progress reporting
+    expect(progressUpdates.length).toBeGreaterThan(1);
+
+    // Check values between 0-1, increasing, with final=1
+    progressUpdates.forEach((p) => {
+      expect(p).toBeGreaterThanOrEqual(0);
+      expect(p).toBeLessThanOrEqual(1);
+    });
+
+    for (let i = 1; i < progressUpdates.length; i++) {
+      expect(progressUpdates[i]!).toBeGreaterThanOrEqual(
+        progressUpdates[i - 1]!,
+      );
+    }
+
+    expect(progressUpdates[progressUpdates.length - 1]).toBe(1);
+  });
+});
+
 describe("waitForSync", async () => {
   test("CoFeed: should resolve when the value is uploaded", async () => {
     class TestStream extends CoFeed.Of(co.string) {}

--- a/packages/jazz-tools/src/tests/imageDef.test.ts
+++ b/packages/jazz-tools/src/tests/imageDef.test.ts
@@ -1,0 +1,190 @@
+import { WasmCrypto } from "cojson/crypto/WasmCrypto";
+import { describe, expect, test } from "vitest";
+import { Account, FileStream, ImageDefinition, co } from "../exports.js";
+
+const Crypto = await WasmCrypto.create();
+
+describe("ImageDefinition", async () => {
+  const me = await Account.create({
+    creationProps: { name: "Test User" },
+    crypto: Crypto,
+  });
+
+  test("Construction with basic properties", () => {
+    const imageDef = ImageDefinition.create(
+      {
+        originalSize: [1920, 1080],
+        placeholderDataURL: "data:image/jpeg;base64,...",
+      },
+      { owner: me },
+    );
+
+    expect(imageDef.originalSize).toEqual([1920, 1080]);
+    expect(imageDef.placeholderDataURL).toBe("data:image/jpeg;base64,...");
+  });
+
+  test("highestResAvailable with no resolutions", () => {
+    const imageDef = ImageDefinition.create(
+      {
+        originalSize: [1920, 1080],
+      },
+      { owner: me },
+    );
+
+    const result = imageDef.highestResAvailable();
+    expect(result).toBeUndefined();
+  });
+
+  test("highestResAvailable with single resolution", () => {
+    const imageDef = ImageDefinition.create(
+      {
+        originalSize: [1920, 1080],
+      },
+      { owner: me },
+    );
+
+    const stream = FileStream.create({ owner: me });
+    stream.start({ mimeType: "image/jpeg" });
+    stream.push(new Uint8Array([1, 2, 3]));
+    stream.end();
+
+    imageDef["1920x1080"] = stream;
+
+    const result = imageDef.highestResAvailable();
+    expect(result).toBeDefined();
+    expect(result?.res).toBe("1920x1080");
+    expect(result?.stream).toStrictEqual(stream);
+  });
+
+  test("highestResAvailable with multiple resolutions", () => {
+    const imageDef = ImageDefinition.create(
+      {
+        originalSize: [1920, 1080],
+      },
+      { owner: me },
+    );
+
+    const stream1 = FileStream.create({ owner: me });
+    stream1.start({ mimeType: "image/jpeg" });
+    stream1.push(new Uint8Array([1, 2, 3]));
+    stream1.end();
+
+    const stream2 = FileStream.create({ owner: me });
+    stream2.start({ mimeType: "image/jpeg" });
+    stream2.push(new Uint8Array([4, 5, 6]));
+    stream2.end();
+
+    imageDef["1920x1080"] = stream1;
+    imageDef["1280x720"] = stream2;
+
+    const result = imageDef.highestResAvailable();
+    expect(result).toBeDefined();
+    expect(result?.res).toBe("1920x1080");
+    expect(result?.stream).toStrictEqual(stream1);
+  });
+
+  test("highestResAvailable with maxWidth option", () => {
+    const imageDef = ImageDefinition.create(
+      {
+        originalSize: [1920, 1080],
+      },
+      { owner: me },
+    );
+
+    const stream1 = FileStream.create({ owner: me });
+    stream1.start({ mimeType: "image/jpeg" });
+    stream1.push(new Uint8Array([1, 2, 3]));
+    stream1.end();
+
+    const stream2 = FileStream.create({ owner: me });
+    stream2.start({ mimeType: "image/jpeg" });
+    stream2.push(new Uint8Array([4, 5, 6]));
+    stream2.end();
+
+    imageDef["1920x1080"] = stream1;
+    imageDef["1280x720"] = stream2;
+
+    const result = imageDef.highestResAvailable({ maxWidth: 1500 });
+    expect(result).toBeDefined();
+    expect(result?.res).toBe("1280x720");
+    expect(result?.stream).toStrictEqual(stream2);
+  });
+
+  test("highestResAvailable with missing chunks", () => {
+    const imageDef = ImageDefinition.create(
+      {
+        originalSize: [1920, 1080],
+      },
+      { owner: me },
+    );
+
+    const stream1 = FileStream.create({ owner: me });
+    stream1.start({ mimeType: "image/jpeg" });
+    stream1.push(new Uint8Array([1, 2, 3]));
+    stream1.end();
+
+    const stream2 = FileStream.create({ owner: me });
+    stream2.start({ mimeType: "image/jpeg" });
+    // Don't end stream2, so it has no chunks
+
+    imageDef["1920x1080"] = stream1;
+    imageDef["1280x720"] = stream2;
+
+    const result = imageDef.highestResAvailable();
+    expect(result).toBeDefined();
+    expect(result?.res).toBe("1920x1080");
+    expect(result?.stream).toStrictEqual(stream1);
+  });
+
+  test("highestResAvailable with missing chunks in middle stream", () => {
+    const imageDef = ImageDefinition.create(
+      {
+        originalSize: [1920, 1080],
+      },
+      { owner: me },
+    );
+
+    const stream1 = FileStream.create({ owner: me });
+    stream1.start({ mimeType: "image/jpeg" });
+    stream1.push(new Uint8Array([1, 2, 3]));
+    stream1.end();
+
+    const stream2 = FileStream.create({ owner: me });
+    stream2.start({ mimeType: "image/jpeg" });
+    // Don't end stream2, so it has no chunks
+
+    const stream3 = FileStream.create({ owner: me });
+    stream3.start({ mimeType: "image/jpeg" });
+    stream3.push(new Uint8Array([7, 8, 9]));
+    stream3.end();
+
+    imageDef["1920x1080"] = stream1;
+    imageDef["1280x720"] = stream2;
+    imageDef["1024x576"] = stream3;
+
+    const result = imageDef.highestResAvailable();
+    expect(result).toBeDefined();
+    expect(result?.res).toBe("1920x1080");
+    expect(result?.stream).toStrictEqual(stream1);
+  });
+
+  test("highestResAvailable with non-resolution keys", () => {
+    const imageDef = ImageDefinition.create(
+      {
+        originalSize: [1920, 1080],
+      },
+      { owner: me },
+    );
+
+    const stream = FileStream.create({ owner: me });
+    stream.start({ mimeType: "image/jpeg" });
+    stream.push(new Uint8Array([1, 2, 3]));
+    stream.end();
+
+    // @ts-expect-error - Testing invalid key
+    imageDef["invalid-key"] = stream;
+
+    const result = imageDef.highestResAvailable();
+    expect(result).toBeUndefined();
+  });
+});


### PR DESCRIPTION
Adds:
- [FilesStream](https://jazz-homepage-git-1572-filestream-docs-gcmp.vercel.app/docs/vanilla/using-covalues/filestreams) docs
- ImageDefinition docs:
  - [VanillaJS](https://jazz-homepage-git-1572-filestream-docs-gcmp.vercel.app/docs/vanilla/using-covalues/imagedef) - Focused on explaining `ImageDefinition` and `createImage` for people looking to implement their own abstractions
  - [React](https://jazz-homepage-git-1572-filestream-docs-gcmp.vercel.app/docs/react/using-covalues/imagedef) - Focused on `createImage` and abstractions: `ProgressiveImg` and `useProgressiveImg`
  - [React Native](https://jazz-homepage-git-1572-filestream-docs-gcmp.vercel.app/docs/react-native/using-covalues/imagedef)  - Focused on `createImage` and abstractions: `ProgressiveImg` and `useProgressiveImg`