### PR TITLE
disable renaming tailwind classes when using jazz-inspector

### DIFF
--- a/.changeset/sharp-planes-work.md
+++ b/.changeset/sharp-planes-work.md
@@ -1,0 +1,5 @@
+---
+"jazz-inspector": patch
+---
+
+disable renaming tailwind classes

--- a/packages/jazz-inspector/src/twind.config.ts
+++ b/packages/jazz-inspector/src/twind.config.ts
@@ -28,6 +28,7 @@ Object.keys(stonePalette).forEach((key) => {
 });
 
 export default defineConfig({
+  hash: false,
   presets: [presetAutoprefix(), presetTailwind()],
   theme: {
     extend: {


### PR DESCRIPTION
Fix for: embedding the inspector renamed tailwind classes
![image](https://github.com/user-attachments/assets/8943289c-c02b-4817-9d89-5c23754681d9)
