### PR TITLE
fix(colist): fix max recursion error happening on large lists

### DIFF
--- a/.changeset/seven-dancers-buy.md
+++ b/.changeset/seven-dancers-buy.md
@@ -1,0 +1,5 @@
+---
+"cojson": patch
+---
+
+Fix max recursion error happening on large colists

--- a/packages/cojson/src/coValues/coList.ts
+++ b/packages/cojson/src/coValues/coList.ts
@@ -304,7 +304,7 @@ export class RawCoListView<
         }
         predecessorsVisited.add(currentOpID);
       } else {
-        // Remove the current opID from the linked list to consider it processed.
+        // Remove the current opID from the todo stack to consider it processed.
         todo.pop();
 
         const deleted =

--- a/packages/cojson/src/coValues/coList.ts
+++ b/packages/cojson/src/coValues/coList.ts
@@ -322,6 +322,7 @@ export class RawCoListView<
         });
       }
 
+      // traverse successors in reverse for correct insertion behavior
       for (const successor of entry.successors) {
         list.prepend(successor);
       }

--- a/packages/cojson/src/coValues/coList.ts
+++ b/packages/cojson/src/coValues/coList.ts
@@ -295,36 +295,36 @@ export class RawCoListView<
         throw new Error("Missing op " + currentOpID);
       }
 
-      if (
-        entry.predecessors.length > 0 &&
-        !predecessorsVisited.has(currentOpID)
-      ) {
+      const shouldTraversePredecessors =
+        entry.predecessors.length > 0 && !predecessorsVisited.has(currentOpID);
+
+      // We navigate the predecessors before processing the current opID in the list
+      if (shouldTraversePredecessors) {
         for (let i = entry.predecessors.length - 1; i >= 0; i--) {
           list.prepend(entry.predecessors[i]!);
         }
         predecessorsVisited.add(currentOpID);
-        continue;
-      }
+      } else {
+        // Remove the current opID from the linked list to consider it processed.
+        list.shift();
 
-      // Remove the current opID from the linked list to consider it processed.
-      list.shift();
+        const deleted =
+          (this.deletionsByInsertion[currentOpID.sessionID]?.[
+            currentOpID.txIndex
+          ]?.[currentOpID.changeIdx]?.length || 0) > 0;
 
-      const deleted =
-        (this.deletionsByInsertion[currentOpID.sessionID]?.[
-          currentOpID.txIndex
-        ]?.[currentOpID.changeIdx]?.length || 0) > 0;
+        if (!deleted) {
+          arr.push({
+            value: entry.value,
+            madeAt: entry.madeAt,
+            opID: currentOpID,
+          });
+        }
 
-      if (!deleted) {
-        arr.push({
-          value: entry.value,
-          madeAt: entry.madeAt,
-          opID: currentOpID,
-        });
-      }
-
-      // traverse successors in reverse for correct insertion behavior
-      for (const successor of entry.successors) {
-        list.prepend(successor);
+        // traverse successors in reverse for correct insertion behavior
+        for (const successor of entry.successors) {
+          list.prepend(successor);
+        }
       }
     }
   }


### PR DESCRIPTION
While working on #1750 I've found that now that the performance of the protocol are better we hit another error:

```ts
Failed to load / subscribe to CoValue RangeError: Maximum call stack size exceeded
    at RawCoList.fillArrayFromOpID
```

Refactoring fillArrayFromOpID to be iterative rather than recursive fixes the bugs. 

Tests for this issue will come in a separate PR where I'm working on the incremental processing of CoList.

Follow up PR --> https://github.com/garden-co/jazz/pull/1970
