### PR TITLE
Removed when="singedUp" from examples apps' Jazz providers

### DIFF
--- a/.changeset/big-pens-pull.md
+++ b/.changeset/big-pens-pull.md
@@ -1,0 +1,18 @@
+---
+"jazz-tailwind-demo-auth-starter": patch
+"file-share-svelte": patch
+"jazz-password-manager": patch
+"version-history": patch
+"passkey-svelte": patch
+"chat-rn-clerk": patch
+"jazz-example-music-player": patch
+"passphrase": patch
+"multiauth": patch
+"reactions": patch
+"passkey": patch
+"clerk": patch
+"jazz-example-pets": patch
+"jazz-example-todo": patch
+---
+
+Removed when="singedUp" from examples apps' Jazz providers. This is a really niche use-case option and can lead to broken-feeling experiences when anonymous users try to load something.

--- a/examples/chat-rn-clerk/src/auth-context.tsx
+++ b/examples/chat-rn-clerk/src/auth-context.tsx
@@ -12,7 +12,6 @@ export function JazzAndAuth({ children }: PropsWithChildren) {
       storage="sqlite"
       sync={{
         peer: `wss://cloud.jazz.tools/?key=${apiKey}`,
-        when: "signedUp", // This makes the app work in local mode when the user is not authenticated
       }}
     >
       {children}

--- a/examples/clerk/src/main.tsx
+++ b/examples/clerk/src/main.tsx
@@ -21,7 +21,6 @@ function JazzProvider({ children }: { children: React.ReactNode }) {
       clerk={clerk}
       sync={{
         peer: `wss://cloud.jazz.tools/?key=${apiKey}`,
-        when: "signedUp", // This makes the app work in local mode when the user is not authenticated
       }}
     >
       {children}

--- a/examples/file-share-svelte/src/routes/+layout.svelte
+++ b/examples/file-share-svelte/src/routes/+layout.svelte
@@ -27,7 +27,6 @@
   AccountSchema={FileShareAccount}
   sync={{
     peer: `wss://cloud.jazz.tools/?key=${apiKey}`,
-    when: "signedUp",
   }}
 >
   <PasskeyAuthBasicUI appName="File Share">

--- a/examples/multiauth/src/main.tsx
+++ b/examples/multiauth/src/main.tsx
@@ -19,7 +19,6 @@ createRoot(document.getElementById("root")!).render(
       <OmniAuth
         sync={{
           peer: `wss://cloud.jazz.tools/?key=${apiKey}`,
-          when: "signedUp", // This makes the app work in local mode when the user is not authenticated
         }}
       >
         <App />

--- a/examples/music-player/src/2_main.tsx
+++ b/examples/music-player/src/2_main.tsx
@@ -72,7 +72,6 @@ ReactDOM.createRoot(document.getElementById("root")!).render(
     <JazzProvider
       sync={{
         peer,
-        when: "signedUp", // This makes the app work in local mode when the user is anonymous
       }}
       storage="indexedDB"
       AccountSchema={MusicaAccount}

--- a/examples/passkey-svelte/src/routes/+layout.svelte
+++ b/examples/passkey-svelte/src/routes/+layout.svelte
@@ -8,7 +8,6 @@
 <JazzProvider
   sync={{
     peer: `wss://cloud.jazz.tools/?key={apiKey}`,
-    when: "signedUp",
   }}
 >
   <PasskeyAuthBasicUI appName="minimal-svelte-auth-passkey">

--- a/examples/passkey/src/main.tsx
+++ b/examples/passkey/src/main.tsx
@@ -10,7 +10,6 @@ function JazzAndAuth({ children }: { children: React.ReactNode }) {
     <JazzProvider
       sync={{
         peer: `wss://cloud.jazz.tools/?key=${apiKey}`,
-        when: "signedUp",
       }}
     >
       <PasskeyAuthBasicUI appName="Jazz Minimal Auth Passkey Example">

--- a/examples/passphrase/src/main.tsx
+++ b/examples/passphrase/src/main.tsx
@@ -142,7 +142,6 @@ function JazzAndAuth({ children }: { children: React.ReactNode }) {
     <JazzProvider
       sync={{
         peer: "wss://cloud.jazz.tools/?key=minimal-auth-passphrase-example@garden.co",
-        when: "signedUp",
       }}
     >
       <PassphraseAuthBasicUI

--- a/examples/password-manager/src/2_main.tsx
+++ b/examples/password-manager/src/2_main.tsx
@@ -12,7 +12,6 @@ function JazzAndAuth({ children }: { children: React.ReactNode }) {
       AccountSchema={PasswordManagerAccount}
       sync={{
         peer: `wss://cloud.jazz.tools/?key=${apiKey}`,
-        when: "signedUp",
       }}
     >
       <PasskeyAuthBasicUI appName="Jazz Password Manager">

--- a/examples/pets/src/2_main.tsx
+++ b/examples/pets/src/2_main.tsx
@@ -52,7 +52,6 @@ ReactDOM.createRoot(document.getElementById("root")!).render(
         <JazzProvider
           sync={{
             peer,
-            when: "signedUp",
           }}
           AccountSchema={PetAccount}
         >

--- a/examples/reactions/src/main.tsx
+++ b/examples/reactions/src/main.tsx
@@ -10,7 +10,6 @@ createRoot(document.getElementById("root")!).render(
     <JazzProvider
       sync={{
         peer: `wss://cloud.jazz.tools/?key=${apiKey}`,
-        when: "signedUp",
       }}
     >
       <PasskeyAuthBasicUI appName="Jazz Reactions Example">

--- a/examples/todo/src/2_main.tsx
+++ b/examples/todo/src/2_main.tsx
@@ -42,7 +42,6 @@ function JazzAndAuth({ children }: { children: React.ReactNode }) {
     <JazzProvider
       sync={{
         peer: `wss://cloud.jazz.tools/?key=${apiKey}`,
-        when: "signedUp",
       }}
       AccountSchema={TodoAccount}
     >

--- a/examples/version-history/src/main.tsx
+++ b/examples/version-history/src/main.tsx
@@ -11,7 +11,6 @@ createRoot(document.getElementById("root")!).render(
     <JazzProvider
       sync={{
         peer: `wss://cloud.jazz.tools/?key=${apiKey}`,
-        when: "signedUp",
       }}
     >
       <DemoAuthBasicUI appName="Jazz Version History Example">

--- a/starters/react-passkey-auth/src/main.tsx
+++ b/starters/react-passkey-auth/src/main.tsx
@@ -20,7 +20,6 @@ createRoot(document.getElementById("root")!).render(
     <JazzProvider
       sync={{
         peer: `wss://cloud.jazz.tools/?key=${apiKey}`,
-        when: "signedUp", // This way when the user hasn't signed up we store the data only locally
       }}
       AccountSchema={JazzAccount}
     >


### PR DESCRIPTION
> This is a really niche use-case option and can lead to broken-feeling experiences when anonymous users try to load something.

Fixes #1667