### PR TITLE
feat: package jazz-inspector as custom element

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -15,6 +15,7 @@
       "jazz-browser-media-images",
       "jazz-expo",
       "jazz-inspector",
+      "jazz-inspector-element",
       "jazz-nodejs",
       "jazz-react",
       "jazz-react-core",

--- a/.changeset/hot-bugs-lie.md
+++ b/.changeset/hot-bugs-lie.md
@@ -1,0 +1,5 @@
+---
+"jazz-inspector": patch
+---
+
+Export JazzInspectorInternal component to be used for jazz-inspector-element

--- a/examples/file-share-svelte/package.json
+++ b/examples/file-share-svelte/package.json
@@ -39,6 +39,7 @@
   },
   "dependencies": {
     "@tailwindcss/typography": "^0.5.15",
+    "jazz-inspector-element": "workspace:*",
     "jazz-svelte": "workspace:*",
     "jazz-tools": "workspace:*",
     "lucide-svelte": "^0.463.0",

--- a/examples/file-share-svelte/src/routes/+layout.svelte
+++ b/examples/file-share-svelte/src/routes/+layout.svelte
@@ -8,7 +8,8 @@
 
 <script lang="ts">
   import { JazzProvider } from 'jazz-svelte';
-  import { PasskeyAuthBasicUI, usePasskeyAuth } from 'jazz-svelte';
+  import "jazz-inspector-element"
+  import { PasskeyAuthBasicUI } from 'jazz-svelte';
   import { Toaster } from 'svelte-sonner';
   import '../app.css';
   import { FileShareAccount } from '$lib/schema';
@@ -29,6 +30,7 @@
     peer: `wss://cloud.jazz.tools/?key=${apiKey}`,
   }}
 >
+  <jazz-inspector></jazz-inspector>
   <PasskeyAuthBasicUI appName="File Share">
     <div class="min-h-screen bg-gray-100">
       {@render children()}

