### PR TITLE
improvement(inspector): show list of members in a Group

### DIFF
--- a/.changeset/slow-shoes-pay.md
+++ b/.changeset/slow-shoes-pay.md
@@ -1,0 +1,5 @@
+---
+"jazz-inspector": patch
+---
+
+show list of members in a Group

--- a/examples/inspector/src/viewer/new-app.tsx
+++ b/examples/inspector/src/viewer/new-app.tsx
@@ -18,7 +18,7 @@ import {
   PageStack,
   Select,
 } from "jazz-inspector";
-import { resolveCoValue, useResolvedCoValue } from "jazz-inspector";
+import { AccountNameDisplay } from "jazz-inspector";
 import React, { useState, useEffect } from "react";
 import { usePagePath } from "./use-page-path";
 
@@ -310,32 +310,4 @@ function AddAccountForm({
       </Button>
     </form>
   );
-}
-
-function AccountNameDisplay({
-  accountId,
-  node,
-}: {
-  accountId: CoID<RawAccount>;
-  node: LocalNode;
-}) {
-  const { snapshot } = useResolvedCoValue(accountId, node);
-  const [name, setName] = useState<string | null>(null);
-
-  useEffect(() => {
-    if (snapshot && typeof snapshot === "object" && "profile" in snapshot) {
-      const profileId = snapshot.profile as CoID<RawCoValue>;
-      resolveCoValue(profileId, node).then((profileResult) => {
-        if (
-          profileResult.snapshot &&
-          typeof profileResult.snapshot === "object" &&
-          "name" in profileResult.snapshot
-        ) {
-          setName(profileResult.snapshot.name as string);
-        }
-      });
-    }
-  }, [snapshot, node]);
-
-  return name ? `${name} <${accountId}>` : accountId;
 }

--- a/packages/jazz-inspector/src/app.tsx
+++ b/packages/jazz-inspector/src/app.tsx
@@ -3,6 +3,7 @@ import React from "react";
 export { JazzInspector } from "./viewer/new-app.js";
 export { PageStack } from "./viewer/page-stack.js";
 export { Breadcrumbs } from "./viewer/breadcrumbs.js";
+export { AccountNameDisplay } from "./viewer/account-name-display.js";
 
 export { Button } from "./ui/button.js";
 export { Input } from "./ui/input.js";

--- a/packages/jazz-inspector/src/viewer/account-name-display.tsx
+++ b/packages/jazz-inspector/src/viewer/account-name-display.tsx
@@ -1,0 +1,32 @@
+import { LocalNode, RawAccount, RawCoValue } from "cojson";
+import { CoID } from "cojson";
+import { useEffect, useState } from "react";
+import { resolveCoValue, useResolvedCoValue } from "./use-resolve-covalue.js";
+
+export function AccountNameDisplay({
+  accountId,
+  node,
+}: {
+  accountId: CoID<RawAccount>;
+  node: LocalNode;
+}) {
+  const { snapshot } = useResolvedCoValue(accountId, node);
+  const [name, setName] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (snapshot && typeof snapshot === "object" && "profile" in snapshot) {
+      const profileId = snapshot.profile as CoID<RawCoValue>;
+      resolveCoValue(profileId, node).then((profileResult) => {
+        if (
+          profileResult.snapshot &&
+          typeof profileResult.snapshot === "object" &&
+          "name" in profileResult.snapshot
+        ) {
+          setName(profileResult.snapshot.name as string);
+        }
+      });
+    }
+  }, [snapshot, node]);
+
+  return name ? `${name} <${accountId}>` : accountId;
+}

--- a/packages/jazz-inspector/src/viewer/co-stream-view.tsx
+++ b/packages/jazz-inspector/src/viewer/co-stream-view.tsx
@@ -162,13 +162,6 @@ const LabelContentPairContainer = styled("div")`
   gap: 0.375rem;
 `;
 
