### PR TITLE
fix: use PureJSCrypto as fallback when WasmCrypto fails to initialize

### DIFF
--- a/.changeset/tiny-ladybugs-laugh.md
+++ b/.changeset/tiny-ladybugs-laugh.md
@@ -1,0 +1,5 @@
+---
+"cojson": patch
+---
+
+Use PureJSCrypto as fallback when WasmCrypto fails to initialize

--- a/packages/cojson-transport-ws/src/tests/integration.test.ts
+++ b/packages/cojson-transport-ws/src/tests/integration.test.ts
@@ -1,4 +1,4 @@
-import { ControlledAgent, LocalNode } from "cojson";
+import { ControlledAgent, type CryptoProvider, LocalNode } from "cojson";
 import { WasmCrypto } from "cojson/crypto/WasmCrypto";
 import { afterEach, beforeEach, describe, expect, test } from "vitest";
 import { WebSocket } from "ws";
@@ -8,7 +8,7 @@ import { startSyncServer } from "./syncServer";
 describe("WebSocket Peer Integration", () => {
   let server: any;
   let syncServerUrl: string;
-  let crypto: WasmCrypto;
+  let crypto: CryptoProvider;
 
   beforeEach(async () => {
     crypto = await WasmCrypto.create();

--- a/packages/cojson/src/crypto/WasmCrypto.ts
+++ b/packages/cojson/src/crypto/WasmCrypto.ts
@@ -20,6 +20,7 @@ import { RawCoID, TransactionID } from "../ids.js";
 import { Stringified, stableStringify } from "../jsonStringify.js";
 import { JsonValue } from "../jsonValue.js";
 import { logger } from "../logger.js";
+import { PureJSCrypto } from "./PureJSCrypto.js";
 import {
   CryptoProvider,
   Encrypted,
@@ -49,8 +50,17 @@ export class WasmCrypto extends CryptoProvider<Blake3State> {
     super();
   }
 
-  static async create(): Promise<WasmCrypto> {
-    await initialize();
+  static async create(): Promise<WasmCrypto | PureJSCrypto> {
+    try {
+      await initialize();
+    } catch (e) {
+      logger.error(
+        "Failed to initialize WasmCrypto, falling back to PureJSCrypto",
+        { err: e },
+      );
+      return new PureJSCrypto();
+    }
+
     return new WasmCrypto();
   }
 

--- a/packages/jazz-tools/src/tests/schemaUnion.test.ts
+++ b/packages/jazz-tools/src/tests/schemaUnion.test.ts
@@ -4,6 +4,7 @@ import { SchemaUnion } from "../coValues/schemaUnion.js";
 import {
   Account,
   CoMap,
+  CryptoProvider,
   co,
   loadCoValue,
   subscribeToCoValue,
@@ -63,7 +64,7 @@ const getWidgetSchemaFromRaw = (raw: BaseWidget["_raw"]) => {
 class WidgetUnion extends SchemaUnion.Of<BaseWidget>(getWidgetSchemaFromRaw) {}
 
 describe("SchemaUnion", () => {
-  let Crypto: WasmCrypto;
+  let Crypto: CryptoProvider;
   let me: Account;
 
   beforeAll(async () => {

--- a/tests/cloudflare-workers/src/index.ts
+++ b/tests/cloudflare-workers/src/index.ts
@@ -1,5 +1,5 @@
 import { createWebSocketPeer } from "cojson-transport-ws";
-import { PureJSCrypto } from "cojson/crypto/PureJSCrypto";
+import { WasmCrypto } from "cojson/crypto/WasmCrypto";
 import { Hono } from "hono";
 import { startWorker } from "jazz-nodejs";
 import { CoMap, co } from "jazz-tools";
@@ -25,9 +25,9 @@ class MyAccount extends Account {
 
 const syncServer = "wss://cloud.jazz.tools/?key=jazz@jazz.tools";
 
-const crypto = await PureJSCrypto.create();
-
 app.get("/", async (c) => {
+  const crypto = await WasmCrypto.create();
+
   const peer = createWebSocketPeer({
     id: "upstream",
     websocket: new WebSocket(syncServer),


### PR DESCRIPTION
Use PureJSCrypto as fallback when WasmCrypto fails to initialize (it can happen on Cloudflare workers and Vercel V0 preview environment)
