### PR TITLE
fix(inspector): CoMaps showing as table instead of grid

### DIFF
--- a/.changeset/dry-moose-unite.md
+++ b/.changeset/dry-moose-unite.md
@@ -1,0 +1,5 @@
+---
+"jazz-inspector": patch
+---
+
+fix: comaps showing in a table instead of grid

--- a/packages/jazz-inspector/src/viewer/use-resolve-covalue.ts
+++ b/packages/jazz-inspector/src/viewer/use-resolve-covalue.ts
@@ -93,17 +93,8 @@ export async function resolveCoValue(
       extendedType = "account";
     } else if (isGroup(snapshot)) {
       extendedType = "group";
-    } else {
-      // This check is a bit of a hack
-      // There might be a better way to do this
-      const children = Object.values(snapshot).slice(0, 10);
-      if (
-        children.every((c) => typeof c === "string" && c.startsWith("co_")) &&
-        children.length > 3
-      ) {
-        extendedType = "record";
-      }
     }
+    // TODO: check for Record-like CoMaps
   }
 
   return {
@@ -139,17 +130,8 @@ function subscribeToCoValue(
           extendedType = "account";
         } else if (isGroup(snapshot)) {
           extendedType = "group";
-        } else {
-          const children = Object.values(snapshot).slice(0, 10);
-          if (
-            children.every(
-              (c) => typeof c === "string" && c.startsWith("co_"),
-            ) &&
-            children.length > 3
-          ) {
-            extendedType = "record";
-          }
         }
+        // TODO: check for Record-like CoMaps
       } else if (type === "costream") {
         const coStream = detectCoStreamType(value as RawCoStream);
 

--- a/packages/jazz-inspector/src/viewer/use-resolve-covalue.ts
+++ b/packages/jazz-inspector/src/viewer/use-resolve-covalue.ts
@@ -94,7 +94,6 @@ export async function resolveCoValue(
     } else if (isGroup(snapshot)) {
       extendedType = "group";
     }
-    // TODO: check for Record-like CoMaps
   }
 
   return {
@@ -131,7 +130,6 @@ function subscribeToCoValue(
         } else if (isGroup(snapshot)) {
           extendedType = "group";
         }
-        // TODO: check for Record-like CoMaps
       } else if (type === "costream") {
         const coStream = detectCoStreamType(value as RawCoStream);
 


### PR DESCRIPTION
This is how we're checking for Record-like CoMaps:

```
          const children = Object.values(snapshot).slice(0, 10);

          if (
            children.every(
              (c) => typeof c === "string" && c.startsWith("co_"),
            ) &&
            children.length > 3
          ) {
            extendedType = "record";
          }
```

It takes the first 10 fields, and if all these fields point to a reference (not a primitive), and if there are more than 3 fields, then it's considered a Record-like CoMap.

This is not correct because a Record-like CoMap can also have primitive values. And it also falsely identifies normal CoMaps as Records if all the fields are references, like the following:

```
export class AccountRoot extends CoMap {
  dreams = co.ref(Dreams)
  dreams_archive = co.ref(DreamsArchive)
  preferences = co.ref(Preferences)
  settings = co.ref(Settings)
  user_dream_tags = co.ref(UserDreamTags)
}
```

I've not found a way to detect Record-like CoMaps, so the fix is to remove this checking, and we'll show Records like a regular CoMap, which looks fine imo.

fixes #1843
