### PR TITLE
Add z-index of 1 to inspector window

### DIFF
--- a/packages/jazz-inspector/src/viewer/page.tsx
+++ b/packages/jazz-inspector/src/viewer/page.tsx
@@ -54,6 +54,7 @@ export function Page({
     <div
       style={{
         position: "absolute",
+        zIndex: 1,
         inset: 0,
         backgroundColor: "white",
         borderWidth: "1px",


### PR DESCRIPTION
This is to show the inspector window at least above other elements that are relatively positioned but have no z-index applied.

Consider increasing the z-index value or make it configurable (maybe @layer could also help?)