### PR TITLE
fix: trigger a single update when loading a locally available list of items

### DIFF
--- a/.changeset/fifty-planes-yawn.md
+++ b/.changeset/fifty-planes-yawn.md
@@ -1,0 +1,6 @@
+---
+"jazz-react-core": patch
+"jazz-tools": patch
+---
+
+Bugfix: Trigger a single update when loading a locally available list of items

--- a/packages/jazz-react-core/src/tests/useCoState.test.ts
+++ b/packages/jazz-react-core/src/tests/useCoState.test.ts
@@ -1,7 +1,7 @@
 // @vitest-environment happy-dom
 
 import { cojsonInternals } from "cojson";
-import { CoMap, CoValue, ID, co } from "jazz-tools";
+import { CoList, CoMap, CoValue, ID, co } from "jazz-tools";
 import { beforeEach, describe, expect, expectTypeOf, it } from "vitest";
 import { useCoState } from "../index.js";
 import { createJazzTestAccount, setupJazzTestSync } from "../testing.js";
@@ -196,5 +196,41 @@ describe("useCoState", () => {
     rerender({ id: undefined });
 
     expect(result.current?.value).toBeUndefined();
+  });
+
+  it("should only render twice when loading a list of values", async () => {
+    class TestMap extends CoMap {
+      value = co.string;
+    }
+
+    class TestList extends CoList.Of(co.ref(TestMap)) {}
+
+    const account = await createJazzTestAccount({
+      isCurrentActiveAccount: true,
+    });
+
+    const list = TestList.create([
+      TestMap.create({ value: "1" }),
+      TestMap.create({ value: "2" }),
+      TestMap.create({ value: "3" }),
+      TestMap.create({ value: "4" }),
+      TestMap.create({ value: "5" }),
+    ]);
+
+    let renderCount = 0;
+
+    renderHook(
+      () => {
+        renderCount++;
+        useCoState(TestList, list.id, [{}]);
+      },
+      {
+        account,
+      },
+    );
+
+    await new Promise((resolve) => setTimeout(resolve, 100));
+
+    expect(renderCount).toBe(2);
   });
 });

--- a/packages/jazz-tools/src/coValues/interfaces.ts
+++ b/packages/jazz-tools/src/coValues/interfaces.ts
@@ -270,19 +270,19 @@ export function subscribeToCoValue<V extends CoValue, Depth>(
     }
     if (unsubscribed) return;
 
-    let checkingDepth = false;
-
     const subscription = new SubscriptionScope(
       value,
       cls as CoValueClass<V> & CoValueFromRaw<V>,
       (update, subscription) => {
         // fullfillsDepth may trigger a syncronous update while accessing values
         // we want to discard those to avoid invalid updates
-        if (checkingDepth) return false;
+        if (subscription.syncResolution) return false;
 
-        checkingDepth = true;
+        // Enabling syncResolution during fullfillsDepth access to block any
+        // unnecessery update triggers related to in-memory values
+        subscription.syncResolution = true;
         const isLoaded = fulfillsDepth(depth, update);
-        checkingDepth = false;
+        subscription.syncResolution = false;
 
         if (isLoaded) {
           listener(


### PR DESCRIPTION
As [reported on discord](https://discord.com/channels/1139617727565271160/1354094729792589835/1354380965706862742) we are triggering unnecessary updates when loading a list of items that is locally available.

This was caused by an inconsitency in the value loading:
- Ref loads the values syncronously when locally available
- SubscriptionScope loads values always in async, triggering an additional update when the promise resolves

Fixed by making SubscriptionScope load the values syncronously and deduping all the updates triggering while checking fulfillsDepth