-const BinaryStreamContainer = styled("div")`
-  margin-top: 2rem;
-  display: flex;
-  flex-direction: column;
-  gap: 2rem;
-`;
-
 const BinaryStreamGrid = styled("div")`
   display: grid;
   grid-template-columns: repeat(3, 1fr);
@@ -269,7 +262,7 @@ function RenderCoBinaryStream({
   const sizeInKB = (file.totalSize || 0) / 1024;
 
   return (
-    <BinaryStreamContainer>
+    <>
       <BinaryStreamGrid>
         <LabelContentPair
           label="Mime Type"
@@ -305,7 +298,7 @@ function RenderCoBinaryStream({
           }
         />
       ) : null}
-    </BinaryStreamContainer>
+    </>
   );
 }
 

--- a/packages/jazz-inspector/src/viewer/grid-view.tsx
+++ b/packages/jazz-inspector/src/viewer/grid-view.tsx
@@ -73,6 +73,7 @@ export function GridView({
   onNavigate: (pages: PageInfo[]) => void;
   node: LocalNode;
 }) {
+  // console.log(data)
   const entries = Object.entries(data);
 
   return (

--- a/packages/jazz-inspector/src/viewer/grid-view.tsx
+++ b/packages/jazz-inspector/src/viewer/grid-view.tsx
@@ -73,7 +73,6 @@ export function GridView({
   onNavigate: (pages: PageInfo[]) => void;
   node: LocalNode;
 }) {
-  // console.log(data)
   const entries = Object.entries(data);
 
   return (

--- a/packages/jazz-inspector/src/viewer/group-view.tsx
+++ b/packages/jazz-inspector/src/viewer/group-view.tsx
@@ -3,7 +3,7 @@ import { Table, TableCell, TableHead, TableRow } from "@/ui/table";
 import { Text } from "@/ui/text";
 import { ValueRenderer } from "@/viewer/value-renderer";
 import { JsonObject, JsonValue } from "cojson";
-import { PageInfo } from "./types.js";
+import { PageInfo, isCoId } from "./types.js";
 
 function TeamMember({
   entry,
@@ -38,9 +38,7 @@ export function GroupView({
   data: JsonObject;
   onNavigate: (pages: PageInfo[]) => void;
 }) {
-  const entries = Object.entries(data).filter((entry) =>
-    entry[0].startsWith("co_"),
-  );
+  const entries = Object.entries(data).filter((entry) => isCoId(entry[0]));
 
   return (
     <>

--- a/packages/jazz-inspector/src/viewer/group-view.tsx
+++ b/packages/jazz-inspector/src/viewer/group-view.tsx
@@ -57,6 +57,12 @@ export function GroupView({
             <TableHeader>Permission</TableHeader>
           </TableRow>
         </TableHead>
+        {"everyone" in data && typeof data.everyone === "string" ? (
+          <TableRow>
+            <TableCell>everyone</TableCell>
+            <TableCell>{data.everyone}</TableCell>
+          </TableRow>
+        ) : null}
         {entries.map((entry, childIndex) => (
           <TeamMember entry={entry} onNavigate={onNavigate} key={childIndex} />
         ))}

--- a/packages/jazz-inspector/src/viewer/group-view.tsx
+++ b/packages/jazz-inspector/src/viewer/group-view.tsx
@@ -1,9 +1,15 @@
-import { Card, CardBody, CardHeader } from "@/ui/card";
-import { Table, TableCell, TableHead, TableRow } from "@/ui/table";
-import { Text } from "@/ui/text";
-import { ValueRenderer } from "@/viewer/value-renderer";
 import { JsonObject, JsonValue } from "cojson";
+import { Card, CardBody, CardHeader } from "../ui/card.js";
+import {
+  Table,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "../ui/table.js";
+import { Text } from "../ui/text.js";
 import { PageInfo, isCoId } from "./types.js";
+import { ValueRenderer } from "./value-renderer.js";
 
 function TeamMember({
   entry,
@@ -47,8 +53,8 @@ export function GroupView({
       <Table>
         <TableHead>
           <TableRow>
-            <TableCell>Account</TableCell>
-            <TableCell>Permission</TableCell>
+            <TableHeader>Account</TableHeader>
+            <TableHeader>Permission</TableHeader>
           </TableRow>
         </TableHead>
         {entries.map((entry, childIndex) => (

--- a/packages/jazz-inspector/src/viewer/group-view.tsx
+++ b/packages/jazz-inspector/src/viewer/group-view.tsx
@@ -1,0 +1,71 @@
+import { Card, CardBody, CardHeader } from "@/ui/card";
+import { Table, TableCell, TableHead, TableRow } from "@/ui/table";
+import { Text } from "@/ui/text";
+import { ValueRenderer } from "@/viewer/value-renderer";
+import { JsonObject, JsonValue } from "cojson";
+import { PageInfo } from "./types.js";
+
+function TeamMember({
+  entry,
+  onNavigate,
+}: {
+  entry: [string, JsonValue | undefined];
+  onNavigate: (pages: PageInfo[]) => void;
+}) {
+  const [key, value] = entry;
+
+  if (!value || typeof value !== "string") return null;
+
+  return (
+    <TableRow>
+      <TableCell>
+        <ValueRenderer
+          json={key}
+          onCoIDClick={(coId) => {
+            onNavigate([{ coId, name: key }]);
+          }}
+        />
+      </TableCell>
+      <TableCell>{value}</TableCell>
+    </TableRow>
+  );
+}
+
+export function GroupView({
+  data,
+  onNavigate,
+}: {
+  data: JsonObject;
+  onNavigate: (pages: PageInfo[]) => void;
+}) {
+  const entries = Object.entries(data).filter((entry) =>
+    entry[0].startsWith("co_"),
+  );
+
+  return (
+    <>
+      <Text strong>Members</Text>
+
+      <Table>
+        <TableHead>
+          <TableRow>
+            <TableCell>Account</TableCell>
+            <TableCell>Permission</TableCell>
+          </TableRow>
+        </TableHead>
+        {entries.map((entry, childIndex) => (
+          <TeamMember entry={entry} onNavigate={onNavigate} key={childIndex} />
+        ))}
+      </Table>
+
+      <Card>
+        <CardHeader>
+          <Text strong>Raw data</Text>
+        </CardHeader>
+        <CardBody>
+          <ValueRenderer json={data} />
+        </CardBody>
+      </Card>
+    </>
+  );
+}

--- a/packages/jazz-inspector/src/viewer/group-view.tsx
+++ b/packages/jazz-inspector/src/viewer/group-view.tsx
@@ -1,7 +1,11 @@
-import { JsonObject, JsonValue } from "cojson";
+import { JsonObject, LocalNode, RawAccount, RawCoValue } from "cojson";
+import { CoID } from "cojson";
+import { useEffect, useState } from "react";
+import { Button } from "../ui/button.js";
 import { Card, CardBody, CardHeader } from "../ui/card.js";
 import {
   Table,
+  TableBody,
   TableCell,
   TableHead,
   TableHeader,
@@ -9,42 +13,53 @@ import {
 } from "../ui/table.js";
 import { Text } from "../ui/text.js";
 import { PageInfo, isCoId } from "./types.js";
+import {
+  resolveCoValue,
+  useResolvedCoValue,
+  useResolvedCoValues,
+} from "./use-resolve-covalue.js";
 import { ValueRenderer } from "./value-renderer.js";
 
-function TeamMember({
-  entry,
-  onNavigate,
+function AccountNameDisplay({
+  accountId,
+  node,
 }: {
-  entry: [string, JsonValue | undefined];
-  onNavigate: (pages: PageInfo[]) => void;
+  accountId: CoID<RawAccount>;
+  node: LocalNode;
 }) {
-  const [key, value] = entry;
+  const { snapshot } = useResolvedCoValue(accountId, node);
+  const [name, setName] = useState<string | null>(null);
 
-  if (!value || typeof value !== "string") return null;
+  useEffect(() => {
+    if (snapshot && typeof snapshot === "object" && "profile" in snapshot) {
+      const profileId = snapshot.profile as CoID<RawCoValue>;
+      resolveCoValue(profileId, node).then((profileResult) => {
+        if (
+          profileResult.snapshot &&
+          typeof profileResult.snapshot === "object" &&
+          "name" in profileResult.snapshot
+        ) {
+          setName(profileResult.snapshot.name as string);
+        }
+      });
+    }
+  }, [snapshot, node]);
 
-  return (
-    <TableRow>
-      <TableCell>
-        <ValueRenderer
-          json={key}
-          onCoIDClick={(coId) => {
-            onNavigate([{ coId, name: key }]);
-          }}
-        />
-      </TableCell>
-      <TableCell>{value}</TableCell>
-    </TableRow>
-  );
+  return name ? `${name} <${accountId}>` : accountId;
 }
 
 export function GroupView({
   data,
   onNavigate,
+  node,
 }: {
   data: JsonObject;
   onNavigate: (pages: PageInfo[]) => void;
+  node: LocalNode;
 }) {
   const entries = Object.entries(data).filter((entry) => isCoId(entry[0]));
+  const memberIds = entries.map((entry) => entry[0] as CoID<RawCoValue>);
+  const result = useResolvedCoValues(memberIds, node);
 
   return (
     <>
@@ -57,15 +72,34 @@ export function GroupView({
             <TableHeader>Permission</TableHeader>
           </TableRow>
         </TableHead>
-        {"everyone" in data && typeof data.everyone === "string" ? (
-          <TableRow>
-            <TableCell>everyone</TableCell>
-            <TableCell>{data.everyone}</TableCell>
-          </TableRow>
-        ) : null}
-        {entries.map((entry, childIndex) => (
-          <TeamMember entry={entry} onNavigate={onNavigate} key={childIndex} />
-        ))}
+        <TableBody>
+          {"everyone" in data && typeof data.everyone === "string" ? (
+            <TableRow>
+              <TableCell>everyone</TableCell>
+              <TableCell>{data.everyone}</TableCell>
+            </TableRow>
+          ) : null}
+          {result.map((row) =>
+            row.snapshot !== "unavailable" ? (
+              <TableRow>
+                <TableCell style={{ maxWidth: "12rem" }}>
+                  <Button
+                    variant="link"
+                    onClick={() => {
+                      onNavigate([{ coId: row.value.id, name: row.value.id }]);
+                    }}
+                  >
+                    <AccountNameDisplay
+                      accountId={row.value.id as CoID<RawAccount>}
+                      node={node}
+                    />
+                  </Button>
+                </TableCell>
+                <TableCell>{data[row.value.id] as string}</TableCell>
+              </TableRow>
+            ) : null,
+          )}
+        </TableBody>
       </Table>
 
       <Card>

--- a/packages/jazz-inspector/src/viewer/page.tsx
+++ b/packages/jazz-inspector/src/viewer/page.tsx
@@ -1,4 +1,3 @@
-import { GroupView } from "@/viewer/group-view";
 import { CoID, LocalNode, RawCoStream, RawCoValue } from "cojson";
 import { styled } from "goober";
 import React from "react";
@@ -7,6 +6,7 @@ import { Heading } from "../ui/heading.js";
 import { Text } from "../ui/text.js";
 import { CoStreamView } from "./co-stream-view.js";
 import { GridView } from "./grid-view.js";
+import { GroupView } from "./group-view.js";
 import { TableView } from "./table-viewer.js";
 import { TypeIcon } from "./type-icon.js";
 import { PageInfo } from "./types.js";

--- a/packages/jazz-inspector/src/viewer/page.tsx
+++ b/packages/jazz-inspector/src/viewer/page.tsx
@@ -69,6 +69,7 @@ const ContentContainer = styled("div")`
   display: flex;
   flex-direction: column;
   gap: 1rem;
