### PR TITLE
prevent horizontal scroll on code sample in landing page

### DIFF
--- a/homepage/homepage/components/home/CodeStepCloud.mdx
+++ b/homepage/homepage/components/home/CodeStepCloud.mdx
@@ -1,6 +1,8 @@
 ```tsx
 <JazzProvider
-  sync={{ peer: "wss://cloud.jazz.tools/?key=you@example.com" }}
+  sync={{
+    peer: "wss://cloud.jazz.tools/?key=you@example.com"
+  }}
 >
     {children}
 </JazzProvider>

--- a/homepage/homepage/components/home/HowJazzWorksSection.tsx
+++ b/homepage/homepage/components/home/HowJazzWorksSection.tsx
@@ -21,7 +21,7 @@ function Code({
     <div
       className={clsx(
         className,
-        "w-full h-full relative -right-2 -bottom-1 max-w-full lg:max-w-[480px] overflow-x-auto ml-auto overflow-hidden",
+        "w-full h-full relative -right-2 -bottom-1 max-w-full lg:max-w-[500px] ml-auto",
         "shadow-xl shadow-blue/20",
         "rounded-tl-lg border",
         "flex-1 bg-white ring ring-4 ring-stone-400/20",
@@ -33,7 +33,9 @@ function Code({
           {fileName}
         </span>
       </div>
-      <pre className="text-xs lg:text-sm p-1 pb-2">{children}</pre>
+      <pre className="text-xs lg:text-sm p-1 pb-2 overflow-x-auto">
+        {children}
+      </pre>
     </div>
   );
 }


### PR DESCRIPTION
Problem: the code in step 2 is cut off
<img width="1325" alt="image" src="https://github.com/user-attachments/assets/519f5e79-dd04-4c6c-b4f1-9d0eadcff048" />

You can scroll horizontally but the border gets cut
<img width="643" alt="image" src="https://github.com/user-attachments/assets/fafa044d-82b0-476d-ac4d-2dafb66a2a7f" />

Solution:
- shorten line by adding line break
- increase width of code snippet

<img width="1301" alt="image" src="https://github.com/user-attachments/assets/8eeab220-febd-4d7a-afbd-b687f396e5a2" />

This also makes the height of the cards more equal

I also fixed the border being cut off
<img width="368" alt="image" src="https://github.com/user-attachments/assets/52b979ff-3f76-47e8-afba-7f934951a5f5" />
