### PR TITLE
fix(docs): body wider than page container

### DIFF
--- a/homepage/homepage/app/globals.css
+++ b/homepage/homepage/app/globals.css
@@ -53,6 +53,7 @@ pre.shiki .line {
 .twoslash-popup-code pre.shiki .line {
   display: inline;
   padding-left: 0;
+  white-space: break-spaces;
 }
 
 html.dark .shiki {

--- a/homepage/homepage/lib/docMdxContent.tsx
+++ b/homepage/homepage/lib/docMdxContent.tsx
@@ -42,7 +42,7 @@ export async function getDocMetadata(framework: string, slug?: string[]) {
 
 function DocProse({ children }: { children: React.ReactNode }) {
   return (
-    <Prose className="overflow-x-hidden lg:overflow-x-visible lg:flex-1 pb-8 pt-[calc(61px+2rem)] md:pt-8 md:max-w-3xl mx-auto">
+    <Prose className="overflow-hidden pb-8 pt-[calc(61px+2rem)] md:pt-8 md:max-w-3xl mx-auto">
       {children}
     </Prose>
   );


### PR DESCRIPTION
Before: the TOC is outside the container. It's not aligned with the top nav.
<img width="1519" alt="image" src="https://github.com/user-attachments/assets/1a0a7c0f-a520-4dc9-9f35-4834cc93716e" />

After
<img width="1376" alt="image" src="https://github.com/user-attachments/assets/3768f8d4-bbff-4be2-8e65-f6f20f418606" />

This fixes the docs body width, but cuts off the twoslash tooltips
<img width="676" alt="image" src="https://github.com/user-attachments/assets/a709a643-1a83-42cd-9c04-a20725514395" />

It used to be able to overflow outside of the docs content
<img width="987" alt="image" src="https://github.com/user-attachments/assets/0dbef7f6-0a1f-4ece-9f48-65429555bd38" />

This doesn't happen too often. I suggest we keep each line in the code samples shorter to minimize this. I've not found a solution that caters to both problems.