### PR TITLE
Add React 19 to peer deps

### DIFF
--- a/packages/jazz-inspector/package.json
+++ b/packages/jazz-inspector/package.json
@@ -21,7 +21,7 @@
     "jazz-tools": "workspace:*"
   },
   "peerDependencies": {
-    "react": "^17.0.0 || ^18.0.0"
+    "react": "^17.0.0 || ^18.0.0 || ^19.0.0"
   },
   "devDependencies": {
     "@types/react": "^18.3.12",


### PR DESCRIPTION
Hope that's enough to make the peer dep warning go away. Been running inspector with react 19 and no problems so far