### PR TITLE
Docs nav: collapse upgrade guides into one item

### DIFF
--- a/homepage/homepage/app/globals.css
+++ b/homepage/homepage/app/globals.css
@@ -10,6 +10,15 @@
   :focus-visible {
     @apply ring-2 ring-blue/75 dark:ring-blue-400/75;
   }
+
+  details > summary {
+    @apply cursor-pointer;
+
+    &.list-none::-webkit-details-marker,
+    &.list-none::marker {
+      display: none;
+    }
+  }
 }
 
 @layer components {

--- a/homepage/homepage/components/SideNav.tsx
+++ b/homepage/homepage/components/SideNav.tsx
@@ -1,7 +1,10 @@
 import { SideNavHeader } from "@/components/SideNavHeader";
 import { SideNavItem } from "@/components/SideNavItem";
 import { Framework } from "@/lib/framework";
+import { useFramework } from "@/lib/use-framework";
 import { clsx } from "clsx";
+import { Icon } from "gcmp-design-system/src/app/components/atoms/Icon";
+import { usePathname } from "next/navigation";
 import React from "react";
 
 interface SideNavItem {
@@ -13,6 +16,8 @@ interface SideNavItem {
         [key in Framework]: number;
       };
   items?: SideNavItem[];
+  collapse?: boolean;
+  prefix?: string;
 }
 export function SideNav({
   items,
@@ -26,40 +31,17 @@ export function SideNav({
   footer?: React.ReactNode;
 }) {
   return (
-    <div className={clsx(className, "text-sm h-full pt-3 md:pt-8 flex flex-col gap-4 px-2")}>
+    <div
+      className={clsx(
+        className,
+        "text-sm h-full pt-3 md:pt-8 flex flex-col gap-4 px-2",
+      )}
+    >
       {children}
 
       <div className="flex-1 relative overflow-y-auto px-2 -mx-2">
-        {items.map(({ name, href, items }) => (
-          <React.Fragment key={name}>
-            <SideNavHeader href={href}>{name}</SideNavHeader>
-            {items &&
-              items.map(({ name, href, items, done }) => (
-                <ul key={name}>
-                  <li>
-                    <SideNavItem href={href}>
-                      <span
-                        className={
-                          done === 0 ? "text-stone-400 dark:text-stone-600" : ""
-                        }
-                      >
-                        {name}
-                      </span>
-                    </SideNavItem>
-                  </li>
-
-                  {items && items?.length > 0 && (
-                    <ul className="pl-4">
-                      {items.map(({ name, href }) => (
-                        <li key={href}>
-                          <SideNavItem href={href}>{name}</SideNavItem>
-                        </li>
-                      ))}
-                    </ul>
-                  )}
-                </ul>
-              ))}
-          </React.Fragment>
+        {items.map((item) => (
+          <SideNavSection item={item} key={item.name} />
         ))}
 
         {footer}
@@ -67,12 +49,80 @@ export function SideNav({
         <div
           aria-hidden
           className={clsx(
-          "h-12 right-0 sticky bottom-0 left-0",
-          "bg-gradient-to-t from-white  to-transparent",
+            "h-12 right-0 sticky bottom-0 left-0",
+            "bg-gradient-to-t from-white  to-transparent",
             "dark:from-stone-950",
-            "hidden md:block"
-        )}/>
+            "hidden md:block",
+          )}
+        />
       </div>
     </div>
+  );
+}
+
+export function SideNavSection({
+  item: { name, href, collapse, items, prefix },
+}: { item: SideNavItem }) {
+  const path = usePathname();
+  const framework = useFramework();
+  if (!collapse) {
+    return (
+      <>
+        <SideNavHeader href={href}>{name}</SideNavHeader>
+
+        <SideNavSectionList items={items} />
+      </>
+    );
+  }
+  return (
+    <>
+      <details
+        className="group [&:not(:first-child)]:mt-4"
+        open={
+          prefix
+            ? path.startsWith(
+                prefix.replace("/docs/", "/docs/" + framework + "/"),
+              )
+            : true
+        }
+      >
+        <summary className="list-none">
+          <SideNavHeader href={href}>
+            {name}
+            {collapse && (
+              <Icon
+                className="group-open:rotate-180 transition-transform group-hover:text-stone-500 text-stone-400 dark:text-stone-600"
+                name="chevronDown"
+                size="xs"
+              />
+            )}
+          </SideNavHeader>
+        </summary>
+
+        <SideNavSectionList items={items} />
+      </details>
+    </>
+  );
+}
+
+export function SideNavSectionList({ items }: { items?: SideNavItem[] }) {
+  return (
+    !!items?.length && (
+      <ul>
+        {items.map(({ name, href, items, done }) => (
+          <li key={name}>
+            <SideNavItem href={href}>
+              <span
+                className={
+                  done === 0 ? "text-stone-400 dark:text-stone-600" : ""
+                }
+              >
+                {name}
+              </span>
+            </SideNavItem>
+          </li>
+        ))}
+      </ul>
+    )
   );
 }

--- a/homepage/homepage/components/SideNavHeader.tsx
+++ b/homepage/homepage/components/SideNavHeader.tsx
@@ -1,5 +1,5 @@
+import { clsx } from "clsx";
 import Link from "next/link";
-import {clsx} from "clsx";
 
 export function SideNavHeader({
   href,
@@ -12,7 +12,7 @@ export function SideNavHeader({
 }) {
   const classes = clsx(
     className,
-    "block font-medium text-stone-900 py-1 dark:text-white mb-1  [&:not(:first-child)]:mt-4",
+    "flex items-center gap-2 justify-between font-medium text-stone-900 py-1 dark:text-white mb-1 [&:not(:first-child)]:mt-4",
   );
   if (href) {
     return (

--- a/homepage/homepage/components/docs/nav.tsx
+++ b/homepage/homepage/components/docs/nav.tsx
@@ -20,8 +20,7 @@ export function DocNav({ className }: { className?: string }) {
           if (!item.href?.startsWith("/docs")) return item;
 
           const frameworkDone = (item.done as any)[framework] ?? 0;
-          let done =
-            typeof item.done === "number" ? item.done : frameworkDone;
+          let done = typeof item.done === "number" ? item.done : frameworkDone;
           let href = item.href.replace("/docs", `/docs/${framework}`);
 
           return {

--- a/homepage/homepage/lib/docNavigationItems.js
+++ b/homepage/homepage/lib/docNavigationItems.js
@@ -63,10 +63,12 @@ export const docNavigationItems = [
         href: "/docs/inspector",
         done: 100,
       },
-    ]
+    ],
   },
   {
     name: "Upgrade guides",
+    collapse: true,
+    prefix: "/docs/upgrade",
     items: [
       {
         // upgrade guides


### PR DESCRIPTION
test here: https://jazz-homepage-git-1702-collapse-upgrade-guides-gcmp.vercel.app/docs/react

<img width="292" alt="image" src="https://github.com/user-attachments/assets/e794f5fe-1f67-4dea-a63c-9d079614e27e" />
<img width="283" alt="image" src="https://github.com/user-attachments/assets/2daf5ed3-dcb2-4fcf-9cf2-392aa45bb084" />

fixes #1702
