### PR TITLE
1816-switch-example-apps-to-use-coplaintext

### DIFF
--- a/examples/chat-rn-expo-clerk/app/chat/[chatId].tsx
+++ b/examples/chat-rn-expo-clerk/app/chat/[chatId].tsx
@@ -7,7 +7,7 @@ import { useLocalSearchParams } from "expo-router";
 import { useAccount, useCoState } from "jazz-expo";
 import { ProgressiveImg } from "jazz-expo";
 import { createImage } from "jazz-react-native-media-images";
-import { Group, ID } from "jazz-tools";
+import { CoPlainText, Group, ID } from "jazz-tools";
 import { useEffect, useLayoutEffect, useState } from "react";
 import React, {
   SafeAreaView,
@@ -82,7 +82,12 @@ export default function Conversation() {
   const sendMessage = () => {
     if (!chat) return;
     if (message.trim()) {
-      chat.push(Message.create({ text: message }, { owner: chat._owner }));
+      chat.push(
+        Message.create(
+          { text: CoPlainText.create(message, { owner: chat._owner }) },
+          { owner: chat._owner },
+        ),
+      );
       setMessage("");
     }
   };
@@ -104,7 +109,12 @@ export default function Conversation() {
           maxSize: 2048,
         });
 
-        chat.push(Message.create({ text: "", image }, { owner: chat._owner }));
+        chat.push(
+          Message.create(
+            { text: CoPlainText.create("", { owner: chat._owner }), image },
+            { owner: chat._owner },
+          ),
+        );
       }
     } catch (error) {
       Alert.alert("Error", "Failed to upload image");
@@ -156,7 +166,7 @@ export default function Conversation() {
                 `text-md max-w-[85%]`,
               )}
             >
-              {item.text}
+              {item.text?.toString()}
             </Text>
           )}
           <Text

--- a/examples/chat-rn-expo-clerk/src/schema.ts
+++ b/examples/chat-rn-expo-clerk/src/schema.ts
@@ -1,7 +1,7 @@
-import { CoList, CoMap, ImageDefinition, co } from "jazz-tools";
+import { CoList, CoMap, CoPlainText, ImageDefinition, co } from "jazz-tools";
 
 export class Message extends CoMap {
-  text = co.string;
+  text = co.ref(CoPlainText);
   image = co.optional.ref(ImageDefinition);
 }
 

--- a/examples/chat-rn-expo/src/chat.tsx
+++ b/examples/chat-rn-expo/src/chat.tsx
@@ -1,6 +1,6 @@
 import clsx from "clsx";
 import * as Clipboard from "expo-clipboard";
