### PR TITLE
fix(chat-example): render "message not readable" if a message is not readable

### DIFF
--- a/.changeset/smooth-laws-admire.md
+++ b/.changeset/smooth-laws-admire.md
@@ -1,0 +1,5 @@
+---
+"jazz-example-chat": patch
+---
+
+In the chat app example, show a "Message not readable" placeholder, if messages from a chat list are not readable by the user.

--- a/examples/chat/src/chatScreen.tsx
+++ b/examples/chat/src/chatScreen.tsx
@@ -1,6 +1,6 @@
 import { createImage } from "jazz-browser-media-images";
-import { useCoState } from "jazz-react";
-import { ID } from "jazz-tools";
+import { useAccount, useCoState } from "jazz-react";
+import { Account, ID } from "jazz-tools";
 import { useState } from "react";
 import { Chat, Message } from "./schema.ts";
 import {
@@ -17,6 +17,7 @@ import {
 } from "./ui.tsx";
 
 export function ChatScreen(props: { chatID: ID<Chat> }) {
+  const account = useAccount();
   const chat = useCoState(Chat, props.chatID, [{}]);
   const [showNLastMessages, setShowNLastMessages] = useState(30);
 
@@ -47,7 +48,7 @@ export function ChatScreen(props: { chatID: ID<Chat> }) {
           chat
             .slice(-showNLastMessages)
             .reverse() // this plus flex-col-reverse on ChatBody gives us scroll-to-bottom behavior
-            .map((msg) => <ChatBubble msg={msg} key={msg.id} />)
+            .map((msg) => <ChatBubble me={account.me} msg={msg} key={msg.id} />)
         ) : (
           <EmptyChatMessage />
         )}
@@ -74,7 +75,20 @@ export function ChatScreen(props: { chatID: ID<Chat> }) {
   );
 }
 
-function ChatBubble(props: { msg: Message }) {
+function ChatBubble(props: { me: Account; msg: Message }) {
+  if (!props.me.canRead(props.msg)) {
+    return (
+      <BubbleContainer fromMe={false}>
+        <BubbleBody fromMe={false}>
+          <BubbleText
+            text="Message not readable"
+            className="text-gray-500 italic"
+          />
+        </BubbleBody>
+      </BubbleContainer>
+    );
+  }
+
   const lastEdit = props.msg._edits.text;
   const fromMe = lastEdit.by?.isMe;
   const { text, image } = props.msg;

--- a/examples/chat/src/ui.tsx
+++ b/examples/chat/src/ui.tsx
@@ -70,8 +70,12 @@ export function BubbleBody(props: {
   );
 }
 
-export function BubbleText(props: { text: string }) {
-  return <p className="px-2 leading-relaxed">{props.text}</p>;
+export function BubbleText(props: { text: string; className?: string }) {
+  return (
+    <p className={clsx("px-2 leading-relaxed", props.className)}>
+      {props.text}
+    </p>
+  );
 }
 
 export function BubbleImage(props: { image: ImageDefinition }) {


### PR DESCRIPTION
Fixes https://github.com/garden-co/jazz/issues/1646

<img width="1721" alt="Screenshot 2025-03-12 at 19 14 22" src="https://github.com/user-attachments/assets/306e7958-35c9-4e17-8c5a-c76be5c7093c" />
