### PR TITLE
create-jazz-app: replace project name param with directory name

### DIFF
--- a/.changeset/dull-tools-run.md
+++ b/.changeset/dull-tools-run.md
@@ -1,0 +1,5 @@
+---
+"create-jazz-app": patch
+---
+
+add directory param to create-jazz-app

--- a/examples/chat-vue/README.md
+++ b/examples/chat-vue/README.md
@@ -16,7 +16,7 @@ npx create-jazz-app@latest chat-vue-app --example chat-vue
 
 Go to the new project directory.
 ```bash
-cd chat-vue
+cd chat-vue-app
 ```
 
 Run the dev server.

--- a/examples/chat-vue/README.md
+++ b/examples/chat-vue/README.md
@@ -11,7 +11,7 @@ You can either
 
 Create a new Jazz project, and use this example as a template.
 ```bash
-npx create-jazz-app@latest --example chat-vue --project-name chat-vue
+npx create-jazz-app@latest chat-vue-app --example chat-vue
 ```
 
 Go to the new project directory.

--- a/examples/chat/README.md
+++ b/examples/chat/README.md
@@ -18,7 +18,7 @@ npx create-jazz-app@latest chat-app --example chat
 
 Go to the new project directory.
 ```bash
-cd chat
+cd chat-app
 ```
 
 Run the dev server.

--- a/examples/chat/README.md
+++ b/examples/chat/README.md
@@ -13,7 +13,7 @@ You can either
 
 Create a new Jazz project, and use this example as a template.
 ```bash
-npx create-jazz-app@latest --example chat --project-name chat
+npx create-jazz-app@latest chat-app --example chat
 ```
 
 Go to the new project directory.

--- a/examples/clerk/README.md
+++ b/examples/clerk/README.md
@@ -20,7 +20,7 @@ npx create-jazz-app@latest clerk-app --example clerk
 
 Go to the new project directory.
 ```bash
-cd clerk
+cd clerk-app
 ```
 
 Run the dev server.

--- a/examples/clerk/README.md
+++ b/examples/clerk/README.md
@@ -15,7 +15,7 @@ You can either
 
 Create a new Jazz project, and use this example as a template.
 ```bash
-npx create-jazz-app@latest --example clerk --project-name clerk
+npx create-jazz-app@latest clerk-app --example clerk
 ```
 
 Go to the new project directory.

--- a/examples/form/README.md
+++ b/examples/form/README.md
@@ -33,7 +33,7 @@ npx create-jazz-app@latest form-app --example form
 
 Go to the new project directory.
 ```bash
-cd form
+cd form-app
 ```
 
 Run the dev server.

--- a/examples/form/README.md
+++ b/examples/form/README.md
@@ -28,7 +28,7 @@ You can either
 
 Create a new Jazz project, and use this example as a template.
 ```bash
-npx create-jazz-app@latest --example form --project-name form
+npx create-jazz-app@latest form-app --example form
 ```
 
 Go to the new project directory.

--- a/examples/image-upload/README.md
+++ b/examples/image-upload/README.md
@@ -20,7 +20,7 @@ npx create-jazz-app@latest image-upload-app --example image-upload
 
 Go to the new project directory.
 ```bash
-cd image-upload
+cd image-upload-app
 ```
 
 Run the dev server.

--- a/examples/image-upload/README.md
+++ b/examples/image-upload/README.md
@@ -15,7 +15,7 @@ You can either
 
 Create a new Jazz project, and use this example as a template.
 ```bash
-npx create-jazz-app@latest --example image-upload --project-name image-upload
+npx create-jazz-app@latest image-upload-app --example image-upload
 ```
 
 Go to the new project directory.

--- a/examples/multiauth/README.md
+++ b/examples/multiauth/README.md
@@ -13,7 +13,7 @@ To run this example, you may either:
 
 1. Create a new Jazz project, and use this example as a template.
 ```bash
-npx create-jazz-app@latest --example counter --project-name counter
+npx create-jazz-app@latest counter-app --example counter
 ```
 2. Navigate to the new project and start the development server.
 ```bash

--- a/examples/multiauth/README.md
+++ b/examples/multiauth/README.md
@@ -17,7 +17,7 @@ npx create-jazz-app@latest counter-app --example counter
 ```
 2. Navigate to the new project and start the development server.
 ```bash
-cd counter
+cd counter-app
 npm run dev
 ```
 

