### PR TITLE
fix(subscribe): fix error management and autoload on $each

### DIFF
--- a/.changeset/empty-icons-appear.md
+++ b/.changeset/empty-icons-appear.md
@@ -1,0 +1,5 @@
+---
+"jazz-tools": patch
+---
+
+Improve error management for autoloaded values and fix autoloading on $each resolve


### PR DESCRIPTION
Fixing some critical bugs related to the autoload on subscribe:
- Errors on autoloaded values were triggering unavailable/unauthorized errors
- Autoload on childs of $each resolve were applied only to the first accessed child
