### PR TITLE
feat: improve error logging

### DIFF
--- a/.changeset/warm-owls-cheer.md
+++ b/.changeset/warm-owls-cheer.md
@@ -1,0 +1,8 @@
+---
+"cojson-storage-sqlite": patch
+"cojson-transport-ws": patch
+"cojson-storage": patch
+"cojson": patch
+---
+
+Improve the error logging to have more information on errors leveraging the pino err serializer

--- a/packages/cojson-storage-sqlite/src/sqliteClient.ts
+++ b/packages/cojson-storage-sqlite/src/sqliteClient.ts
@@ -61,6 +61,7 @@ export class SQLiteClient implements DBClientInterface {
       const headerValue = coValueRow?.header ?? "";
       logger.warn(`Invalid JSON in header: ${headerValue}`, {
         id: coValueId,
+        err: e,
       });
       return;
     }
@@ -99,7 +100,7 @@ export class SQLiteClient implements DBClientInterface {
         tx: JSON.parse(transactionRow.tx) as Transaction,
       }));
     } catch (e) {
-      logger.warn("Invalid JSON in transaction");
+      logger.warn("Invalid JSON in transaction", { err: e });
       return [];
     }
   }

--- a/packages/cojson-storage-sqlite/src/sqliteNode.ts
+++ b/packages/cojson-storage-sqlite/src/sqliteNode.ts
@@ -41,21 +41,16 @@ export class SQLiteNode {
             await new Promise((resolve) => setTimeout(resolve, 0));
           }
         } catch (e) {
-          logger.error(
-            `Error reading from localNode, handling msg\n\n${JSON.stringify(
-              msg,
-              (k, v) =>
-                k === "changes" || k === "encryptedChanges"
-                  ? `${v.slice(0, 20)}...`
-                  : v,
-            )}`,
-          );
+          logger.error("Error reading from localNode, handling msg", {
+            msg,
+            err: e,
+          });
         }
       }
     };
 
     processMessages().catch((e) =>
-      logger.error("Error in processMessages in sqlite", e),
+      logger.error("Error in processMessages in sqlite", { err: e }),
     );
   }
 

--- a/packages/cojson-storage/src/syncManager.ts
+++ b/packages/cojson-storage/src/syncManager.ts
@@ -320,10 +320,10 @@ export class SyncManager {
       | CojsonInternalTypes.KnownStateMessage
       | CojsonInternalTypes.NewContentMessage,
   ): Promise<unknown> {
-    return this.toLocalNode
-      .push(msg)
-      .catch((e) =>
-        logger.error(`Error sending ${msg.action} state, id ${msg.id}`, e),
-      );
+    return this.toLocalNode.push(msg).catch((e) =>
+      logger.error(`Error sending ${msg.action} state, id ${msg.id}`, {
+        err: e,
+      }),
+    );
   }
 }