--- a/examples/music-player/README.md
+++ b/examples/music-player/README.md
@@ -18,7 +18,7 @@ npx create-jazz-app@latest music-player-app --example music-player
 
 Go to the new project directory.
 ```bash
-cd music-player
+cd music-player-app
 ```
 
 Run the dev server.

--- a/examples/music-player/README.md
+++ b/examples/music-player/README.md
@@ -13,7 +13,7 @@ You can either
 
 Create a new Jazz project, and use this example as a template.
 ```bash
-npx create-jazz-app@latest --example music-player --project-name music-player
+npx create-jazz-app@latest music-player-app --example music-player
 ```
 
 Go to the new project directory.

--- a/examples/organization/README.md
+++ b/examples/organization/README.md
@@ -21,7 +21,7 @@ npx create-jazz-app@latest organization-app --example organization
 
 Go to the new project directory.
 ```bash
-cd organization
+cd organization-app
 ```
 
 Run the dev server.

--- a/examples/organization/README.md
+++ b/examples/organization/README.md
@@ -16,7 +16,7 @@ You can either
 
 Create a new Jazz project, and use this example as a template.
 ```bash
-npx create-jazz-app@latest --example organization --project-name organization
+npx create-jazz-app@latest organization-app --example organization
 ```
 
 Go to the new project directory.

--- a/examples/passkey-svelte/README.md
+++ b/examples/passkey-svelte/README.md
@@ -26,7 +26,7 @@ npx create-jazz-app@latest passkey-svelte-app --example passkey-svelte
 
 Go to the new project directory.
 ```bash
-cd passkey-svelte
+cd passkey-svelte-app
 ```
 
 Run the dev server.

--- a/examples/passkey-svelte/README.md
+++ b/examples/passkey-svelte/README.md
@@ -21,7 +21,7 @@ You can either
 
 Create a new Jazz project, and use this example as a template.
 ```bash
-npx create-jazz-app@latest --example passkey-svelte --project-name passkey-svelte
+npx create-jazz-app@latest passkey-svelte-app --example passkey-svelte
 ```
 
 Go to the new project directory.

--- a/examples/passkey/README.md
+++ b/examples/passkey/README.md
@@ -20,7 +20,7 @@ npx create-jazz-app@latest passkey-app --example passkey
 
 Go to the new project directory.
 ```bash
-cd passkey
+cd passkey-app
 ```
 
 Run the dev server.

--- a/examples/passkey/README.md
+++ b/examples/passkey/README.md
@@ -15,7 +15,7 @@ You can either
 
 Create a new Jazz project, and use this example as a template.
 ```bash
-npx create-jazz-app@latest --example passkey --project-name passkey
+npx create-jazz-app@latest passkey-app --example passkey
 ```
 
 Go to the new project directory.

--- a/examples/passphrase/README.md
+++ b/examples/passphrase/README.md
@@ -17,7 +17,7 @@ npx create-jazz-app@latest passphrase-app --example passphrase
 
 Go to the new project directory.
 ```bash
-cd passphrase
+cd passphrase-app
 ```
 
 Run the dev server.

--- a/examples/passphrase/README.md
+++ b/examples/passphrase/README.md
@@ -12,7 +12,7 @@ You can either
 
 Create a new Jazz project, and use this example as a template.
 ```bash
-npx create-jazz-app@latest --example passphrase --project-name passphrase
+npx create-jazz-app@latest passphrase-app --example passphrase
 ```
 
 Go to the new project directory.

--- a/examples/password-manager/README.md
+++ b/examples/password-manager/README.md
@@ -15,7 +15,7 @@ You can either
 
 Create a new Jazz project, and use this example as a template.
 ```bash
-npx create-jazz-app@latest --example password-manager --project-name password-manager
+npx create-jazz-app@latest password-manager-app --example password-manager
 ```
 
 Go to the new project directory.

--- a/examples/password-manager/README.md
+++ b/examples/password-manager/README.md
@@ -20,7 +20,7 @@ npx create-jazz-app@latest password-manager-app --example password-manager
 
 Go to the new project directory.
 ```bash
-cd password-manager
+cd password-manager-app
 ```
 
 Run the dev server.

