### PR TITLE
fix: handle invalid or undefined id

### DIFF
--- a/.changeset/odd-bananas-hug.md
+++ b/.changeset/odd-bananas-hug.md
@@ -1,0 +1,5 @@
+---
+"cojson": patch
+---
+
+Throw an error when the user tries to load an invalid or undefined id

--- a/packages/cojson/src/localNode.ts
+++ b/packages/cojson/src/localNode.ts
@@ -288,6 +288,14 @@ export class LocalNode {
    * @category 3. Low-level
    */
   async load<T extends RawCoValue>(id: CoID<T>): Promise<T | "unavailable"> {
+    if (!id) {
+      throw new Error("Trying to load CoValue with undefined id");
+    }
+
+    if (!id.startsWith("co_z")) {
+      throw new Error(`Trying to load CoValue with invalid id ${id}`);
+    }
+
     const core = await this.loadCoValueCore(id);
 
     if (core === "unavailable") {

--- a/packages/cojson/src/sync.ts
+++ b/packages/cojson/src/sync.ts
@@ -159,7 +159,18 @@ export class SyncManager {
         `Skipping message ${msg.action} on errored coValue ${msg.id} from peer ${peer.id}`,
       );
       return;
+    } else if (msg.id === undefined) {
+      logger.info("Received sync message with undefined id", {
+        msg,
+      });
+      return;
+    } else if (!msg.id.startsWith("co_z")) {
+      logger.info("Received sync message with invalid id", {
+        msg,
+      });
+      return;
     }
+
     // TODO: validate
     switch (msg.action) {
       case "load":


### PR DESCRIPTION
When trying to load the multi-cursor example I found that:
- The app breaks if a non-valid id is provided
- The Jazz cloud server crashes if a message with an invailid id is synced

This PR addresses those issues.