### PR TITLE
fix(inspector): show inboxInvite as string

### DIFF
--- a/.changeset/large-cooks-flash.md
+++ b/.changeset/large-cooks-flash.md
@@ -1,0 +1,5 @@
+---
+"jazz-inspector": patch
+---
+
+show inboxInvite as string

--- a/packages/jazz-inspector/src/viewer/table-viewer.tsx
+++ b/packages/jazz-inspector/src/viewer/table-viewer.tsx
@@ -38,9 +38,7 @@ function CoValuesTableView({
   const [coIdArray, visibleRows] = useMemo(() => {
     const coIdArray = Array.isArray(data)
       ? data
-      : Object.values(data).every(
-            (k) => typeof k === "string" && k.startsWith("co_"),
-          )
+      : Object.values(data).every((k) => typeof k === "string" && isCoId(k))
         ? Object.values(data).map((k) => k as CoID<RawCoValue>)
         : [];
 

--- a/packages/jazz-inspector/src/viewer/types.ts
+++ b/packages/jazz-inspector/src/viewer/types.ts
@@ -6,4 +6,6 @@ export type PageInfo = {
 };
 
 export const isCoId = (coId: unknown): coId is CoID<RawCoValue> =>
-  typeof coId === "string" && coId.startsWith("co_");
+  typeof coId === "string" &&
+  coId.startsWith("co_") &&
+  !coId.includes("inviteSecret");

--- a/packages/jazz-inspector/src/viewer/value-renderer.tsx
+++ b/packages/jazz-inspector/src/viewer/value-renderer.tsx
@@ -4,6 +4,7 @@ import React, { useEffect, useState } from "react";
 import { Button } from "../ui/button.js";
 import { Icon } from "../ui/icon.js";
 import { Text } from "../ui/text.js";
+import { isCoId } from "./types.js";
 import {
   isBrowserImage,
   resolveCoValue,
@@ -99,7 +100,7 @@ export function ValueRenderer({
     return <Text muted>null</Text>;
   }
 
-  if (typeof json === "string" && json.startsWith("co_")) {
+  if (typeof json === "string" && isCoId(json)) {
     const content = (
       <>
         {json}


### PR DESCRIPTION
inboxInvite is showing as unavailable because we're trying to load it as a CoValue since it starts with `co_`
![image](https://github.com/user-attachments/assets/0bf0ce34-d248-4f32-9a71-580ccc4a606a)

Fixed by showing as string
<img width="1710" alt="image" src="https://github.com/user-attachments/assets/780bc738-80f9-4fe9-afd7-26b3e86b1275" />