--- a/examples/pets/README.md
+++ b/examples/pets/README.md
@@ -13,7 +13,7 @@ You can either
 
 Create a new Jazz project, and use this example as a template.
 ```bash
-npx create-jazz-app@latest --example pets --project-name pets
+npx create-jazz-app@latest pets-app --example pets
 ```
 
 Go to the new project directory.

--- a/examples/pets/README.md
+++ b/examples/pets/README.md
@@ -18,7 +18,7 @@ npx create-jazz-app@latest pets-app --example pets
 
 Go to the new project directory.
 ```bash
-cd pets
+cd pets-app
 ```
 
 Run the dev server.

--- a/examples/reactions/README.md
+++ b/examples/reactions/README.md
@@ -18,7 +18,7 @@ npx create-jazz-app@latest reactions-app --example reactions
 
 Go to the new project directory.
 ```bash
-cd reactions
+cd reactions-app
 ```
 
 Run the dev server.

--- a/examples/reactions/README.md
+++ b/examples/reactions/README.md
@@ -13,7 +13,7 @@ You can either
 
 Create a new Jazz project, and use this example as a template.
 ```bash
-npx create-jazz-app@latest --example reactions --project-name reactions
+npx create-jazz-app@latest reactions-app --example reactions
 ```
 
 Go to the new project directory.

--- a/examples/todo-vue/README.md
+++ b/examples/todo-vue/README.md
@@ -16,7 +16,7 @@ npx create-jazz-app@latest todo-vue-app --example todo-vue
 
 Go to the new project directory.
 ```bash
-cd todo-vue
+cd todo-vue-app
 ```
 
 Run the dev server.

--- a/examples/todo-vue/README.md
+++ b/examples/todo-vue/README.md
@@ -11,7 +11,7 @@ You can either
 
 Create a new Jazz project, and use this example as a template.
 ```bash
-npx create-jazz-app@latest --example todo-vue --project-name todo-vue
+npx create-jazz-app@latest todo-vue-app --example todo-vue
 ```
 
 Go to the new project directory.

--- a/examples/todo/README.md
+++ b/examples/todo/README.md
@@ -13,7 +13,7 @@ You can either
 
 Create a new Jazz project, and use this example as a template.
 ```bash
-npx create-jazz-app@latest --example todo --project-name todo
+npx create-jazz-app@latest todo-app --example todo
 ```
 
 Go to the new project directory.

--- a/examples/todo/README.md
+++ b/examples/todo/README.md
@@ -18,7 +18,7 @@ npx create-jazz-app@latest todo-app --example todo
 
 Go to the new project directory.
 ```bash
-cd todo
+cd todo-app
 ```
 
 Run the dev server.

--- a/examples/version-history/README.md
+++ b/examples/version-history/README.md
@@ -13,7 +13,7 @@ You can either
 
 Create a new Jazz project, and use this example as a template.
 ```bash
-npx create-jazz-app@latest --example version-history --project-name version-history
+npx create-jazz-app@latest version-history-app --example version-history
 ```
 
 Go to the new project directory.

--- a/examples/version-history/README.md
+++ b/examples/version-history/README.md
@@ -18,7 +18,7 @@ npx create-jazz-app@latest version-history-app --example version-history
 
 Go to the new project directory.
 ```bash
-cd version-history
+cd version-history-app
 ```
 
 Run the dev server.

--- a/packages/create-jazz-app/README.md
+++ b/packages/create-jazz-app/README.md
@@ -31,7 +31,7 @@ Then follow the interactive prompts to select your:
 Or specify all options directly:
 
 ```bash
-npx create-jazz-app@latest --starter react-demo-auth --project-name my-app --package-manager npm
+npx create-jazz-app@latest my-app --starter react-demo-auth --package-manager npm
 ```
 
 ### Start with an example app

