### PR TITLE
createJazzPlugin support custom ProseMirror schema

### DIFF
--- a/.changeset/tall-kiwis-search.md
+++ b/.changeset/tall-kiwis-search.md
@@ -1,0 +1,5 @@
+---
+"jazz-richtext-prosemirror": patch
+---
+
+createJazzPlugin support custom ProseMirror schema

--- a/examples/richtext/package.json
+++ b/examples/richtext/package.json
@@ -19,6 +19,7 @@
     "prosemirror-example-setup": "^1.2.3",
     "prosemirror-model": "^1.25.0",
     "prosemirror-schema-basic": "^1.2.4",
+    "prosemirror-schema-list": "^1.5.1",
     "prosemirror-state": "^1.4.3",
     "prosemirror-view": "^1.39.1",
     "react": "18.3.1",

--- a/examples/richtext/src/Editor.tsx
+++ b/examples/richtext/src/Editor.tsx
@@ -1,7 +1,9 @@
 import { useAccount } from "jazz-react";
 import { createJazzPlugin } from "jazz-richtext-prosemirror";
 import { exampleSetup } from "prosemirror-example-setup";
-import { schema } from "prosemirror-schema-basic";
+import { Schema } from "prosemirror-model";
+import { schema as basicSchema } from "prosemirror-schema-basic";
+import { addListNodes } from "prosemirror-schema-list";
 import { EditorState } from "prosemirror-state";
 import { EditorView } from "prosemirror-view";
 import { useEffect, useRef } from "react";
@@ -13,6 +15,11 @@ export function Editor() {
 
   useEffect(() => {
     if (!me || !editorRef.current || !me.profile.bio) return;
+
+    const schema = new Schema({
+      nodes: addListNodes(basicSchema.spec.nodes, "paragraph block*", "block"),
+      marks: basicSchema.spec.marks,
+    });
 
     const setupPlugins = exampleSetup({ schema });
     const jazzPlugin = createJazzPlugin(me.profile.bio);

--- a/examples/richtext/src/index.css
+++ b/examples/richtext/src/index.css
@@ -1,3 +1,10 @@
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
+
+.ProseMirror ul {
+  @apply list-disc;
+}
+.ProseMirror ol {
+  @apply list-decimal;
+}

--- a/packages/jazz-richtext-prosemirror/src/lib/converter.ts
+++ b/packages/jazz-richtext-prosemirror/src/lib/converter.ts
@@ -2,8 +2,8 @@ import {
   DOMParser as PMDOMParser,
   DOMSerializer as PMDOMSerializer,
   Node as PMNode,
+  Schema as PMSchema,
 } from "prosemirror-model";
-import { schema } from "prosemirror-schema-basic";
 
 /**
  * Converts HTML content to a ProseMirror document.
@@ -20,7 +20,7 @@ import { schema } from "prosemirror-schema-basic";
  * const doc = htmlToProseMirror(html);
  * ```
  */
-export function htmlToProseMirror(content: string) {
+export function htmlToProseMirror(content: string, schema: PMSchema) {
   const doc = new DOMParser().parseFromString(content, "text/html");
   return PMDOMParser.fromSchema(schema).parse(doc);
 }
@@ -42,7 +42,9 @@ export function htmlToProseMirror(content: string) {
 export function proseMirrorToHtml(doc: PMNode) {
   return new XMLSerializer()
     .serializeToString(
-      PMDOMSerializer.fromSchema(schema).serializeFragment(doc.content),
+      PMDOMSerializer.fromSchema(doc.type.schema).serializeFragment(
+        doc.content,
+      ),
     )
     .replace(/\sxmlns="[^"]+"/g, "");
 }

--- a/packages/jazz-richtext-prosemirror/src/lib/plugin.ts
+++ b/packages/jazz-richtext-prosemirror/src/lib/plugin.ts
@@ -70,7 +70,7 @@ export function createJazzPlugin(
     state: {
       init(_config, state) {
         if (coRichText) {
-          const pmDoc = htmlToProseMirror(coRichText.toString());
+          const pmDoc = htmlToProseMirror(coRichText.toString(), state.schema);
           state.doc = pmDoc;
         }
         return { coRichText };

--- a/packages/jazz-richtext-prosemirror/src/lib/sync.ts
+++ b/packages/jazz-richtext-prosemirror/src/lib/sync.ts
@@ -49,7 +49,10 @@ export function createSyncHandlers(coRichText: CoRichText | undefined) {
   function handleCoRichTextChange(newText: CoRichText) {
     if (!view || !newText) return;
 
-    const pmDoc = htmlToProseMirror(newText.toString());
+    const pmDoc = htmlToProseMirror(
+      newText.toString(),
+      view.state.doc.type.schema,
+    );
     const transform = recreateTransform(view.state.doc, pmDoc);
 
     // Create a new transaction

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1570,6 +1570,9 @@ importers:
       prosemirror-schema-basic:
         specifier: ^1.2.4
         version: 1.2.4
+      prosemirror-schema-list:
+        specifier: ^1.5.1
+        version: 1.5.1
       prosemirror-state:
         specifier: ^1.4.3
         version: 1.4.3


### PR DESCRIPTION
infer custom schema from view/doc

enables stuff like unordered/ordered lists as per [ProseMirror Basic Example](https://prosemirror.net/examples/basic/)

![Screen Recording 2025-05-01 at 10 36 59](https://github.com/user-attachments/assets/d26b0462-b846-409e-b0bf-4cf2f8e48d39)
