### PR TITLE
fix(useCoState): return null when the id is undefined

### DIFF
--- a/.changeset/rich-carpets-tell.md
+++ b/.changeset/rich-carpets-tell.md
@@ -1,0 +1,5 @@
+---
+"jazz-tools": patch
+---
+
+Accept null as initial value for createCoValueObservable

--- a/.changeset/tender-cows-raise.md
+++ b/.changeset/tender-cows-raise.md
@@ -1,0 +1,5 @@
+---
+"jazz-react-core": patch
+---
+
+Return null when the id provided to useCoState is undefined

--- a/packages/jazz-react-core/src/hooks.ts
+++ b/packages/jazz-react-core/src/hooks.ts
@@ -95,8 +95,8 @@ function useCoValueObservable<
     getCurrentObservable() {
       return ref.current;
     },
-    reset() {
-      ref.current = createCoValueObservable<V, R>();
+    reset(initialValue?: undefined | null) {
+      ref.current = createCoValueObservable<V, R>(initialValue);
     },
   };
 }
@@ -117,9 +117,13 @@ export function useCoState<
   const value = React.useSyncExternalStore<Resolved<V, R> | undefined | null>(
     React.useCallback(
       (callback) => {
-        observable.reset();
+        if (!id) {
+          observable.reset(null);
 
-        if (!id) return () => {};
+          return () => {};
+        }
+
+        observable.reset();
 
         // We subscribe to the context manager to react to the account updates
         // faster than the useSyncExternalStore callback update to keep the isAuthenticated state

--- a/packages/jazz-react-core/src/tests/useCoState.test.ts
+++ b/packages/jazz-react-core/src/tests/useCoState.test.ts
@@ -4,7 +4,11 @@ import { cojsonInternals } from "cojson";
 import { CoList, CoMap, CoValue, Group, ID, co } from "jazz-tools";
 import { beforeEach, describe, expect, expectTypeOf, it } from "vitest";
 import { useCoState } from "../index.js";
-import { createJazzTestAccount, setupJazzTestSync } from "../testing.js";
+import {
+  createJazzTestAccount,
+  linkAccounts,
+  setupJazzTestSync,
+} from "../testing.js";
 import { act, renderHook, waitFor } from "./testUtils.js";
 
 beforeEach(async () => {
@@ -263,6 +267,16 @@ describe("useCoState", () => {
       expect(result.current).not.toBeNull();
       expect(result.current?.value).toBe("123");
     });
+  });
+
+  it("should return a null value when the coValue becomes inaccessible", async () => {
+    class TestMap extends CoMap {
+      value = co.string;
+    }
+
+    const { result } = renderHook(() => useCoState(TestMap, undefined));
+
+    expect(result.current).toBeNull();
   });
 
   it("should update when an inner coValue is updated", async () => {

--- a/packages/jazz-tools/src/coValues/interfaces.ts
+++ b/packages/jazz-tools/src/coValues/interfaces.ts
@@ -406,8 +406,8 @@ export function subscribeToCoValue<
 export function createCoValueObservable<
   V extends CoValue,
   const R extends RefsToResolve<V>,
->() {
-  let currentValue: Resolved<V, R> | undefined | null = undefined;
+>(initialValue: undefined | null = undefined) {
+  let currentValue: Resolved<V, R> | undefined | null = initialValue;
   let subscriberCount = 0;
 
   function subscribe(


### PR DESCRIPTION
Fixes #1754 

> As per new spec undefined means loading state, so when the id is undefined we should return null to flag an "unavailable" state