### PR TITLE
fix(inspector): invalid html, set z-index to 999

### DIFF
--- a/.changeset/blue-hats-juggle.md
+++ b/.changeset/blue-hats-juggle.md
@@ -1,0 +1,5 @@
+---
+"jazz-inspector": patch
+---
+
+fix: invalid html

--- a/packages/jazz-inspector/src/ui/text.tsx
+++ b/packages/jazz-inspector/src/ui/text.tsx
@@ -10,7 +10,9 @@ interface TextProps extends React.HTMLAttributes<HTMLParagraphElement> {
 }
 
 const BaseText = React.forwardRef<HTMLParagraphElement, TextProps>(
-  ({ muted, strong, small, inline, ...rest }, ref) => <p ref={ref} {...rest} />,
+  ({ muted, strong, small, inline, mono, ...rest }, ref) => (
+    <div ref={ref} {...rest} />
+  ),
 );
 
 const StyledText = styled(BaseText)<TextProps>`

--- a/packages/jazz-inspector/src/viewer/inpsector-button.tsx
+++ b/packages/jazz-inspector/src/viewer/inpsector-button.tsx
@@ -19,6 +19,7 @@ const StyledInspectorButton = styled("button")<{ position: Position }>`
   padding: 0.5rem !important;
   border: 1px solid #e5e3e4;
   border-radius: 0.375rem;
+  z-index: 999;
   
   ${(props) => {
     switch (props.position) {

--- a/packages/jazz-inspector/src/viewer/new-app.tsx
+++ b/packages/jazz-inspector/src/viewer/new-app.tsx
@@ -83,7 +83,7 @@ export function JazzInspector({ position = "right" }: { position?: Position }) {
   }
 
   return (
-    <InspectorContainer as={GlobalStyles} id="__jazz_inspector">
+    <InspectorContainer as={GlobalStyles} style={{ zIndex: 999 }}>
       <HeaderContainer>
         <Breadcrumbs path={path} onBreadcrumbClick={goToIndex} />
         <Form onSubmit={handleCoValueIdSubmit}>

--- a/packages/jazz-inspector/src/viewer/value-renderer.tsx
+++ b/packages/jazz-inspector/src/viewer/value-renderer.tsx
@@ -239,9 +239,7 @@ export const CoMapPreview = ({
           .map(([key, value]) => (
             <React.Fragment key={key}>
               <Text strong>{key}: </Text>
-              <Text inline>
-                <ValueRenderer compact json={value} />
-              </Text>
+              <ValueRenderer compact json={value} />
             </React.Fragment>
           ))}
       </PreviewGrid>


### PR DESCRIPTION
- fix nested `<p>` tags
- fix invalid "mono" property written to an HTML element
- set z-index of embedded inspector to 999

fixes #1845