### PR TITLE
cojson subscription refactors

### DIFF
--- a/packages/cojson/src/coValueCore.ts
+++ b/packages/cojson/src/coValueCore.ts
@@ -8,28 +8,21 @@ import {
   Encrypted,
   Hash,
   KeyID,
-  KeySecret,
   Signature,
   SignerID,
   StreamingHash,
 } from "./crypto/crypto.js";
 import {
+  AgentID,
   RawCoID,
   SessionID,
   TransactionID,
   getGroupDependentKeyList,
-  getParentGroupId,
-  isParentGroupReference,
 } from "./ids.js";
-import { Stringified, parseJSON, stableStringify } from "./jsonStringify.js";
+import { Stringified, stableStringify } from "./jsonStringify.js";
 import { JsonObject, JsonValue } from "./jsonValue.js";
 import { LocalNode, ResolveAccountAgentError } from "./localNode.js";
-import { logger } from "./logger.js";
-import {
-  PermissionsDef as RulesetDef,
-  determineValidTransactions,
-  isKeyForKeyField,
-} from "./permissions.js";
+import { PermissionsDef as RulesetDef } from "./permissions.js";
 import { getPriorityFromHeader } from "./priority.js";
 import { CoValueKnownState, NewContentMessage } from "./sync.js";
 import { accountOrAgentIDfromSessionID } from "./typeUtils/accountOrAgentIDfromSessionID.js";
