### PR TITLE
fix(auth): removed throw error when the profile is unavailable after a login

### DIFF
--- a/.changeset/cyan-forks-lie.md
+++ b/.changeset/cyan-forks-lie.md
@@ -1,0 +1,6 @@
+---
+"cojson-storage": patch
+"cojson": patch
+---
+
+Make waitForSync work on storage peers by handling optimistic/known states

--- a/.changeset/forty-apricots-flow.md
+++ b/.changeset/forty-apricots-flow.md
@@ -1,0 +1,5 @@
+---
+"cojson": patch
+---
+
+Removed throw error when the profile is unavailable after a login

--- a/.changeset/gold-cobras-glow.md
+++ b/.changeset/gold-cobras-glow.md
@@ -1,0 +1,5 @@
+---
+"cojson": patch
+---
+
+Wait for storage sync before resolving new account creation

--- a/.changeset/sour-cycles-watch.md
+++ b/.changeset/sour-cycles-watch.md
@@ -1,0 +1,5 @@
+---
+"cojson": patch
+---
+
+Skip closed and unsubscribed peers when calling waitForSync

--- a/packages/cojson-storage-indexeddb/src/idbNode.ts
+++ b/packages/cojson-storage-indexeddb/src/idbNode.ts
@@ -44,10 +44,7 @@ export class IDBNode {
   }
 
   static async asPeer(
-    {
-      trace,
-      localNodeName = "local",
-    }: { trace?: boolean; localNodeName?: string } | undefined = {
+    { localNodeName = "local" }: { localNodeName?: string } | undefined = {
       localNodeName: "local",
     },
   ): Promise<Peer> {
@@ -57,7 +54,6 @@ export class IDBNode {
       {
         peer1role: "client",
         peer2role: "storage",
-        trace,
         crashOnClose: true,
       },
     );

--- a/packages/cojson-storage-sqlite/src/sqliteNode.ts
+++ b/packages/cojson-storage-sqlite/src/sqliteNode.ts
@@ -56,17 +56,15 @@ export class SQLiteNode {
 
   static async asPeer({
     filename,
-    trace,
     localNodeName = "local",
   }: {
     filename: string;
-    trace?: boolean;
     localNodeName?: string;
   }): Promise<Peer> {
     const [localNodeAsPeer, storageAsPeer] = cojsonInternals.connectedPeers(
       localNodeName,
       "storage",
-      { peer1role: "client", peer2role: "storage", trace, crashOnClose: true },
+      { peer1role: "client", peer2role: "storage", crashOnClose: true },
     );
 
     await SQLiteNode.open(

--- a/packages/cojson-storage-sqlite/src/tests/sqlite.test.ts
+++ b/packages/cojson-storage-sqlite/src/tests/sqlite.test.ts
@@ -79,7 +79,9 @@ test("should sync and load data from storage", async () => {
   ).toMatchInlineSnapshot(`
     [
       "client -> CONTENT Group header: true new: After: 0 New: 3",
+      "storage -> KNOWN Group sessions: header/3",
       "client -> CONTENT Map header: true new: After: 0 New: 1",
+      "storage -> KNOWN Map sessions: header/1",
     ]
   `);
 
@@ -164,8 +166,11 @@ test("should load dependencies correctly (group inheritance)", async () => {
   ).toMatchInlineSnapshot(`
     [
       "client -> CONTENT ParentGroup header: true new: After: 0 New: 4",
+      "storage -> KNOWN ParentGroup sessions: header/4",
       "client -> CONTENT Group header: true new: After: 0 New: 5",
+      "storage -> KNOWN Group sessions: header/5",
       "client -> CONTENT Map header: true new: After: 0 New: 1",
+      "storage -> KNOWN Map sessions: header/1",
     ]
   `);
 
@@ -342,10 +347,13 @@ test("should recover from data loss", async () => {
   ).toMatchInlineSnapshot(`
     [
       "client -> CONTENT Group header: true new: After: 0 New: 3",
+      "storage -> KNOWN Group sessions: header/3",
       "client -> CONTENT Map header: true new: After: 0 New: 1",
+      "storage -> KNOWN Map sessions: header/1",
       "client -> CONTENT Map header: false new: After: 3 New: 1",
       "storage -> KNOWN CORRECTION Map sessions: header/1",
       "client -> CONTENT Map header: false new: After: 1 New: 3",
+      "storage -> KNOWN Map sessions: header/4",
     ]
   `);
 

--- a/packages/cojson-storage/src/tests/syncManager.test.ts
+++ b/packages/cojson-storage/src/tests/syncManager.test.ts
@@ -291,7 +291,7 @@ describe("DB sync manager", () => {
       });
     });
 
-    test("Saves new transaction without sending message when IDB has fewer transactions", async () => {
+    test("Saves new transaction and sends an ack message as response", async () => {
       DBClient.prototype.getCoValue.mockResolvedValueOnce({
         id: coValueIdToLoad,
         header: coValueHeader,
@@ -314,7 +314,12 @@ describe("DB sync manager", () => {
         incomingTxCount,
       );
 
-      expect(syncManager.sendStateMessage).not.toBeCalled();
+      expect(syncManager.sendStateMessage).toBeCalledWith({
+        action: "known",
+        header: true,
+        id: coValueIdToLoad,
+        sessions: expect.any(Object),
+      });
     });
 
     test("Sends correction message when peer sends a message far ahead of our state due to invalid assumption", async () => {

--- a/packages/cojson/src/PeerState.ts
+++ b/packages/cojson/src/PeerState.ts
@@ -23,15 +23,7 @@ export class PeerState {
     });
 
     this._knownStates = knownStates?.clone() ?? new PeerKnownStates();
-
-    // We assume that exchanges with storage peers are always successful
-    // hence we don't need to differentiate between knownStates and optimisticKnownStates
-    if (peer.role === "storage") {
-      this._optimisticKnownStates = "assumeInfallible";
-    } else {
-      this._optimisticKnownStates =
-        knownStates?.clone() ?? new PeerKnownStates();
-    }
+    this._optimisticKnownStates = knownStates?.clone() ?? new PeerKnownStates();
   }
 
   /**
@@ -52,13 +44,9 @@ export class PeerState {
    * The main difference with knownState is that this is updated when the content is sent to the peer without
    * waiting for any acknowledgement from the peer.
    */
-  readonly _optimisticKnownStates: PeerKnownStates | "assumeInfallible";
+  readonly _optimisticKnownStates: PeerKnownStates;
 
   get optimisticKnownStates(): ReadonlyPeerKnownStates {
-    if (this._optimisticKnownStates === "assumeInfallible") {
-      return this.knownStates;
-    }
-
     return this._optimisticKnownStates;
   }
 
@@ -76,53 +64,33 @@ export class PeerState {
 
   updateHeader(id: RawCoID, header: boolean) {
     this._knownStates.updateHeader(id, header);
-
-    if (this._optimisticKnownStates !== "assumeInfallible") {
-      this._optimisticKnownStates.updateHeader(id, header);
-    }
+    this._optimisticKnownStates.updateHeader(id, header);
   }
 
   combineWith(id: RawCoID, value: CoValueKnownState) {
     this._knownStates.combineWith(id, value);
-
-    if (this._optimisticKnownStates !== "assumeInfallible") {
-      this._optimisticKnownStates.combineWith(id, value);
-    }
+    this._optimisticKnownStates.combineWith(id, value);
   }
 
   combineOptimisticWith(id: RawCoID, value: CoValueKnownState) {
-    if (this._optimisticKnownStates === "assumeInfallible") {
-      this._knownStates.combineWith(id, value);
-    } else {
-      this._optimisticKnownStates.combineWith(id, value);
-    }
+    this._optimisticKnownStates.combineWith(id, value);
   }
 
   updateSessionCounter(id: RawCoID, sessionId: SessionID, value: number) {
     this._knownStates.updateSessionCounter(id, sessionId, value);
-
-    if (this._optimisticKnownStates !== "assumeInfallible") {
-      this._optimisticKnownStates.updateSessionCounter(id, sessionId, value);
-    }
+    this._optimisticKnownStates.updateSessionCounter(id, sessionId, value);
   }
 
   setKnownState(id: RawCoID, knownState: CoValueKnownState | "empty") {
     this._knownStates.set(id, knownState);
-
-    if (this._optimisticKnownStates !== "assumeInfallible") {
-      this._optimisticKnownStates.set(id, knownState);
-    }
+    this._optimisticKnownStates.set(id, knownState);
   }
 
   setOptimisticKnownState(
     id: RawCoID,
     knownState: CoValueKnownState | "empty",
   ) {
-    if (this._optimisticKnownStates === "assumeInfallible") {
-      this._knownStates.set(id, knownState);
-    } else {
-      this._optimisticKnownStates.set(id, knownState);
-    }
+    this._optimisticKnownStates.set(id, knownState);
   }
 
   get id() {

--- a/packages/cojson/src/coValueCore/coValueCore.ts
+++ b/packages/cojson/src/coValueCore/coValueCore.ts
@@ -2,11 +2,7 @@ import { UpDownCounter, ValueType, metrics } from "@opentelemetry/api";
 import { Result, err } from "neverthrow";
 import { PeerState } from "../PeerState.js";
 import { RawCoValue } from "../coValue.js";
-import {
-  ControlledAccount,
-  ControlledAccountOrAgent,
-  RawAccountID,
-} from "../coValues/account.js";
+import { ControlledAccountOrAgent, RawAccountID } from "../coValues/account.js";
 import { RawGroup } from "../coValues/group.js";
 import { coreToCoValue } from "../coreToCoValue.js";
 import {
@@ -656,15 +652,15 @@ export class CoValueCore {
     a: Pick<DecryptedTransaction, "madeAt" | "txID">,
     b: Pick<DecryptedTransaction, "madeAt" | "txID">,
   ) {
-    return (
-      a.madeAt - b.madeAt ||
-      (a.txID.sessionID === b.txID.sessionID
-        ? 0
-        : a.txID.sessionID < b.txID.sessionID
-          ? -1
-          : 1) ||
-      a.txID.txIndex - b.txID.txIndex
-    );
+    if (a.madeAt !== b.madeAt) {
+      return a.madeAt - b.madeAt;
+    }
+
+    if (a.txID.sessionID === b.txID.sessionID) {
+      return a.txID.txIndex - b.txID.txIndex;
+    }
+
+    return 0;
   }
 
   getCurrentReadKey(): {
@@ -1006,6 +1002,10 @@ export class CoValueCore {
       const waitingForPeer = new Promise<void>((resolve) => {
         const markNotFound = () => {
           if (this.peers.get(peer.id)?.type === "pending") {
+            logger.warn("Timeout waiting for peer to load coValue", {
+              id: this.id,
+              peerID: peer.id,
+            });
             this.markNotFoundInPeer(peer.id);
           }
         };

--- a/packages/cojson/src/localNode.ts
+++ b/packages/cojson/src/localNode.ts
@@ -272,11 +272,9 @@ export class LocalNode {
       if (!profileID) {
         throw new Error("Account has no profile");
       }
-      const profile = await node.load(profileID);
 
-      if (profile === "unavailable") {
-        throw new Error("Profile unavailable from all peers");
-      }
+      // Preload the profile
+      await node.load(profileID);
 
       if (migration) {
         await migration(account, node);

--- a/packages/cojson/src/localNode.ts
+++ b/packages/cojson/src/localNode.ts
@@ -1,4 +1,4 @@
-import { Result, ResultAsync, err, ok, okAsync } from "neverthrow";
+import { Result, err, ok } from "neverthrow";
 import { CoID } from "./coValue.js";
 import { RawCoValue } from "./coValue.js";
 import {
@@ -223,8 +223,17 @@ export class LocalNode {
       account.set("profile", profile.id, "trusting");
     }
 
-    if (!account.get("profile")) {
+    const profileId = account.get("profile");
+
+    if (!profileId) {
       throw new Error("Must set account profile in initial migration");
+    }
+
+    if (node.syncManager.hasStoragePeers()) {
+      await Promise.all([
+        node.syncManager.waitForStorageSync(account.id),
+        node.syncManager.waitForStorageSync(profileId),
+      ]);
     }
 
     return {

--- a/packages/cojson/src/sync.ts
+++ b/packages/cojson/src/sync.ts
@@ -674,6 +674,21 @@ export class SyncManager {
       return true;
     }
 
+    const peerState = this.peers[peerId];
+
+    // The peer has been closed, so it isn't possible to sync
+    if (!peerState || peerState.closed) {
+      return true;
+    }
+
+    // The client isn't subscribed to the coValue, so we won't sync it
+    if (
+      peerState.role === "client" &&
+      !peerState.optimisticKnownStates.has(id)
+    ) {
+      return true;
+    }
+
     return new Promise((resolve, reject) => {
       const unsubscribe = this.syncState.subscribeToPeerUpdates(
         peerId,

--- a/packages/cojson/src/sync.ts
+++ b/packages/cojson/src/sync.ts
@@ -159,6 +159,12 @@ export class SyncManager {
     );
   }
 
+  hasStoragePeers(): boolean {
+    return this.getPeers().some(
+      (peer) => peer.role === "storage" && !peer.closed,
+    );
+  }
+
   handleSyncMessage(msg: SyncMessage, peer: PeerState) {
     if (this.local.getCoValue(msg.id).isErroredInPeer(peer.id)) {
       logger.warn(
@@ -393,10 +399,12 @@ export class SyncManager {
 
         return;
       } else {
-        // Should move the state to loading
-        this.local.loadCoValueCore(msg.id, peer.id).catch((e) => {
-          logger.error("Error loading coValue in handleLoad", { err: e });
-        });
+        // Syncronously updates the state loading is possible
+        coValue
+          .loadFromPeers(this.getServerAndStoragePeers(peer.id))
+          .catch((e) => {
+            logger.error("Error loading coValue in handleLoad", { err: e });
+          });
       }
     }
 
@@ -622,28 +630,24 @@ export class SyncManager {
 
   handleUnsubscribe(_msg: DoneMessage) {}
 
-  requestedSyncs = new Map<RawCoID, Promise<void>>();
-
-  async requestCoValueSync(coValue: CoValueCore) {
-    const promise = this.requestedSyncs.get(coValue.id);
-
-    if (promise) {
-      return promise;
-    } else {
-      const promise = new Promise<void>((resolve) => {
-        queueMicrotask(() => {
-          this.requestedSyncs.delete(coValue.id);
-          this.syncCoValue(coValue);
-          resolve();
-        });
-      });
-
-      this.requestedSyncs.set(coValue.id, promise);
-      return promise;
+  requestedSyncs = new Set<RawCoID>();
+  requestCoValueSync(coValue: CoValueCore) {
+    if (this.requestedSyncs.has(coValue.id)) {
+      return;
     }
+
+    queueMicrotask(() => {
+      if (this.requestedSyncs.has(coValue.id)) {
+        this.syncCoValue(coValue);
+      }
+    });
+
+    this.requestedSyncs.add(coValue.id);
   }
 
   async syncCoValue(coValue: CoValueCore) {
+    this.requestedSyncs.delete(coValue.id);
+
     for (const peer of this.peersInPriorityOrder()) {
       if (peer.closed) continue;
       if (coValue.isErroredInPeer(peer.id)) continue;
@@ -708,10 +712,20 @@ export class SyncManager {
     });
   }
 
+  async waitForStorageSync(id: RawCoID, timeout = 30_000) {
+    const peers = this.getPeers();
+
+    await Promise.all(
+      peers
+        .filter((peer) => peer.role === "storage")
+        .map((peer) => this.waitForSyncWithPeer(peer.id, id, timeout)),
+    );
+  }
+
   async waitForSync(id: RawCoID, timeout = 30_000) {
     const peers = this.getPeers();
 
-    return Promise.all(
+    await Promise.all(
       peers.map((peer) => this.waitForSyncWithPeer(peer.id, id, timeout)),
     );
   }

--- a/packages/cojson/src/tests/PeerState.test.ts
+++ b/packages/cojson/src/tests/PeerState.test.ts
@@ -174,9 +174,6 @@ describe("PeerState", () => {
   test("should dispatch to both states", () => {
     const { peerState } = setup();
     const knownStatesSpy = vi.spyOn(peerState._knownStates, "set");
-    if (peerState._optimisticKnownStates === "assumeInfallible") {
-      throw new Error("Expected normal optimisticKnownStates");
-    }
 
     const optimisticKnownStatesSpy = vi.spyOn(
       peerState._optimisticKnownStates,
@@ -193,40 +190,6 @@ describe("PeerState", () => {
 
     expect(knownStatesSpy).toHaveBeenCalledWith("co_z1", state);
     expect(optimisticKnownStatesSpy).toHaveBeenCalledWith("co_z1", state);
-  });
-
-  test("should use same reference for knownStates and optimisticKnownStates for storage peers", () => {
-    const mockStoragePeer: Peer = {
-      id: "test-storage-peer",
-      role: "storage",
-      priority: 1,
-      crashOnClose: false,
-      incoming: (async function* () {})(),
-      outgoing: {
-        push: vi.fn().mockResolvedValue(undefined),
-        close: vi.fn(),
-      },
-    };
-    const peerState = new PeerState(mockStoragePeer, undefined);
-
-    // Verify they are the same reference
-    expect(peerState.knownStates).toBe(peerState.optimisticKnownStates);
-
-    // Verify that dispatching only updates one state
-    const knownStatesSpy = vi.spyOn(peerState._knownStates, "set");
-    expect(peerState._optimisticKnownStates).toBe("assumeInfallible");
-
-    const state: CoValueKnownState = {
-      id: "co_z1",
-      header: false,
-      sessions: {},
-    };
-
-    peerState.setKnownState("co_z1", state);
-
-    // Only one dispatch should happen since they're the same reference
-    expect(knownStatesSpy).toHaveBeenCalledTimes(1);
-    expect(knownStatesSpy).toHaveBeenCalledWith("co_z1", state);
   });
 
   test("should use separate references for knownStates and optimisticKnownStates for non-storage peers", () => {

--- a/packages/cojson/src/tests/group.test.ts
+++ b/packages/cojson/src/tests/group.test.ts
@@ -750,7 +750,6 @@ describe("extend with role mapping", () => {
     const mapOnNode2 = await loadCoValueOrFail(node2.node, map.id);
 
     expect(mapOnNode2.get("test")).toEqual("Written from the admin");
-
     mapOnNode2.set("test", "Written from the inherited role");
     expect(mapOnNode2.get("test")).toEqual("Written from the inherited role");
 

--- a/packages/cojson/src/tests/sync.load.test.ts
+++ b/packages/cojson/src/tests/sync.load.test.ts
@@ -197,8 +197,6 @@ describe("loading coValues from server", () => {
     await map.core.waitForSync();
     await mapOnClient.core.waitForSync();
 
-    expect(mapOnClient.get("fromServer")).toEqual("updated");
-    expect(mapOnClient.get("fromClient")).toEqual("updated");
     expect(
       SyncMessagesLog.getMessages({
         Group: group.core,
@@ -217,6 +215,9 @@ describe("loading coValues from server", () => {
         "client -> server | KNOWN Map sessions: header/3",
       ]
     `);
+
+    expect(mapOnClient.get("fromServer")).toEqual("updated");
+    expect(mapOnClient.get("fromClient")).toEqual("updated");
   });
 
   test("wrong optimistic known state should be corrected", async () => {

--- a/packages/cojson/src/tests/testUtils.ts
+++ b/packages/cojson/src/tests/testUtils.ts
@@ -448,6 +448,31 @@ export function getSyncServerConnectedPeer(opts: {
   };
 }
 
+export function createMockStoragePeer(opts: {
+  ourName?: string;
+  peerId: string;
+}) {
+  const storage = createTestNode();
+
+  const { peer1, peer2 } = connectedPeersWithMessagesTracking({
+    peer1: { id: storage.getCurrentAgent().id, role: "storage" },
+    peer2: {
+      id: opts.peerId,
+      role: "client",
+      name: opts.ourName,
+    },
+  });
+
+  peer1.priority = 100;
+
+  storage.syncManager.addPeer(peer2);
+
+  return {
+    storage,
+    peer: peer1,
+  };
+}
+
 export function setupTestNode(
   opts: {
     isSyncServer?: boolean;
@@ -485,26 +510,14 @@ export function setupTestNode(
   }
 
   function addStoragePeer(opts: { ourName?: string } = {}) {
-    const storage = createTestNode();
-
-    const { peer1, peer2 } = connectedPeersWithMessagesTracking({
-      peer1: { id: storage.getCurrentAgent().id, role: "storage" },
-      peer2: {
-        id: node.getCurrentAgent().id,
-        role: "client",
-        name: opts.ourName,
-      },
+    const { peer, storage } = createMockStoragePeer({
+      peerId: node.getCurrentAgent().id,
+      ourName: opts.ourName,
     });
 
-    peer1.priority = 100;
+    node.syncManager.addPeer(peer);
 
-    node.syncManager.addPeer(peer1);
-    storage.syncManager.addPeer(peer2);
-
-    return {
-      storage,
-      peer: node.syncManager.peers[peer1.id]!,
-    };
+    return { peer, peerState: node.syncManager.peers[peer.id]!, storage };
   }
 
   if (opts.connected) {
@@ -575,26 +588,14 @@ export async function setupTestAccount(
   }
 
   function addStoragePeer(opts: { ourName?: string } = {}) {
-    const storage = createTestNode();
-
-    const { peer1, peer2 } = connectedPeersWithMessagesTracking({
-      peer1: { id: storage.getCurrentAgent().id, role: "storage" },
-      peer2: {
-        id: ctx.node.getCurrentAgent().id,
-        role: "client",
-        name: opts.ourName,
-      },
+    const { peer, storage } = createMockStoragePeer({
+      peerId: ctx.node.getCurrentAgent().id,
+      ourName: opts.ourName,
     });
 
-    peer1.priority = 100;
+    ctx.node.syncManager.addPeer(peer);
 
-    ctx.node.syncManager.addPeer(peer1);
-    storage.syncManager.addPeer(peer2);
-
-    return {
-      storage,
-      peer: ctx.node.syncManager.peers[peer1.id]!,
-    };
+    return { peer, peerState: ctx.node.syncManager.peers[peer.id]!, storage };
   }
 
   if (opts.connected) {

--- a/packages/jazz-react-native-core/src/storage/sqlite-react-native.ts
+++ b/packages/jazz-react-native-core/src/storage/sqlite-react-native.ts
@@ -103,7 +103,6 @@ export class SQLiteReactNative {
       {
         peer1role: "client",
         peer2role: "storage",
-        trace: false,
         crashOnClose: true,
       },
     );

--- a/tests/browser-integration/src/sync.test.ts
+++ b/tests/browser-integration/src/sync.test.ts
@@ -231,4 +231,28 @@ describe("Browser sync", () => {
     expect(loadedMap).toBeDefined();
     expect(loadedMap?.value).toBe("test data");
   });
+
+  test("manage to persist the account even when the node is closed immediately after creating the value", async () => {
+    const syncServer = await startSyncServer();
+
+    const { contextManager } = await createAccountContext({
+      sync: {
+        peer: syncServer.url,
+      },
+      storage: "indexedDB",
+      AccountSchema: CustomAccount,
+    });
+
+    contextManager.done();
+
+    const { account } = await createAccountContext({
+      sync: {
+        peer: syncServer.url,
+      },
+      storage: "indexedDB",
+      AccountSchema: CustomAccount,
+    });
+
+    expect(account).toBeDefined();
+  });
 });

--- a/tests/browser-integration/src/unstableConnection.test.ts
+++ b/tests/browser-integration/src/unstableConnection.test.ts
@@ -59,9 +59,7 @@ describe("Browser sync on unstable connection", () => {
 
     await syncServer.disconnectAllClients();
 
-    const fileStream = await file.waitForSync();
-
-    expect(fileStream).toBeDefined();
+    await file.waitForSync();
 
     contextManager.done();
     await new AuthSecretStorage().clear();


### PR DESCRIPTION
Related to: https://github.com/garden-co/jazz/pull/2123#issuecomment-2860586004

Kinda realized that we don't really need that the profile must be available on login.
I think that would be better to let users authenticate and let them face the issue when loading the profile.