### PR TITLE
perf: optimize Group.roleOf getter and made the transactions validation incremental for CoMap and CoFeed

### DIFF
--- a/.changeset/giant-mails-sneeze.md
+++ b/.changeset/giant-mails-sneeze.md
@@ -2,4 +2,4 @@
 "cojson": patch
 ---
 
-Performance: optimize Group.roleOf getter
+Performance: optimize Group.roleOf getter and made the transactions validation incremental for CoMap and CoFeed

--- a/.changeset/giant-mails-sneeze.md
+++ b/.changeset/giant-mails-sneeze.md
@@ -1,0 +1,5 @@
+---
+"cojson": patch
+---
+
+Performance: optimize Group.roleOf getter

--- a/packages/cojson/src/coValueCore.ts
+++ b/packages/cojson/src/coValueCore.ts
@@ -35,7 +35,6 @@ import { CoValueKnownState, NewContentMessage } from "./sync.js";
 import { accountOrAgentIDfromSessionID } from "./typeUtils/accountOrAgentIDfromSessionID.js";
 import { expectGroup } from "./typeUtils/expectGroup.js";
 import { isAccountID } from "./typeUtils/isAccountID.js";
-import { parseError } from "./utils.js";
 
 /**
     In order to not block other concurrently syncing CoValues we introduce a maximum size of transactions,

--- a/packages/cojson/src/coValueCore.ts
+++ b/packages/cojson/src/coValueCore.ts
@@ -497,7 +497,10 @@ export class CoValueCore {
     ignorePrivateTransactions: boolean;
     knownTransactions?: CoValueKnownState["sessions"];
   }): DecryptedTransaction[] {
-    const validTransactions = determineValidTransactions(this);
+    const validTransactions = determineValidTransactions(
+      this,
+      options?.knownTransactions,
+    );
 
     const allTransactions: DecryptedTransaction[] = [];
 

--- a/packages/cojson/src/coValues/coMap.ts
+++ b/packages/cojson/src/coValues/coMap.ts
@@ -84,6 +84,15 @@ export class RawCoMapView<
       throw new Error("Cannot process transactions on a time travel entity");
     }
 
+    const newValidTransactions = this.core.getValidTransactions({
+      ignorePrivateTransactions: this.ignorePrivateTransactions,
+      knownTransactions: this.knownTransactions,
+    });
+
+    if (newValidTransactions.length === 0) {
+      return;
+    }
+
     const { ops } = this;
 
     const changedEntries = new Map<
@@ -91,12 +100,7 @@ export class RawCoMapView<
       NonNullable<(typeof ops)[keyof typeof ops]>
     >();
 
-    const nextValidTransactions = this.core.getValidTransactions({
-      ignorePrivateTransactions: this.ignorePrivateTransactions,
-      knownTransactions: this.knownTransactions,
-    });
-
-    for (const { txID, changes, madeAt } of nextValidTransactions) {
+    for (const { txID, changes, madeAt } of newValidTransactions) {
       for (let changeIdx = 0; changeIdx < changes.length; changeIdx++) {
         const change = changes[changeIdx] as MapOpPayload<
           keyof Shape & string,

--- a/packages/cojson/src/coValues/coStream.ts
+++ b/packages/cojson/src/coValues/coStream.ts
@@ -99,10 +99,16 @@ export class RawCoStreamView<
   protected processNewTransactions() {
     const changeEntries = new Set<CoStreamItem<Item>[]>();
 
-    for (const { txID, madeAt, changes } of this.core.getValidTransactions({
+    const newValidTransactions = this.core.getValidTransactions({
       ignorePrivateTransactions: false,
       knownTransactions: this.knownTransactions,
-    })) {
+    });
+
+    if (newValidTransactions.length === 0) {
+      return;
+    }
+
+    for (const { txID, madeAt, changes } of newValidTransactions) {
       for (const changeUntyped of changes) {
         const change = changeUntyped as Item;
         let entries = this.items[txID.sessionID];

--- a/packages/cojson/src/permissions.ts
+++ b/packages/cojson/src/permissions.ts
@@ -101,7 +101,7 @@ export function determineValidTransactions(
         }
 
         const transactorRoleAtTxTime =
-          groupAtTime.roleOfInternal(effectiveTransactor)?.role;
+          groupAtTime.roleOfInternal(effectiveTransactor);
 
         if (
           transactorRoleAtTxTime !== "admin" &&

--- a/packages/cojson/src/permissions.ts
+++ b/packages/cojson/src/permissions.ts
@@ -90,9 +90,10 @@ export function determineValidTransactions(
 
     for (const [sessionID, sessionLog] of coValue.sessionLogs.entries()) {
       const transactor = accountOrAgentIDfromSessionID(sessionID);
+      const knownTransactionsForSession = knownTransactions?.[sessionID] ?? -1;
 
       sessionLog.transactions.forEach((tx, txIndex) => {
-        if (knownTransactions?.[sessionID]! >= txIndex) {
+        if (knownTransactionsForSession >= txIndex) {
           return;
         }
 
@@ -126,8 +127,10 @@ export function determineValidTransactions(
     const validTransactions: ValidTransactionsResult[] = [];
 
     for (const [sessionID, sessionLog] of coValue.sessionLogs.entries()) {
+      const knownTransactionsForSession = knownTransactions?.[sessionID] ?? -1;
+
       sessionLog.transactions.forEach((tx, txIndex) => {
-        if (knownTransactions?.[sessionID]! >= txIndex) {
+        if (knownTransactionsForSession >= txIndex) {
           return;
         }
 

--- a/packages/cojson/src/tests/permissions.test.ts
+++ b/packages/cojson/src/tests/permissions.test.ts
@@ -2277,30 +2277,16 @@ test("Member roles are inherited by child groups (except invites)", () => {
   parentGroup.addMember(writerInvite, "writerInvite");
   parentGroup.addMember(readerInvite, "readerInvite");
 
-  expect(group.roleOfInternal(admin.id)).toEqual({
-    role: "admin",
-    via: undefined,
-  });
+  expect(group.roleOfInternal(admin.id)).toEqual("admin");
 
-  expect(group.roleOfInternal(writer.id)).toEqual({
-    role: "writer",
-    via: parentGroup.id,
-  });
   expect(group.roleOf(writer.id)).toEqual("writer");
 
-  expect(group.roleOfInternal(reader.id)).toEqual({
-    role: "reader",
-    via: parentGroup.id,
-  });
   expect(group.roleOf(reader.id)).toEqual("reader");
 
-  expect(group.roleOfInternal(adminInvite.id)).toEqual(undefined);
   expect(group.roleOf(adminInvite.id)).toEqual(undefined);
 
-  expect(group.roleOfInternal(writerInvite.id)).toEqual(undefined);
   expect(group.roleOf(writerInvite.id)).toEqual(undefined);
 
-  expect(group.roleOfInternal(readerInvite.id)).toEqual(undefined);
   expect(group.roleOf(readerInvite.id)).toEqual(undefined);
 });
 
@@ -2324,30 +2310,16 @@ test("Member roles are inherited by grand-children groups (except invites)", () 
   grandParentGroup.addMember(writerInvite, "writerInvite");
   grandParentGroup.addMember(readerInvite, "readerInvite");
 
-  expect(group.roleOfInternal(admin.id)).toEqual({
-    role: "admin",
-    via: undefined,
-  });
+  expect(group.roleOfInternal(admin.id)).toEqual("admin");
 
-  expect(group.roleOfInternal(writer.id)).toEqual({
-    role: "writer",
-    via: parentGroup.id,
-  });
   expect(group.roleOf(writer.id)).toEqual("writer");
 
-  expect(group.roleOfInternal(reader.id)).toEqual({
-    role: "reader",
-    via: parentGroup.id,
-  });
   expect(group.roleOf(reader.id)).toEqual("reader");
 
-  expect(group.roleOfInternal(adminInvite.id)).toEqual(undefined);
   expect(group.roleOf(adminInvite.id)).toEqual(undefined);
 
-  expect(group.roleOfInternal(writerInvite.id)).toEqual(undefined);
   expect(group.roleOf(writerInvite.id)).toEqual(undefined);
 
-  expect(group.roleOfInternal(readerInvite.id)).toEqual(undefined);
   expect(group.roleOf(readerInvite.id)).toEqual(undefined);
 });
 

--- a/packages/jazz-tools/src/coValues/group.ts
+++ b/packages/jazz-tools/src/coValues/group.ts
@@ -212,7 +212,7 @@ export class Group extends CoValueBase implements CoValue {
   }
 
   getParentGroups(): Array<Group> {
-    return this._raw.getParentGroups().map(({ group }) => Group.fromRaw(group));
+    return this._raw.getParentGroups().map((group) => Group.fromRaw(group));
   }
 
   extend(


### PR DESCRIPTION
Refactored Group.roleOf to avoid any unneccessary value allocation.

Tested on the multi-cursor example.

Before:
![Screenshot 2025-03-26 at 12 59 02](https://github.com/user-attachments/assets/75bcdb9c-8b57-4e57-8afa-4f7e68b1a621)

After the Group.roleOf optimization:
![Screenshot 2025-03-26 at 12 59 12](https://github.com/user-attachments/assets/0faecec3-b7e3-41d8-bf08-b245b55228e3)

After the transactions validation optimization:
![Screenshot 2025-03-26 at 14 21 19](https://github.com/user-attachments/assets/2b8d1796-3116-40e9-a844-5fb21fae8f03)
