### PR TITLE
[expo] Fix CSS import when using `create-jazz-app`

### DIFF
--- a/.changeset/seven-rings-bake.md
+++ b/.changeset/seven-rings-bake.md
@@ -1,0 +1,5 @@
+---
+"create-jazz-app": patch
+---
+
+Fix CSS import for Expo starter app when using create-jazz-app

--- a/packages/create-jazz-app/src/index.ts
+++ b/packages/create-jazz-app/src/index.ts
@@ -264,7 +264,7 @@ const { withNativeWind } = require("nativewind/metro");
 
 const config = getDefaultConfig(__dirname);
 
-module.exports = withNativeWind(config, { input: "./src/global.css" });
+module.exports = withNativeWind(config, { input: "./global.css" });
 `;
       fs.writeFileSync(metroConfigPath, metroConfig);
 


### PR DESCRIPTION
The metro config is generated with a wrong .css path therefore stylings doesn't work after using `npx create-jazz-app@latest --example chat-rn-expo`