### PR TITLE
fix(biome): ignore package.json files

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -14,7 +14,8 @@
       "packages/jazz-svelte/**",
       "examples/*svelte*/**",
       "examples/jazz-paper-scissors/src/routeTree.gen.ts",
-      "homepage/homepage/**"
+      "homepage/homepage/**",
+      "**/package.json"
     ]
   },
   "formatter": {


### PR DESCRIPTION
Adding the package.json files to the ignore of Biome due to some formatting incompatibilities with our release tools.