--- a/packages/jazz-inspector-element/.gitignore
+++ b/packages/jazz-inspector-element/.gitignore
@@ -1,0 +1,26 @@
+# Logs
+logs
+*.log
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+pnpm-debug.log*
+lerna-debug.log*
+
+node_modules
+dist
+dist-ssr
+*.local
+
+# Editor directories and files
+.vscode/*
+!.vscode/extensions.json
+.idea
+.DS_Store
+*.suo
+*.ntvs*
+*.njsproj
+*.sln
+*.sw?
+
+sync-db/

--- a/packages/jazz-inspector-element/README.md
+++ b/packages/jazz-inspector-element/README.md
@@ -1,0 +1,31 @@
+# Jazz Inspector Element
+
+A custom element that renders the Jazz Inspector component for inspecting Jazz accounts and CoValues.
+
+## Installation
+
+```bash
+npm install jazz-inspector-element
+```
+
+## Usage
+
+By default jazz-inspector-element relies on `Account.getMe()` to link itself to the Jazz context, so it's enough to mount the html element in a page with a loaded Jazz app:
+
+```ts
+import "jazz-inspector-element"
+
+document.body.appendChild(document.createElement("jazz-inspector"))
+```
+
+OR
+
+```ts
+import "jazz-inspector-element" // somewhere in your app modules
+```
+
+and
+
+```html
+<jazz-inspector />
+```

--- a/packages/jazz-inspector-element/package.json
+++ b/packages/jazz-inspector-element/package.json
@@ -1,0 +1,32 @@
+{
+  "name": "jazz-inspector-element",
+  "version": "0.13.20",
+  "type": "module",
+  "main": "./dist/main.js",
+  "types": "./dist/main.d.ts",
+  "files": [
+    "dist/**",
+    "src"
+  ],
+  "scripts": {
+    "dev": "rm -rf ./dist && tsc --emitDeclarationOnly --watch & vite build --watch",
+    "build": "rm -rf ./dist && tsc --sourceMap --declaration --outDir dist",
+    "format-and-lint": "biome check .",
+    "format-and-lint:fix": "biome check . --write",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "jazz-inspector": "workspace:*",
+    "jazz-tools": "workspace:*",
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1"
+  },
+  "devDependencies": {
+    "@types/react": "^18.3.12",
+    "@types/react-dom": "^18.3.1",
+    "@vitejs/plugin-react-swc": "^3.3.2",
+    "rollup-plugin-node-externals": "^8.0.0",
+    "typescript": "catalog:",
+    "vite": "catalog:"
+  }
+}

--- a/packages/jazz-inspector-element/src/element.tsx
+++ b/packages/jazz-inspector-element/src/element.tsx
@@ -1,0 +1,63 @@
+import { JazzInspectorInternal } from "jazz-inspector";
+import { Account } from "jazz-tools";
+import { createRoot } from "react-dom/client";
+
+export class JazzInspectorElement extends HTMLElement {
+  private root: ReturnType<typeof createRoot> | null = null;
+
+  account: Account | null = null;
+
+  private interval: ReturnType<typeof setInterval> | undefined;
+
+  loadAccount() {
+    try {
+      const value = Account.getMe();
+
+      if (value !== this.account) {
+        this.account = value;
+        this.render();
+      }
+    } catch {}
+  }
+
+  startAccountPolling() {
+    if (this.interval) return;
+
+    this.loadAccount();
+
+    this.interval = setInterval(() => {
+      this.loadAccount();
+    }, 1000);
+  }
+
+  stopAccountPolling() {
+    if (this.interval) clearInterval(this.interval);
+  }
+
+  connectedCallback() {
+    this.root = createRoot(this);
+    this.startAccountPolling();
+    this.render();
+  }
+
+  disconnectedCallback() {
+    this.root?.unmount();
+    this.root = null;
+    this.stopAccountPolling();
+  }
+
+  private render() {
+    if (!this.account) {
+      return;
+    }
+
+    this.root?.render(
+      <JazzInspectorInternal
+        localNode={this.account._raw.core.node}
+        accountId={this.account._raw.id}
+      />,
+    );
+  }
+}
+
+customElements.define("jazz-inspector", JazzInspectorElement);

--- a/packages/jazz-inspector-element/src/main.ts
+++ b/packages/jazz-inspector-element/src/main.ts
@@ -1,0 +1,3 @@
+if (typeof window !== "undefined" && process.env.NODE_ENV === "development") {
+  import("./element.js");
+}

--- a/packages/jazz-inspector-element/src/vite-env.d.ts
+++ b/packages/jazz-inspector-element/src/vite-env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="vite/client" />

--- a/packages/jazz-inspector-element/tsconfig.json
+++ b/packages/jazz-inspector-element/tsconfig.json
@@ -1,0 +1,29 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "useDefineForClassFields": true,
+    "lib": ["ES2023", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "skipLibCheck": true,
+
+    /* Bundler mode */
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "react-jsx",
+
+    /* Linting */
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noFallthroughCasesInSwitch": true,
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["./src/*"]
+    },
+    "declaration": true,
+    "declarationDir": "./dist"
+  },
+  "include": ["src"],
+  "references": [{ "path": "./tsconfig.node.json" }]
+}

--- a/packages/jazz-inspector-element/tsconfig.node.json
+++ b/packages/jazz-inspector-element/tsconfig.node.json
@@ -1,0 +1,10 @@
+{
+  "compilerOptions": {
+    "composite": true,
+    "skipLibCheck": true,
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "allowSyntheticDefaultImports": true
+  },
+  "include": ["vite.config.ts"]
+}