--- a/packages/cojson-transport-ws/src/createWebSocketPeer.ts
+++ b/packages/cojson-transport-ws/src/createWebSocketPeer.ts
@@ -139,7 +139,9 @@ export function createWebSocketPeer({
   function handleClose() {
     incoming
       .push("Disconnected")
-      .catch((e) => logger.error("Error while pushing disconnect msg", e));
+      .catch((e) =>
+        logger.error("Error while pushing disconnect msg", { err: e }),
+      );
     emitClosedEvent();
   }
 
@@ -148,7 +150,7 @@ export function createWebSocketPeer({
   // biome-ignore lint/suspicious/noExplicitAny: WebSocket error event type
   websocket.addEventListener("error" as any, (err) => {
     if (err.message) {
-      logger.warn(err.message);
+      logger.warn("WebSocket error", { err });
     }
 
     handleClose();
@@ -157,7 +159,9 @@ export function createWebSocketPeer({
   const pingTimeout = createPingTimeoutListener(expectPings, () => {
     incoming
       .push("PingTimeout")
-      .catch((e) => logger.error("Error while pushing ping timeout", e));
+      .catch((e) =>
+        logger.error("Error while pushing ping timeout", { err: e }),
+      );
     emitClosedEvent();
   });
 
@@ -175,9 +179,7 @@ export function createWebSocketPeer({
     const result = deserializeMessages(event.data);
 
     if (!result.ok) {
-      logger.warn(
-        `Error while deserializing messages: ${getErrorMessage(result.error)}`,
-      );
+      logger.warn("Error while deserializing messages", { err: result.error });
       return;
     }
 
@@ -201,7 +203,9 @@ export function createWebSocketPeer({
       if (msg && "action" in msg) {
         incoming
           .push(msg)
-          .catch((e) => logger.error("Error while pushing incoming msg", e));
+          .catch((e) =>
+            logger.error("Error while pushing incoming msg", { err: e }),
+          );
       }
     }
   }

--- a/packages/cojson-transport-ws/src/serialization.ts
+++ b/packages/cojson-transport-ws/src/serialization.ts
@@ -28,7 +28,7 @@ export function deserializeMessages(messages: unknown) {
         | PingMsg[],
     } as const;
   } catch (e) {
-    logger.error(`Error while deserializing messages: ${getErrorMessage(e)}`);
+    logger.error("Error while deserializing messages", { err: e });
     return {
       ok: false,
       error: e,

--- a/packages/cojson/src/coValueCore.ts
+++ b/packages/cojson/src/coValueCore.ts
@@ -328,10 +328,7 @@ export class CoValueCore {
         try {
           listener(content);
         } catch (e) {
-          logger.error(
-            "Error in listener for coValue " + this.id,
-            parseError(e),
-          );
+          logger.error("Error in listener for coValue " + this.id, { err: e });
         }
       }
     } else {
@@ -345,10 +342,9 @@ export class CoValueCore {
               try {
                 listener(content);
               } catch (e) {
-                logger.error(
-                  "Error in listener for coValue " + this.id,
-                  parseError(e),
-                );
+                logger.error("Error in listener for coValue " + this.id, {
+                  err: e,
+                });
               }
             }
             resolve();
@@ -545,7 +541,9 @@ export class CoValueCore {
       }
 
       if (!decryptedChanges) {
-        logger.error("Failed to decrypt transaction despite having key");
+        logger.error("Failed to decrypt transaction despite having key", {
+          err: new Error("Failed to decrypt transaction despite having key"),
+        });
         continue;
       }
 

--- a/packages/cojson/src/coValueState.ts
+++ b/packages/cojson/src/coValueState.ts
@@ -285,7 +285,9 @@ async function loadCoValueFromPeers(
           ...coValueEntry.state.coValue.knownState(),
         })
         .catch((err) => {
-          logger.warn(`Failed to push load message to peer ${peer.id}`, err);
+          logger.warn(`Failed to push load message to peer ${peer.id}`, {
+            err,
+          });
         });
     } else {
       /**
@@ -299,7 +301,9 @@ async function loadCoValueFromPeers(
           sessions: {},
         })
         .catch((err) => {
-          logger.warn(`Failed to push load message to peer ${peer.id}`, err);
+          logger.warn(`Failed to push load message to peer ${peer.id}`, {
+            err,
+          });
         });
     }
 

--- a/packages/cojson/src/crypto/PureJSCrypto.ts
+++ b/packages/cojson/src/crypto/PureJSCrypto.ts
@@ -195,9 +195,7 @@ export class PureJSCrypto extends CryptoProvider<Blake3State> {
     try {
       return JSON.parse(textDecoder.decode(plaintext));
     } catch (e) {
-      logger.error(
-        "Failed to decrypt/parse sealed message: " + (e as Error)?.message,
-      );
+      logger.error("Failed to decrypt/parse sealed message", { err: e });
       return undefined;
     }
   }

--- a/packages/cojson/src/crypto/WasmCrypto.ts
+++ b/packages/cojson/src/crypto/WasmCrypto.ts
@@ -179,9 +179,7 @@ export class WasmCrypto extends CryptoProvider<Blake3State> {
     try {
       return JSON.parse(plaintext) as T;
     } catch (e) {
-      logger.error(
-        "Failed to decrypt/parse sealed message: " + (e as Error)?.message,
-      );
+      logger.error("Failed to decrypt/parse sealed message", { err: e });
       return undefined;
     }
   }

--- a/packages/cojson/src/crypto/crypto.ts
+++ b/packages/cojson/src/crypto/crypto.ts
@@ -163,7 +163,7 @@ export abstract class CryptoProvider<Blake3State = any> {
     try {
       return parseJSON(this.decryptRaw(encrypted, keySecret, nOnceMaterial));
     } catch (e) {
-      logger.error("Decryption error: " + (e as Error)?.message);
+      logger.error("Decryption error", { err: e });
       return undefined;
     }
   }

--- a/packages/cojson/src/localNode.ts
+++ b/packages/cojson/src/localNode.ts
@@ -231,7 +231,7 @@ export class LocalNode {
 
       return node;
     } catch (e) {
-      logger.error("Error withLoadedAccount: " + (e as Error)?.message);
+      logger.error("Error withLoadedAccount", { err: e });
       throw e;
     }
   }
@@ -270,8 +270,9 @@ export class LocalNode {
         this.syncManager.getServerAndStoragePeers(skipLoadingFromPeer);
 
       await entry.loadFromPeers(peers).catch((e) => {
-        logger.error("Error loading from peers: " + (e as Error)?.message, {
+        logger.error("Error loading from peers", {
           id,
+          err: e,
         });
       });
     }
@@ -326,9 +327,10 @@ export class LocalNode {
         unsubscribe = coValue.subscribe(callback);
       })
       .catch((e) => {
-        logger.error(
-          "Error subscribing to " + id + ": " + (e as Error)?.message,
-        );
+        logger.error("Subscription error", {
+          id,
+          err: e,
+        });
       });
 
     return () => {

--- a/packages/cojson/src/logger.ts
+++ b/packages/cojson/src/logger.ts
@@ -8,11 +8,19 @@ export enum LogLevel {
   NONE = 4,
 }
 
+type ErrorAttributes = { err: unknown };
+
 export interface LogSystem {
   debug(message: string, attributes?: Record<string, JsonValue>): void;
   info(message: string, attributes?: Record<string, JsonValue>): void;
-  warn(message: string, attributes?: Record<string, JsonValue>): void;
-  error(message: string, attributes?: Record<string, JsonValue>): void;
+  warn(
+    message: string,
+    attributes?: Record<string, JsonValue> | ErrorAttributes,
+  ): void;
+  error(
+    message: string,
+    attributes?: Record<string, JsonValue> | ErrorAttributes,
+  ): void;
 }
 
 // Default console-based logging system
@@ -23,10 +31,16 @@ export class ConsoleLogSystem implements LogSystem {
   info(message: string, attributes?: Record<string, JsonValue>) {
     console.info(message, attributes);
   }
-  warn(message: string, attributes?: Record<string, JsonValue>) {
+  warn(
+    message: string,
+    attributes?: Record<string, JsonValue> | ErrorAttributes,
+  ) {
     console.warn(message, attributes);
   }
-  error(message: string, attributes?: Record<string, JsonValue>) {
+  error(
+    message: string,
+    attributes?: Record<string, JsonValue> | ErrorAttributes,
+  ) {
     console.error(message, attributes);
   }
 }
@@ -63,13 +77,19 @@ export class Logger {
     }
   }
 
-  warn(message: string, attributes?: Record<string, JsonValue>) {
+  warn(
+    message: string,
+    attributes?: Record<string, JsonValue> | ErrorAttributes,
+  ) {
     if (this.level <= LogLevel.WARN) {
       this.logSystem.warn(message, attributes);
     }
   }
 
-  error(message: string, attributes?: Record<string, JsonValue>) {
+  error(
+    message: string,
+    attributes?: Record<string, JsonValue> | ErrorAttributes,
+  ) {
     if (this.level <= LogLevel.ERROR) {
       this.logSystem.error(message, attributes);
     }

--- a/packages/cojson/src/storage/index.ts
+++ b/packages/cojson/src/storage/index.ts
@@ -83,30 +83,23 @@ export class LSMStorage<WH, RH, FS extends FileSystem<WH, RH>> {
             await this.sendNewContent(msg.id, msg, undefined);
           }
         } catch (e) {
-          logger.error(
-            `Error reading from localNode, handling msg\n\n${JSON.stringify(
-              msg,
-              (k, v) =>
-                k === "changes" || k === "encryptedChanges"
-                  ? v.slice(0, 20) + "..."
-                  : v,
-            )}
-            Error: ${e instanceof Error ? e.message : "Unknown error"},
-            `,
-          );
+          logger.error(`Error reading from localNode, handling msg`, {
+            msg,
+            err: e,
+          });
         }
         nMsg++;
       }
     };
 
     processMessages().catch((e) =>
-      logger.error("Error in processMessages in storage", e),
+      logger.error("Error in processMessages in storage", { err: e }),
     );
 
     setTimeout(
       () =>
         this.compact().catch((e) => {
-          logger.error("Error while compacting", e);
+          logger.error("Error while compacting", { err: e });
         }),
       20000,
     );
@@ -132,7 +125,7 @@ export class LSMStorage<WH, RH, FS extends FileSystem<WH, RH>> {
           sessions: {},
           asDependencyOf,
         })
-        .catch((e) => logger.error("Error while pushing known", e));
+        .catch((e) => logger.error("Error while pushing known", { err: e }));
 
       return;
     }
@@ -188,13 +181,15 @@ export class LSMStorage<WH, RH, FS extends FileSystem<WH, RH>> {
         ...ourKnown,
         asDependencyOf,
       })
-      .catch((e) => logger.error("Error while pushing known", e));
+      .catch((e) => logger.error("Error while pushing known", { err: e }));
 
     for (const message of newContentMessages) {
       if (Object.keys(message.new).length === 0) continue;
       this.toLocalNode
         .push(message)
-        .catch((e) => logger.error("Error while pushing new content", e));
+        .catch((e) =>
+          logger.error("Error while pushing new content", { err: e }),
+        );
     }
 
     this.coValues[id] = coValue;
@@ -502,7 +497,7 @@ export class LSMStorage<WH, RH, FS extends FileSystem<WH, RH>> {
     setTimeout(
       () =>
         this.compact().catch((e) => {
-          logger.error("Error while compacting", e);
+          logger.error("Error while compacting", { err: e });
         }),
       5000,
     );


### PR DESCRIPTION
Moving the raw errors in the { err } attribute to get better logging with the console (because the stack would be always visible) and when pino is used (because the `err` property is serialized using the "error" serializer)