--- a/packages/create-jazz-app/src/index.ts
+++ b/packages/create-jazz-app/src/index.ts
@@ -535,20 +535,16 @@ program.on("--help", () => {
   });
   console.log(chalk.blue("\nExample usage:"));
   console.log(
-    chalk.white(
-      "npx create-jazz-app@latest --project-name my-app --framework react\n",
-    ),
+    chalk.white("npx create-jazz-app@latest my-app --framework react\n"),
   );
   console.log(chalk.blue("With example app as a template:"));
   console.log(
-    chalk.white(
-      "npx create-jazz-app@latest --example chat --project-name my-chat-app\n",
-    ),
+    chalk.white("npx create-jazz-app@latest my-chat-app --example chat\n"),
   );
   console.log(chalk.blue("With API key:"));
   console.log(
     chalk.white(
-      "npx create-jazz-app@latest --project-name my-app --api-key your-api-key@garden.co\n",
+      "npx create-jazz-app@latest my-app --api-key your-api-key@garden.co\n",
     ),
   );
   console.log(chalk.blue("Create in current directory:"));

--- a/packages/create-jazz-app/src/index.ts
+++ b/packages/create-jazz-app/src/index.ts
@@ -160,7 +160,13 @@ async function scaffoldProject({
       updateWorkspaceDependencies("devDependencies"),
     ]);
 
-    packageJson.name = projectName;
+    // If projectName is ".", use the current directory name instead
+    if (projectName === ".") {
+      const currentDir = process.cwd().split("/").pop() || "jazz-app";
+      packageJson.name = currentDir;
+    } else {
+      packageJson.name = projectName;
+    }
     fs.writeFileSync(packageJsonPath, JSON.stringify(packageJson, null, 2));
     depsSpinner.succeed(chalk.green("Dependencies updated"));
   } catch (error) {
@@ -541,7 +547,7 @@ program.on("--help", () => {
     ),
   );
   console.log(chalk.blue("Create in current directory:"));
-  console.log(chalk.white("npx create-jazz-app@latest . --framework react\n"));
+  console.log(chalk.white("npx create-jazz-app@latest .\n"));
 });
 
 program.parse(process.argv);

--- a/packages/create-jazz-app/src/index.ts
+++ b/packages/create-jazz-app/src/index.ts
@@ -450,7 +450,13 @@ program
   .description(
     chalk.blue("CLI to generate Jazz projects using starter templates"),
   )
-  .option("-n, --project-name <name>", chalk.cyan("Name of your project"))
+  .option(
+    "-f, --framework <framework>",
+    chalk.cyan(`Framework to use (${frameworkOptions})`),
+  )
+  .option("-s, --starter <starter>", chalk.cyan("Starter template to use"))
+  .option("-e, --example <name>", chalk.cyan("Example project to use"))
+  .option("-n, --project-name <name>", chalk.cyan("Name of the project"))
   .option(
     "-p, --package-manager <manager>",
     chalk.cyan("Package manager to use (npm, yarn, pnpm, bun, deno)"),

--- a/packages/create-jazz-app/src/index.ts
+++ b/packages/create-jazz-app/src/index.ts
@@ -456,7 +456,6 @@ program
   )
   .option("-s, --starter <starter>", chalk.cyan("Starter template to use"))
   .option("-e, --example <name>", chalk.cyan("Example project to use"))
-  .option("-n, --project-name <name>", chalk.cyan("Name of the project"))
   .option(
     "-p, --package-manager <manager>",
     chalk.cyan("Package manager to use (npm, yarn, pnpm, bun, deno)"),

--- a/packages/create-jazz-app/src/index.ts
+++ b/packages/create-jazz-app/src/index.ts
@@ -107,20 +107,9 @@ async function scaffoldProject({
     );
   }
 
-  // Determine target directory - use current directory if projectName is "."
-  const targetDir = projectName === "." ? "." : projectName;
-
-  // For display purposes, use current directory name if projectName is "."
-  const displayName =
-    projectName === "."
-      ? process.cwd().split("/").pop() || "current directory"
-      : projectName;
-
   // Step 2: Clone starter
   const cloneSpinner = ora({
-    text: chalk.blue(
-      `Cloning template: ${chalk.bold(starterConfig.name)} into ${chalk.bold(displayName)}`,
-    ),
+    text: chalk.blue(`Cloning template: ${chalk.bold(starterConfig.name)}`),
     spinner: "dots",
   }).start();
 
@@ -130,7 +119,7 @@ async function scaffoldProject({
       force: true,
       verbose: true,
     });
-    await emitter.clone(targetDir);
+    await emitter.clone(projectName);
     cloneSpinner.succeed(chalk.green("Template cloned successfully"));
   } catch (error) {
     cloneSpinner.fail(chalk.red("Failed to clone template"));
@@ -144,7 +133,7 @@ async function scaffoldProject({
   }).start();
 
   try {
-    const packageJsonPath = `${targetDir}/package.json`;
+    const packageJsonPath = `${projectName}/package.json`;
     const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, "utf8"));
 
     // Helper function to update workspace dependencies