--- a/packages/jazz-inspector-element/vite.config.ts
+++ b/packages/jazz-inspector-element/vite.config.ts
@@ -1,0 +1,23 @@
+import path from "path";
+import react from "@vitejs/plugin-react-swc";
+import depsExternal from "rollup-plugin-node-externals";
+import { defineConfig } from "vite";
+
+// https://vitejs.dev/config/
+export default defineConfig({
+  plugins: [react(), depsExternal()],
+  resolve: {
+    alias: {
+      "@": path.resolve(__dirname, "./src"),
+    },
+  },
+  build: {
+    lib: {
+      entry: path.resolve(__dirname, "src/app.tsx"),
+      name: "JazzInspector",
+      // the proper extensions will be added
+      fileName: "app",
+      formats: ["es"],
+    },
+  },
+});

--- a/packages/jazz-inspector/src/app.tsx
+++ b/packages/jazz-inspector/src/app.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 
-export { JazzInspector } from "./viewer/new-app.js";
+export { JazzInspector, JazzInspectorInternal } from "./viewer/new-app.js";
 export { PageStack } from "./viewer/page-stack.js";
 export { Breadcrumbs } from "./viewer/breadcrumbs.js";
 export { AccountOrGroupText } from "./viewer/account-or-group-text.js";

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -624,6 +624,9 @@ importers:
       '@tailwindcss/typography':
         specifier: ^0.5.15
         version: 0.5.15(tailwindcss@3.4.17(ts-node@10.9.2(@swc/core@1.10.1(@swc/helpers@0.5.15))(@types/node@22.10.2)(typescript@5.6.2)))
+      jazz-inspector-element:
+        specifier: workspace:*
+        version: link:../../packages/jazz-inspector-element
       jazz-svelte:
         specifier: workspace:*
         version: link:../../packages/jazz-svelte
@@ -2084,6 +2087,40 @@ importers:
       react:
         specifier: 18.3.1
         version: 18.3.1
+    devDependencies:
+      '@types/react':
+        specifier: ^18.3.12
+        version: 18.3.12
+      '@types/react-dom':
+        specifier: ^18.3.1
+        version: 18.3.1
+      '@vitejs/plugin-react-swc':
+        specifier: ^3.3.2
+        version: 3.7.2(@swc/helpers@0.5.15)(vite@6.0.11(@types/node@22.10.2)(jiti@2.4.2)(lightningcss@1.29.2)(terser@5.37.0)(tsx@4.19.3)(yaml@2.6.1))
+      rollup-plugin-node-externals:
+        specifier: ^8.0.0
+        version: 8.0.0(rollup@4.28.1)
+      typescript:
+        specifier: 'catalog:'
+        version: 5.6.2
+      vite:
+        specifier: 'catalog:'
+        version: 6.0.11(@types/node@22.10.2)(jiti@2.4.2)(lightningcss@1.29.2)(terser@5.37.0)(tsx@4.19.3)(yaml@2.6.1)
+
+  packages/jazz-inspector-element:
+    dependencies:
+      jazz-inspector:
+        specifier: workspace:*
+        version: link:../jazz-inspector
+      jazz-tools:
+        specifier: workspace:*
+        version: link:../jazz-tools
+      react:
+        specifier: 18.3.1
+        version: 18.3.1
+      react-dom:
+        specifier: 18.3.1
+        version: 18.3.1(react@18.3.1)
     devDependencies:
       '@types/react':
         specifier: ^18.3.12


### PR DESCRIPTION
Adding a new package `jazz-inspector-element` to make the inspector mountable as custom element.

![Screenshot 2025-05-08 at 17 50 27](https://github.com/user-attachments/assets/4a7fb0b9-e266-4622-9df9-8f6d31effb2f)

## Usage

By default jazz-inspector-element relies on `Account.getMe()` to link itself to the Jazz context, so it's enough to mount the html element in a page with a loaded Jazz app:

```ts
import "jazz-inspector-element"

document.body.appendChild(document.createElement("jazz-inspector"))
```

OR

```ts
import "jazz-inspector-element" // somewhere in your app modules
```
and
```html
<jazz-inspector />
```
