### PR TITLE
fix(inspector): handle displaying a CoList of primitives

### DIFF
--- a/.changeset/tender-goats-chew.md
+++ b/.changeset/tender-goats-chew.md
@@ -1,0 +1,5 @@
+---
+"jazz-inspector": patch
+---
+
+handle displaying a CoList of primitives

--- a/packages/jazz-inspector/src/ui/table.tsx
+++ b/packages/jazz-inspector/src/ui/table.tsx
@@ -1,4 +1,5 @@
 import { styled } from "goober";
+import React from "react";
 
 const StyledTable = styled("table")`
   width: 100%;
@@ -34,26 +35,56 @@ const StyledTd = styled("td")`
   padding: 0.5rem 0.75rem;
 `;
 
-export function Table({ children }: React.PropsWithChildren<{}>) {
-  return <StyledTable>{children}</StyledTable>;
-}
+export const Table = React.forwardRef<
+  HTMLTableElement,
+  React.HTMLAttributes<HTMLTableElement>
+>(({ children, ...props }, ref) => (
+  <StyledTable ref={ref} {...props}>
+    {children}
+  </StyledTable>
+));
 
-export function TableHead({ children }: React.PropsWithChildren<{}>) {
-  return <StyledThead>{children}</StyledThead>;
-}
+export const TableHead = React.forwardRef<
+  HTMLTableSectionElement,
+  React.HTMLAttributes<HTMLTableSectionElement>
+>(({ children, ...props }, ref) => (
+  <StyledThead ref={ref} {...props}>
+    {children}
+  </StyledThead>
+));
 
-export function TableBody({ children }: React.PropsWithChildren<{}>) {
-  return <StyledTbody>{children}</StyledTbody>;
-}
+export const TableBody = React.forwardRef<
+  HTMLTableSectionElement,
+  React.HTMLAttributes<HTMLTableSectionElement>
+>(({ children, ...props }, ref) => (
+  <StyledTbody ref={ref} {...props}>
+    {children}
+  </StyledTbody>
+));
 
-export function TableRow({ children }: React.PropsWithChildren<{}>) {
-  return <tr>{children}</tr>;
-}
+export const TableRow = React.forwardRef<
+  HTMLTableRowElement,
+  React.HTMLAttributes<HTMLTableRowElement>
+>(({ children, ...props }, ref) => (
+  <tr ref={ref} {...props}>
+    {children}
+  </tr>
+));
 
-export function TableHeader({ children }: React.PropsWithChildren<{}>) {
-  return <StyledTh>{children}</StyledTh>;
-}
+export const TableHeader = React.forwardRef<
+  HTMLTableCellElement,
+  React.ThHTMLAttributes<HTMLTableCellElement>
+>(({ children, ...props }, ref) => (
+  <StyledTh ref={ref} {...props}>
+    {children}
+  </StyledTh>
+));
 
-export function TableCell({ children }: React.PropsWithChildren<{}>) {
-  return <StyledTd>{children}</StyledTd>;
-}
+export const TableCell = React.forwardRef<
+  HTMLTableCellElement,
+  React.TdHTMLAttributes<HTMLTableCellElement>
+>(({ children, ...props }, ref) => (
+  <StyledTd ref={ref} {...props}>
+    {children}
+  </StyledTd>
+));

--- a/packages/jazz-inspector/src/viewer/table-viewer.tsx
+++ b/packages/jazz-inspector/src/viewer/table-viewer.tsx
@@ -3,7 +3,7 @@ import type { JsonObject } from "cojson";
 import { styled } from "goober";
 import { useMemo, useState } from "react";
 import { Button } from "../ui/button.js";
-import { PageInfo } from "./types.js";
+import { PageInfo, isCoId } from "./types.js";
 import { useResolvedCoValues } from "./use-resolve-covalue.js";
 import { ValueRenderer } from "./value-renderer.js";
 
@@ -29,7 +29,13 @@ const PaginationContainer = styled("div")`
   gap: 0.5rem;
 `;
 
-export function TableView({
+const ListItem = styled("li")`
+  display: flex;
+  gap: 0.5rem;
+  margin-bottom: 0.5rem;
+`;
+
+function CoValuesTableView({
   data,
   node,
   onNavigate,
@@ -140,5 +146,39 @@ export function TableView({
         )}
       </PaginationContainer>
     </TableContainer>
+  );
+}
+
+export function TableView({
+  data,
+  node,
+  onNavigate,
+}: {
+  data: JsonObject;
+  node: LocalNode;
+  onNavigate: (pages: PageInfo[]) => void;
+}) {
+  const isListOfCoValues = useMemo(() => {
+    return Array.isArray(data) && data.every((k) => isCoId(k));
+  }, [data]);
+
+  // if data is a list of covalue ids, we need to resolve those covalues
+  if (isListOfCoValues) {
+    return (
+      <CoValuesTableView data={data} node={node} onNavigate={onNavigate} />
+    );
+  }
+
+  // if data is a list of primitives, we can render those values directly
+  return (
+    <ul>
+      {Array.isArray(data) &&
+        data?.map((value, index) => (
+          <ListItem key={index}>
+            <Text mono>[{index}]</Text>
+            <ValueRenderer json={value} />
+          </ListItem>
+        ))}
+    </ul>
   );
 }

--- a/packages/jazz-inspector/src/viewer/table-viewer.tsx
+++ b/packages/jazz-inspector/src/viewer/table-viewer.tsx
@@ -29,12 +29,6 @@ const PaginationContainer = styled("div")`
   gap: 0.5rem;
 `;
 
-const ListItem = styled("li")`
-  display: flex;
-  gap: 0.5rem;
-  margin-bottom: 0.5rem;
-`;
-
 function CoValuesTableView({
   data,
   node,
@@ -171,14 +165,26 @@ export function TableView({
 
   // if data is a list of primitives, we can render those values directly
   return (
-    <ul>
-      {Array.isArray(data) &&
-        data?.map((value, index) => (
-          <ListItem key={index}>
-            <Text mono>[{index}]</Text>
-            <ValueRenderer json={value} />
-          </ListItem>
-        ))}
-    </ul>
+    <Table>
+      <TableHead>
+        <TableRow>
+          <TableHeader style={{ width: "5rem" }}>Index</TableHeader>
+          <TableHeader>Value</TableHeader>
+        </TableRow>
+      </TableHead>
+      <TableBody>
+        {Array.isArray(data) &&
+          data?.map((value, index) => (
+            <TableRow key={index}>
+              <TableCell>
+                <Text mono>{index}</Text>
+              </TableCell>
+              <TableCell>
+                <ValueRenderer json={value} />
+              </TableCell>
+            </TableRow>
+          ))}
+      </TableBody>
+    </Table>
   );
 }


### PR DESCRIPTION
Before: inspecting a CoList of primitives would result into an error because we were treating the value of each item as a covalue id to subscribe to.

After:
This is a colist of co.strings
<img width="668" alt="image" src="https://github.com/user-attachments/assets/40679162-d399-4534-86df-ca89c3bfd997" />


fixes #1844