+  padding-bottom: 2rem;
 `;
 
 type PageProps = {
@@ -103,7 +104,7 @@ function View(
   }
 
   if (extendedType === "group") {
-    return <GroupView data={snapshot} onNavigate={onNavigate} />;
+    return <GroupView data={snapshot} node={node} onNavigate={onNavigate} />;
   }
 
   if (type === "colist" || extendedType === "record") {

--- a/packages/jazz-inspector/src/viewer/page.tsx
+++ b/packages/jazz-inspector/src/viewer/page.tsx
@@ -66,10 +66,9 @@ const BadgeContainer = styled("div")`
 
 const ContentContainer = styled("div")`
   overflow: auto;
-`;
-
-const OwnerText = styled(Text)`
-  margin-top: 1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
 `;
 
 type PageProps = {
@@ -172,7 +171,7 @@ export function Page(props: PageProps) {
       <ContentContainer>
         <View {...props} coValue={coValue} />
         {extendedType !== "account" && extendedType !== "group" && (
-          <OwnerText muted>
+          <Text muted>
             Owned by{" "}
             <AccountOrGroupPreview
               coId={value.group.id}
@@ -182,7 +181,7 @@ export function Page(props: PageProps) {
                 onNavigate([{ coId: value.group.id, name: "owner" }]);
               }}
             />
-          </OwnerText>
+          </Text>
         )}
       </ContentContainer>
     </PageContainer>

--- a/packages/jazz-inspector/src/viewer/table-viewer.tsx
+++ b/packages/jazz-inspector/src/viewer/table-viewer.tsx
@@ -17,10 +17,6 @@ import {
 } from "../ui/table.js";
 import { Text } from "../ui/text.js";
 
-const TableContainer = styled("div")`
-  margin-top: 2rem;
-`;
-
 const PaginationContainer = styled("div")`
   padding: 1rem 0;
   display: flex;
@@ -73,7 +69,7 @@ function CoValuesTableView({
   };
 
   return (
-    <TableContainer>
+    <>
       <Table>
         <TableHead>
           <TableRow>
@@ -139,7 +135,7 @@ function CoValuesTableView({
           </Button>
         )}
       </PaginationContainer>
-    </TableContainer>
+    </>
   );
 }
 

--- a/packages/jazz-inspector/src/viewer/value-renderer.tsx
+++ b/packages/jazz-inspector/src/viewer/value-renderer.tsx
@@ -134,25 +134,30 @@ export function ValueRenderer({
   if (typeof json === "boolean") {
     return <BooleanText value={json}>{json.toString()}</BooleanText>;
   }
+  const longJson = JSON.stringify(json, null, 2);
+  const shortJson = longJson
+    .split("\n")
+    .slice(0, compact ? 3 : 8)
+    .join("\n");
+
+  // Check if collapsed differs from full
+  const hasDifference = longJson !== shortJson;
 
   if (typeof json === "object") {
     return (
       <>
         <p>{Array.isArray(json) ? <>Array ({json.length})</> : <>Object</>}</p>
         <ObjectContent>
-          {isExpanded
-            ? JSON.stringify(json, null, 2)
-            : JSON.stringify(json, null, 2)
-                .split("\n")
-                .slice(0, compact ? 3 : 8)
-                .join("\n") + (Object.keys(json).length > 2 ? "\n..." : "")}
+          {isExpanded ? longJson : shortJson}
+
+          {hasDifference && !isExpanded ? "\n ..." : null}
         </ObjectContent>
 
-        {!compact && (
+        {!compact && hasDifference ? (
           <Button variant="link" onClick={() => setIsExpanded(!isExpanded)}>
             {isExpanded ? "Show less" : "Show more"}
           </Button>
-        )}
+        ) : null}
       </>
     );
   }


### PR DESCRIPTION
I took all the `co_z...` properties
<img width="1349" alt="image" src="https://github.com/user-attachments/assets/a8935efb-8d5a-49dd-a74f-8a7a92e78779" />

And displayed them in a table
<img width="1380" alt="image" src="https://github.com/user-attachments/assets/3114e1ee-a3d3-4ccd-8518-46b48b0aa731" />


Then "Raw data" for a JSON view of everything

Example with "everyone" as writer:
<img width="1278" alt="image" src="https://github.com/user-attachments/assets/a1d438f3-0b37-4d77-aa75-4482fce0b4fc" />

fixes #1899
