### PR TITLE
Simplify/move content out of the Installation docs

### DIFF
--- a/homepage/homepage/docs/installation-content-reorganization.md
+++ b/homepage/homepage/docs/installation-content-reorganization.md
@@ -1,0 +1,46 @@
+# Jazz Documentation Reorganization
+
+## Content to Move from Installation Guides
+
+### 1. Schema Documentation
+- Detailed schema examples and explanations
+- Class definitions with field types
+- Migration methods
+- Complex model relationships
+
+→ Move to: `/docs/schemas/covalues`
+
+### 2. CoValue Operations
+- Detailed examples of subscribing to CoValues
+- Mutation patterns and examples
+- Working with lists, maps, and other data structures
+- Complex usage patterns
+
+→ Move to: `/docs/covalues/using-covalues`
+
+### 3. Platform-Specific Advanced Usage
+- Advanced framework integration (Next.js SSR, Vue Router specifics, etc.)
+- Framework-specific patterns and optimizations
+
+→ Move to: `/docs/[framework]/advanced-usage`
+
+### 4. Authentication Methods
+- Detailed examples of different auth methods
+- Authentication flows
+- Security considerations
+
+→ Move to: `/docs/authentication/methods`
+
+### 5. Group and Permissions Examples
+- Creating groups
+- Managing permissions
+- Access control patterns
+
+→ Move to: `/docs/permissions/groups-and-sharing`
+
+### 6. Server Worker Implementation Details
+- Complex worker patterns
+- State machine examples
+- Worker-specific account configurations
+
+→ Move to: `/docs/server/worker-patterns`

--- a/homepage/homepage/docs/installation-template.mdx
+++ b/homepage/homepage/docs/installation-template.mdx
@@ -1,0 +1,79 @@
+export const metadata = { title: "Installation Template" };
+
+import { CodeGroup } from "@/components/forMdx";
+
+# [Platform] Setup
+
+Get Jazz running in your [Platform] project quickly.
+
+## Install
+
+<CodeGroup>
+```bash
+npm install jazz-tools jazz-[platform]
+```
+</CodeGroup>
+
+## Set up
+
+Create your schema:
+
+<CodeGroup>
+```typescript
+// schema.ts
+import { Account, Profile, co } from "jazz-tools";
+
+export class MyAppAccount extends Account {
+  profile = co.ref(Profile);
+}
+
+// Register the schema
+declare module "jazz-[platform]" {
+  interface Register {
+    Account: MyAppAccount;
+  }
+}
+```
+</CodeGroup>
+
+Add the provider:
+
+<CodeGroup>
+```tsx
+import { JazzProvider } from "jazz-[platform]";
+import { MyAppAccount } from "./schema";
+
+// Wrap your app
+<JazzProvider
+  sync={{ peer: "wss://cloud.jazz.tools/?key=you@example.com" }}
+  AccountSchema={MyAppAccount}
+>
+  <App />
+</JazzProvider>
+```
+</CodeGroup>
+
+## Use it
+
+<CodeGroup>
+```tsx
+// In your components
+import { useAccount, useCoState } from "jazz-[platform]";
+import { MyDataType } from "./schema";
+
+function MyComponent() {
+  const { me } = useAccount();
+  const dataId = "..."; // ID of the data you want to access
+  const data = useCoState(MyDataType, dataId);
+  
+  // Now you can use data.value
+}
+```
+</CodeGroup>
+
+## Next steps
+
+- [Define your schemas](/docs/schemas/covalues)
+- [Work with CoValues](/docs/covalues/using-covalues)
+- [Authentication options](/docs/authentication/methods)
+- [Shared data and permissions](/docs/permissions/groups-and-sharing)


### PR DESCRIPTION
The original React installation docs are doing a lot more work than they should. We should move the content out, reference other pages, and strip it back to to just:
- Install
- Set up