@@ -87,27 +80,14 @@ export type TrustingTransaction = {
 
 export type Transaction = PrivateTransaction | TrustingTransaction;
 
-export type DecryptedTransaction = {
-  txID: TransactionID;
-  changes: JsonValue[];
-  madeAt: number;
-};
-
-const readKeyCache = new WeakMap<CoValueCore, { [id: KeyID]: KeySecret }>();
-
 export class CoValueCore {
   id: RawCoID;
-  node: LocalNode;
+
   crypto: CryptoProvider;
   header: CoValueHeader;
   _sessionLogs: Map<SessionID, SessionLog>;
-  _cachedContent?: RawCoValue;
-  listeners: Set<(content?: RawCoValue) => void> = new Set();
-  _decryptionCache: {
-    [key: Encrypted<JsonValue[], JsonValue>]: JsonValue[] | undefined;
-  } = {};
   _cachedKnownState?: CoValueKnownState;
-  _cachedDependentOn?: RawCoID[];
+
   _cachedNewContentSinceEmpty?: NewContentMessage[] | undefined;
 
   constructor(
@@ -119,37 +99,6 @@ export class CoValueCore {
     this.id = idforHeader(header, node.crypto);
     this.header = header;
     this._sessionLogs = internalInitSessions;
-    this.node = node;
-  }
-
-  groupInvalidationSubscription?: () => void;
-
-  subscribeToGroupInvalidation() {
-    if (this.groupInvalidationSubscription) {
-      return;
-    }
-
-    const header = this.header;
-
-    if (header.ruleset.type == "ownedByGroup") {
-      const groupId = header.ruleset.group;
-      const entry = this.node.coValuesStore.get(groupId);
-
-      if (entry.isAvailable()) {
-        this.groupInvalidationSubscription = entry.core.subscribe(
-          (_groupUpdate) => {
-            this._cachedContent = undefined;
-            this.notifyUpdate("immediate");
-          },
-          false,
-        );
-      } else {
-        logger.error("CoValueCore: Owner group not available", {
-          id: this.id,
-          groupId,
-        });
-      }
-    }
   }
 
   get sessionLogs(): Map<SessionID, SessionLog> {
@@ -197,23 +146,8 @@ export class CoValueCore {
     return this.header?.meta ?? null;
   }
 
-  nextTransactionID(): TransactionID {
-    // This is an ugly hack to get a unique but stable session ID for editing the current account
-    const sessionID =
-      this.header.meta?.type === "account"
-        ? (this.node.currentSessionID.replace(
-            this.node.account.id,
-            this.node.account.currentAgentID(),
-          ) as SessionID)
-        : this.node.currentSessionID;
-
-    return {
-      sessionID,
-      txIndex: this.sessionLogs.get(sessionID)?.transactions.length || 0,
-    };
-  }
-
-  tryAddTransactions(
+  int_tryAddTransactions(
+    agent: AgentID,
     sessionID: SessionID,
     newTransactions: Transaction[],
     givenExpectedNewHash: Hash | undefined,
@@ -221,65 +155,51 @@ export class CoValueCore {
     skipVerify: boolean = false,
     givenNewStreamingHash?: StreamingHash,
   ): Result<true, TryAddTransactionsError> {
-    return this.node
-      .resolveAccountAgent(
-        accountOrAgentIDfromSessionID(sessionID),
-        "Expected to know signer of transaction",
-      )
-      .andThen((agent) => {
-        const signerID = this.crypto.getAgentSignerID(agent);
+    const signerID = this.crypto.getAgentSignerID(agent);
 
-        if (
-          skipVerify === true &&
-          givenNewStreamingHash &&
-          givenExpectedNewHash
-        ) {
-          this.doAddTransactions(
-            sessionID,
-            newTransactions,
-            newSignature,
-            givenExpectedNewHash,
-            givenNewStreamingHash,
-            "immediate",
-          );
-        } else {
-          const { expectedNewHash, newStreamingHash } =
-            this.expectedNewHashAfter(sessionID, newTransactions);
+    if (skipVerify === true && givenNewStreamingHash && givenExpectedNewHash) {
+      this.doAddTransactions(
+        sessionID,
+        newTransactions,
+        newSignature,
+        givenExpectedNewHash,
+        givenNewStreamingHash,
+      );
+    } else {
+      const { expectedNewHash, newStreamingHash } = this.expectedNewHashAfter(
+        sessionID,
+        newTransactions,
+      );
 
-          if (
-            givenExpectedNewHash &&
-            givenExpectedNewHash !== expectedNewHash
-          ) {
-            return err({
-              type: "InvalidHash",
-              id: this.id,
-              expectedNewHash,
-              givenExpectedNewHash,
-            } satisfies InvalidHashError);
-          }
+      if (givenExpectedNewHash && givenExpectedNewHash !== expectedNewHash) {
+        return err({
+          type: "InvalidHash",
+          id: this.id,
+          expectedNewHash,
+          givenExpectedNewHash,
+        } satisfies InvalidHashError);
+      }
 
-          if (!this.crypto.verify(newSignature, expectedNewHash, signerID)) {
-            return err({
-              type: "InvalidSignature",
-              id: this.id,
-              newSignature,
-              sessionID,
-              signerID,
-            } satisfies InvalidSignatureError);
-          }
+      if (!this.crypto.verify(newSignature, expectedNewHash, signerID)) {
+        return err({
+          type: "InvalidSignature",
+          id: this.id,
+          newSignature,
+          sessionID,
+          signerID,
+        } satisfies InvalidSignatureError);
+      }
 
-          this.doAddTransactions(
-            sessionID,
-            newTransactions,
-            newSignature,
-            expectedNewHash,
-            newStreamingHash,
-            "immediate",
-          );
-        }
+      this.doAddTransactions(
+        sessionID,
+        newTransactions,
+        newSignature,
+        expectedNewHash,
+        newStreamingHash,
+      );
+    }
 
-        return ok(true as const);
-      });
+    return ok(true as const);
   }
 
   private doAddTransactions(
@@ -288,11 +208,7 @@ export class CoValueCore {
     newSignature: Signature,
     expectedNewHash: Hash,
     newStreamingHash: StreamingHash,
-    notifyMode: "immediate" | "deferred",
   ) {
-    if (this.node.crashed) {
-      throw new Error("Trying to add transactions after node is crashed");
-    }
     const transactions = this.sessionLogs.get(sessionID)?.transactions ?? [];
 
     for (const tx of newTransactions) {
@@ -330,78 +246,24 @@ export class CoValueCore {
       signatureAfter: signatureAfter,
     });
 
-    if (
-      this._cachedContent &&
-      "processNewTransactions" in this._cachedContent &&
-      typeof this._cachedContent.processNewTransactions === "function"
-    ) {
-      this._cachedContent.processNewTransactions();
-    } else {
-      this._cachedContent = undefined;
-    }
-
     this._cachedKnownState = undefined;
-    this._cachedDependentOn = undefined;
     this._cachedNewContentSinceEmpty = undefined;
-
-    this.notifyUpdate(notifyMode);
   }
 
-  deferredUpdates = 0;
-  nextDeferredNotify: Promise<void> | undefined;
+  // subscribe(
+  //   listener: (content?: RawCoValue) => void,
+  //   immediateInvoke = true,
+  // ): () => void {
+  //   this.listeners.add(listener);
 
-  notifyUpdate(notifyMode: "immediate" | "deferred") {
-    if (this.listeners.size === 0) {
-      return;
-    }
+  //   if (immediateInvoke) {
+  //     listener(this.getCurrentContent());
+  //   }
 
-    if (notifyMode === "immediate") {
-      const content = this.getCurrentContent();
-      for (const listener of this.listeners) {
-        try {
-          listener(content);
-        } catch (e) {
-          logger.error("Error in listener for coValue " + this.id, { err: e });
-        }
-      }
-    } else {
-      if (!this.nextDeferredNotify) {
-        this.nextDeferredNotify = new Promise((resolve) => {
-          setTimeout(() => {
-            this.nextDeferredNotify = undefined;
-            this.deferredUpdates = 0;
-            const content = this.getCurrentContent();
-            for (const listener of this.listeners) {
-              try {
-                listener(content);
-              } catch (e) {
-                logger.error("Error in listener for coValue " + this.id, {
-                  err: e,
-                });
-              }
-            }
-            resolve();
-          }, 0);
-        });
-      }
-      this.deferredUpdates++;
-    }
-  }
-
-  subscribe(
-    listener: (content?: RawCoValue) => void,
-    immediateInvoke = true,
-  ): () => void {
-    this.listeners.add(listener);
-
-    if (immediateInvoke) {
-      listener(this.getCurrentContent());
-    }
-
-    return () => {
-      this.listeners.delete(listener);
-    };
-  }
+  //   return () => {
+  //     this.listeners.delete(listener);
+  //   };
+  // }
 
   expectedNewHashAfter(
     sessionID: SessionID,
@@ -419,391 +281,6 @@ export class CoValueCore {
       expectedNewHash: streamingHash.digest(),
       newStreamingHash: streamingHash,
     };
-  }
-
-  makeTransaction(
-    changes: JsonValue[],
-    privacy: "private" | "trusting",
-  ): boolean {
-    const madeAt = Date.now();
-
-    let transaction: Transaction;
-
-    if (privacy === "private") {
-      const { secret: keySecret, id: keyID } = this.getCurrentReadKey();
-
-      if (!keySecret) {
-        throw new Error("Can't make transaction without read key secret");
-      }
-
-      const encrypted = this.crypto.encryptForTransaction(changes, keySecret, {
-        in: this.id,
-        tx: this.nextTransactionID(),
-      });
-
-      this._decryptionCache[encrypted] = changes;
-
-      transaction = {
-        privacy: "private",
-        madeAt,
-        keyUsed: keyID,
-        encryptedChanges: encrypted,
-      };
-    } else {
-      transaction = {
-        privacy: "trusting",
-        madeAt,
-        changes: stableStringify(changes),
-      };
-    }
-
-    // This is an ugly hack to get a unique but stable session ID for editing the current account
-    const sessionID =
-      this.header.meta?.type === "account"
-        ? (this.node.currentSessionID.replace(
-            this.node.account.id,
-            this.node.account.currentAgentID(),
-          ) as SessionID)
-        : this.node.currentSessionID;
-
-    const { expectedNewHash, newStreamingHash } = this.expectedNewHashAfter(
-      sessionID,
-      [transaction],
-    );
-
-    const signature = this.crypto.sign(
-      this.node.account.currentSignerSecret(),
-      expectedNewHash,
-    );
-
-    const success = this.tryAddTransactions(
-      sessionID,
-      [transaction],
-      expectedNewHash,
-      signature,
-      true,
-      newStreamingHash,
-    )._unsafeUnwrap({ withStackTrace: true });
-
-    if (success) {
-      this.node.syncManager.recordTransactionsSize([transaction], "local");
-      void this.node.syncManager.syncCoValue(this);
-    }
-
-    return success;
-  }
-
-  getCurrentContent(options?: {
-    ignorePrivateTransactions: true;
-  }): RawCoValue {
-    if (!options?.ignorePrivateTransactions && this._cachedContent) {
-      return this._cachedContent;
-    }
-
-    this.subscribeToGroupInvalidation();
-
-    const newContent = coreToCoValue(this, options);
-
-    if (!options?.ignorePrivateTransactions) {
-      this._cachedContent = newContent;
-    }
-
-    return newContent;
-  }
-
-  getValidTransactions(options?: {
-    ignorePrivateTransactions: boolean;
-    knownTransactions?: CoValueKnownState["sessions"];
-  }): DecryptedTransaction[] {
-    const validTransactions = determineValidTransactions(
-      this,
-      options?.knownTransactions,
-    );
-
-    const allTransactions: DecryptedTransaction[] = [];
-
-    for (const { txID, tx } of validTransactions) {
-      if (options?.knownTransactions?.[txID.sessionID]! >= txID.txIndex) {
-        continue;
-      }
-
-      if (tx.privacy === "trusting") {
-        allTransactions.push({
-          txID,
-          madeAt: tx.madeAt,
-          changes: parseJSON(tx.changes),
-        });
-        continue;
-      }
-
-      if (options?.ignorePrivateTransactions) {
-        continue;
-      }
-
-      const readKey = this.getReadKey(tx.keyUsed);
-
-      if (!readKey) {
-        continue;
-      }
-
-      let decryptedChanges = this._decryptionCache[tx.encryptedChanges];
-
-      if (!decryptedChanges) {
-        const decryptedString = this.crypto.decryptRawForTransaction(
-          tx.encryptedChanges,
-          readKey,
-          {
-            in: this.id,
-            tx: txID,
-          },
-        );
-        decryptedChanges = decryptedString && parseJSON(decryptedString);
-        this._decryptionCache[tx.encryptedChanges] = decryptedChanges;
-      }
-
-      if (!decryptedChanges) {
-        logger.error("Failed to decrypt transaction despite having key", {
-          err: new Error("Failed to decrypt transaction despite having key"),
-        });
-        continue;
-      }
-
-      allTransactions.push({
-        txID,
-        madeAt: tx.madeAt,
-        changes: decryptedChanges,
-      });
-    }
-
-    return allTransactions;
-  }
-
-  getValidSortedTransactions(options?: {
-    ignorePrivateTransactions: boolean;
-  }): DecryptedTransaction[] {
-    const allTransactions = this.getValidTransactions(options);
-
-    allTransactions.sort(this.compareTransactions);
-
-    return allTransactions;
-  }
-
-  compareTransactions(
-    a: Pick<DecryptedTransaction, "madeAt" | "txID">,
-    b: Pick<DecryptedTransaction, "madeAt" | "txID">,
-  ) {
-    return (
-      a.madeAt - b.madeAt ||
-      (a.txID.sessionID === b.txID.sessionID
-        ? 0
-        : a.txID.sessionID < b.txID.sessionID
-          ? -1
-          : 1) ||
-      a.txID.txIndex - b.txID.txIndex
-    );
-  }
-
-  getCurrentReadKey(): { secret: KeySecret | undefined; id: KeyID } {
-    if (this.header.ruleset.type === "group") {
-      const content = expectGroup(this.getCurrentContent());
-
-      const currentKeyId = content.getCurrentReadKeyId();
-
-      if (!currentKeyId) {
-        throw new Error("No readKey set");
-      }
-
-      const secret = this.getReadKey(currentKeyId);
-
-      return {
-        secret: secret,
-        id: currentKeyId,
-      };
-    } else if (this.header.ruleset.type === "ownedByGroup") {
-      return this.node
-        .expectCoValueLoaded(this.header.ruleset.group)
-        .getCurrentReadKey();
-    } else {
-      throw new Error(
-        "Only groups or values owned by groups have read secrets",
-      );
-    }
-  }
-
-  getReadKey(keyID: KeyID): KeySecret | undefined {
-    let key = readKeyCache.get(this)?.[keyID];
-    if (!key) {
-      key = this.getUncachedReadKey(keyID);
-      if (key) {
-        let cache = readKeyCache.get(this);
-        if (!cache) {
-          cache = {};
-          readKeyCache.set(this, cache);
-        }
-        cache[keyID] = key;
-      }
-    }
-    return key;
-  }
-
-  getUncachedReadKey(keyID: KeyID): KeySecret | undefined {
-    if (this.header.ruleset.type === "group") {
-      const content = expectGroup(
-        this.getCurrentContent({ ignorePrivateTransactions: true }),
-      );
-
-      const keyForEveryone = content.get(`${keyID}_for_everyone`);
-      if (keyForEveryone) return keyForEveryone;
-
-      // Try to find key revelation for us
-      const lookupAccountOrAgentID =
-        this.header.meta?.type === "account"
-          ? this.node.account.currentAgentID()
-          : this.node.account.id;
-
-      const lastReadyKeyEdit = content.lastEditAt(
-        `${keyID}_for_${lookupAccountOrAgentID}`,
-      );
-
-      if (lastReadyKeyEdit?.value) {
-        const revealer = lastReadyKeyEdit.by;
-        const revealerAgent = this.node
-          .resolveAccountAgent(revealer, "Expected to know revealer")
-          ._unsafeUnwrap({ withStackTrace: true });
-
-        const secret = this.crypto.unseal(
-          lastReadyKeyEdit.value,
-          this.node.account.currentSealerSecret(),
-          this.crypto.getAgentSealerID(revealerAgent),
-          {
-            in: this.id,
-            tx: lastReadyKeyEdit.tx,
-          },
-        );
-
-        if (secret) {
-          return secret as KeySecret;
-        }
-      }
-
-      // Try to find indirect revelation through previousKeys
-
-      for (const co of content.keys()) {
-        if (isKeyForKeyField(co) && co.startsWith(keyID)) {
-          const encryptingKeyID = co.split("_for_")[1] as KeyID;
-          const encryptingKeySecret = this.getReadKey(encryptingKeyID);
-
-          if (!encryptingKeySecret) {
-            continue;
-          }
-
-          const encryptedPreviousKey = content.get(co)!;
-
-          const secret = this.crypto.decryptKeySecret(
-            {
-              encryptedID: keyID,
-              encryptingID: encryptingKeyID,
-              encrypted: encryptedPreviousKey,
-            },
-            encryptingKeySecret,
-          );
-
-          if (secret) {
-            return secret as KeySecret;
-          } else {
-            logger.warn(
-              `Encrypting ${encryptingKeyID} key didn't decrypt ${keyID}`,
-            );
-          }
-        }
-      }
-
-      // try to find revelation to parent group read keys
-      for (const co of content.keys()) {
-        if (isParentGroupReference(co)) {
-          const parentGroupID = getParentGroupId(co);
-          const parentGroup = this.node.expectCoValueLoaded(
-            parentGroupID,
-            "Expected parent group to be loaded",
-          );
-
-          const parentKeys = this.findValidParentKeys(
-            keyID,
-            content,
-            parentGroup,
-          );
-
-          for (const parentKey of parentKeys) {
-            const revelationForParentKey = content.get(
-              `${keyID}_for_${parentKey.id}`,
-            );
-
-            if (revelationForParentKey) {
-              const secret = parentGroup.crypto.decryptKeySecret(
-                {
-                  encryptedID: keyID,
-                  encryptingID: parentKey.id,
-                  encrypted: revelationForParentKey,
-                },
-                parentKey.secret,
-              );
-
-              if (secret) {
-                return secret as KeySecret;
-              } else {
-                logger.warn(
-                  `Encrypting parent ${parentKey.id} key didn't decrypt ${keyID}`,
-                );
-              }
-            }
-          }
-        }
-      }
-
-      return undefined;
-    } else if (this.header.ruleset.type === "ownedByGroup") {
-      return this.node
-        .expectCoValueLoaded(this.header.ruleset.group)
-        .getReadKey(keyID);
-    } else {
-      throw new Error(
-        "Only groups or values owned by groups have read secrets",
-      );
-    }
-  }
-
-  findValidParentKeys(keyID: KeyID, group: RawGroup, parentGroup: CoValueCore) {
-    const validParentKeys: { id: KeyID; secret: KeySecret }[] = [];
-
-    for (const co of group.keys()) {
-      if (isKeyForKeyField(co) && co.startsWith(keyID)) {
-        const encryptingKeyID = co.split("_for_")[1] as KeyID;
-        const encryptingKeySecret = parentGroup.getReadKey(encryptingKeyID);
-
-        if (!encryptingKeySecret) {
-          continue;
-        }
-
-        validParentKeys.push({
-          id: encryptingKeyID,
-          secret: encryptingKeySecret,
-        });
-      }
-    }
-
-    return validParentKeys;
-  }
-
-  getGroup(): RawGroup {
-    if (this.header.ruleset.type !== "ownedByGroup") {
-      throw new Error("Only values owned by groups have groups");
-    }
-
-    return expectGroup(
-      this.node
-        .expectCoValueLoaded(this.header.ruleset.group)
-        .getCurrentContent(),
-    );
   }
 
   getTx(txID: TransactionID): Transaction | undefined {
@@ -932,37 +409,6 @@ export class CoValueCore {
     }
 
     return piecesWithContent;
-  }
-
-  getDependedOnCoValues(): RawCoID[] {
-    if (this._cachedDependentOn) {
-      return this._cachedDependentOn;
-    } else {
-      const dependentOn = this.getDependedOnCoValuesUncached();
-      this._cachedDependentOn = dependentOn;
-      return dependentOn;
-    }
-  }
-
-  /** @internal */
-  getDependedOnCoValuesUncached(): RawCoID[] {
-    return this.header.ruleset.type === "group"
-      ? getGroupDependentKeyList(expectGroup(this.getCurrentContent()).keys())
-      : this.header.ruleset.type === "ownedByGroup"
-        ? [
-            this.header.ruleset.group,
-            ...new Set(
-              [...this.sessionLogs.keys()]
-                .map((sessionID) =>
-                  accountOrAgentIDfromSessionID(sessionID as SessionID),
-                )
-                .filter(
-                  (session): session is RawAccountID =>
-                    isAccountID(session) && session !== this.id,
-                ),
-            ),
-          ]
-        : [];
   }
 
   waitForSync(options?: {

--- a/packages/cojson/src/coValueCore.ts
+++ b/packages/cojson/src/coValueCore.ts
@@ -109,7 +109,6 @@ export class CoValueCore {
   _cachedKnownState?: CoValueKnownState;
   _cachedDependentOn?: RawCoID[];
   _cachedNewContentSinceEmpty?: NewContentMessage[] | undefined;
-  _currentAsyncAddTransaction?: Promise<void>;
 
   constructor(
     header: CoValueHeader,

--- a/packages/cojson/src/coValueDecryptedState.ts
+++ b/packages/cojson/src/coValueDecryptedState.ts
@@ -1,0 +1,545 @@
+import { CoValueCore } from "./coValueCore.js";
+import { CoValueState } from "./coValueState.js";
+import { RawAccountID } from "./coValues/account.js";
+import { RawGroup } from "./coValues/group.js";
+import {
+  CryptoProvider,
+  Encrypted,
+  KeyID,
+  KeySecret,
+} from "./crypto/crypto.js";
+import {
+  RawCoID,
+  SessionID,
+  TransactionID,
+  getGroupDependentKeyList,
+} from "./ids.js";
+import { RawCoValue } from "./index.js";
+import { parseJSON } from "./jsonStringify.js";
+import { JsonValue } from "./jsonValue.js";
+import { LocalNode } from "./localNode.js";
+import { logger } from "./logger.js";
+import { determineValidTransactions } from "./permissions.js";
+import { CoValueKnownState } from "./sync.js";
+import { accountOrAgentIDfromSessionID } from "./typeUtils/accountOrAgentIDfromSessionID.js";
+import { expectGroup } from "./typeUtils/expectGroup.js";
+import { isAccountID } from "./typeUtils/isAccountID.js";
+
+export type DecryptedTransaction = {
+  txID: TransactionID;
+  changes: JsonValue[];
+  madeAt: number;
+};
+
+const readKeyCache = new WeakMap<CoValueCore, { [id: KeyID]: KeySecret }>();
+
+export class CoValueDecryptedState {
+  private state: CoValueState;
+  private crypto: CryptoProvider;
+  private node: LocalNode;
+  private _decryptionCache: {
+    [key: Encrypted<JsonValue[], JsonValue>]: JsonValue[] | undefined;
+  } = {};
+  private _cachedDependentOn?: RawCoID[];
+  private _cachedContent?: RawCoValue;
+
+  private listeners: Set<
+    (state: CoValueDecryptedState, unsub: () => void) => void
+  > = new Set();
+
+  unsubFromGroup?: () => void;
+
+  subscribeToGroupInvalidation() {
+    if (this.unsubFromGroup) {
+      return;
+    }
+
+    const header = this.header;
+
+    if (header.ruleset.type == "ownedByGroup") {
+      const groupId = header.ruleset.group;
+      const entry = this.node.coValuesStore.get(groupId);
+
+      if (entry.isAvailable()) {
+        this.unsubFromGroup = entry.addListener((_groupUpdate) => {
+          this._cachedContent = undefined;
+          this.notifyUpdate("immediate");
+        }, false);
+      } else {
+        logger.error("CoValueCore: Owner group not available", {
+          id: this.id,
+          groupId,
+        });
+      }
+    }
+  }
+
+  subscribe(
+    listener: (state: CoValueDecryptedState, unsub: () => void) => void,
+  ) {
+    if (this.listeners.size === 0) {
+      this.state.addListener((state) => {
+        if (state.highLevelState === "available") {
+          this._cachedDependentOn = undefined;
+          if (
+            this._cachedContent &&
+            "processNewTransactions" in this._cachedContent &&
+            typeof this._cachedContent.processNewTransactions === "function"
+          ) {
+            this._cachedContent.processNewTransactions();
+          } else {
+            this._cachedContent = undefined;
+          }
+        }
+      });
+    }
+    this.listeners.add(listener);
+    return () => this.listeners.delete(listener);
+  }
+
+  private unsubscribe(
+    listener: (state: CoValueDecryptedState, unsub: () => void) => void,
+  ) {
+    this.listeners.delete(listener);
+    if (this.listeners.size === 0) {
+      this.unsubFromGroup?.();
+      this.unsubFromGroup = undefined;
+    }
+  }
+
+  constructor(state: CoValueState) {
+    this.state = state;
+  }
+
+  getGroup(): RawGroup {
+    if (this.core.header.ruleset.type !== "ownedByGroup") {
+      throw new Error("Only values owned by groups have groups");
+    }
+
+    return expectGroup(
+      this.node
+        .expectCoValueLoaded(this.core.header.ruleset.group)
+        .getCurrentContent(),
+    );
+  }
+
+  getValidTransactions(options?: {
+    ignorePrivateTransactions: boolean;
+    knownTransactions?: CoValueKnownState["sessions"];
+  }): DecryptedTransaction[] {
+    const validTransactions = determineValidTransactions(
+      this.core,
+      options?.knownTransactions,
+    );
+
+    const allTransactions: DecryptedTransaction[] = [];
+
+    for (const { txID, tx } of validTransactions) {
+      if (options?.knownTransactions?.[txID.sessionID]! >= txID.txIndex) {
+        continue;
+      }
+
+      if (tx.privacy === "trusting") {
+        allTransactions.push({
+          txID,
+          madeAt: tx.madeAt,
+          changes: parseJSON(tx.changes),
+        });
+        continue;
+      }
+
+      if (options?.ignorePrivateTransactions) {
+        continue;
+      }
+
+      const readKey = this.getReadKey(tx.keyUsed);
+
+      if (!readKey) {
+        continue;
+      }
+
+      let decryptedChanges = this._decryptionCache[tx.encryptedChanges];
+
+      if (!decryptedChanges) {
+        const decryptedString = this.crypto.decryptRawForTransaction(
+          tx.encryptedChanges,
+          readKey,
+          {
+            in: this.id,
+            tx: txID,
+          },
+        );
+        decryptedChanges = decryptedString && parseJSON(decryptedString);
+        this._decryptionCache[tx.encryptedChanges] = decryptedChanges;
+      }
+
+      if (!decryptedChanges) {
+        logger.error("Failed to decrypt transaction despite having key", {
+          err: new Error("Failed to decrypt transaction despite having key"),
+        });
+        continue;
+      }
+
+      allTransactions.push({
+        txID,
+        madeAt: tx.madeAt,
+        changes: decryptedChanges,
+      });
+    }
+
+    return allTransactions;
+  }
+
+  getValidSortedTransactions(options?: {
+    ignorePrivateTransactions: boolean;
+  }): DecryptedTransaction[] {
+    const allTransactions = this.getValidTransactions(options);
+
+    allTransactions.sort(this.compareTransactions);
+
+    return allTransactions;
+  }
+
+  getCurrentReadKey(): { secret: KeySecret | undefined; id: KeyID } {
+    if (this.header.ruleset.type === "group") {
+      const content = expectGroup(this.getCurrentContent());
+
+      const currentKeyId = content.getCurrentReadKeyId();
+
+      if (!currentKeyId) {
+        throw new Error("No readKey set");
+      }
+
+      const secret = this.getReadKey(currentKeyId);
+
+      return {
+        secret: secret,
+        id: currentKeyId,
+      };
+    } else if (this.header.ruleset.type === "ownedByGroup") {
+      return this.node
+        .expectCoValueLoaded(this.header.ruleset.group)
+        .getCurrentReadKey();
+    } else {
+      throw new Error(
+        "Only groups or values owned by groups have read secrets",
+      );
+    }
+  }
+
+  getReadKey(keyID: KeyID): KeySecret | undefined {
+    let key = readKeyCache.get(this)?.[keyID];
+    if (!key) {
+      key = this.getUncachedReadKey(keyID);
+      if (key) {
+        let cache = readKeyCache.get(this);
+        if (!cache) {
+          cache = {};
+          readKeyCache.set(this, cache);
+        }
+        cache[keyID] = key;
+      }
+    }
+    return key;
+  }
+
+  getUncachedReadKey(keyID: KeyID): KeySecret | undefined {
+    if (this.header.ruleset.type === "group") {
+      const content = expectGroup(
+        this.getCurrentContent({ ignorePrivateTransactions: true }),
+      );
+
+      const keyForEveryone = content.get(`${keyID}_for_everyone`);
+      if (keyForEveryone) return keyForEveryone;
+
+      // Try to find key revelation for us
+      const lookupAccountOrAgentID =
+        this.header.meta?.type === "account"
+          ? this.node.account.currentAgentID()
+          : this.node.account.id;
+
+      const lastReadyKeyEdit = content.lastEditAt(
+        `${keyID}_for_${lookupAccountOrAgentID}`,
+      );
+
+      if (lastReadyKeyEdit?.value) {
+        const revealer = lastReadyKeyEdit.by;
+        const revealerAgent = this.node
+          .resolveAccountAgent(revealer, "Expected to know revealer")
+          ._unsafeUnwrap({ withStackTrace: true });
+
+        const secret = this.crypto.unseal(
+          lastReadyKeyEdit.value,
+          this.node.account.currentSealerSecret(),
+          this.crypto.getAgentSealerID(revealerAgent),
+          {
+            in: this.id,
+            tx: lastReadyKeyEdit.tx,
+          },
+        );
+
+        if (secret) {
+          return secret as KeySecret;
+        }
+      }
+
+      // Try to find indirect revelation through previousKeys
+
+      for (const co of content.keys()) {
+        if (isKeyForKeyField(co) && co.startsWith(keyID)) {
+          const encryptingKeyID = co.split("_for_")[1] as KeyID;
+          const encryptingKeySecret = this.getReadKey(encryptingKeyID);
+
+          if (!encryptingKeySecret) {
+            continue;
+          }
+
+          const encryptedPreviousKey = content.get(co)!;
+
+          const secret = this.crypto.decryptKeySecret(
+            {
+              encryptedID: keyID,
+              encryptingID: encryptingKeyID,
+              encrypted: encryptedPreviousKey,
+            },
+            encryptingKeySecret,
+          );
+
+          if (secret) {
+            return secret as KeySecret;
+          } else {
+            logger.warn(
+              `Encrypting ${encryptingKeyID} key didn't decrypt ${keyID}`,
+            );
+          }
+        }
+      }
+
+      // try to find revelation to parent group read keys
+      for (const co of content.keys()) {
+        if (isParentGroupReference(co)) {
+          const parentGroupID = getParentGroupId(co);
+          const parentGroup = this.node.expectCoValueLoaded(
+            parentGroupID,
+            "Expected parent group to be loaded",
+          );
+
+          const parentKeys = this.findValidParentKeys(
+            keyID,
+            content,
+            parentGroup,
+          );
+
+          for (const parentKey of parentKeys) {
+            const revelationForParentKey = content.get(
+              `${keyID}_for_${parentKey.id}`,
+            );
+
+            if (revelationForParentKey) {
+              const secret = parentGroup.crypto.decryptKeySecret(
+                {
+                  encryptedID: keyID,
+                  encryptingID: parentKey.id,
+                  encrypted: revelationForParentKey,
+                },
+                parentKey.secret,
+              );
+
+              if (secret) {
+                return secret as KeySecret;
+              } else {
+                logger.warn(
+                  `Encrypting parent ${parentKey.id} key didn't decrypt ${keyID}`,
+                );
+              }
+            }
+          }
+        }
+      }
+
+      return undefined;
+    } else if (this.header.ruleset.type === "ownedByGroup") {
+      return this.node
+        .expectCoValueLoaded(this.header.ruleset.group)
+        .getReadKey(keyID);
+    } else {
+      throw new Error(
+        "Only groups or values owned by groups have read secrets",
+      );
+    }
+  }
+
+  findValidParentKeys(keyID: KeyID, group: RawGroup, parentGroup: CoValueCore) {
+    const validParentKeys: { id: KeyID; secret: KeySecret }[] = [];
+
+    for (const co of group.keys()) {
+      if (isKeyForKeyField(co) && co.startsWith(keyID)) {
+        const encryptingKeyID = co.split("_for_")[1] as KeyID;
+        const encryptingKeySecret = parentGroup.getReadKey(encryptingKeyID);
+
+        if (!encryptingKeySecret) {
+          continue;
+        }
+
+        validParentKeys.push({
+          id: encryptingKeyID,
+          secret: encryptingKeySecret,
+        });
+      }
+    }
+
+    return validParentKeys;
+  }
+
+  getDependedOnCoValues(): RawCoID[] {
+    if (this._cachedDependentOn) {
+      return this._cachedDependentOn;
+    } else {
+      const dependentOn = this.getDependedOnCoValuesUncached();
+      this._cachedDependentOn = dependentOn;
+      return dependentOn;
+    }
+  }
+
+  /** @internal */
+  getDependedOnCoValuesUncached(): RawCoID[] {
+    return this.core.header.ruleset.type === "group"
+      ? getGroupDependentKeyList(expectGroup(this.getCurrentContent()).keys())
+      : this.core.header.ruleset.type === "ownedByGroup"
+        ? [
+            this.core.header.ruleset.group,
+            ...new Set(
+              [...this.core.sessionLogs.keys()]
+                .map((sessionID) =>
+                  accountOrAgentIDfromSessionID(sessionID as SessionID),
+                )
+                .filter(
+                  (session): session is RawAccountID =>
+                    isAccountID(session) && session !== this.id,
+                ),
+            ),
+          ]
+        : [];
+  }
+
+  nextTransactionID(): TransactionID {
+    // This is an ugly hack to get a unique but stable session ID for editing the current account
+    const sessionID =
+      this.core.header.meta?.type === "account"
+        ? (this.node.currentSessionID.replace(
+            this.node.account.id,
+            this.node.account.currentAgentID(),
+          ) as SessionID)
+        : this.node.currentSessionID;
+
+    return {
+      sessionID,
+      txIndex: this.sessionLogs.get(sessionID)?.transactions.length || 0,
+    };
+  }
+
+  makeTransaction(
+    changes: JsonValue[],
+    privacy: "private" | "trusting",
+  ): boolean {
+    const madeAt = Date.now();
+
+    let transaction: Transaction;
+
+    if (privacy === "private") {
+      const { secret: keySecret, id: keyID } = this.getCurrentReadKey();
+
+      if (!keySecret) {
+        throw new Error("Can't make transaction without read key secret");
+      }
+
+      const encrypted = this.crypto.encryptForTransaction(changes, keySecret, {
+        in: this.id,
+        tx: this.nextTransactionID(),
+      });
+
+      this._decryptionCache[encrypted] = changes;
+
+      transaction = {
+        privacy: "private",
+        madeAt,
+        keyUsed: keyID,
+        encryptedChanges: encrypted,
+      };
+    } else {
+      transaction = {
+        privacy: "trusting",
+        madeAt,
+        changes: stableStringify(changes),
+      };
+    }
+
+    // This is an ugly hack to get a unique but stable session ID for editing the current account
+    const sessionID =
+      this.header.meta?.type === "account"
+        ? (this.node.currentSessionID.replace(
+            this.node.account.id,
+            this.node.account.currentAgentID(),
+          ) as SessionID)
+        : this.node.currentSessionID;
+
+    const { expectedNewHash, newStreamingHash } = this.expectedNewHashAfter(
+      sessionID,
+      [transaction],
+    );
+
+    const signature = this.crypto.sign(
+      this.node.account.currentSignerSecret(),
+      expectedNewHash,
+    );
+
+    const success = this.int_tryAddTransactions(
+      sessionID,
+      [transaction],
+      expectedNewHash,
+      signature,
+      true,
+      newStreamingHash,
+    )._unsafeUnwrap({ withStackTrace: true });
+
+    if (success) {
+      this.node.syncManager.recordTransactionsSize([transaction], "local");
+      void this.node.syncManager.syncCoValue(this);
+    }
+
+    return success;
+  }
+
+  getCurrentContent(options?: {
+    ignorePrivateTransactions: true;
+  }): RawCoValue {
+    if (!options?.ignorePrivateTransactions && this._cachedContent) {
+      return this._cachedContent;
+    }
+
+    this.subscribeToGroupInvalidation();
+
+    const newContent = coreToCoValue(this, options);
+
+    if (!options?.ignorePrivateTransactions) {
+      this._cachedContent = newContent;
+    }
+
+    return newContent;
+  }
+}
+
+function compareTransactions(
+  a: Pick<DecryptedTransaction, "madeAt" | "txID">,
+  b: Pick<DecryptedTransaction, "madeAt" | "txID">,
+) {
+  return (
+    a.madeAt - b.madeAt ||
+    (a.txID.sessionID === b.txID.sessionID
+      ? 0
+      : a.txID.sessionID < b.txID.sessionID
+        ? -1
+        : 1) ||
+    a.txID.txIndex - b.txID.txIndex
+  );
+}

--- a/packages/cojson/src/coValueState.ts
+++ b/packages/cojson/src/coValueState.ts
@@ -1,10 +1,18 @@
 import { ValueType } from "@opentelemetry/api";
 import { UpDownCounter, metrics } from "@opentelemetry/api";
+import { Result } from "neverthrow";
 import { PeerState } from "./PeerState.js";
-import { CoValueCore, TryAddTransactionsError } from "./coValueCore.js";
-import { RawCoID } from "./ids.js";
+import {
+  CoValueCore,
+  Transaction,
+  TryAddTransactionsError,
+} from "./coValueCore.js";
+import { Hash, Signature, StreamingHash } from "./crypto/crypto.js";
+import { RawCoID, SessionID } from "./ids.js";
+import { LocalNode } from "./index.js";
 import { logger } from "./logger.js";
 import { PeerID, emptyKnownState } from "./sync.js";
+import { accountOrAgentIDfromSessionID } from "./typeUtils/accountOrAgentIDfromSessionID.js";
 
 export const CO_VALUE_LOADING_CONFIG = {
   MAX_RETRIES: 2,
@@ -12,6 +20,7 @@ export const CO_VALUE_LOADING_CONFIG = {
 };
 
 export class CoValueState {
+  private node: LocalNode;
   private peers = new Map<
     PeerID,
     | { type: "unknown" | "pending" | "available" | "unavailable" }
@@ -26,6 +35,8 @@ export class CoValueState {
 
   private listeners: Set<(state: CoValueState, unsub: () => void) => void> =
     new Set();
+  private deferredUpdates = 0;
+  private nextDeferredNotify: Promise<void> | undefined;
   private counter: UpDownCounter;
 
   constructor(id: RawCoID) {
@@ -78,9 +89,36 @@ export class CoValueState {
     return unsub;
   }
 
-  private notifyListeners() {
-    for (const listener of this.listeners) {
-      listener(this, () => this.listeners.delete(listener));
+  private notifyListeners(notifyMode: "immediate" | "deferred") {
+    if (this.listeners.size === 0) {
+      return;
+    }
+
+    if (notifyMode === "immediate") {
+      for (const listener of this.listeners) {
+        listener(this, () => this.listeners.delete(listener));
+      }
+    } else {
+      if (!this.nextDeferredNotify) {
+        this.nextDeferredNotify = new Promise((resolve) => {
+          setTimeout(() => {
+            this.nextDeferredNotify = undefined;
+            this.deferredUpdates = 0;
+            for (const listener of this.listeners) {
+              const unsub = () => this.listeners.delete(listener);
+              try {
+                listener(this, unsub);
+              } catch (e) {
+                logger.error("Error in listener for coValue " + this.id, {
+                  err: e,
+                });
+              }
+            }
+            resolve();
+          }, 0);
+        });
+      }
+      this.deferredUpdates++;
     }
   }
 
@@ -240,7 +278,7 @@ export class CoValueState {
     const previousState = this.highLevelState;
     this.peers.set(peerId, { type: "unavailable" });
     this.updateCounter(previousState);
-    this.notifyListeners();
+    this.notifyListeners("immediate");
   }
 
   // TODO: rename to "provided"
@@ -249,28 +287,67 @@ export class CoValueState {
     this.core = coValue;
     this.peers.set(fromPeerId, { type: "available" });
     this.updateCounter(previousState);
-    this.notifyListeners();
+    this.notifyListeners("immediate");
   }
 
   internalMarkMagicallyAvailable(coValue: CoValueCore) {
     const previousState = this.highLevelState;
     this.core = coValue;
     this.updateCounter(previousState);
-    this.notifyListeners();
+    this.notifyListeners("immediate");
   }
 
   markErrored(peerId: PeerID, error: TryAddTransactionsError) {
     const previousState = this.highLevelState;
     this.peers.set(peerId, { type: "errored", error });
     this.updateCounter(previousState);
-    this.notifyListeners();
+    this.notifyListeners("immediate");
   }
 
   private markPending(peerId: PeerID) {
     const previousState = this.highLevelState;
     this.peers.set(peerId, { type: "pending" });
     this.updateCounter(previousState);
-    this.notifyListeners();
+    this.notifyListeners("immediate");
+  }
+
+  tryAddTransactions(
+    sessionID: SessionID,
+    newTransactions: Transaction[],
+    givenExpectedNewHash: Hash | undefined,
+    newSignature: Signature,
+    skipVerify: boolean = false,
+    givenNewStreamingHash?: StreamingHash,
+  ): Result<true, TryAddTransactionsError> {
+    if (this.node.crashed) {
+      throw new Error("Trying to add transactions after node is crashed");
+    }
+    if (!this.isAvailable()) {
+      throw new Error("");
+    }
+
+    const result = this.node
+      .resolveAccountAgent(
+        accountOrAgentIDfromSessionID(sessionID),
+        "Expected to know signer of transaction",
+      )
+      .andThen((agentID) =>
+        this.core.int_tryAddTransactions(
+          agentID,
+          sessionID,
+          newTransactions,
+          givenExpectedNewHash,
+          newSignature,
+          skipVerify,
+          givenNewStreamingHash,
+        ),
+      );
+
+    if (result.isOk()) {
+      this.notifyListeners("immediate");
+    }
+
+    return result;
   }
 }
 


### PR DESCRIPTION
This started as a humble PR for implementing load in terms of subscribe instead of the other way around, implementing #1976

In the process, I realised that CoValueCore is doing way too much and decided on the following new architecture:

- `CoValueState` manages subscriptions to both the loading state as well as updates to *verified* transactions
  - this is now the single place to subscribe to an individual CoValue without caring about its content
- `CoValueCore` only contains the session and header and the logic for *verifying* new transactions
  - no more dependency on node, other CoValues, cached content, etc.
- new: `CoValueDecryptedState` subscribes to a `CoValueState` of a  CoValue and the `CoValueDecryptedState` of its dependencies (such as owning Groups) and exposes a subscribable state of *validated* transactions
  - this now holds the `RawCoValue` content that is incrementally updated as the *validated* transactions change, you can also subscribe to that
  - this is now the single place to subscribe to the validated content of a CoValue, and the only place of coordination between that CoValue, the node and dependent CoValues

One important detail is that each "layer" in the subscription will make sure to unsubscribe from its own upstream subscriptions if it has no more listeners itself, which is an important step for #952 and #1985 more generally