### PR TITLE
changed the constructor parameters of the BrowserPasskeyAUth class iin jazz-browser's PasskeyAuth.ts to enable extension of the class

### DIFF
--- a/packages/jazz-browser/src/auth/PasskeyAuth.ts
+++ b/packages/jazz-browser/src/auth/PasskeyAuth.ts
@@ -19,9 +19,9 @@ import {
  */
 export class BrowserPasskeyAuth {
   constructor(
-    private crypto: CryptoProvider,
-    private authenticate: AuthenticateAccountFunction,
-    private authSecretStorage: AuthSecretStorage,
+    protected crypto: CryptoProvider,
+    protected authenticate: AuthenticateAccountFunction,
+    protected authSecretStorage: AuthSecretStorage,
     public appName: string,
     public appHostname: string = window.location.hostname,
   ) {}


### PR DESCRIPTION
So that we can have this and override the default methods like signUp, users can extend signup adding more proprties to profile on signup
even sending verification code and checking for email verification status on login
  ```
export class AppBrowserPasskeyAuth extends BrowserPasskeyAuth { 
  constructor(
    protected crypto: CryptoProvider,
    protected authenticate: AuthenticateAccountFunction,
    protected authSecretStorage: AuthSecretStorage,
    public appName: string,
    public appHostname: string = window.location.hostname,
  ) {
    super(crypto, authenticate, authSecretStorage, appName, appHostname);
  }
}
```