-import { Group, ID, Profile } from "jazz-tools";
+import { CoPlainText, Group, ID, Profile } from "jazz-tools";
 import { useEffect, useState } from "react";
 import React, {
   Button,
@@ -84,7 +84,10 @@ export default function ChatScreen({ navigation }: { navigation: any }) {
     if (!loadedChat) return;
     if (message.trim()) {
       loadedChat.push(
-        Message.create({ text: message }, { owner: loadedChat?._owner }),
+        Message.create(
+          { text: CoPlainText.create(message, { owner: loadedChat?._owner }) },
+          { owner: loadedChat?._owner },
+        ),
       );
       setMessage("");
     }
@@ -117,7 +120,7 @@ export default function ChatScreen({ navigation }: { navigation: any }) {
           )}
         >
           <Text className={clsx(`text-black text-md max-w-[85%]`)}>
-            {item.text}
+            {item.text?.toString()}
           </Text>
           <Text
             className={clsx(

--- a/examples/chat-rn-expo/src/schema.ts
+++ b/examples/chat-rn-expo/src/schema.ts
@@ -1,7 +1,7 @@
-import { CoList, CoMap, co } from "jazz-tools";
+import { CoList, CoMap, CoPlainText, co } from "jazz-tools";
 
 export class Message extends CoMap {
-  text = co.string;
+  text = co.ref(CoPlainText);
 }
 
 export class Chat extends CoList.Of(co.ref(Message)) {}

--- a/examples/chat-rn/src/chat.tsx
+++ b/examples/chat-rn/src/chat.tsx
@@ -1,6 +1,6 @@
 import Clipboard from "@react-native-clipboard/clipboard";
 import { useAccount, useCoState } from "jazz-react-native";
-import { Group, ID, Profile } from "jazz-tools";
+import { CoPlainText, Group, ID, Profile } from "jazz-tools";
 import { useEffect, useState } from "react";
 import {
   Alert,
@@ -83,7 +83,10 @@ export function ChatScreen({ navigation }: { navigation: any }) {
     if (!loadedChat) return;
     if (message.trim()) {
       loadedChat.push(
-        Message.create({ text: message }, { owner: loadedChat?._owner }),
+        Message.create(
+          { text: CoPlainText.create(message, { owner: loadedChat?._owner }) },
+          { owner: loadedChat?._owner },
+        ),
       );
       setMessage("");
     }
@@ -109,7 +112,7 @@ export function ChatScreen({ navigation }: { navigation: any }) {
           </Text>
         ) : null}
         <View style={styles.messageContent}>
-          <Text style={styles.messageText}>{item.text}</Text>
+          <Text style={styles.messageText}>{item.text?.toString()}</Text>
           <Text
             style={[
               styles.timestamp,

--- a/examples/chat-rn/src/schema.ts
+++ b/examples/chat-rn/src/schema.ts
@@ -1,7 +1,7 @@
-import { CoList, CoMap, co } from "jazz-tools";
+import { CoList, CoMap, CoPlainText, co } from "jazz-tools";
 
 export class Message extends CoMap {
-  text = co.string;
+  text = co.ref(CoPlainText);
 }
 
 export class Chat extends CoList.Of(co.ref(Message)) {}

--- a/examples/chat-vue/src/components/ChatBubble.vue
+++ b/examples/chat-vue/src/components/ChatBubble.vue
@@ -1,9 +1,9 @@
 <template>
-    <BubbleContainer :fromMe="lastEdit.by?.isMe">
-      <BubbleBody>{{ msg.text }}</BubbleBody>
-      <BubbleInfo :by="lastEdit.by?.profile?.name" :madeAt="lastEdit.madeAt" />
-    </BubbleContainer>
-  </template>
+  <BubbleContainer :fromMe="lastEdit.by?.isMe">
+    <BubbleBody>{{ msg.text?.toString() }}</BubbleBody>
+    <BubbleInfo :by="lastEdit.by?.profile?.name" :madeAt="lastEdit.madeAt" />
+  </BubbleContainer>
+</template>
   
   <script lang="ts">
 import { computed, defineComponent } from "vue";

--- a/examples/chat-vue/src/schema.ts
+++ b/examples/chat-vue/src/schema.ts
@@ -1,7 +1,7 @@
-import { CoList, CoMap, co } from "jazz-tools";
+import { CoList, CoMap, CoPlainText, co } from "jazz-tools";
 
 export class Message extends CoMap {
-  text = co.string;
+  text = co.ref(CoPlainText);
 }
 
 export class Chat extends CoList.Of(co.ref(Message)) {}

--- a/examples/chat-vue/src/views/ChatView.vue
+++ b/examples/chat-vue/src/views/ChatView.vue
@@ -25,7 +25,7 @@
 </template>
 
 <script lang="ts">
-import type { ID } from "jazz-tools";
+import { CoPlainText, type ID } from "jazz-tools";
 import { useCoState } from "jazz-vue";
 import { type PropType, computed, defineComponent, ref } from "vue";
 import ChatBody from "../components/ChatBody.vue";
@@ -61,7 +61,12 @@ export default defineComponent({
     }
 
     function handleSubmit(text: string) {
-      chat?.value?.push(Message.create({ text }, { owner: chat.value._owner }));
+      chat?.value?.push(
+        Message.create(
+          { text: CoPlainText.create(text, { owner: chat.value._owner }) },
+          { owner: chat.value._owner },
+        ),
+      );
     }
 
     return {

--- a/examples/chat/src/chatScreen.tsx
+++ b/examples/chat/src/chatScreen.tsx
@@ -1,5 +1,5 @@
 import { createImage, useAccount, useCoState } from "jazz-react";
-import { Account, ID } from "jazz-tools";
+import { Account, CoPlainText, ID } from "jazz-tools";
 import { useState } from "react";
 import { Chat, Message } from "./schema.ts";
 import {
@@ -36,7 +36,15 @@ export function ChatScreen(props: { chatID: ID<Chat> }) {
     }
 
     createImage(file, { owner: chat._owner }).then((image) => {
-      chat.push(Message.create({ text: file.name, image: image }, chat._owner));
+      chat.push(
+        Message.create(
+          {
+            text: CoPlainText.create(file.name, { owner: chat._owner }),
+            image: image,
+          },
+          chat._owner,
+        ),
+      );
     });
   };
 
@@ -66,7 +74,12 @@ export function ChatScreen(props: { chatID: ID<Chat> }) {
 
         <TextInput
           onSubmit={(text) => {
-            chat.push(Message.create({ text }, { owner: chat._owner }));
+            chat.push(
+              Message.create(
+                { text: CoPlainText.create(text, { owner: chat._owner }) },
+                { owner: chat._owner },
+              ),
+            );
           }}
         />
       </InputBar>
@@ -75,7 +88,7 @@ export function ChatScreen(props: { chatID: ID<Chat> }) {
 }
 
 function ChatBubble(props: { me: Account; msg: Message }) {
-  if (!props.me.canRead(props.msg)) {
+  if (!props.me.canRead(props.msg) || !props.msg.text) {
     return (
       <BubbleContainer fromMe={false}>
         <BubbleBody fromMe={false}>

--- a/examples/chat/src/schema.ts
+++ b/examples/chat/src/schema.ts
@@ -1,7 +1,7 @@
-import { CoList, CoMap, ImageDefinition, co } from "jazz-tools";
+import { CoList, CoMap, CoPlainText, ImageDefinition, co } from "jazz-tools";
 
 export class Message extends CoMap {
-  text = co.string;
+  text = co.ref(CoPlainText);
   image = co.optional.ref(ImageDefinition);
 }
 

--- a/examples/chat/src/ui.tsx
+++ b/examples/chat/src/ui.tsx
@@ -1,6 +1,6 @@
 import clsx from "clsx";
 import { ProgressiveImg } from "jazz-react";
-import { ImageDefinition } from "jazz-tools";
+import { CoPlainText, ImageDefinition } from "jazz-tools";
 import { ImageIcon } from "lucide-react";
 import { useId, useRef } from "react";
 
@@ -70,10 +70,13 @@ export function BubbleBody(props: {
   );
 }
 
-export function BubbleText(props: { text: string; className?: string }) {
+export function BubbleText(props: {
+  text: CoPlainText | string;
+  className?: string;
+}) {
   return (
     <p className={clsx("px-2 leading-relaxed", props.className)}>
-      {props.text}
+      {props.text.toString()}
     </p>
   );
 }

--- a/examples/form/src/CreateOrder.tsx
+++ b/examples/form/src/CreateOrder.tsx
@@ -1,6 +1,6 @@
 import { useIframeHashRouter } from "hash-slash";
 import { useAccount, useCoState } from "jazz-react";
-import { CoPlainText, ID } from "jazz-tools";
+import { ID } from "jazz-tools";
 import { useState } from "react";
 import { Errors } from "./Errors.tsx";
 import { LinkToHome } from "./LinkToHome.tsx";
@@ -35,7 +35,6 @@ export function CreateOrder() {
     me.root.draft = DraftBubbleTeaOrder.create(
       {
         addOns: ListOfBubbleTeaAddOns.create([]),
-        instructions: CoPlainText.create("", { owner: me }),
       },
       me,
     );

--- a/examples/form/src/CreateOrder.tsx
+++ b/examples/form/src/CreateOrder.tsx
@@ -1,6 +1,6 @@
 import { useIframeHashRouter } from "hash-slash";
 import { useAccount, useCoState } from "jazz-react";
-import { ID } from "jazz-tools";
+import { CoPlainText, ID } from "jazz-tools";
 import { useState } from "react";
 import { Errors } from "./Errors.tsx";
 import { LinkToHome } from "./LinkToHome.tsx";
@@ -32,9 +32,13 @@ export function CreateOrder() {
     me.root.orders.push(draft as BubbleTeaOrder);
 
     // reset the draft
-    me.root.draft = DraftBubbleTeaOrder.create({
-      addOns: ListOfBubbleTeaAddOns.create([]),
-    });
+    me.root.draft = DraftBubbleTeaOrder.create(
+      {
+        addOns: ListOfBubbleTeaAddOns.create([]),
+        instructions: CoPlainText.create("", { owner: me }),
+      },
+      me,
+    );
 
     router.navigate("/");
   };
@@ -62,7 +66,7 @@ function CreateOrderForm({
   onSave: (draft: DraftBubbleTeaOrder) => void;
 }) {
   const draft = useCoState(DraftBubbleTeaOrder, id, {
-    resolve: { addOns: true },
+    resolve: { addOns: true, instructions: true },
   });
 
   if (!draft) return;

--- a/examples/form/src/OrderForm.tsx
+++ b/examples/form/src/OrderForm.tsx
@@ -1,3 +1,4 @@
+import { CoPlainText } from "jazz-tools";
 import {
   BubbleTeaAddOnTypes,
   BubbleTeaBaseTeaTypes,
@@ -12,6 +13,17 @@ export function OrderForm({
   order: BubbleTeaOrder | DraftBubbleTeaOrder;
   onSave?: (e: React.FormEvent<HTMLFormElement>) => void;
 }) {
+  const handleInstructionsChange = (
+    e: React.ChangeEvent<HTMLTextAreaElement>,
+  ) => {
+    if (order.instructions) {
+      return order.instructions.applyDiff(e.target.value);
+    }
+    order.instructions = CoPlainText.create(e.target.value, {
+      owner: order._owner,
+    });
+  };
+
   return (
     <form onSubmit={onSave} className="grid gap-5">
       <div className="flex flex-col gap-2">
@@ -88,9 +100,9 @@ export function OrderForm({
         <textarea
           name="instructions"
           id="instructions"
-          value={order.instructions}
+          value={order.instructions?.toString() || ""}
           className="dark:bg-transparent"
-          onChange={(e) => (order.instructions = e.target.value)}
+          onChange={handleInstructionsChange}
         ></textarea>
       </div>
 

--- a/examples/form/src/OrderThumbnail.tsx
+++ b/examples/form/src/OrderThumbnail.tsx
@@ -19,7 +19,9 @@ export function OrderThumbnail({ order }: { order: BubbleTeaOrder }) {
           </p>
         )}
         {instructions && (
-          <p className="text-sm text-stone-600 italic">{instructions}</p>
+          <p className="text-sm text-stone-600 italic">
+            {instructions.toString()}
+          </p>
         )}
       </div>
       <div className="text-sm text-stone-600">{date}</div>

--- a/examples/form/src/schema.ts
+++ b/examples/form/src/schema.ts
@@ -1,4 +1,4 @@
-import { Account, CoList, CoMap, co } from "jazz-tools";
+import { Account, CoList, CoMap, CoPlainText, co } from "jazz-tools";
 
 export const BubbleTeaAddOnTypes = [
   "Pearl",
@@ -28,7 +28,7 @@ export class BubbleTeaOrder extends CoMap {
   addOns = co.ref(ListOfBubbleTeaAddOns);
   deliveryDate = co.Date;
   withMilk = co.boolean;
-  instructions = co.optional.string;
+  instructions = co.optional.ref(CoPlainText);
 }
 
 export class DraftBubbleTeaOrder extends CoMap {
@@ -36,7 +36,7 @@ export class DraftBubbleTeaOrder extends CoMap {
   addOns = co.optional.ref(ListOfBubbleTeaAddOns);
   deliveryDate = co.optional.Date;
   withMilk = co.optional.boolean;
-  instructions = co.optional.string;
+  instructions = co.optional.ref(CoPlainText);
 
   get hasChanges() {
     return Object.keys(this._edits).length > 1 || this.addOns?.hasChanges;
@@ -77,6 +77,7 @@ export class JazzAccount extends Account {
       const draft = DraftBubbleTeaOrder.create(
         {
           addOns: ListOfBubbleTeaAddOns.create([], account),
+          instructions: CoPlainText.create("", { owner: account }),
         },
         account,
       );

--- a/examples/form/src/schema.ts
+++ b/examples/form/src/schema.ts
@@ -77,7 +77,6 @@ export class JazzAccount extends Account {
       const draft = DraftBubbleTeaOrder.create(
         {
           addOns: ListOfBubbleTeaAddOns.create([], account),
-          instructions: CoPlainText.create("", { owner: account }),
         },
         account,
       );

--- a/examples/music-player/src/1_schema.ts
+++ b/examples/music-player/src/1_schema.ts
@@ -1,4 +1,12 @@
-import { Account, CoList, CoMap, FileStream, Profile, co } from "jazz-tools";
+import {
+  Account,
+  CoList,
+  CoMap,
+  CoPlainText,
+  FileStream,
+  Profile,
+  co,
+} from "jazz-tools";
 
 /** Walkthrough: Defining the data model with CoJSON
  *
@@ -18,7 +26,7 @@ export class MusicTrack extends CoMap {
    *
    *  Tip: try to follow the co.string defintion to discover the other available primitives!
    */
-  title = co.string;
+  title = co.ref(CoPlainText);
   duration = co.number;
 
   /**
@@ -53,7 +61,7 @@ export class MusicTrackWaveform extends CoMap {
 export class ListOfTracks extends CoList.Of(co.ref(MusicTrack)) {}
 
 export class Playlist extends CoMap {
-  title = co.string;
+  title = co.ref(CoPlainText);
   tracks = co.ref(ListOfTracks);
 }
 
@@ -92,7 +100,7 @@ export class MusicaAccount extends Account {
       const tracks = ListOfTracks.create([]);
       const rootPlaylist = Playlist.create({
         tracks,
-        title: "",
+        title: CoPlainText.create("My Playlist", { owner: this }),
       });
 
       this.root = MusicaAccountRoot.create({

--- a/examples/music-player/src/4_actions.ts
+++ b/examples/music-player/src/4_actions.ts
@@ -1,5 +1,5 @@
 import { getAudioFileData } from "@/lib/audio/getAudioFileData";
-import { FileStream, Group } from "jazz-tools";
+import { CoPlainText, FileStream, Group } from "jazz-tools";
 import {
   ListOfTracks,
   MusicTrack,
@@ -53,7 +53,7 @@ export async function uploadMusicTracks(
         file: fileStream,
         duration: data.duration,
         waveform: MusicTrackWaveform.create({ data: data.waveform }, group),
-        title: file.name,
+        title: CoPlainText.create(file.name, { owner: group }),
         isExampleTrack,
       },
       group,
@@ -81,7 +81,7 @@ export async function createNewPlaylist() {
 
   const playlist = Playlist.create(
     {
-      title: "New Playlist",
+      title: CoPlainText.create("New Playlist", { owner: playlistGroup }),
       tracks: ListOfTracks.create([], playlistGroup),
     },
     playlistGroup,
@@ -144,11 +144,11 @@ export async function removeTrackFromPlaylist(
 }
 
 export async function updatePlaylistTitle(playlist: Playlist, title: string) {
-  playlist.title = title;
+  playlist.title?.applyDiff(title);
 }
 
 export async function updateMusicTrackTitle(track: MusicTrack, title: string) {
-  track.title = title;
+  track.title?.applyDiff(title);
 }
 
 export async function updateActivePlaylist(playlist?: Playlist) {

--- a/examples/music-player/src/components/MusicTrackTitleInput.tsx
+++ b/examples/music-player/src/components/MusicTrackTitleInput.tsx
@@ -19,7 +19,7 @@ export function MusicTrackTitleInput({
 
   function handleFoucsIn() {
     setIsEditing(true);
-    setLocalTrackTitle(track?.title ?? "");
+    setLocalTrackTitle(track?.title?.toString() ?? "");
   }
 
   function handleFocusOut() {
@@ -28,7 +28,9 @@ export function MusicTrackTitleInput({
     track && updateMusicTrackTitle(track, localTrackTitle);
   }
 
-  const inputValue = isEditing ? localTrackTitle : (track?.title ?? "");
+  const inputValue = isEditing
+    ? localTrackTitle
+    : (track?.title?.toString() ?? "");
 
   return (
     <div
@@ -42,7 +44,7 @@ export function MusicTrackTitleInput({
         spellCheck="false"
         onFocus={handleFoucsIn}
         onBlur={handleFocusOut}
-        aria-label={`Edit track title: ${track?.title}`}
+        aria-label={`Edit track title: ${track?.title?.toString()}`}
       />
       <span className="opacity-0 px-1 w-fit pointer-events-none whitespace-pre">
         {inputValue}

--- a/examples/music-player/src/components/PlaylistTitleInput.tsx
+++ b/examples/music-player/src/components/PlaylistTitleInput.tsx
@@ -19,7 +19,7 @@ export function PlaylistTitleInput({
 
   function handleFoucsIn() {
     setIsEditing(true);
-    setLocalPlaylistTitle(playlist?.title ?? "");
+    setLocalPlaylistTitle(playlist?.title?.toString() ?? "");
   }
 
   function handleFocusOut() {
@@ -28,7 +28,9 @@ export function PlaylistTitleInput({
     playlist && updatePlaylistTitle(playlist, localPlaylistTitle);
   }
 
-  const inputValue = isEditing ? localPlaylistTitle : (playlist?.title ?? "");
+  const inputValue = isEditing
+    ? localPlaylistTitle
+    : (playlist?.title?.toString() ?? "");
 
   return (
     <input

--- a/examples/organization/src/OrganizationPage.tsx
+++ b/examples/organization/src/OrganizationPage.tsx
@@ -21,7 +21,9 @@ export function OrganizationPage() {
   return (
     <Layout>
       <div className="grid gap-8">
-        <Heading text={`Welcome to ${organization.name} organization!`} />
+        <Heading
+          text={`Welcome to ${organization.name?.toString() || "Your"} organization!`}
+        />
 
         <div className="rounded-lg border shadow-sm bg-white dark:bg-stone-925">
           <div className="border-b px-4 py-5 sm:px-6">
@@ -50,7 +52,7 @@ export function OrganizationPage() {
                     key={project.id}
                     className="px-4 py-5 sm:px-6 font-medium block"
                   >
-                    {project.name}
+                    {project.name?.toString()}
                   </strong>
                 ) : null,
               )

--- a/examples/organization/src/components/CreateProject.tsx
+++ b/examples/organization/src/components/CreateProject.tsx
@@ -1,3 +1,4 @@
+import { CoPlainText } from "jazz-tools";
 import { useState } from "react";
 import { Organization, Project } from "../schema.ts";
 
@@ -14,7 +15,10 @@ export function CreateProject({
     if (!organization?.projects) return;
 
     if (name.length > 0) {
-      const project = Project.create({ name }, { owner: organization._owner });
+      const project = Project.create(
+        { name: CoPlainText.create(name, { owner: organization._owner }) },
+        { owner: organization._owner },
+      );
       organization.projects.push(project);
       setName("");
     }

--- a/examples/organization/src/components/OrganizationForm.tsx
+++ b/examples/organization/src/components/OrganizationForm.tsx
@@ -1,3 +1,4 @@
+import { CoPlainText } from "jazz-tools";
 import { DraftOrganization, Organization } from "../schema.ts";
 
 export function OrganizationForm({
@@ -7,6 +8,16 @@ export function OrganizationForm({
   organization: Organization | DraftOrganization;
   onSave?: (e: React.FormEvent<HTMLFormElement>) => void;
 }) {
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    if (organization.name) {
+      return organization.name.applyDiff(e.target.value);
+    }
+
+    organization.name = CoPlainText.create(e.target.value, {
+      owner: organization._owner,
+    });
+  };
+
   return (
     <form onSubmit={onSave} className="flex gap-3 items-center">
       <label className="flex-1">
@@ -15,10 +26,10 @@ export function OrganizationForm({
           type="text"
           name="name"
           id="name"
-          value={organization.name}
+          value={organization.name?.toString() || ""}
           placeholder="Enter organization name..."
           className="rounded-md shadow-sm dark:bg-transparent w-full"
-          onChange={(e) => (organization.name = e.target.value)}
+          onChange={handleChange}
           required
         />
       </label>

--- a/examples/organization/src/components/OrganizationSelector.tsx
+++ b/examples/organization/src/components/OrganizationSelector.tsx
@@ -50,7 +50,7 @@ export function OrganizationSelector({ className }: { className?: string }) {
         {me?.root.organizations.map((organization) => {
           return (
             <option key={organization.id} value={organization.id}>
-              {organization.name}
+              {organization.name?.toString()}
             </option>
           );
         })}

--- a/examples/organization/src/schema.ts
+++ b/examples/organization/src/schema.ts
@@ -1,24 +1,24 @@
-import { Account, CoList, CoMap, Group, co } from "jazz-tools";
+import { Account, CoList, CoMap, CoPlainText, Group, co } from "jazz-tools";
 
 export class Project extends CoMap {
-  name = co.string;
+  name = co.ref(CoPlainText);
 }
 
 export class ListOfProjects extends CoList.Of(co.ref(Project)) {}
 
 export class Organization extends CoMap {
-  name = co.string;
+  name = co.ref(CoPlainText);
   projects = co.ref(ListOfProjects);
 }
 
 export class DraftOrganization extends CoMap {
-  name = co.optional.string;
+  name = co.optional.ref(CoPlainText);
   projects = co.ref(ListOfProjects);
 
   validate() {
     const errors: string[] = [];
 
-    if (!this.name) {
+    if (!this.name?.toString()) {
       errors.push("Please enter a name.");
     }
 
@@ -58,8 +58,10 @@ export class JazzAccount extends Account {
           Organization.create(
             {
               name: this.profile?.name
-                ? `${this.profile.name}'s projects`
-                : "Your projects",
+                ? CoPlainText.create(`${this.profile.name}'s projects`, {
+                    owner: this,
+                  })
+                : CoPlainText.create("Your projects", { owner: this }),
               projects: ListOfProjects.create([], initialOrganizationOwnership),
             },
             initialOrganizationOwnership,

--- a/examples/password-manager/src/1_schema.ts
+++ b/examples/password-manager/src/1_schema.ts
@@ -1,12 +1,20 @@
-import { Account, CoList, CoMap, Group, Profile, co } from "jazz-tools";
+import {
+  Account,
+  CoList,
+  CoMap,
+  CoPlainText,
+  Group,
+  Profile,
+  co,
+} from "jazz-tools";
 
 export class PasswordItem extends CoMap {
-  name = co.string;
-  username = co.optional.string;
+  name = co.ref(CoPlainText);
+  username = co.optional.ref(CoPlainText);
   username_input_selector = co.optional.string;
-  password = co.string;
+  password = co.ref(CoPlainText);
   password_input_selector = co.optional.string;
-  uri = co.optional.string;
+  uri = co.optional.ref(CoPlainText);
   folder = co.ref(Folder);
   deleted = co.boolean;
 }
@@ -14,7 +22,7 @@ export class PasswordItem extends CoMap {
 export class PasswordList extends CoList.Of(co.ref(PasswordItem)) {}
 
 export class Folder extends CoMap {
-  name = co.string;
+  name = co.ref(CoPlainText);
   items = co.ref(PasswordList);
 }
 
@@ -33,7 +41,7 @@ export class PasswordManagerAccount extends Account {
       const group = Group.create({ owner: this });
       const firstFolder = Folder.create(
         {
-          name: "Default",
+          name: CoPlainText.create("Default", { owner: group }),
           items: PasswordList.create([], { owner: group }),
         },
         { owner: group },
@@ -42,10 +50,10 @@ export class PasswordManagerAccount extends Account {
       firstFolder.items?.push(
         PasswordItem.create(
           {
-            name: "Gmail",
-            username: "user@gmail.com",
-            password: "password123",
-            uri: "https://gmail.com",
+            name: CoPlainText.create("Gmail", { owner: group }),
+            username: CoPlainText.create("user@gmail.com", { owner: group }),
+            password: CoPlainText.create("password123", { owner: group }),
+            uri: CoPlainText.create("https://gmail.com", { owner: group }),
             folder: firstFolder,
             deleted: false,
           },
@@ -56,10 +64,10 @@ export class PasswordManagerAccount extends Account {
       firstFolder.items?.push(
         PasswordItem.create(
           {
-            name: "Facebook",
-            username: "user@facebook.com",
-            password: "facebookpass",
-            uri: "https://facebook.com",
+            name: CoPlainText.create("Facebook", { owner: group }),
+            username: CoPlainText.create("user@facebook.com", { owner: group }),
+            password: CoPlainText.create("facebookpass", { owner: group }),
+            uri: CoPlainText.create("https://facebook.com", { owner: group }),
             folder: firstFolder,
             deleted: false,
           },

--- a/examples/password-manager/src/3_vault.tsx
+++ b/examples/password-manager/src/3_vault.tsx
@@ -6,7 +6,7 @@ import NewItemModal from "./components/new-item-modal";
 import Table from "./components/table";
 
 import { useAccount, useCoState } from "jazz-react";
-import { CoMapInit, ID } from "jazz-tools";
+import { CoMapInit, CoPlainText, ID } from "jazz-tools";
 import { useNavigate, useParams } from "react-router-dom";
 import { Folder, FolderList, PasswordItem } from "./1_schema";
 import {
@@ -59,7 +59,9 @@ const VaultPage: React.FC = () => {
 
   const filteredItems = selectedFolder
     ? items?.filter(
-        (item) => item?.folder?.name === selectedFolder.name && !item.deleted,
+        (item) =>
+          item?.folder?.name?.toString() === selectedFolder.name?.toString() &&
+          !item.deleted,
       )
     : items?.filter((item) => !item?.deleted);
 
@@ -133,7 +135,11 @@ const VaultPage: React.FC = () => {
       accessor: "id" as const,
       render: (item: PasswordItem) => (
         <div className="flex flex-wrap gap-2">
-          <Button onClick={() => navigator.clipboard.writeText(item.password)}>
+          <Button
+            onClick={() =>
+              navigator.clipboard.writeText(item.password?.toString() || "")
+            }
+          >
             Copy Password
           </Button>
           <Button
@@ -235,7 +241,21 @@ const VaultPage: React.FC = () => {
           folders={folders}
           selectedFolder={selectedFolder}
           initialValues={
-            editingItem && editingItem.folder ? { ...editingItem } : undefined
+            editingItem && editingItem.folder
+              ? {
+                  name:
+                    editingItem.name ?? CoPlainText.create("", { owner: me }),
+                  username:
+                    editingItem.username ??
+                    CoPlainText.create("", { owner: me }),
+                  password:
+                    editingItem.password ??
+                    CoPlainText.create("", { owner: me }),
+                  uri: editingItem.uri ?? CoPlainText.create("", { owner: me }),
+                  deleted: editingItem.deleted ?? false,
+                  folder: editingItem.folder,
+                }
+              : undefined
           }
         />
       ) : null}

--- a/examples/password-manager/src/4_actions.ts
+++ b/examples/password-manager/src/4_actions.ts
@@ -1,5 +1,5 @@
 import { createInviteLink } from "jazz-react";
-import { Group, ID } from "jazz-tools";
+import { CoPlainText, Group, ID } from "jazz-tools";
 import { CoMapInit } from "jazz-tools";
 import {
   Folder,
@@ -38,7 +38,10 @@ export const createFolder = (
 ): Folder => {
   const group = Group.create({ owner: me });
   const folder = Folder.create(
-    { name: folderName, items: PasswordList.create([], { owner: group }) },
+    {
+      name: CoPlainText.create(folderName, { owner: group }),
+      items: PasswordList.create([], { owner: group }),
+    },
     { owner: group },
   );
   me.root?.folders?.push(folder);

--- a/examples/password-manager/src/types.ts
+++ b/examples/password-manager/src/types.ts
@@ -1,11 +1,12 @@
+import { CoPlainText } from "jazz-tools";
 import { FieldValues } from "react-hook-form";
 import { Folder } from "./1_schema";
 
 export interface PasswordItemFormValues extends FieldValues {
-  name: string;
-  username?: string;
-  password: string;
-  uri?: string;
+  name: CoPlainText;
+  username?: CoPlainText;
+  password: CoPlainText;
+  uri?: CoPlainText;
   deleted: boolean;
   folder: Folder | null;
 }

--- a/examples/pets/src/1_schema.ts
+++ b/examples/pets/src/1_schema.ts
@@ -3,6 +3,7 @@ import {
   CoFeed,
   CoList,
   CoMap,
+  CoPlainText,
   ImageDefinition,
   Profile,
   co,
@@ -29,7 +30,7 @@ export type ReactionType = (typeof ReactionTypes)[number];
 export class PetReactions extends CoFeed.Of(co.json<ReactionType>()) {}
 
 export class PetPost extends CoMap {
-  name = co.string;
+  name = co.ref(CoPlainText);
   image = co.ref(ImageDefinition);
   reactions = co.ref(PetReactions);
 }

--- a/examples/pets/src/3_NewPetPostForm.tsx
+++ b/examples/pets/src/3_NewPetPostForm.tsx
@@ -3,7 +3,7 @@ import { useNavigate } from "react-router";
 
 import { ProgressiveImg } from "jazz-react";
 import { createImage, useAccount, useCoState } from "jazz-react";
-import { CoMap, Group, ID, ImageDefinition, co } from "jazz-tools";
+import { CoMap, CoPlainText, Group, ID, ImageDefinition, co } from "jazz-tools";
 import { PetPost, PetReactions } from "./1_schema";
 import { Button, Input } from "./basicComponents";
 
@@ -11,7 +11,7 @@ import { Button, Input } from "./basicComponents";
  */
 
 class PartialPetPost extends CoMap {
-  name = co.string;
+  name = co.ref(CoPlainText);
   image = co.ref(ImageDefinition, { optional: true });
   reactions = co.ref(PetReactions);
 }
@@ -30,12 +30,12 @@ export function NewPetPostForm() {
     (name: string) => {
       if (!me) return;
       if (newPetPost) {
-        newPetPost.name = name;
+        newPetPost.name = CoPlainText.create(name, { owner: me });
       } else {
         const petPostGroup = Group.create();
         const petPost = PartialPetPost.create(
           {
-            name,
+            name: CoPlainText.create(name, { owner: petPostGroup }),
             reactions: PetReactions.create([], {
               owner: petPostGroup,
             }),
@@ -83,7 +83,7 @@ export function NewPetPostForm() {
         placeholder="Pet Name"
         className="text-3xl py-6"
         onChange={(event) => onChangeName(event.target.value)}
-        value={newPetPost?.name || ""}
+        value={newPetPost?.name?.toString() || ""}
       />
 
       {newPetPost?.image ? (
@@ -99,7 +99,7 @@ export function NewPetPostForm() {
         />
       )}
 
-      {newPetPost?.name && newPetPost?.image && (
+      {newPetPost?.name?.toString() && newPetPost?.image && (
         <Button onClick={onSubmit}>Submit Post</Button>
       )}
     </div>

--- a/examples/todo-vue/index.html
+++ b/examples/todo-vue/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8">
     <link rel="icon" href="./public/favicon.ico" type="image/png">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Vite App</title>
+    <title>Todo Example | Jazz</title>
   </head>
   <body>
     <div id="app"></div>

--- a/examples/todo-vue/src/schema.ts
+++ b/examples/todo-vue/src/schema.ts
@@ -1,14 +1,22 @@
-import { Account, CoList, CoMap, Group, Profile, co } from "jazz-tools";
+import {
+  Account,
+  CoList,
+  CoMap,
+  CoPlainText,
+  Group,
+  Profile,
+  co,
+} from "jazz-tools";
 
 export class ToDoItem extends CoMap {
-  name = co.string;
+  name = co.ref(CoPlainText);
   completed = co.boolean;
 }
 
 export class ToDoList extends CoList.Of(co.ref(ToDoItem)) {}
 
 export class Folder extends CoMap {
-  name = co.string;
+  name = co.ref(CoPlainText);
   items = co.ref(ToDoList);
 }
 
@@ -26,13 +34,16 @@ export class ToDoAccount extends Account {
     if (!this._refs.root) {
       const group = Group.create({ owner: this });
       const exampleTodo = ToDoItem.create(
-        { name: "Example todo", completed: false },
+        {
+          name: CoPlainText.create("Example todo", { owner: group }),
+          completed: false,
+        },
         { owner: group },
       );
 
       const defaultFolder = Folder.create(
         {
-          name: "Default",
+          name: CoPlainText.create("Default", { owner: group }),
           items: ToDoList.create([exampleTodo], { owner: group }),
         },
         { owner: group },

--- a/examples/todo-vue/src/views/HomeView.vue
+++ b/examples/todo-vue/src/views/HomeView.vue
@@ -20,7 +20,7 @@
           :class="['folder-item', { active: selectedFolder?.id === folder?.id }]"
           @click="selectFolder(folder)"
         >
-          <span class="folder-name">{{ folder?.name }}</span>
+          <span class="folder-name">{{ folder?.name?.toString() }}</span>
           <button class="btn btn-icon" @click.stop="deleteFolder(folder?.id)">
             <span class="material-icons">delete</span>
           </button>
@@ -30,7 +30,7 @@
 
     <div class="todos" v-if="selectedFolder">
       <div class="section-header">
-        <h2>{{ selectedFolder?.name }}</h2>
+        <h2>{{ selectedFolder?.name?.toString() }}</h2>
         <div class="new-todo">
           <input
             v-model="newTodoTitle"
@@ -50,7 +50,7 @@
                 :checked="todo?.completed"
                 @change="toggleTodo(todo)"
               />
-              <span :class="{ completed: todo?.completed }">{{ todo?.name }}</span>
+              <span :class="{ completed: todo?.completed }">{{ todo?.name?.toString() }}</span>
             </label>
             <button class="btn btn-icon" @click="deleteTodo(todo?.id)">
               <span class="material-icons">delete</span>
@@ -63,7 +63,7 @@
 </template>
 
 <script setup lang="ts">
-import { Group, type ID } from "jazz-tools";
+import { CoPlainText, Group, type ID } from "jazz-tools";
 import { useAccount, useCoState } from "jazz-vue";
 import { ref, toRaw, watch } from "vue";
 import { computed } from "vue";
@@ -99,7 +99,7 @@ const createFolder = () => {
   // Create the folder
   const newFolder = Folder.create(
     {
-      name: newFolderName.value,
+      name: CoPlainText.create(newFolderName.value, { owner: group }),
       items: ToDoList.create([], { owner: group }),
     },
     { owner: group },
@@ -130,7 +130,7 @@ const createTodo = () => {
   const group = Group.create({ owner: me.value });
   const newTodo = ToDoItem.create(
     {
-      name: newTodoTitle.value,
+      name: CoPlainText.create(newTodoTitle.value, { owner: group }),
       completed: false,
     },
     { owner: group },

--- a/examples/todo/index.html
+++ b/examples/todo/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/png" href="/jazz-logo.png" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Jazz Todo List Example</title>
+    <title>Todo Example | Jazz</title>
   </head>
   <body>
     <div id="root"></div>

--- a/examples/todo/src/1_schema.ts
+++ b/examples/todo/src/1_schema.ts
@@ -1,4 +1,4 @@
-import { Account, CoList, CoMap, Profile, co } from "jazz-tools";
+import { Account, CoList, CoMap, CoPlainText, Profile, co } from "jazz-tools";
 
 /** Walkthrough: Defining the data model with CoJSON
  *
@@ -13,14 +13,14 @@ import { Account, CoList, CoMap, Profile, co } from "jazz-tools";
 /** An individual task which collaborators can tick or rename */
 export class Task extends CoMap {
   done = co.boolean;
-  text = co.string;
+  text = co.ref(CoPlainText);
 }
 
 export class ListOfTasks extends CoList.Of(co.ref(Task)) {}
 
 /** Our top level object: a project with a title, referencing a list of tasks */
 export class TodoProject extends CoMap {
-  title = co.string;
+  title = co.ref(CoPlainText);
   tasks = co.ref(ListOfTasks);
 }
 

--- a/examples/todo/src/3_NewProjectForm.tsx
+++ b/examples/todo/src/3_NewProjectForm.tsx
@@ -5,7 +5,7 @@ import { ListOfTasks, TodoProject } from "./1_schema";
 import { SubmittableInput } from "./basicComponents";
 
 import { useAccount } from "jazz-react";
-import { Group } from "jazz-tools";
+import { CoPlainText, Group } from "jazz-tools";
 import { useNavigate } from "react-router";
 
 export function NewProjectForm() {
@@ -26,7 +26,7 @@ export function NewProjectForm() {
       // Then we create an empty todo project within that group
       const project = TodoProject.create(
         {
-          title,
+          title: CoPlainText.create(title, { owner: projectGroup }),
           tasks: ListOfTasks.create([], { owner: projectGroup }),
         },
         { owner: projectGroup },

--- a/examples/todo/src/4_ProjectTodoTable.tsx
+++ b/examples/todo/src/4_ProjectTodoTable.tsx
@@ -15,7 +15,7 @@ import {
 } from "./basicComponents";
 
 import { useCoState } from "jazz-react";
-import { ID } from "jazz-tools";
+import { CoPlainText, ID } from "jazz-tools";
 import { useParams } from "react-router";
 import uniqolor from "uniqolor";
 import { InviteButton } from "./components/InviteButton";
@@ -46,7 +46,7 @@ export function ProjectTodoTable() {
       const task = Task.create(
         {
           done: false,
-          text,
+          text: CoPlainText.create(text, { owner: project._owner }),
         },
         { owner: project._owner },
       );
@@ -66,7 +66,8 @@ export function ProjectTodoTable() {
             // accounting for the fact that note everything might be loaded yet
             project?.title ? (
               <>
-                {project.title} <span className="text-sm">({project.id})</span>
+                {project.title?.toString()}{" "}
+                <span className="text-sm">({project.id})</span>
               </>
             ) : (
               <Skeleton className="mt-1 w-[200px] h-[1em] rounded-full" />

--- a/examples/version-history/src/App.tsx
+++ b/examples/version-history/src/App.tsx
@@ -1,5 +1,5 @@
 import { useAccount, useCoState } from "jazz-react";
-import { Group, ID } from "jazz-tools";
+import { CoPlainText, Group, ID } from "jazz-tools";
 import { useState } from "react";
 import { IssueComponent } from "./Issue.tsx";
 import { IssueVersionHistory } from "./IssueVersionHistory.tsx";
@@ -20,8 +20,11 @@ function App() {
 
     const newIssue = Issue.create(
       {
-        title: "Buy terrarium",
-        description: "Make sure it's big enough for 10 snails.",
+        title: CoPlainText.create("Buy terrarium", { owner: group }),
+        description: CoPlainText.create(
+          "Make sure it's big enough for 10 snails.",
+          { owner: group },
+        ),
         estimate: 5,
         status: "backlog",
       },

--- a/examples/version-history/src/Issue.tsx
+++ b/examples/version-history/src/Issue.tsx
@@ -1,3 +1,4 @@
+import { CoPlainText } from "jazz-tools";
 import { Issue } from "./schema";
 export function IssueComponent({ issue }: { issue: Issue }) {
   return (
@@ -6,9 +7,11 @@ export function IssueComponent({ issue }: { issue: Issue }) {
         Title
         <input
           type="text"
-          value={issue.title}
+          value={issue.title?.toString()}
           onChange={(event) => {
-            issue.title = event.target.value;
+            issue.title = CoPlainText.create(event.target.value, {
+              owner: issue._owner,
+            });
           }}
         />
       </label>
@@ -16,9 +19,11 @@ export function IssueComponent({ issue }: { issue: Issue }) {
       <label className="flex flex-col gap-2">
         Description
         <textarea
-          value={issue.description}
+          value={issue.description?.toString()}
           onChange={(event) => {
-            issue.description = event.target.value;
+            issue.description = CoPlainText.create(event.target.value, {
+              owner: issue._owner,
+            });
           }}
         />
       </label>

--- a/examples/version-history/src/Project.tsx
+++ b/examples/version-history/src/Project.tsx
@@ -1,6 +1,6 @@
 import { createInviteLink, useAccount } from "jazz-react";
 import { useCoState } from "jazz-react";
-import { ID } from "jazz-tools";
+import { CoPlainText, ID } from "jazz-tools";
 import { IssueComponent } from "./Issue.tsx";
 import { Issue, Project } from "./schema.ts";
 export function ProjectComponent({ projectID }: { projectID: ID<Project> }) {
@@ -18,8 +18,8 @@ export function ProjectComponent({ projectID }: { projectID: ID<Project> }) {
     project?.issues.push(
       Issue.create(
         {
-          title: "",
-          description: "",
+          title: CoPlainText.create("New Issue", { owner: project._owner }),
+          description: CoPlainText.create("", { owner: project._owner }),
           estimate: 0,
           status: "backlog",
         },

--- a/examples/version-history/src/schema.ts
+++ b/examples/version-history/src/schema.ts
@@ -3,11 +3,11 @@
  * https://jazz.tools/docs/react/schemas/covalues
  */
 
-import { CoList, CoMap, co } from "jazz-tools";
+import { CoList, CoMap, CoPlainText, co } from "jazz-tools";
 
 export class Issue extends CoMap {
-  title = co.string;
-  description = co.string;
+  title = co.ref(CoPlainText);
+  description = co.ref(CoPlainText);
   estimate = co.number;
   status? = co.literal("backlog", "in progress", "done");
 }


### PR DESCRIPTION
Replaces use of `co.string` with `CoPlainText` as a better example

- [x] chat
  - Message.text
- [x] chat-rn
  - Message.text
- [x] chat-vue
  - Message.text
- [x] chat-rn-expo
  - Message.text
- [x] chat-rn-expo-clerk
  - Message.text
- [x] organization
  - Project.name
  - Organization.name
  - DraftOrganixation.name
- [x] version-history
  - Issue.title
  - Issue.description
  - Project.name
- [x] todo
  - Task.text
  - TodoProject.title
- [x] todo-vue
  - ToDoItem.name
  - Folder.name
- [x] music-player
  - MusicTrack.title
  - Playlist.title
- [x] pets
  - PetPost.name
- [x] form
  - BubbleTeaOrder.instructions
  - DraftBubbleTeaOrder.instructions
- [x] password-manager
  - PasswordItem.name
  - PasswordItem.username
  - PasswordItem.password
  - Folder.name
- [ ] Fix e2e tests: https://github.com/garden-co/jazz/issues/2151 Meg's looking into building chat-rn-expo locally to see what's going on
