### PR TITLE
CoPlainText shorthands

### DIFF
--- a/.changeset/shaggy-geckos-remember.md
+++ b/.changeset/shaggy-geckos-remember.md
@@ -1,0 +1,5 @@
+---
+"jazz-tools": patch
+---
+
+Adds creation owner and consume-as-string shorthands to `CoPlainText`

--- a/packages/jazz-tools/src/coValues/coPlainText.ts
+++ b/packages/jazz-tools/src/coValues/coPlainText.ts
@@ -274,7 +274,7 @@ export class CoPlainText extends String implements CoValue {
   [Symbol.toPrimitive](hint: string) {
     if (hint === "number") {
       // Not meaningful for text, but required for completeness
-      return NaN;
+      return Number(this._raw.toString());
     }
     // For 'string' and 'default', return the string representation
     return this._raw.toString();

--- a/packages/jazz-tools/src/coValues/coPlainText.ts
+++ b/packages/jazz-tools/src/coValues/coPlainText.ts
@@ -260,4 +260,23 @@ export class CoPlainText extends String implements CoValue {
   ): () => void {
     return subscribeToExistingCoValue(this, {}, listener);
   }
+
+  /**
+   * Allow CoPlainText to behave like a primitive string in most contexts (e.g.,
+   * string concatenation, template literals, React rendering, etc.) by implementing
+   * Symbol.toPrimitive. This eliminates the need to call .toString() explicitly.
+   *
+   * The 'hint' parameter indicates the preferred type of conversion:
+   * - 'string': prefer string conversion
+   * - 'number': prefer number conversion (not meaningful for text, so return NaN)
+   * - 'default': usually treat as string
+   */
+  [Symbol.toPrimitive](hint: string) {
+    if (hint === "number") {
+      // Not meaningful for text, but required for completeness
+      return NaN;
+    }
+    // For 'string' and 'default', return the string representation
+    return this._raw.toString();
+  }
 }

--- a/packages/jazz-tools/src/tests/coPlainText.test.ts
+++ b/packages/jazz-tools/src/tests/coPlainText.test.ts
@@ -113,6 +113,11 @@ describe("CoPlainText", () => {
         expect(text.length).toBe(11);
       });
 
+      test("as string", () => {
+        const text = CoPlainText.create("hello world", { owner: me });
+        expect(`${text}`).toBe("hello world");
+      });
+
       test("toString", () => {
         const text = CoPlainText.create("hello world", { owner: me });
         expect(text.toString()).toBe("hello world");

--- a/packages/jazz-tools/src/tests/coPlainText.test.ts
+++ b/packages/jazz-tools/src/tests/coPlainText.test.ts
@@ -25,6 +25,56 @@ describe("CoPlainText", () => {
     return { me, text };
   };
 
+  describe("Creation", () => {
+    test("should allow `create`", async () => {
+      const me = await Account.create({
+        creationProps: { name: "Hermes Puggington" },
+        crypto: Crypto,
+      });
+      const text = CoPlainText.create("hello world", me);
+      expect(text._owner.id).toBe(me.id);
+    });
+
+    test("should allow `new CoPlainText`", async () => {
+      const me = await Account.create({
+        creationProps: { name: "Hermes Puggington" },
+        crypto: Crypto,
+      });
+      const text = new CoPlainText({ text: "hello world", owner: me });
+      expect(text._owner.id).toBe(me.id);
+    });
+
+    test("should allow `create` from raw", async () => {
+      const me = await Account.create({
+        creationProps: { name: "Hermes Puggington" },
+        crypto: Crypto,
+      });
+      const text = CoPlainText.create("hello world", me);
+      const raw = text._raw;
+      const text2 = CoPlainText.fromRaw(raw);
+      expect(text2._owner.id).toBe(me.id);
+    });
+
+    test("should allow creation of new instance from raw", async () => {
+      const me = await Account.create({
+        creationProps: { name: "Hermes Puggington" },
+        crypto: Crypto,
+      });
+      const raw = me._raw.createPlainText("hello world");
+      const text = new CoPlainText({ fromRaw: raw });
+      expect(text._owner.id).toBe(me.id);
+    });
+
+    test("should allow owner shorthand", async () => {
+      const me = await Account.create({
+        creationProps: { name: "Hermes Puggington" },
+        crypto: Crypto,
+      });
+      const text = CoPlainText.create("hello world", me);
+      expect(text._owner.id).toBe(me.id);
+    });
+  });
+
   describe("Simple CoPlainText operations", async () => {
     const { me, text } = await initNodeAndText();
 

--- a/packages/jazz-tools/src/tests/coPlainText.test.ts
+++ b/packages/jazz-tools/src/tests/coPlainText.test.ts
@@ -118,6 +118,21 @@ describe("CoPlainText", () => {
         expect(`${text}`).toBe("hello world");
       });
 
+      test("as number", () => {
+        const text = CoPlainText.create("hello world", { owner: me });
+        expect(Number(text)).toBe(NaN);
+      });
+
+      test("as number", () => {
+        const text = CoPlainText.create("123", { owner: me });
+        expect(Number(text)).toBe(123);
+      });
+
+      test("toJSON", () => {
+        const text = CoPlainText.create("hello world", { owner: me });
+        expect(text.toJSON()).toBe("hello world");
+      });
+
       test("toString", () => {
         const text = CoPlainText.create("hello world", { owner: me });
         expect(text.toString()).toBe("hello world");


### PR DESCRIPTION
Adds support for the owner shorthand, and read as string.

```ts
// const text = CoPlainText.create(“hello there”, { owner: group }); // old
const text = CoPlainText.create(“hello there”, group);

// <p>{text.toString()}</p> // old
<p>{text}</p>
```

Closes #2158 