### PR TITLE
1856 - Fix twoslash popup container overflow on hover

### DIFF
--- a/homepage/homepage/app/globals.css
+++ b/homepage/homepage/app/globals.css
@@ -29,6 +29,10 @@ pre.shiki {
   background-color: transparent !important;
 }
 
+.twoslash-popup-container {
+  white-space: break-spaces;
+}
+
 .twoslash-popup-code pre.shiki {
   padding: 0.2em;
   font-size: 0.8em;

--- a/homepage/homepage/lib/docMdxContent.tsx
+++ b/homepage/homepage/lib/docMdxContent.tsx
@@ -68,7 +68,7 @@ export async function DocPage({
 
     return (
       <DocsLayout nav={<DocNav />} tocItems={tocItems}>
-        <Prose className="overflow-x-hidden lg:flex-1 py-10  max-w-3xl mx-auto">
+        <Prose className="overflow-x-visible lg:flex-1 py-10  max-w-3xl mx-auto">
           <Content />
         </Prose>
       </DocsLayout>


### PR DESCRIPTION
## Fixes:
[#1856](https://github.com/garden-co/jazz/issues/1856)

## What this does: 
- Sets `overflow:visible` on prose container
- Breaks on space for text in twoslash popup container

## Screengrab

### Before: 
<img width="728" alt="Screenshot 2025-04-15 at 1 06 50 PM" src="https://github.com/user-attachments/assets/2c9a1e1a-7bfe-4219-906c-275a3db15d02" />

### After:
<img width="915" alt="Screenshot 2025-04-15 at 1 00 40 PM" src="https://github.com/user-attachments/assets/4a92a962-0419-4695-bd09-0496478ed8df" />