@@ -187,7 +176,7 @@ async function scaffoldProject({
     }).start();
 
     try {
-      const apiKeyPath = `${targetDir}/src/apiKey.ts`;
+      const apiKeyPath = `${projectName}/src/apiKey.ts`;
       if (fs.existsSync(apiKeyPath)) {
         let content = fs.readFileSync(apiKeyPath, "utf8");
         // Replace the apiKey export value
@@ -221,7 +210,7 @@ async function scaffoldProject({
   }).start();
 
   try {
-    execSync(`cd "${targetDir}" && ${packageManager} install`, {
+    execSync(`cd "${projectName}" && ${packageManager} install`, {
       stdio: "pipe",
     });
     installSpinner.succeed(chalk.green("Dependencies installed"));
@@ -238,11 +227,11 @@ async function scaffoldProject({
     }).start();
 
     try {
-      execSync(`cd "${targetDir}" && npx expo prebuild`, { stdio: "pipe" });
-      execSync(`cd "${targetDir}" && npx pod-install`, { stdio: "pipe" });
+      execSync(`cd "${projectName}" && npx expo prebuild`, { stdio: "pipe" });
+      execSync(`cd "${projectName}" && npx pod-install`, { stdio: "pipe" });
 
       // Update metro.config.js
-      const metroConfigPath = `${targetDir}/metro.config.js`;
+      const metroConfigPath = `${projectName}/metro.config.js`;
       const metroConfig = `
 const { getDefaultConfig } = require("expo/metro-config");
 const { withNativeWind } = require("nativewind/metro");
@@ -268,7 +257,7 @@ module.exports = withNativeWind(config, { input: "./src/global.css" });
 
   try {
     // Create a temporary directory for cursor-docs
-    const tempDocsDir = `${targetDir}-cursor-docs-temp`;
+    const tempDocsDir = `${projectName}-cursor-docs-temp`;
     const emitter = degit("garden-co/jazz/packages/cursor-docs", {
       cache: false,
       force: true,
@@ -280,7 +269,7 @@ module.exports = withNativeWind(config, { input: "./src/global.css" });
 
     // Copy only the .cursor directory to project root
     const cursorDirSource = `${tempDocsDir}/.cursor`;
-    const cursorDirTarget = `${targetDir}/.cursor`;
+    const cursorDirTarget = `${projectName}/.cursor`;
 
     if (fs.existsSync(cursorDirSource)) {
       fs.cpSync(cursorDirSource, cursorDirTarget, { recursive: true });
@@ -304,7 +293,7 @@ module.exports = withNativeWind(config, { input: "./src/global.css" });
 
   try {
     execSync(
-      `cd "${targetDir}" && git init && git add . && git commit -m "Initial commit from create-jazz-app"`,
+      `cd "${projectName}" && git init && git add . && git commit -m "Initial commit from create-jazz-app"`,
       { stdio: "pipe" },
     );
     gitSpinner.succeed(chalk.green("Git repository initialized"));
@@ -319,7 +308,7 @@ module.exports = withNativeWind(config, { input: "./src/global.css" });
 
   // Skip the cd command if we're already in the project directory
   if (projectName !== ".") {
-    console.log(chalk.white(`  cd ${chalk.bold(displayName)}`));
+    console.log(chalk.white(`  cd ${chalk.bold(projectName)}`));
   }
 
   console.log(


### PR DESCRIPTION
`npx create-jazz-app .` creates a new jazz app under current directory, and takes current directory name as the project name to put in package.json

You can also pass a directory name `npx create-jazz-app my-app` and it create a my-app directory, and take my-app as the project name.

This makes `--project-name` redundant, so I removed that now.

fixes #1588