### PR TITLE
Update examples to CoPlainText

### DIFF
--- a/examples/chat-rn-expo-clerk/app/chat/[chatId].tsx
+++ b/examples/chat-rn-expo-clerk/app/chat/[chatId].tsx
@@ -7,7 +7,7 @@ import { useLocalSearchParams } from "expo-router";
 import { useAccount, useCoState } from "jazz-expo";
 import { ProgressiveImg } from "jazz-expo";
 import { createImage } from "jazz-react-native-media-images";
-import { Group, ID } from "jazz-tools";
+import { CoPlainText, Group, ID } from "jazz-tools";
 import { useEffect, useLayoutEffect, useState } from "react";
 import React, {
   SafeAreaView,
@@ -71,8 +71,8 @@ export default function Conversation() {
 
   const loadChat = async (chatId: ID<Chat>) => {
     try {
-      const chat = await Chat.load(chatId, me);
-      setChat(chat);
+      const chat = await Chat.load(chatId);
+      if (chat) setChat(chat);
     } catch (error) {
       console.log("Error loading chat", error);
       Alert.alert("Error", `Error loading chat: ${error}`);
@@ -82,7 +82,12 @@ export default function Conversation() {
   const sendMessage = () => {
     if (!chat) return;
     if (message.trim()) {
-      chat.push(Message.create({ text: message }, { owner: chat._owner }));
+      chat.push(
+        Message.create(
+          { text: CoPlainText.create(message, { owner: chat._owner }) },
+          { owner: chat._owner },
+        ),
+      );
       setMessage("");
     }
   };
@@ -104,7 +109,12 @@ export default function Conversation() {
           maxSize: 2048,
         });
 
-        chat.push(Message.create({ text: "", image }, { owner: chat._owner }));
+        chat.push(
+          Message.create(
+            { text: CoPlainText.create("", { owner: chat._owner }), image },
+            { owner: chat._owner },
+          ),
+        );
       }
     } catch (error) {
       Alert.alert("Error", "Failed to upload image");

--- a/examples/chat-rn-expo-clerk/app/chat/[chatId].tsx
+++ b/examples/chat-rn-expo-clerk/app/chat/[chatId].tsx
@@ -84,8 +84,8 @@ export default function Conversation() {
     if (message.trim()) {
       chat.push(
         Message.create(
-          { text: CoPlainText.create(message, { owner: chat._owner }) },
-          { owner: chat._owner },
+          { text: CoPlainText.create(message, chat._owner) },
+          chat._owner,
         ),
       );
       setMessage("");
@@ -111,8 +111,8 @@ export default function Conversation() {
 
         chat.push(
           Message.create(
-            { text: CoPlainText.create("", { owner: chat._owner }), image },
-            { owner: chat._owner },
+            { text: CoPlainText.create("", chat._owner), image },
+            chat._owner,
           ),
         );
       }

--- a/examples/chat-rn-expo-clerk/src/schema.ts
+++ b/examples/chat-rn-expo-clerk/src/schema.ts
@@ -1,7 +1,7 @@
-import { CoList, CoMap, ImageDefinition, co } from "jazz-tools";
+import { CoList, CoMap, CoPlainText, ImageDefinition, co } from "jazz-tools";
 
 export class Message extends CoMap {
-  text = co.string;
+  text = co.ref(CoPlainText);
   image = co.optional.ref(ImageDefinition);
 }
 

--- a/examples/chat-rn/src/chat.tsx
+++ b/examples/chat-rn/src/chat.tsx
@@ -1,6 +1,6 @@
 import Clipboard from "@react-native-clipboard/clipboard";
 import { useAccount, useCoState } from "jazz-react-native";
-import { Group, ID, Profile } from "jazz-tools";
+import { CoPlainText, Group, ID, Profile } from "jazz-tools";
 import { useEffect, useState } from "react";
 import {
   Alert,
@@ -83,7 +83,10 @@ export function ChatScreen({ navigation }: { navigation: any }) {
     if (!loadedChat) return;
     if (message.trim()) {
       loadedChat.push(
-        Message.create({ text: message }, { owner: loadedChat?._owner }),
+        Message.create(
+          { text: CoPlainText.create(message, { owner: loadedChat?._owner }) },
+          { owner: loadedChat?._owner },
+        ),
       );
       setMessage("");
     }
@@ -109,7 +112,7 @@ export function ChatScreen({ navigation }: { navigation: any }) {
           </Text>
         ) : null}
         <View style={styles.messageContent}>
-          <Text style={styles.messageText}>{item.text}</Text>
+          <Text style={styles.messageText}>{item.text?.toString()}</Text>
           <Text
             style={[
               styles.timestamp,

--- a/examples/chat-rn/src/chat.tsx
+++ b/examples/chat-rn/src/chat.tsx
@@ -84,8 +84,8 @@ export function ChatScreen({ navigation }: { navigation: any }) {
     if (message.trim()) {
       loadedChat.push(
         Message.create(
-          { text: CoPlainText.create(message, { owner: loadedChat?._owner }) },
-          { owner: loadedChat?._owner },
+          { text: CoPlainText.create(message, loadedChat?._owner) },
+          loadedChat?._owner,
         ),
       );
       setMessage("");
@@ -112,7 +112,7 @@ export function ChatScreen({ navigation }: { navigation: any }) {
           </Text>
         ) : null}
         <View style={styles.messageContent}>
-          <Text style={styles.messageText}>{item.text?.toString()}</Text>
+          <Text style={styles.messageText}>{item.text}</Text>
           <Text
             style={[
               styles.timestamp,

--- a/examples/chat-rn/src/schema.ts
+++ b/examples/chat-rn/src/schema.ts
@@ -1,7 +1,7 @@
-import { CoList, CoMap, co } from "jazz-tools";
+import { CoList, CoMap, CoPlainText, co } from "jazz-tools";
 
 export class Message extends CoMap {
-  text = co.string;
+  text = co.ref(CoPlainText);
 }
 
 export class Chat extends CoList.Of(co.ref(Message)) {}

--- a/examples/chat-vue/package.json
+++ b/examples/chat-vue/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
-    "build-type-check": "run-p type-check \"build-only {@}\" --",
+    "build-type-check": "run-p type-check \"build {@}\" --",
     "preview": "vite preview",
     "build": "vite build",
     "type-check": "vue-tsc --build --force",

--- a/examples/chat-vue/src/components/ChatBubble.vue
+++ b/examples/chat-vue/src/components/ChatBubble.vue
@@ -1,9 +1,9 @@
 <template>
-    <BubbleContainer :fromMe="lastEdit.by?.isMe">
-      <BubbleBody>{{ msg.text }}</BubbleBody>
-      <BubbleInfo :by="lastEdit.by?.profile?.name" :madeAt="lastEdit.madeAt" />
-    </BubbleContainer>
-  </template>
+  <BubbleContainer :fromMe="lastEdit.by?.isMe">
+    <BubbleBody>{{ msg.text?.toString() }}</BubbleBody>
+    <BubbleInfo :by="lastEdit.by?.profile?.name" :madeAt="lastEdit.madeAt" />
+  </BubbleContainer>
+</template>
   
   <script lang="ts">
 import { computed, defineComponent } from "vue";

--- a/examples/chat-vue/src/components/ChatBubble.vue
+++ b/examples/chat-vue/src/components/ChatBubble.vue
@@ -1,6 +1,6 @@
 <template>
   <BubbleContainer :fromMe="lastEdit.by?.isMe">
-    <BubbleBody>{{ msg.text?.toString() }}</BubbleBody>
+    <BubbleBody>{{ msg.text }}</BubbleBody>
     <BubbleInfo :by="lastEdit.by?.profile?.name" :madeAt="lastEdit.madeAt" />
   </BubbleContainer>
 </template>

--- a/examples/chat-vue/src/schema.ts
+++ b/examples/chat-vue/src/schema.ts
@@ -1,7 +1,7 @@
-import { CoList, CoMap, co } from "jazz-tools";
+import { CoList, CoMap, CoPlainText, co } from "jazz-tools";
 
 export class Message extends CoMap {
-  text = co.string;
+  text = co.ref(CoPlainText);
 }
 
 export class Chat extends CoList.Of(co.ref(Message)) {}

--- a/examples/chat-vue/src/views/ChatView.vue
+++ b/examples/chat-vue/src/views/ChatView.vue
@@ -25,7 +25,7 @@
 </template>
 
 <script lang="ts">
-import type { ID } from "jazz-tools";
+import { CoPlainText, type ID } from "jazz-tools";
 import { useCoState } from "jazz-vue";
 import { type PropType, computed, defineComponent, ref } from "vue";
 import ChatBody from "../components/ChatBody.vue";
@@ -61,7 +61,12 @@ export default defineComponent({
     }
 
     function handleSubmit(text: string) {
-      chat?.value?.push(Message.create({ text }, { owner: chat.value._owner }));
+      chat?.value?.push(
+        Message.create(
+          { text: CoPlainText.create(text, { owner: chat.value._owner }) },
+          { owner: chat.value._owner },
+        ),
+      );
     }
 
     return {

--- a/examples/chat-vue/src/views/ChatView.vue
+++ b/examples/chat-vue/src/views/ChatView.vue
@@ -63,7 +63,7 @@ export default defineComponent({
     function handleSubmit(text: string) {
       chat?.value?.push(
         Message.create(
-          { text: CoPlainText.create(text,chat.value._owner) },
+          { text: CoPlainText.create(text, chat.value._owner) },
           chat.value._owner,
         ),
       );

--- a/examples/chat-vue/src/views/ChatView.vue
+++ b/examples/chat-vue/src/views/ChatView.vue
@@ -63,8 +63,8 @@ export default defineComponent({
     function handleSubmit(text: string) {
       chat?.value?.push(
         Message.create(
-          { text: CoPlainText.create(text, { owner: chat.value._owner }) },
-          { owner: chat.value._owner },
+          { text: CoPlainText.create(text,chat.value._owner) },
+          chat.value._owner,
         ),
       );
     }

--- a/examples/chat/src/chatScreen.tsx
+++ b/examples/chat/src/chatScreen.tsx
@@ -39,7 +39,7 @@ export function ChatScreen(props: { chatID: ID<Chat> }) {
       chat.push(
         Message.create(
           {
-            text: CoPlainText.create(file.name, { owner: chat._owner }),
+            text: CoPlainText.create(file.name, chat._owner),
             image: image,
           },
           chat._owner,
@@ -76,7 +76,7 @@ export function ChatScreen(props: { chatID: ID<Chat> }) {
           onSubmit={(text) => {
             chat.push(
               Message.create(
-                { text: CoPlainText.create(text, { owner: chat._owner }) },
+                { text: CoPlainText.create(text, chat._owner) },
                 chat._owner,
               ),
             );
@@ -109,7 +109,7 @@ function ChatBubble(props: { me: Account; msg: Message }) {
     <BubbleContainer fromMe={fromMe}>
       <BubbleBody fromMe={fromMe}>
         {image && <BubbleImage image={image} />}
-        <BubbleText text={text.toString()} />
+        <BubbleText text={text} />
       </BubbleBody>
       <BubbleInfo by={lastEdit.by?.profile?.name} madeAt={lastEdit.madeAt} />
     </BubbleContainer>

--- a/examples/chat/src/chatScreen.tsx
+++ b/examples/chat/src/chatScreen.tsx
@@ -1,5 +1,5 @@
 import { createImage, useAccount, useCoState } from "jazz-react";
-import { Account, ID } from "jazz-tools";
+import { Account, CoPlainText, ID } from "jazz-tools";
 import { useState } from "react";
 import { Chat, Message } from "./schema.ts";
 import {
@@ -36,7 +36,15 @@ export function ChatScreen(props: { chatID: ID<Chat> }) {
     }
 
     createImage(file, { owner: chat._owner }).then((image) => {
-      chat.push(Message.create({ text: file.name, image: image }, chat._owner));
+      chat.push(
+        Message.create(
+          {
+            text: CoPlainText.create(file.name, { owner: chat._owner }),
+            image: image,
+          },
+          chat._owner,
+        ),
+      );
     });
   };
 
@@ -66,7 +74,12 @@ export function ChatScreen(props: { chatID: ID<Chat> }) {
 
         <TextInput
           onSubmit={(text) => {
-            chat.push(Message.create({ text }, { owner: chat._owner }));
+            chat.push(
+              Message.create(
+                { text: CoPlainText.create(text, { owner: chat._owner }) },
+                chat._owner,
+              ),
+            );
           }}
         />
       </InputBar>
@@ -75,7 +88,7 @@ export function ChatScreen(props: { chatID: ID<Chat> }) {
 }
 
 function ChatBubble(props: { me: Account; msg: Message }) {
-  if (!props.me.canRead(props.msg)) {
+  if (!props.me.canRead(props.msg) || !props.msg.text?.toString()) {
     return (
       <BubbleContainer fromMe={false}>
         <BubbleBody fromMe={false}>
@@ -96,7 +109,7 @@ function ChatBubble(props: { me: Account; msg: Message }) {
     <BubbleContainer fromMe={fromMe}>
       <BubbleBody fromMe={fromMe}>
         {image && <BubbleImage image={image} />}
-        <BubbleText text={text} />
+        <BubbleText text={text.toString()} />
       </BubbleBody>
       <BubbleInfo by={lastEdit.by?.profile?.name} madeAt={lastEdit.madeAt} />
     </BubbleContainer>

--- a/examples/chat/src/schema.ts
+++ b/examples/chat/src/schema.ts
@@ -1,7 +1,7 @@
-import { CoList, CoMap, ImageDefinition, co } from "jazz-tools";
+import { CoList, CoMap, CoPlainText, ImageDefinition, co } from "jazz-tools";
 
 export class Message extends CoMap {
-  text = co.string;
+  text = co.ref(CoPlainText);
   image = co.optional.ref(ImageDefinition);
 }
 

--- a/examples/chat/src/ui.tsx
+++ b/examples/chat/src/ui.tsx
@@ -1,6 +1,6 @@
 import clsx from "clsx";
 import { ProgressiveImg } from "jazz-react";
-import { ImageDefinition } from "jazz-tools";
+import { CoPlainText, ImageDefinition } from "jazz-tools";
 import { ImageIcon } from "lucide-react";
 import { useId, useRef } from "react";
 
@@ -70,10 +70,13 @@ export function BubbleBody(props: {
   );
 }
 
-export function BubbleText(props: { text: string; className?: string }) {
+export function BubbleText(props: {
+  text: CoPlainText | string;
+  className?: string;
+}) {
   return (
     <p className={clsx("px-2 leading-relaxed", props.className)}>
-      {props.text}
+      {props.text.toString()}
     </p>
   );
 }

--- a/examples/chat/src/ui.tsx
+++ b/examples/chat/src/ui.tsx
@@ -76,7 +76,7 @@ export function BubbleText(props: {
 }) {
   return (
     <p className={clsx("px-2 leading-relaxed", props.className)}>
-      {props.text.toString()}
+      {props.text}
     </p>
   );
 }

--- a/examples/form/src/CreateOrder.tsx
+++ b/examples/form/src/CreateOrder.tsx
@@ -62,7 +62,7 @@ function CreateOrderForm({
   onSave: (draft: DraftBubbleTeaOrder) => void;
 }) {
   const draft = useCoState(DraftBubbleTeaOrder, id, {
-    resolve: { addOns: true },
+    resolve: { addOns: true, instructions: true },
   });
 
   if (!draft) return;

--- a/examples/form/src/OrderForm.tsx
+++ b/examples/form/src/OrderForm.tsx
@@ -1,3 +1,4 @@
+import { CoPlainText } from "jazz-tools";
 import {
   BubbleTeaAddOnTypes,
   BubbleTeaBaseTeaTypes,
@@ -12,6 +13,17 @@ export function OrderForm({
   order: BubbleTeaOrder | DraftBubbleTeaOrder;
   onSave?: (e: React.FormEvent<HTMLFormElement>) => void;
 }) {
+  const handleInstructionsChange = (
+    e: React.ChangeEvent<HTMLTextAreaElement>,
+  ) => {
+    if (order.instructions) {
+      return order.instructions.applyDiff(e.target.value);
+    }
+    order.instructions = CoPlainText.create(e.target.value, {
+      owner: order._owner,
+    });
+  };
+
   return (
     <form onSubmit={onSave} className="grid gap-5">
       <div className="flex flex-col gap-2">
@@ -88,9 +100,9 @@ export function OrderForm({
         <textarea
           name="instructions"
           id="instructions"
-          value={order.instructions}
+          value={order.instructions?.toString() || ""}
           className="dark:bg-transparent"
-          onChange={(e) => (order.instructions = e.target.value)}
+          onChange={handleInstructionsChange}
         ></textarea>
       </div>
 

--- a/examples/form/src/OrderForm.tsx
+++ b/examples/form/src/OrderForm.tsx
@@ -22,9 +22,7 @@ export function OrderForm({
     if (order.instructions) {
       return order.instructions.applyDiff(e.target.value);
     }
-    order.instructions = CoPlainText.create(e.target.value, {
-      owner: order._owner,
-    });
+    order.instructions = CoPlainText.create(e.target.value, order._owner);
   };
 
   return (
@@ -103,7 +101,7 @@ export function OrderForm({
         <textarea
           name="instructions"
           id="instructions"
-          value={order.instructions?.toString() || ""}
+          value={`${order.instructions}`}
           className="dark:bg-transparent"
           onChange={handleInstructionsChange}
         ></textarea>

--- a/examples/form/src/OrderForm.tsx
+++ b/examples/form/src/OrderForm.tsx
@@ -13,6 +13,9 @@ export function OrderForm({
   order: BubbleTeaOrder | DraftBubbleTeaOrder;
   onSave?: (e: React.FormEvent<HTMLFormElement>) => void;
 }) {
+  // Handles updates to the instructions field of the order.
+  // If instructions already exist, applyDiff updates them incrementally.
+  // Otherwise, creates a new CoPlainText instance for the instructions.
   const handleInstructionsChange = (
     e: React.ChangeEvent<HTMLTextAreaElement>,
   ) => {

--- a/examples/form/src/OrderThumbnail.tsx
+++ b/examples/form/src/OrderThumbnail.tsx
@@ -19,7 +19,9 @@ export function OrderThumbnail({ order }: { order: BubbleTeaOrder }) {
           </p>
         )}
         {instructions && (
-          <p className="text-sm text-stone-600 italic">{instructions}</p>
+          <p className="text-sm text-stone-600 italic">
+            {instructions.toString()}
+          </p>
         )}
       </div>
       <div className="text-sm text-stone-600">{date}</div>

--- a/examples/form/src/OrderThumbnail.tsx
+++ b/examples/form/src/OrderThumbnail.tsx
@@ -19,9 +19,7 @@ export function OrderThumbnail({ order }: { order: BubbleTeaOrder }) {
           </p>
         )}
         {instructions && (
-          <p className="text-sm text-stone-600 italic">
-            {instructions.toString()}
-          </p>
+          <p className="text-sm text-stone-600 italic">{instructions}</p>
         )}
       </div>
       <div className="text-sm text-stone-600">{date}</div>

--- a/examples/form/src/schema.ts
+++ b/examples/form/src/schema.ts
@@ -1,4 +1,4 @@
-import { Account, CoList, CoMap, co } from "jazz-tools";
+import { Account, CoList, CoMap, CoPlainText, co } from "jazz-tools";
 
 export const BubbleTeaAddOnTypes = [
   "Pearl",
@@ -28,7 +28,7 @@ export class BubbleTeaOrder extends CoMap {
   addOns = co.ref(ListOfBubbleTeaAddOns);
   deliveryDate = co.Date;
   withMilk = co.boolean;
-  instructions = co.optional.string;
+  instructions = co.optional.ref(CoPlainText);
 }
 
 export class DraftBubbleTeaOrder extends CoMap {
@@ -36,7 +36,7 @@ export class DraftBubbleTeaOrder extends CoMap {
   addOns = co.optional.ref(ListOfBubbleTeaAddOns);
   deliveryDate = co.optional.Date;
   withMilk = co.optional.boolean;
-  instructions = co.optional.string;
+  instructions = co.optional.ref(CoPlainText);
 
   get hasChanges() {
     return Object.keys(this._edits).length > 1 || this.addOns?.hasChanges;

--- a/examples/richtext/src/Editor.tsx
+++ b/examples/richtext/src/Editor.tsx
@@ -9,7 +9,9 @@ import { EditorView } from "prosemirror-view";
 import { useEffect, useRef } from "react";
 
 export function Editor() {
-  const { me } = useAccount({ resolve: { profile: true, root: true } });
+  const { me } = useAccount({
+    resolve: { profile: { bio: true }, root: true },
+  });
   const editorRef = useRef<HTMLDivElement>(null);
   const viewRef = useRef<EditorView | null>(null);
 
@@ -53,7 +55,7 @@ export function Editor() {
           </label>
           <textarea
             className="flex-1 border border-stone-200 dark:border-stone-700 rounded shadow-sm py-2 px-3 font-mono text-sm bg-stone-50 dark:bg-stone-900 text-stone-900 dark:text-stone-100 whitespace-pre-wrap break-words resize-none"
-            value={me.profile.bio?.toString()}
+            value={`${me.profile.bio}`}
             onChange={(e) => me.profile.bio?.applyDiff(e.target.value)}
             rows={10}
           />

--- a/examples/richtext/src/schema.ts
+++ b/examples/richtext/src/schema.ts
@@ -59,9 +59,10 @@ export class JazzAccount extends Account {
         {
           name: "Anonymous user",
           firstName: "",
-          bio: CoRichText.create("<p>A <strong>hu<em>man</strong></em>.</p>", {
-            owner: group,
-          }),
+          bio: CoRichText.create(
+            "<p>A <strong>hu<em>man</strong></em>.</p>",
+            group,
+          ),
         },
         group,
       );

--- a/examples/todo/src/1_schema.ts
+++ b/examples/todo/src/1_schema.ts
@@ -1,4 +1,4 @@
-import { Account, CoList, CoMap, Profile, co } from "jazz-tools";
+import { Account, CoList, CoMap, CoPlainText, Profile, co } from "jazz-tools";
 
 /** Walkthrough: Defining the data model with CoJSON
  *
@@ -13,7 +13,7 @@ import { Account, CoList, CoMap, Profile, co } from "jazz-tools";
 /** An individual task which collaborators can tick or rename */
 export class Task extends CoMap {
   done = co.boolean;
-  text = co.string;
+  text = co.ref(CoPlainText);
 }
 
 export class ListOfTasks extends CoList.Of(co.ref(Task)) {}

--- a/examples/todo/src/4_ProjectTodoTable.tsx
+++ b/examples/todo/src/4_ProjectTodoTable.tsx
@@ -15,7 +15,7 @@ import {
 } from "./basicComponents";
 
 import { useCoState } from "jazz-react";
-import { ID } from "jazz-tools";
+import { CoPlainText, ID } from "jazz-tools";
 import { useParams } from "react-router";
 import uniqolor from "uniqolor";
 import { InviteButton } from "./components/InviteButton";
@@ -50,7 +50,7 @@ export function ProjectTodoTable() {
       const task = Task.create(
         {
           done: false,
-          text,
+          text: CoPlainText.create(text, { owner: project._owner }),
         },
         { owner: project._owner },
       );

--- a/examples/todo/src/4_ProjectTodoTable.tsx
+++ b/examples/todo/src/4_ProjectTodoTable.tsx
@@ -50,9 +50,9 @@ export function ProjectTodoTable() {
       const task = Task.create(
         {
           done: false,
-          text: CoPlainText.create(text, { owner: project._owner }),
+          text: CoPlainText.create(text, project._owner),
         },
-        { owner: project._owner },
+        project._owner,
       );
 
       // push will cause useCoState to rerender this component, both here and on other devices

--- a/examples/todo/src/generate.ts
+++ b/examples/todo/src/generate.ts
@@ -13,9 +13,10 @@ export function generateRandomProject(numTasks: number): TodoProject {
   for (let i = 0; i < numTasks; i++) {
     const task = Task.create({
       done: faker.datatype.boolean(),
-      text: CoPlainText.create(faker.lorem.sentence({ min: 3, max: 8 }), {
-        owner: tasks._owner,
-      }),
+      text: CoPlainText.create(
+        faker.lorem.sentence({ min: 3, max: 8 }),
+        tasks._owner,
+      ),
     });
     tasks.push(task);
   }

--- a/examples/todo/src/generate.ts
+++ b/examples/todo/src/generate.ts
@@ -1,4 +1,5 @@
 import { faker } from "@faker-js/faker";
+import { CoPlainText } from "jazz-tools";
 import { ListOfTasks, Task, TodoProject } from "./1_schema";
 
 export function generateRandomProject(numTasks: number): TodoProject {
@@ -12,7 +13,9 @@ export function generateRandomProject(numTasks: number): TodoProject {
   for (let i = 0; i < numTasks; i++) {
     const task = Task.create({
       done: faker.datatype.boolean(),
-      text: faker.lorem.sentence({ min: 3, max: 8 }),
+      text: CoPlainText.create(faker.lorem.sentence({ min: 3, max: 8 }), {
+        owner: tasks._owner,
+      }),
     });
     tasks.push(task);
   }

--- a/examples/version-history/src/App.tsx
+++ b/examples/version-history/src/App.tsx
@@ -1,5 +1,5 @@
 import { useAccount, useCoState } from "jazz-react";
-import { Group, ID } from "jazz-tools";
+import { CoPlainText, Group, ID } from "jazz-tools";
 import { useState } from "react";
 import { IssueComponent } from "./Issue.tsx";
 import { IssueVersionHistory } from "./IssueVersionHistory.tsx";
@@ -21,7 +21,12 @@ function App() {
     const newIssue = Issue.create(
       {
         title: "Buy terrarium",
-        description: "Make sure it's big enough for 10 snails.",
+        description: CoPlainText.create(
+          "Make sure it's big enough for 10 snails.",
+          {
+            owner: group,
+          },
+        ),
         estimate: 5,
         status: "backlog",
       },

--- a/examples/version-history/src/App.tsx
+++ b/examples/version-history/src/App.tsx
@@ -23,14 +23,12 @@ function App() {
         title: "Buy terrarium",
         description: CoPlainText.create(
           "Make sure it's big enough for 10 snails.",
-          {
-            owner: group,
-          },
+          group,
         ),
         estimate: 5,
         status: "backlog",
       },
-      { owner: group },
+      group,
     );
     setIssueID(newIssue.id);
     window.history.pushState({}, "", `?issue=${newIssue.id}`);

--- a/examples/version-history/src/Issue.tsx
+++ b/examples/version-history/src/Issue.tsx
@@ -17,11 +17,12 @@ export function IssueComponent({ issue }: { issue: Issue }) {
       <label className="flex flex-col gap-2">
         Description
         <textarea
-          value={issue.description?.toString() || ""}
+          value={`${issue.description}`}
           onChange={(event) => {
-            issue.description = CoPlainText.create(event.target.value, {
-              owner: issue._owner,
-            });
+            issue.description = CoPlainText.create(
+              event.target.value,
+              issue._owner,
+            );
           }}
         />
       </label>

--- a/examples/version-history/src/Issue.tsx
+++ b/examples/version-history/src/Issue.tsx
@@ -1,3 +1,4 @@
+import { CoPlainText } from "jazz-tools";
 import { Issue } from "./schema";
 export function IssueComponent({ issue }: { issue: Issue }) {
   return (
@@ -16,9 +17,11 @@ export function IssueComponent({ issue }: { issue: Issue }) {
       <label className="flex flex-col gap-2">
         Description
         <textarea
-          value={issue.description}
+          value={issue.description?.toString() || ""}
           onChange={(event) => {
-            issue.description = event.target.value;
+            issue.description = CoPlainText.create(event.target.value, {
+              owner: issue._owner,
+            });
           }}
         />
       </label>

--- a/examples/version-history/src/Project.tsx
+++ b/examples/version-history/src/Project.tsx
@@ -1,6 +1,6 @@
 import { createInviteLink, useAccount } from "jazz-react";
 import { useCoState } from "jazz-react";
-import { ID } from "jazz-tools";
+import { CoPlainText, ID } from "jazz-tools";
 import { IssueComponent } from "./Issue.tsx";
 import { Issue, Project } from "./schema.ts";
 export function ProjectComponent({ projectID }: { projectID: ID<Project> }) {
@@ -19,7 +19,7 @@ export function ProjectComponent({ projectID }: { projectID: ID<Project> }) {
       Issue.create(
         {
           title: "",
-          description: "",
+          description: CoPlainText.create("", { owner: project._owner }),
           estimate: 0,
           status: "backlog",
         },

--- a/examples/version-history/src/Project.tsx
+++ b/examples/version-history/src/Project.tsx
@@ -19,7 +19,7 @@ export function ProjectComponent({ projectID }: { projectID: ID<Project> }) {
       Issue.create(
         {
           title: "",
-          description: CoPlainText.create("", { owner: project._owner }),
+          description: CoPlainText.create("", project._owner),
           estimate: 0,
           status: "backlog",
         },

--- a/examples/version-history/src/schema.ts
+++ b/examples/version-history/src/schema.ts
@@ -3,11 +3,11 @@
  * https://jazz.tools/docs/react/schemas/covalues
  */
 
-import { CoList, CoMap, co } from "jazz-tools";
+import { CoList, CoMap, CoPlainText, co } from "jazz-tools";
 
 export class Issue extends CoMap {
   title = co.string;
-  description = co.string;
+  description = co.ref(CoPlainText);
   estimate = co.number;
   status? = co.literal("backlog", "in progress", "done");
 }

--- a/homepage/homepage/content/docs/using-covalues/cotexts.mdx
+++ b/homepage/homepage/content/docs/using-covalues/cotexts.mdx
@@ -102,7 +102,7 @@ See [Groups as permission scopes](/docs/groups/intro) for more information on ho
 
 ## Reading Text
 
-CoText values work like JavaScript strings:
+CoText values work similarly to JavaScript strings:
 
 <CodeGroup>
 ```ts twoslash
@@ -114,11 +114,31 @@ const note = CoPlainText.create("Meeting notes", { owner: me });
 // ---cut---
 // Get the text content
 console.log(note.toString());  // "Meeting notes"
+console.log(`${note}`);    // "Meeting notes"
 
 // Check the text length
 console.log(note.length);      // 14
 ```
 </CodeGroup>
+
+<ContentByFramework framework="react">
+When using CoTexts in JSX, you can read the text directly:
+<CodeGroup>
+```tsx twoslash
+import * as React from "react";
+import { CoPlainText, Account } from "jazz-tools";
+import { createJazzTestAccount } from 'jazz-tools/testing';
+const me = await createJazzTestAccount();
+const note = CoPlainText.create("Meeting notes", { owner: me });
+
+// ---cut---
+<>
+  <p>{note.toString()}</p>
+  <p>{note}</p>
+</>
+```
+</CodeGroup>
+</ContentByFramework>
 
 ## Making Edits
 

--- a/packages/jazz-richtext-prosemirror/src/tests/plugin.test.ts
+++ b/packages/jazz-richtext-prosemirror/src/tests/plugin.test.ts
@@ -18,7 +18,7 @@ beforeEach(async () => {
   account = await createJazzTestAccount({ isCurrentActiveAccount: true });
 
   // Create a real CoRichText with the test account as owner
-  coRichText = new CoRichText({ text: "<p>Hello</p>", owner: account });
+  coRichText = CoRichText.create("<p>Hello</p>", account);
 
   plugin = createJazzPlugin(coRichText);
   state = EditorState.create({
@@ -69,7 +69,7 @@ describe("createJazzPlugin", () => {
   });
 
   it("handles empty CoRichText initialization", () => {
-    const emptyCoRichText = new CoRichText({ text: "", owner: account });
+    const emptyCoRichText = CoRichText.create("", account);
     const emptyPlugin = createJazzPlugin(emptyCoRichText);
     const emptyState = EditorState.create({
       schema,

--- a/packages/jazz-tools/src/coValues/coPlainText.ts
+++ b/packages/jazz-tools/src/coValues/coPlainText.ts
@@ -268,7 +268,7 @@ export class CoPlainText extends String implements CoValue {
    *
    * The 'hint' parameter indicates the preferred type of conversion:
    * - 'string': prefer string conversion
-   * - 'number': prefer number conversion (not meaningful for text, so return NaN)
+   * - 'number': prefer number conversion (attempt to parse the text as a number)
    * - 'default': usually treat as string
    */
   [Symbol.toPrimitive](hint: string) {


### PR DESCRIPTION
Closes #1816

Replaces use of `co.string` with `CoPlainText` to illuminate use

- [x] chat
  - Message.text
- [x] chat-rn
  - Message.text
- [x] chat-vue
  - Message.text
- [ ] chat-rn-expo (Moved to #2180)
  - Message.text
- [x] chat-rn-expo-clerk
  - Message.text
- [x] version-history
  - Issue.description
- [x] todo
  - Task.text
- [x] form
  - BubbleTeaOrder.instructions
  - DraftBubbleTeaOrder.instructions

Depends on #2160 
