### PR TITLE
adjusting footer title styling on dark mode

### DIFF
--- a/homepage/design-system/src/app/components/organisms/Footer.tsx
+++ b/homepage/design-system/src/app/components/organisms/Footer.tsx
@@ -57,7 +57,9 @@ export function Footer({
               key={index}
               className="flex flex-col gap-2 text-sm col-span-6 md:col-span-2"
             >
-              <h2 className="font-medium">{section.title}</h2>
+              <h2 className="font-medium dark:text-stone-700 cursor-default">
+                {section.title}
+              </h2>
               {section.links.map((link, linkIndex) => (
                 <FooterLink
                   key={linkIndex}


### PR DESCRIPTION
Titles for the footer were unclear on dark mode, improving styling to reflect the style on light mode to differentiate headers from links

<img width="1045" alt="Screenshot 2025-04-10 at 10 22 43" src="https://github.com/user-attachments/assets/2b4eff9d-e5a6-4088-bda3-ea946c53ed9b" />
