### PR TITLE
Relax the WebSocket types on jazz-nodejs

### DIFF
--- a/.changeset/gold-news-thank.md
+++ b/.changeset/gold-news-thank.md
@@ -1,0 +1,6 @@
+---
+"cojson-transport-ws": patch
+"jazz-nodejs": patch
+---
+
+Relax the WebSocket types on jazz-nodejs

--- a/packages/cojson-transport-ws/src/index.ts
+++ b/packages/cojson-transport-ws/src/index.ts
@@ -1,2 +1,3 @@
 export * from "./createWebSocketPeer.js";
 export * from "./WebSocketPeerWithReconnection.js";
+export { AnyWebSocketConstructor } from "./types.js";

--- a/packages/cojson-transport-ws/src/types.ts
+++ b/packages/cojson-transport-ws/src/types.ts
@@ -25,3 +25,7 @@ export interface AnyWebSocket {
   readyState: number;
   bufferedAmount: number;
 }
+
+export interface AnyWebSocketConstructor {
+  new (url: string): AnyWebSocket;
+}

--- a/packages/jazz-nodejs/src/index.ts
+++ b/packages/jazz-nodejs/src/index.ts
@@ -1,4 +1,5 @@
 import { AgentSecret, CryptoProvider, LocalNode } from "cojson";
+import { type AnyWebSocketConstructor } from "cojson-transport-ws";
 import { WasmCrypto } from "cojson/crypto/WasmCrypto";
 import {
   Account,
@@ -14,7 +15,7 @@ type WorkerOptions<Acc extends Account> = {
   accountID?: string;
   accountSecret?: string;
   syncServer?: string;
-  WebSocket?: typeof WebSocket;
+  WebSocket?: AnyWebSocketConstructor;
   AccountSchema?: AccountClass<Acc>;
   crypto?: CryptoProvider;
 };

--- a/packages/jazz-nodejs/src/webSocketWithReconnection.ts
+++ b/packages/jazz-nodejs/src/webSocketWithReconnection.ts
@@ -1,10 +1,13 @@
 import { Peer } from "cojson";
-import { createWebSocketPeer } from "cojson-transport-ws";
+import {
+  AnyWebSocketConstructor,
+  createWebSocketPeer,
+} from "cojson-transport-ws";
 
 export function webSocketWithReconnection(
   peer: string,
   addPeer: (peer: Peer) => void,
-  ws?: typeof WebSocket,
+  ws?: AnyWebSocketConstructor,
 ) {
   let done = false;
 
@@ -25,7 +28,7 @@ export function webSocketWithReconnection(
     timer = setTimeout(() => {
       const wsPeer: Peer = createWebSocketPeer({
         id: "upstream",
-        websocket: new WebSocketConstructor(peer) as any,
+        websocket: new WebSocketConstructor(peer),
         role: "server",
         onClose: handleClose,
       });


### PR DESCRIPTION
new `AnyWebSocketConstructor` type based on `AnyWebSocket` used in place of `typeof WebSocket`

fixes #1869 