### PR TITLE
fix(docs): hide inspector widget docs for non-react

### DIFF
--- a/homepage/homepage/app/(others)/examples/page.tsx
+++ b/homepage/homepage/app/(others)/examples/page.tsx
@@ -516,7 +516,7 @@ const reactExamples: Example[] = [
     tech: [tech.react],
     features: [features.serverWorker, features.inbox],
     illustration: <JazzPaperScissorsIllustration />,
-    demoUrl: "https://jazz-paper-scissors.vercel.app"
+    demoUrl: "https://jazz-paper-scissors.vercel.app",
   },
   {
     name: "Clerk",
@@ -552,7 +552,7 @@ const reactExamples: Example[] = [
     tech: [tech.react],
     features: [features.inviteLink],
     illustration: <OrganizationIllustration />,
-    demoUrl: "https://jazz-organization.vercel.app"
+    demoUrl: "https://jazz-organization.vercel.app",
   },
   {
     name: "Version history",
@@ -561,7 +561,7 @@ const reactExamples: Example[] = [
       "Track and restore previous versions of your data, and see who made the changes.",
     tech: [tech.react],
     illustration: <VersionHistoryIllustration />,
-    demoUrl: "https://jazz-version-history.vercel.app"
+    demoUrl: "https://jazz-version-history.vercel.app",
   },
 ];
 

--- a/homepage/homepage/content/docs/inspector.mdx
+++ b/homepage/homepage/content/docs/inspector.mdx
@@ -1,4 +1,4 @@
-import { CodeGroup } from '@/components/forMdx'
+import { CodeGroup, ContentByFramework } from '@/components/forMdx'
 import { JazzIcon } from "@garden-co/design-system/src/components/atoms/logos/JazzIcon";
 
 # Jazz Inspector
@@ -9,11 +9,14 @@ For now, you can get your account credentials from the `jazz-logged-in-secret` l
 
 [https://inspector.jazz.tools](https://inspector.jazz.tools)
 
-## Exporting current account to Inspector from your app
+<ContentByFramework framework={["react", "svelte", "vue", "vanilla"]}>
+## Exporting current account to Inspector from your app [!framework=react,svelte,vue,vanilla]
 
 In development mode, you can launch the Inspector from your Jazz app to inspect your account by pressing `Cmd+J`.
+</ContentByFramework>
 
-## Embedding the Inspector widget into your app
+<ContentByFramework framework="react">
+## Embedding the Inspector widget into your app [!framework=react]
 
 Alternatively, you can embed the Inspector directly into your app, so you don't need to open a separate window.
 
@@ -40,7 +43,7 @@ import { JazzInspector } from "jazz-inspector";
 
 This will show the Inspector launch button on the right of your page.
 
-### Positioning the Inspector button
+### Positioning the Inspector button [!framework=react]
 
 You can also customize the button position with the following options:
 
@@ -67,3 +70,4 @@ For example:
 </div>
 
 Check out the [music player app](https://github.com/garden-co/jazz/blob/main/examples/music-player/src/2_main.tsx) for a full example.
+</ContentByFramework>


### PR DESCRIPTION
Hiding the content related to the inspector widget for non-react
The TOC headings are showing. This broke at some point, and I'll fix separately.