### PR TITLE
feat(svelte):  new CoState and AccountCoState APIs

### DIFF
--- a/.changeset/fuzzy-forks-enjoy.md
+++ b/.changeset/fuzzy-forks-enjoy.md
@@ -3,3 +3,4 @@
 ---
 
 Add CoState and AccountCoState class APIs to subscribe CoValues for better integration with Svelte runes
+Accept reactive ids on useCoState and CoState via value callback

--- a/.changeset/fuzzy-forks-enjoy.md
+++ b/.changeset/fuzzy-forks-enjoy.md
@@ -1,0 +1,5 @@
+---
+"jazz-svelte": patch
+---
+
+Add CoState and AccountCoState class APIs to subscribe CoValues for better integration with Svelte runes

--- a/examples/file-share-svelte/src/lib/components/FileItem.svelte
+++ b/examples/file-share-svelte/src/lib/components/FileItem.svelte
@@ -61,6 +61,8 @@
     </div>
     <div class="flex-grow">
       {#if isAdmin}
+        <!-- Jazz values are reactive, but they are not recognized as reactive by Svelte -->
+        <!-- svelte-ignore binding_property_non_reactive -->
         <input  class="font-medium text-gray-900 w-full py-1" type="text" bind:value={file.name} />
       {:else}
         <h3 class="font-medium text-gray-900">{file.name}</h3>

--- a/examples/file-share-svelte/src/lib/components/FileItem.svelte
+++ b/examples/file-share-svelte/src/lib/components/FileItem.svelte
@@ -3,9 +3,8 @@
   import { SharedFile } from '$lib/schema';
   import { FileStream } from 'jazz-tools';
   import { File, FileDown, Trash2, Link2 } from 'lucide-svelte';
-  import { useAccount } from 'jazz-svelte';
   import { toast } from 'svelte-sonner';
-  import { formatFileSize } from '$lib/utils';
+  import { downloadFileBlob, formatFileSize } from '$lib/utils';
 
   const {
     file,
@@ -17,32 +16,22 @@
     onDelete: (file: SharedFile) => void;
   } = $props();
 
-  const { me } = useAccount();
-  const isAdmin = $derived(me && file._owner?.myRole() === 'admin');
+  const isAdmin = $derived(file._owner?.myRole() === 'admin');
+  const fileStreamId = $derived(file._refs.file?.id);
 
   async function downloadFile() {
-    if (!file._refs.file?.id || !me) {
+    if (!fileStreamId) {
       toast.error('Failed to download file');
       return;
     }
 
     try {
-      const fileId = file._refs.file.id;
-
-      // Load the file as a blob, can take a while
-      const blob = await FileStream.loadAsBlob(fileId);
+      const blob = await FileStream.loadAsBlob(fileStreamId);
       if (!blob) {
         toast.error('Failed to download file');
         return;
       }
-      const url = URL.createObjectURL(blob);
-      const a = document.createElement('a');
-      a.href = url;
-      a.download = file.name;
-      document.body.appendChild(a);
-      a.click();
-      document.body.removeChild(a);
-      URL.revokeObjectURL(url);
+      downloadFileBlob(blob, file.name);
       toast.success('File downloaded successfully');
     } catch (error) {
       console.error('Error downloading file:', error);
@@ -66,14 +55,16 @@
   class="flex items-center justify-between rounded-lg border border-gray-200 bg-white p-4"
   transition:slide={{ duration: 200 }}
 >
-  <div class="flex items-center space-x-4">
+  <div class="flex items-center space-x-4 flex-grow">
     <div class="flex h-10 w-10 items-center justify-center rounded-lg bg-blue-100 text-blue-600">
       <File class="h-6 w-6" />
     </div>
-    <div>
-      <a href="/file/{file.id}" class="hover:text-blue-600 hover:underline">
+    <div class="flex-grow">
+      {#if isAdmin}
+        <input  class="font-medium text-gray-900 w-full py-1" type="text" bind:value={file.name} />
+      {:else}
         <h3 class="font-medium text-gray-900">{file.name}</h3>
-      </a>
+      {/if}
       <p class="text-sm text-gray-500">
         {isAdmin ? 'Owned by you' : ''} • Uploaded {new Date(
           file.createdAt || 0

--- a/examples/file-share-svelte/src/lib/components/FileItem.svelte
+++ b/examples/file-share-svelte/src/lib/components/FileItem.svelte
@@ -61,9 +61,10 @@
     </div>
     <div class="flex-grow">
       {#if isAdmin}
+        <label class="sr-only" for={`file-name-${file.id}`}>File name</label>
         <!-- Jazz values are reactive, but they are not recognized as reactive by Svelte -->
         <!-- svelte-ignore binding_property_non_reactive -->
-        <input  class="font-medium text-gray-900 w-full py-1" type="text" bind:value={file.name} />
+        <input class="font-medium text-gray-900 w-full py-1" type="text" bind:value={file.name} id={`file-name-${file.id}`} />
       {:else}
         <h3 class="font-medium text-gray-900">{file.name}</h3>
       {/if}

--- a/examples/file-share-svelte/src/lib/schema.ts
+++ b/examples/file-share-svelte/src/lib/schema.ts
@@ -15,9 +15,8 @@ export class FileShareProfile extends Profile {
 export class ListOfSharedFiles extends CoList.Of(co.ref(SharedFile)) {}
 
 export class FileShareAccountRoot extends CoMap {
-  type = co.string;
+  type = co.literal('file-share-account');
   sharedFiles = co.ref(ListOfSharedFiles);
-  publicGroup = co.ref(Group);
 }
 
 export class FileShareAccount extends Account {
@@ -31,7 +30,7 @@ export class FileShareAccount extends Account {
     await this._refs.root?.load();
 
     // Initialize root if it doesn't exist
-    if (!this.root || this.root.type !== 'file-share-account') {
+    if (this.root === undefined || this.root?.type !== 'file-share-account') {
       // Create a group that will own all shared files
       const publicGroup = Group.create({ owner: this });
       publicGroup.addMember('everyone', 'reader');
@@ -40,9 +39,7 @@ export class FileShareAccount extends Account {
         {
           type: 'file-share-account',
           sharedFiles: ListOfSharedFiles.create([], { owner: publicGroup }),
-          publicGroup
         },
-        { owner: this }
       );
     }
   }

--- a/examples/file-share-svelte/src/lib/utils.ts
+++ b/examples/file-share-svelte/src/lib/utils.ts
@@ -20,3 +20,13 @@ export function formatFileSize(bytes: number): string {
 export function generateTempFileId(fileName: string | undefined, createdAt: Date | undefined): string {
   return `file-${fileName ?? 'unknown'}-${createdAt?.getTime() ?? 0}`;
 }
+
+export function downloadFileBlob(blob: Blob, fileName: string) {
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement('a');
+  a.href = url;
+  a.download = fileName;
+  document.body.appendChild(a);
+  a.click();
+  document.body.removeChild(a);
+}

--- a/examples/file-share-svelte/tests/upload.spec.ts
+++ b/examples/file-share-svelte/tests/upload.spec.ts
@@ -59,7 +59,7 @@ test('can login with passkey and upload file', async ({ page, browser }) => {
   await fileChooser.setFiles(filePath);
   
   // Verify the uploaded file appears in the list
-  await expect(page.getByText('test-file.txt')).toBeVisible();
+  await expect(page.getByRole("textbox", { name: "File name" })).toHaveValue("test-file.txt");
 
   await page.getByRole('button', { name: 'Share file' }).click();
   const inviteLink = await page.evaluate(() => navigator.clipboard.readText());

--- a/packages/jazz-svelte/src/lib/index.ts
+++ b/packages/jazz-svelte/src/lib/index.ts
@@ -1,4 +1,5 @@
 export { createInviteLink, parseInviteLink } from "jazz-browser";
 export * from "./auth/index.js";
 export * from "./jazz.svelte.js";
+export * from "./jazz.class.svelte.js";
 export { useIsAuthenticated } from "./auth/useIsAuthenticated.svelte.js";

--- a/packages/jazz-svelte/src/lib/jazz.class.svelte.ts
+++ b/packages/jazz-svelte/src/lib/jazz.class.svelte.ts
@@ -1,0 +1,132 @@
+import type { Account, CoValue, CoValueClass, ID, RefsToResolve, RefsToResolveStrict, RegisteredAccount, Resolved } from "jazz-tools";
+import { createSubscriber } from "svelte/reactivity";
+import { getJazzContext } from "./jazz.svelte.js";
+import { subscribeToCoValue } from "jazz-tools";
+
+export class CoState<V extends CoValue, R extends RefsToResolve<V> = true> {
+    #value: Resolved<V, R> | undefined | null = undefined;
+    #subscribe: VoidFunction;
+    #ctx = $derived(getJazzContext<RegisteredAccount>());
+    #version = $state(0);
+
+    constructor(
+        Schema: CoValueClass<V>,
+        id: ID<CoValue> | undefined | null | (() => ID<CoValue>),
+        options?: { resolve?: RefsToResolveStrict<V, R> }
+    ) {
+        this.#subscribe = createSubscriber(() => {
+            // Reset state when dependencies change
+            this.updateValue(undefined);
+
+            // Return early if no context or id, effectively cleaning up any previous subscription
+            if (!this.#ctx?.current || !id) return;
+
+            const agent = "me" in this.#ctx.current ? this.#ctx.current.me : this.#ctx.current.guest;
+
+            // Setup subscription with current values
+            return subscribeToCoValue<V, R>(
+                Schema,
+                id,
+                {
+                    resolve: options?.resolve,
+                    loadAs: agent,
+                    onUnavailable: () => {
+                        this.updateValue(null);
+                    },
+                    onUnauthorized: () => {
+                        this.updateValue(null);
+                    },
+                    syncResolution: true,
+                },
+                (value) => {
+                    this.updateValue(value as Resolved<V, R>);
+                },
+            );
+        });
+    }
+
+    updateValue(value: Resolved<V, R> | undefined | null) {
+        if (value !== this.#value) {
+            this.#value = value;
+            this.#version++;
+        }
+    }
+
+    get current() {
+        this.#subscribe();
+
+        // Accessing the version state to subscribe to it's state
+        // eslint-disable-next-line @typescript-eslint/no-unused-expressions
+        this.#version;
+
+        return this.#value;
+    }
+}
+
+export class AccountCoState<A extends Account = RegisteredAccount, R extends RefsToResolve<A> = true> {
+    #value: Resolved<A, R> | undefined | null = undefined;
+    #version = $state(0);
+    #subscribe: VoidFunction;
+    #ctx = $derived(getJazzContext<A>());
+
+    constructor(
+        options?: { resolve?: RefsToResolveStrict<A, R> }
+    ) {
+        this.#subscribe = createSubscriber(() => {
+            // Reset state when dependencies change
+            this.updateValue(undefined);
+
+            // Return early if no context or id, effectively cleaning up any previous subscription
+            if (!this.#ctx?.current) return;
+
+            if (!('me' in this.#ctx.current)) {
+                throw new Error(
+                    "useAccount can't be used in a JazzProvider with auth === 'guest' - consider using useAccountOrGuest()"
+                );
+            }
+
+            const me = this.#ctx.current.me;
+
+            // Setup subscription with current values
+            return subscribeToCoValue<A, R>(
+                me.constructor as CoValueClass<A>,
+                me.id,
+                {
+                    resolve: options?.resolve,
+                    loadAs: me,
+                    onUnavailable: () => {
+                        this.updateValue(null);
+                    },
+                    onUnauthorized: () => {
+                        this.updateValue(null);
+                    },
+                    syncResolution: true,
+                },
+                (value) => {
+                    this.updateValue(value as Resolved<A, R>);
+                },
+            );
+        });
+    }
+
+    logOut = () => {
+      this.#ctx.current?.logOut();
+    }
+
+    updateValue(value: Resolved<A, R> | undefined | null) {
+        if (value !== this.#value) {
+            this.#value = value;
+            this.#version++;
+        }
+    }
+
+    get current() {
+        this.#subscribe();
+
+        // Accessing the version state to subscribe to it's state
+        // eslint-disable-next-line @typescript-eslint/no-unused-expressions
+        this.#version;
+
+        return this.#value;
+    }
+}

--- a/packages/jazz-svelte/src/lib/jazz.class.svelte.ts
+++ b/packages/jazz-svelte/src/lib/jazz.class.svelte.ts
@@ -7,57 +7,80 @@ export class CoState<V extends CoValue, R extends RefsToResolve<V> = true> {
     #value: Resolved<V, R> | undefined | null = undefined;
     #subscribe: VoidFunction;
     #ctx = $derived(getJazzContext<RegisteredAccount>());
-    #version = $state(0);
+    #update: VoidFunction = () => {};
+    #Schema: CoValueClass<V>;
+    #options: { resolve?: RefsToResolveStrict<V, R> } | undefined;
+    #id: ID<CoValue> | undefined | null;
+
+    #unsubscribe: VoidFunction = () => {};
 
     constructor(
         Schema: CoValueClass<V>,
         id: ID<CoValue> | undefined | null | (() => ID<CoValue>),
         options?: { resolve?: RefsToResolveStrict<V, R> }
     ) {
-        this.#subscribe = createSubscriber(() => {
-            // Reset state when dependencies change
-            this.updateValue(undefined);
+        this.#Schema = Schema;
+        this.#options = options;
+        this.#id = typeof id === 'function' ? id() : id;
 
-            // Return early if no context or id, effectively cleaning up any previous subscription
-            if (!this.#ctx?.current || !id) return;
+        this.#subscribe = createSubscriber((update) => {
+            this.#update = update;
+    
+            // Using an effect to react to the id and ctx changes 
+            $effect.pre(() => {
+                this.#id =  typeof id === 'function' ? id() : id;
+                   
+                this.subscribeTo();
+            });
 
-            const agent = "me" in this.#ctx.current ? this.#ctx.current.me : this.#ctx.current.guest;
-
-            // Setup subscription with current values
-            return subscribeToCoValue<V, R>(
-                Schema,
-                id,
-                {
-                    resolve: options?.resolve,
-                    loadAs: agent,
-                    onUnavailable: () => {
-                        this.updateValue(null);
-                    },
-                    onUnauthorized: () => {
-                        this.updateValue(null);
-                    },
-                    syncResolution: true,
-                },
-                (value) => {
-                    this.updateValue(value as Resolved<V, R>);
-                },
-            );
+            return () => {
+                this.#unsubscribe();
+            }
         });
+    }
+
+    subscribeTo() {
+        const ctx = this.#ctx;
+        const id = this.#id;
+
+        // Reset state when dependencies change
+        this.updateValue(undefined);
+        this.#unsubscribe();
+
+        if (!ctx.current || !id) return;
+
+        const agent = "me" in ctx.current ? ctx.current.me : ctx.current.guest;
+
+        // Setup subscription with current values
+        this.#unsubscribe = subscribeToCoValue<V, R>(
+            this.#Schema,
+            id,
+            {
+                resolve: this.#options?.resolve,
+                loadAs: agent,
+                onUnavailable: () => {
+                    this.updateValue(null);
+                },
+                onUnauthorized: () => {
+                    this.updateValue(null);
+                },
+                syncResolution: true,
+            },
+            (value) => {
+                this.updateValue(value as Resolved<V, R>);
+            },
+        );
     }
 
     updateValue(value: Resolved<V, R> | undefined | null) {
         if (value !== this.#value) {
             this.#value = value;
-            this.#version++;
+            this.#update();
         }
     }
 
     get current() {
         this.#subscribe();
-
-        // Accessing the version state to subscribe to it's state
-        // eslint-disable-next-line @typescript-eslint/no-unused-expressions
-        this.#version;
 
         return this.#value;
     }
@@ -65,48 +88,66 @@ export class CoState<V extends CoValue, R extends RefsToResolve<V> = true> {
 
 export class AccountCoState<A extends Account = RegisteredAccount, R extends RefsToResolve<A> = true> {
     #value: Resolved<A, R> | undefined | null = undefined;
-    #version = $state(0);
     #subscribe: VoidFunction;
     #ctx = $derived(getJazzContext<A>());
+    #update: VoidFunction = () => {};
+    #unsubscribe: VoidFunction = () => {};
+    #options: { resolve?: RefsToResolveStrict<A, R> } | undefined;
 
     constructor(
         options?: { resolve?: RefsToResolveStrict<A, R> }
     ) {
-        this.#subscribe = createSubscriber(() => {
-            // Reset state when dependencies change
-            this.updateValue(undefined);
+        this.#options = options;
+        this.#subscribe = createSubscriber((update) => {
+            this.#update = update;
 
-            // Return early if no context or id, effectively cleaning up any previous subscription
-            if (!this.#ctx?.current) return;
+            // Using an effect to react to the ctx changes
+            $effect.pre(() => {
+                this.subscribeTo();
+            });
 
-            if (!('me' in this.#ctx.current)) {
-                throw new Error(
-                    "useAccount can't be used in a JazzProvider with auth === 'guest' - consider using useAccountOrGuest()"
-                );
+            return () => {
+                this.#unsubscribe();
             }
-
-            const me = this.#ctx.current.me;
-
-            // Setup subscription with current values
-            return subscribeToCoValue<A, R>(
-                me.constructor as CoValueClass<A>,
-                me.id,
-                {
-                    resolve: options?.resolve,
-                    loadAs: me,
-                    onUnavailable: () => {
-                        this.updateValue(null);
-                    },
-                    onUnauthorized: () => {
-                        this.updateValue(null);
-                    },
-                    syncResolution: true,
-                },
-                (value) => {
-                    this.updateValue(value as Resolved<A, R>);
-                },
-            );
         });
+    }
+
+    subscribeTo() {
+        const ctx = this.#ctx;
+
+        // Reset state when dependencies change
+        this.updateValue(undefined);
+        this.#unsubscribe();
+
+        if (!ctx.current) return;
+
+        if (!('me' in ctx.current)) {
+            throw new Error(
+                "useAccount can't be used in a JazzProvider with auth === 'guest' - consider using useAccountOrGuest()"
+            );
+        }
+
+        const me = this.#ctx.current.me;
+
+        // Setup subscription with current values
+        this.#unsubscribe = subscribeToCoValue<A, R>(
+            me.constructor as CoValueClass<A>,
+            me.id,
+            {
+                resolve: this.#options?.resolve,
+                loadAs: me,
+                onUnavailable: () => {
+                    this.updateValue(null);
+                },
+                onUnauthorized: () => {
+                    this.updateValue(null);
+                },
+                syncResolution: true,
+            },
+            (value) => {
+                this.updateValue(value as Resolved<V, R>);
+            },
+        );
     }
 
     logOut = () => {
@@ -116,16 +157,12 @@ export class AccountCoState<A extends Account = RegisteredAccount, R extends Ref
     updateValue(value: Resolved<A, R> | undefined | null) {
         if (value !== this.#value) {
             this.#value = value;
-            this.#version++;
+            this.#update();
         }
     }
 
     get current() {
         this.#subscribe();
-
-        // Accessing the version state to subscribe to it's state
-        // eslint-disable-next-line @typescript-eslint/no-unused-expressions
-        this.#version;
 
         return this.#value;
     }

--- a/packages/jazz-svelte/src/lib/jazz.svelte.ts
+++ b/packages/jazz-svelte/src/lib/jazz.svelte.ts
@@ -160,7 +160,7 @@ export function useAccountOrGuest<R extends RefsToResolve<RegisteredAccount>>(
 
 export function useCoState<V extends CoValue, R extends RefsToResolve<V>>(
   Schema: CoValueClass<V>,
-  id: ID<CoValue> | undefined,
+  id: ID<CoValue> | undefined | (() => ID<CoValue>),
   options?: { resolve?: RefsToResolveStrict<V, R> }
 ): {
   current: Resolved<V, R> | undefined | null;
@@ -175,15 +175,17 @@ export function useCoState<V extends CoValue, R extends RefsToResolve<V>>(
     // Reset state when dependencies change
     state = undefined;
 
+    const idValue = typeof id === 'function' ? id() : id;
+
     // Return early if no context or id, effectively cleaning up any previous subscription
-    if (!ctx?.current || !id) return;
+    if (!ctx?.current || !idValue) return;
 
     const agent = "me" in ctx.current ? ctx.current.me : ctx.current.guest;
 
     // Setup subscription with current values
     return subscribeToCoValue<V, R>(
       Schema,
-      id,
+      idValue,
       {
         resolve: options?.resolve,
         loadAs: agent,

--- a/packages/jazz-svelte/src/lib/testing.ts
+++ b/packages/jazz-svelte/src/lib/testing.ts
@@ -4,7 +4,7 @@ import {
   AuthSecretStorage,
 } from "jazz-tools";
 import { JAZZ_AUTH_CTX, JAZZ_CTX, type JazzContext } from './jazz.svelte.js';
-import {  TestJazzContextManager } from "jazz-tools/testing";
+import { TestJazzContextManager } from "jazz-tools/testing";
 
 export function createJazzTestContext<Acc extends Account>(opts: {
   account?: Acc | { guest: AnonymousJazzAgent };

--- a/packages/jazz-svelte/src/lib/tests/AccountCoState.svelte.test.ts
+++ b/packages/jazz-svelte/src/lib/tests/AccountCoState.svelte.test.ts
@@ -1,0 +1,57 @@
+import { render, screen } from '@testing-library/svelte';
+import { userEvent } from '@testing-library/user-event';
+import { describe, expect, it, beforeEach } from 'vitest';
+import { createJazzTestAccount, createJazzTestContext, setupJazzTestSync } from '../testing.js';
+import UpdateNestedValueAccount from './components/CoState/UpdateNestedValueAccount.svelte';
+import { MyAccount } from './components/CoState/schema.js';
+
+beforeEach(async () => {
+  await setupJazzTestSync();
+  await createJazzTestAccount({
+    AccountSchema: MyAccount,
+    isCurrentActiveAccount: true
+  });
+});
+
+function setup() {
+  const result = render(UpdateNestedValueAccount, {
+    context: createJazzTestContext(),
+  });
+
+  return {
+    ...result,
+    nameInput: screen.getByLabelText('Name'),
+    dogNameInput: screen.getByLabelText('Dog'),
+    personNameOutput: screen.getByTestId('person-name'),
+    personDogNameOutput: screen.getByTestId('person-dog-name')
+  };
+}
+describe('CoState', () => {
+  it('should show the and update properties', async () => {
+    const me = MyAccount.getMe()
+
+    const { nameInput, personNameOutput } = setup();
+
+    expect(nameInput).toHaveValue(me.root!.name);
+
+    await userEvent.clear(nameInput);
+    await userEvent.type(nameInput, 'Jane');
+
+    expect(nameInput).toHaveValue('Jane');
+    expect(personNameOutput).toHaveTextContent('Jane');
+  });
+
+  it('should show the and update nested properties', async () => {
+    const me = MyAccount.getMe()
+
+    const { dogNameInput, personDogNameOutput } = setup();
+
+    expect(dogNameInput).toHaveValue(me.root!.dog!.name);
+
+    await userEvent.clear(dogNameInput);
+    await userEvent.type(dogNameInput, 'Fuffy');
+
+    expect(dogNameInput).toHaveValue('Fuffy');
+    expect(personDogNameOutput).toHaveTextContent('Fuffy');
+  });
+});

--- a/packages/jazz-svelte/src/lib/tests/AccountCoState.svelte.test.ts
+++ b/packages/jazz-svelte/src/lib/tests/AccountCoState.svelte.test.ts
@@ -26,7 +26,7 @@ function setup() {
     personDogNameOutput: screen.getByTestId('person-dog-name')
   };
 }
-describe('CoState', () => {
+describe('AccountCoState', () => {
   it('should show the and update properties', async () => {
     const me = MyAccount.getMe()
 

--- a/packages/jazz-svelte/src/lib/tests/CoState.svelte.test.ts
+++ b/packages/jazz-svelte/src/lib/tests/CoState.svelte.test.ts
@@ -1,0 +1,104 @@
+import { render, screen } from '@testing-library/svelte';
+import { userEvent } from '@testing-library/user-event';
+import { describe, expect, it, beforeEach } from 'vitest';
+import { createJazzTestAccount, createJazzTestContext, setupJazzTestSync } from '../testing.js';
+import UpdateNestedValue from './components/CoState/UpdateNestedValue.svelte';
+import { Person } from './components/CoState/schema.js';
+import { Dog } from './components/CoState/schema.js';
+
+beforeEach(async () => {
+  await setupJazzTestSync();
+  await createJazzTestAccount({
+    isCurrentActiveAccount: true
+  });
+});
+
+function setup(person: Person) {
+  const result = render(UpdateNestedValue, {
+    context: createJazzTestContext(),
+    props: { id: person.id }
+  });
+
+  return {
+    ...result,
+    nameInput: screen.getByLabelText('Name'),
+    dogNameInput: screen.getByLabelText('Dog'),
+    personNameOutput: screen.getByTestId('person-name'),
+    personDogNameOutput: screen.getByTestId('person-dog-name')
+  };
+}
+describe('CoState', () => {
+  it('should show the and update properties', async () => {
+    const person = Person.create(
+      {
+        name: 'John',
+        age: 30,
+        dog: Dog.create({
+          name: 'Rex'
+        })
+      },
+    );
+
+    const { nameInput, personNameOutput } = setup(person);
+
+    expect(nameInput).toHaveValue('John');
+
+    await userEvent.clear(nameInput);
+    await userEvent.type(nameInput, 'Jane');
+
+    expect(nameInput).toHaveValue('Jane');
+    expect(personNameOutput).toHaveTextContent('Jane');
+  });
+
+  it('should show the and update nested properties', async () => {
+    const person = Person.create(
+      {
+        name: 'John',
+        age: 30,
+        dog: Dog.create({
+          name: 'Rex'
+        })
+      },
+    );
+
+    const { dogNameInput, personDogNameOutput } = setup(person);
+
+    expect(dogNameInput).toHaveValue('Rex');
+
+    await userEvent.clear(dogNameInput);
+    await userEvent.type(dogNameInput, 'Fuffy');
+
+    expect(dogNameInput).toHaveValue('Fuffy');
+    expect(personDogNameOutput).toHaveTextContent('Fuffy');
+  });
+
+
+  it('should react to id changes', async () => {
+    const person = Person.create(
+      {
+        name: 'John',
+        age: 30,
+        dog: Dog.create({
+          name: 'Rex'
+        })
+      },
+    );
+
+    const person2 = Person.create(
+      {
+        name: 'Jane',
+        age: 30,
+        dog: Dog.create({
+          name: 'Fluffy'
+        })
+      },
+    );
+
+    const { personNameOutput, personDogNameOutput, rerender } = setup(person);
+
+    await rerender({ id: person2.id });
+
+    expect(personNameOutput).toHaveTextContent('Jane');
+    expect(personDogNameOutput).toHaveTextContent('Fluffy');
+  });
+});

--- a/packages/jazz-svelte/src/lib/tests/components/CoState/UpdateNestedValue.svelte
+++ b/packages/jazz-svelte/src/lib/tests/components/CoState/UpdateNestedValue.svelte
@@ -12,13 +12,11 @@
 
   let props: Props = $props();
 
-  const person = $derived(
-    new CoState(Person, props.id, {
-      resolve: {
-        dog: true
-      }
-    })
-  );
+  const person = new CoState(Person, () => props.id, {
+    resolve: {
+      dog: true
+    }
+  })
 </script>
 
 <!-- Using non-null assertions because we want to test that locally available values are never null -->

--- a/packages/jazz-svelte/src/lib/tests/components/CoState/UpdateNestedValue.svelte
+++ b/packages/jazz-svelte/src/lib/tests/components/CoState/UpdateNestedValue.svelte
@@ -22,11 +22,15 @@
 <!-- Using non-null assertions because we want to test that locally available values are never null -->
 <label>
   Name
+  <!-- Jazz values are reactive, but they are not recognized as reactive by Svelte -->
+  <!-- svelte-ignore binding_property_non_reactive -->
   <input type="text" bind:value={person.current!.name} />
 </label>
 
 <label>
   Dog
+   <!-- Jazz values are reactive, but they are not recognized as reactive by Svelte -->
+  <!-- svelte-ignore binding_property_non_reactive -->
   <input type="text" bind:value={person.current!.dog.name} />
 </label>
 

--- a/packages/jazz-svelte/src/lib/tests/components/CoState/UpdateNestedValue.svelte
+++ b/packages/jazz-svelte/src/lib/tests/components/CoState/UpdateNestedValue.svelte
@@ -1,0 +1,36 @@
+<script lang="ts" module>
+  export type Props = {
+    id: ID<Person>;
+  };
+</script>
+
+<script lang="ts">
+  import { CoState } from '../../../jazz.class.svelte.js';
+
+  import { type ID } from 'jazz-tools';
+  import { Person } from './schema.js';
+
+  let props: Props = $props();
+
+  const person = $derived(
+    new CoState(Person, props.id, {
+      resolve: {
+        dog: true
+      }
+    })
+  );
+</script>
+
+<!-- Using non-null assertions because we want to test that locally available values are never null -->
+<label>
+  Name
+  <input type="text" bind:value={person.current!.name} />
+</label>
+
+<label>
+  Dog
+  <input type="text" bind:value={person.current!.dog.name} />
+</label>
+
+<div data-testid="person-name">{person.current!.name}</div>
+<div data-testid="person-dog-name">{person.current!.dog.name}</div>

--- a/packages/jazz-svelte/src/lib/tests/components/CoState/UpdateNestedValueAccount.svelte
+++ b/packages/jazz-svelte/src/lib/tests/components/CoState/UpdateNestedValueAccount.svelte
@@ -1,0 +1,34 @@
+<script lang="ts" module>
+  export type Props = {
+    id: ID<Person>;
+  };
+</script>
+
+<script lang="ts">
+  import { AccountCoState } from '../../../jazz.class.svelte.js';
+
+  import { type ID } from 'jazz-tools';
+  import { MyAccount, Person } from './schema.js';
+
+  const person = new AccountCoState<MyAccount, { root: { dog: true } }>({
+    resolve: {
+      root: {
+        dog: true
+      }
+    }
+  });
+</script>
+
+<!-- Using non-null assertions because we want to test that locally available values are never null -->
+<label>
+  Name
+  <input type="text" bind:value={person.current!.root.name} />
+</label>
+
+<label>
+  Dog
+  <input type="text" bind:value={person.current!.root.dog.name} />
+</label>
+
+<div data-testid="person-name">{person.current!.root.name}</div>
+<div data-testid="person-dog-name">{person.current!.root.dog.name}</div>

--- a/packages/jazz-svelte/src/lib/tests/components/CoState/schema.ts
+++ b/packages/jazz-svelte/src/lib/tests/components/CoState/schema.ts
@@ -1,0 +1,21 @@
+import { Account, co, CoMap } from "jazz-tools";
+
+export class Dog extends CoMap {
+    name = co.string;
+  }
+
+export class Person extends CoMap {
+    name = co.string;
+    age = co.number;
+    dog = co.ref(Dog);
+}
+
+export class MyAccount extends Account {
+    root = co.ref(Person);
+
+    migrate() {
+        if (!this._refs.root) {
+            this.root = Person.create({ name: "John", age: 30, dog: Dog.create({ name: "Rex" }, this) }, this);
+        }
+    }
+}

--- a/packages/jazz-svelte/src/lib/tests/components/ProviderTestComponent.svelte
+++ b/packages/jazz-svelte/src/lib/tests/components/ProviderTestComponent.svelte
@@ -5,7 +5,9 @@
 </script>
 
 <div data-testid="provider-test">
-  <JazzProvider {guestMode} peer="wss://cloud.jazz.tools/?key=jazz-svelte-test">
+  <JazzProvider {guestMode} sync={{
+    peer: "wss://cloud.jazz.tools/?key=jazz-svelte-test"
+  }}>
     <span data-testid="provider-auth-test">Hello</span>
   </JazzProvider>
 </div>

--- a/packages/jazz-svelte/src/lib/tests/components/useAccount.svelte
+++ b/packages/jazz-svelte/src/lib/tests/components/useAccount.svelte
@@ -1,18 +1,20 @@
 <script lang="ts" module>
   export type Props = {
-    depth?: DepthsIn<RegisteredAccount>;
+    depth?: RefsToResolve<RegisteredAccount>;
     setResult: (result: ReturnType<typeof useAccount> | undefined) => void;
   };
 </script>
 
 <script lang="ts">
   import { useAccount, type RegisteredAccount } from '../../jazz.svelte.js';
-  import type { DepthsIn } from 'jazz-tools';
+  import type { RefsToResolve } from 'jazz-tools';
 
   let { depth, setResult }: Props = $props();
 
   if (depth) {
-    const result = $derived(useAccount(depth));
+    const result = $derived(useAccount({
+      resolve: depth
+    }));
 
     $effect(() => {
       setResult(result);

--- a/packages/jazz-svelte/src/lib/tests/components/useAccountOrGuest.svelte
+++ b/packages/jazz-svelte/src/lib/tests/components/useAccountOrGuest.svelte
@@ -1,18 +1,20 @@
 <script lang="ts" module>
   export type Props = {
-    depth?: DepthsIn<RegisteredAccount>;
+    depth?: RefsToResolve<RegisteredAccount>;
     setResult: (result: ReturnType<typeof useAccountOrGuest> | undefined) => void;
   };
 </script>
 
 <script lang="ts">
   import { useAccountOrGuest, type RegisteredAccount } from '../../jazz.svelte.js';
-  import type { DepthsIn } from 'jazz-tools';
+  import type { RefsToResolve } from 'jazz-tools';
 
   let { depth, setResult }: Props = $props();
 
   if (depth) {
-    const result = $derived(useAccountOrGuest(depth));
+    const result = $derived(useAccountOrGuest({
+      resolve: depth
+    }));
 
     $effect(() => {
       setResult(result);

--- a/packages/jazz-svelte/src/lib/tests/components/useCoState.svelte
+++ b/packages/jazz-svelte/src/lib/tests/components/useCoState.svelte
@@ -2,18 +2,18 @@
   export type Props<R extends CoValue> = {
     Schema: CoValueClass<R>;
     id: ID<R>;
-    depth: DepthsIn<R>;
-    setResult: (result: R | undefined) => void;
+    resolve: RefsToResolve<R>;
+    setResult: (result: R | undefined | null) => void;
   };
 </script>
 
 <script lang="ts" generics="R extends CoValue">
   import { useCoState } from '../../jazz.svelte.js';
-  import type { CoValue, CoValueClass, DepthsIn, ID } from 'jazz-tools';
+  import type { CoValue, CoValueClass, RefsToResolve, ID } from 'jazz-tools';
 
-  let { Schema, id, depth, setResult }: Props<R> = $props();
+  let { Schema, id, resolve, setResult }: Props<R> = $props();
 
-  const result = $derived(useCoState(Schema, id, depth));
+  const result = $derived(useCoState(Schema, id, { resolve: resolve as any }));
 
   $effect(() => {
     setResult(result.current);

--- a/packages/jazz-svelte/src/lib/tests/components/usePassphraseAuth.svelte
+++ b/packages/jazz-svelte/src/lib/tests/components/usePassphraseAuth.svelte
@@ -1,18 +1,25 @@
 <script lang="ts">
-  import { usePassphraseAuth } from "../../auth/PassphraseAuth.svelte.js";
+  import { usePassphraseAuth } from '../../auth/PassphraseAuth.svelte.js';
 
-  let { wordlist, setResult }: { wordlist: string[]; setResult: (value: ReturnType<typeof usePassphraseAuth>) => void } = $props();
+  let {
+    wordlist,
+    setResult
+  }: { wordlist: string[]; setResult: (value: Result) => void } = $props();
 
   const auth = usePassphraseAuth({ wordlist });
-  
+
+  const result = $derived({
+    state: auth.state,
+    passphrase: auth.passphrase,
+    logIn: auth.logIn,
+    signUp: auth.signUp
+  });
+
+  type Result = typeof result;
+
   $effect(() => {
-    setResult({
-      state: auth.state,
-      passphrase: auth.passphrase,
-      logIn: auth.logIn,
-      signUp: auth.signUp
-    });
+    setResult(result);
   });
 </script>
 
-<div>Test Component</div> 
+<div>Test Component</div>

--- a/packages/jazz-svelte/src/lib/tests/useAccount.svelte.test.ts
+++ b/packages/jazz-svelte/src/lib/tests/useAccount.svelte.test.ts
@@ -1,5 +1,5 @@
 import { render } from "@testing-library/svelte";
-import { Account, CoMap, co, type DepthsIn } from "jazz-tools";
+import { Account, CoMap, co, type RefsToResolve } from "jazz-tools";
 import { describe, expect, it } from "vitest";
 import { useAccount, type RegisteredAccount } from "../index.js";
 import { createJazzTestAccount, createJazzTestContext } from "../testing.js";
@@ -7,14 +7,14 @@ import UseAccount from "./components/useAccount.svelte";
 
 function setup(options: {
   account: RegisteredAccount;
-  depth?: DepthsIn<RegisteredAccount>;
+  depth?: RefsToResolve<RegisteredAccount>;
 }) {
   const result = { current: undefined } as { current: ReturnType<typeof useAccount> | undefined };
 
     render(UseAccount, {
       context: createJazzTestContext({ account: options.account }),
       props: {
-        depth: options.depth ?? [],
+        depth: options.depth ?? {},
         setResult: (value) => {
           result.current = value
         },

--- a/packages/jazz-svelte/src/lib/tests/useAccountOrGuest.svelte.test.ts
+++ b/packages/jazz-svelte/src/lib/tests/useAccountOrGuest.svelte.test.ts
@@ -1,5 +1,5 @@
 import { render } from "@testing-library/svelte";
-import { Account, AnonymousJazzAgent, CoMap, co, type DepthsIn } from "jazz-tools";
+import { Account, AnonymousJazzAgent, CoMap, co, type RefsToResolve } from "jazz-tools";
 import { describe, expect, it } from "vitest";
 import { useAccountOrGuest, type RegisteredAccount } from "../index.js";
 import { createJazzTestAccount, createJazzTestContext, createJazzTestGuest } from "../testing.js";
@@ -7,14 +7,14 @@ import UseAccountOrGuest from "./components/useAccountOrGuest.svelte";
 
 function setup(options: {
   account: RegisteredAccount | { guest: AnonymousJazzAgent };
-  depth?: DepthsIn<RegisteredAccount>;
+  depth?: RefsToResolve<RegisteredAccount>;
 }) {
   const result = { current: undefined } as { current: ReturnType<typeof useAccountOrGuest> | undefined };
 
     render(UseAccountOrGuest, {
       context: createJazzTestContext({ account: options.account }),
       props: {
-        depth: options.depth ?? [],
+        depth: options.depth ?? {},
         setResult: (value) => {
           result.current = value
         },

--- a/packages/jazz-svelte/src/lib/tests/useCoState.svelte.test.ts
+++ b/packages/jazz-svelte/src/lib/tests/useCoState.svelte.test.ts
@@ -6,9 +6,9 @@ import {
   cojsonInternals,
   type CoValue,
   type CoValueClass,
-  type DepthsIn
+  type RefsToResolve,
 } from 'jazz-tools';
-import { describe, expect, it, expectTypeOf } from 'vitest';
+import { describe, expect, it, expectTypeOf, beforeEach } from 'vitest';
 import { createJazzTestAccount, createJazzTestContext, setupJazzTestSync } from '../testing.js';
 import UseCoState from './components/useCoState.svelte';
 
@@ -21,7 +21,7 @@ beforeEach(() => {
   cojsonInternals.CO_VALUE_LOADING_CONFIG.TIMEOUT = 1;
 });
 
-function setup<T extends CoValue>(options: { account: Account; map: T; depth?: DepthsIn<T> }) {
+function setup<T extends CoValue>(options: { account: Account; map: T; resolve?: RefsToResolve<T> }) {
   const result = { current: undefined } as { current: T | undefined };
 
   render(UseCoState, {
@@ -29,9 +29,9 @@ function setup<T extends CoValue>(options: { account: Account; map: T; depth?: D
     props: {
       Schema: options.map.constructor as CoValueClass<T>,
       id: options.map.id,
-      depth: options.depth ?? [],
-      setResult: (value: T | undefined) => {
-        result.current = value;
+      resolve: options.resolve ?? true,
+      setResult: (value) => {
+        result.current = value as T;
       }
     }
   });
@@ -116,7 +116,7 @@ describe('useCoState', () => {
     const result = setup({
       account,
       map,
-      depth: {
+      resolve: {
         nested: {}
       }
     });
@@ -153,7 +153,7 @@ describe('useCoState', () => {
     const result = setup({
       account,
       map,
-      depth: {
+      resolve: {
         nested: {}
       }
     });

--- a/packages/jazz-svelte/src/lib/tests/usePassphraseAuth.svelte.test.ts
+++ b/packages/jazz-svelte/src/lib/tests/usePassphraseAuth.svelte.test.ts
@@ -6,21 +6,26 @@ import { describe, expect, it, beforeEach } from "vitest";
 import { createJazzTestAccount, createJazzTestContext, setupJazzTestSync } from "../testing.js";
 import { testWordlist } from "./fixtures.js";
 import UsePassphraseAuth from "./components/usePassphraseAuth.svelte";
-import type { usePassphraseAuth } from "../auth/PassphraseAuth.svelte.js";
 
 beforeEach(async () => {
   await setupJazzTestSync();
 });
 
+type Result = {
+  state: string;
+  passphrase: string;
+  logIn: (passphrase: string) => Promise<void>;
+  signUp: (name?: string) => Promise<string>;
+}
+
 async function setup() {
-  type PassphraseAuthResult = ReturnType<typeof usePassphraseAuth>;
-  const result = { current: null as PassphraseAuthResult | null };
+  const result = { current: null as Result | null };
 
   render(UsePassphraseAuth, {
     context: createJazzTestContext({ account: await createJazzTestAccount() }),
     props: {
       wordlist: testWordlist,
-      setResult: (value: PassphraseAuthResult) => {
+      setResult: (value) => {
         result.current = value;
       },
     },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2350,16 +2350,16 @@ importers:
     devDependencies:
       '@bam.tech/react-native-image-resizer':
         specifier: ^3.0.11
-        version: 3.0.11(react-native@0.76.7(@babel/core@7.26.10)(@babel/preset-env@7.26.0(@babel/core@7.26.10))(@react-native-community/cli-server-api@15.0.1)(@types/react@18.3.18)(react@18.3.1))(react@18.3.1)
+        version: 3.0.11(react-native@0.76.7(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@react-native-community/cli-server-api@15.0.1)(@types/react@18.3.18)(react@18.3.1))(react@18.3.1)
       expo-file-system:
         specifier: ^18.0.4
-        version: 18.0.12(expo@52.0.42(@babel/core@7.26.10)(@babel/preset-env@7.26.0(@babel/core@7.26.10))(@expo/metro-runtime@4.0.1(react-native@0.76.7(@babel/core@7.26.10)(@babel/preset-env@7.26.0(@babel/core@7.26.10))(@react-native-community/cli-server-api@15.0.1)(@types/react@18.3.18)(react@18.3.1)))(graphql@16.10.0)(react-native@0.76.7(@babel/core@7.26.10)(@babel/preset-env@7.26.0(@babel/core@7.26.10))(@react-native-community/cli-server-api@15.0.1)(@types/react@18.3.18)(react@18.3.1))(react@18.3.1))(react-native@0.76.7(@babel/core@7.26.10)(@babel/preset-env@7.26.0(@babel/core@7.26.10))(@react-native-community/cli-server-api@15.0.1)(@types/react@18.3.18)(react@18.3.1))
+        version: 18.0.12(expo@52.0.42(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@expo/metro-runtime@4.0.1(react-native@0.76.7(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@react-native-community/cli-server-api@15.0.1)(@types/react@18.3.18)(react@18.3.1)))(graphql@16.10.0)(react-native@0.76.7(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@react-native-community/cli-server-api@15.0.1)(@types/react@18.3.18)(react@18.3.1))(react@18.3.1))(react-native@0.76.7(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@react-native-community/cli-server-api@15.0.1)(@types/react@18.3.18)(react@18.3.1))
       react:
         specifier: 18.3.1
         version: 18.3.1
       react-native:
         specifier: 0.76.7
-        version: 0.76.7(@babel/core@7.26.10)(@babel/preset-env@7.26.0(@babel/core@7.26.10))(@react-native-community/cli-server-api@15.0.1)(@types/react@18.3.18)(react@18.3.1)
+        version: 0.76.7(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@react-native-community/cli-server-api@15.0.1)(@types/react@18.3.18)(react@18.3.1)
       typescript:
         specifier: 'catalog:'
         version: 5.6.2
@@ -15266,10 +15266,10 @@ snapshots:
       react: 18.3.1
       react-native: 0.76.7(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@react-native-community/cli-server-api@15.0.1)(@types/react@18.3.12)(react@18.3.1)
 
-  '@bam.tech/react-native-image-resizer@3.0.11(react-native@0.76.7(@babel/core@7.26.10)(@babel/preset-env@7.26.0(@babel/core@7.26.10))(@react-native-community/cli-server-api@15.0.1)(@types/react@18.3.18)(react@18.3.1))(react@18.3.1)':
+  '@bam.tech/react-native-image-resizer@3.0.11(react-native@0.76.7(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@react-native-community/cli-server-api@15.0.1)(@types/react@18.3.18)(react@18.3.1))(react@18.3.1)':
     dependencies:
       react: 18.3.1
-      react-native: 0.76.7(@babel/core@7.26.10)(@babel/preset-env@7.26.0(@babel/core@7.26.10))(@react-native-community/cli-server-api@15.0.1)(@types/react@18.3.18)(react@18.3.1)
+      react-native: 0.76.7(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@react-native-community/cli-server-api@15.0.1)(@types/react@18.3.18)(react@18.3.1)
 
   '@bcoe/v8-coverage@0.2.3':
     optional: true
@@ -16167,6 +16167,11 @@ snapshots:
   '@expo/metro-runtime@4.0.1(react-native@0.76.7(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@react-native-community/cli-server-api@15.0.1)(@types/react@18.3.12)(react@18.3.1))':
     dependencies:
       react-native: 0.76.7(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@react-native-community/cli-server-api@15.0.1)(@types/react@18.3.12)(react@18.3.1)
+
+  '@expo/metro-runtime@4.0.1(react-native@0.76.7(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@react-native-community/cli-server-api@15.0.1)(@types/react@18.3.18)(react@18.3.1))':
+    dependencies:
+      react-native: 0.76.7(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@react-native-community/cli-server-api@15.0.1)(@types/react@18.3.18)(react@18.3.1)
+    optional: true
 
   '@expo/metro-runtime@4.0.1(react-native@0.76.7(@babel/core@7.26.10)(@babel/preset-env@7.26.0(@babel/core@7.26.10))(@react-native-community/cli-server-api@15.0.1)(@types/react@18.3.18)(react@18.3.1))':
     dependencies:
@@ -18007,6 +18012,15 @@ snapshots:
       react-native: 0.76.7(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@react-native-community/cli-server-api@15.0.1)(@types/react@18.3.12)(react@18.3.1)
     optionalDependencies:
       '@types/react': 18.3.12
+
+  '@react-native/virtualized-lists@0.76.7(@types/react@18.3.18)(react-native@0.76.7(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@react-native-community/cli-server-api@15.0.1)(@types/react@18.3.18)(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      invariant: 2.2.4
+      nullthrows: 1.1.1
+      react: 18.3.1
+      react-native: 0.76.7(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@react-native-community/cli-server-api@15.0.1)(@types/react@18.3.18)(react@18.3.1)
+    optionalDependencies:
+      '@types/react': 18.3.18
 
   '@react-native/virtualized-lists@0.76.7(@types/react@18.3.18)(react-native@0.76.7(@babel/core@7.26.10)(@babel/preset-env@7.26.0(@babel/core@7.26.10))(@react-native-community/cli-server-api@15.0.1)(@types/react@18.3.18)(react@18.3.1))(react@18.3.1)':
     dependencies:
@@ -21365,6 +21379,18 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  expo-asset@11.0.5(expo@52.0.42(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@expo/metro-runtime@4.0.1(react-native@0.76.7(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@react-native-community/cli-server-api@15.0.1)(@types/react@18.3.18)(react@18.3.1)))(graphql@16.10.0)(react-native@0.76.7(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@react-native-community/cli-server-api@15.0.1)(@types/react@18.3.18)(react@18.3.1))(react@18.3.1))(react-native@0.76.7(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@react-native-community/cli-server-api@15.0.1)(@types/react@18.3.18)(react@18.3.1))(react@18.3.1):
+    dependencies:
+      '@expo/image-utils': 0.6.5
+      expo: 52.0.42(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@expo/metro-runtime@4.0.1(react-native@0.76.7(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@react-native-community/cli-server-api@15.0.1)(@types/react@18.3.18)(react@18.3.1)))(graphql@16.10.0)(react-native@0.76.7(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@react-native-community/cli-server-api@15.0.1)(@types/react@18.3.18)(react@18.3.1))(react@18.3.1)
+      expo-constants: 17.0.8(expo@52.0.42(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@expo/metro-runtime@4.0.1(react-native@0.76.7(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@react-native-community/cli-server-api@15.0.1)(@types/react@18.3.18)(react@18.3.1)))(graphql@16.10.0)(react-native@0.76.7(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@react-native-community/cli-server-api@15.0.1)(@types/react@18.3.18)(react@18.3.1))(react@18.3.1))(react-native@0.76.7(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@react-native-community/cli-server-api@15.0.1)(@types/react@18.3.18)(react@18.3.1))
+      invariant: 2.2.4
+      md5-file: 3.2.3
+      react: 18.3.1
+      react-native: 0.76.7(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@react-native-community/cli-server-api@15.0.1)(@types/react@18.3.18)(react@18.3.1)
+    transitivePeerDependencies:
+      - supports-color
+
   expo-asset@11.0.5(expo@52.0.42(@babel/core@7.26.10)(@babel/preset-env@7.26.0(@babel/core@7.26.10))(@expo/metro-runtime@4.0.1(react-native@0.76.7(@babel/core@7.26.10)(@babel/preset-env@7.26.0(@babel/core@7.26.10))(@react-native-community/cli-server-api@15.0.1)(@types/react@18.3.18)(react@18.3.1)))(graphql@16.10.0)(react-native@0.76.7(@babel/core@7.26.10)(@babel/preset-env@7.26.0(@babel/core@7.26.10))(@react-native-community/cli-server-api@15.0.1)(@types/react@18.3.18)(react@18.3.1))(react@18.3.1))(react-native@0.76.7(@babel/core@7.26.10)(@babel/preset-env@7.26.0(@babel/core@7.26.10))(@react-native-community/cli-server-api@15.0.1)(@types/react@18.3.18)(react@18.3.1))(react@18.3.1):
     dependencies:
       '@expo/image-utils': 0.6.5
@@ -21430,6 +21456,15 @@ snapshots:
       '@expo/env': 0.4.2
       expo: 52.0.42(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@expo/metro-runtime@4.0.1(react-native@0.76.7(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@react-native-community/cli-server-api@15.0.1)(@types/react@18.3.12)(react@18.3.1)))(graphql@16.10.0)(react-native@0.76.7(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@react-native-community/cli-server-api@15.0.1)(@types/react@18.3.12)(react@18.3.1))(react@18.3.1)
       react-native: 0.76.7(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@react-native-community/cli-server-api@15.0.1)(@types/react@18.3.12)(react@18.3.1)
+    transitivePeerDependencies:
+      - supports-color
+
+  expo-constants@17.0.8(expo@52.0.42(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@expo/metro-runtime@4.0.1(react-native@0.76.7(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@react-native-community/cli-server-api@15.0.1)(@types/react@18.3.18)(react@18.3.1)))(graphql@16.10.0)(react-native@0.76.7(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@react-native-community/cli-server-api@15.0.1)(@types/react@18.3.18)(react@18.3.1))(react@18.3.1))(react-native@0.76.7(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@react-native-community/cli-server-api@15.0.1)(@types/react@18.3.18)(react@18.3.1)):
+    dependencies:
+      '@expo/config': 10.0.11
+      '@expo/env': 0.4.2
+      expo: 52.0.42(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@expo/metro-runtime@4.0.1(react-native@0.76.7(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@react-native-community/cli-server-api@15.0.1)(@types/react@18.3.18)(react@18.3.1)))(graphql@16.10.0)(react-native@0.76.7(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@react-native-community/cli-server-api@15.0.1)(@types/react@18.3.18)(react@18.3.1))(react@18.3.1)
+      react-native: 0.76.7(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@react-native-community/cli-server-api@15.0.1)(@types/react@18.3.18)(react@18.3.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -21524,6 +21559,12 @@ snapshots:
       react-native: 0.76.7(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@react-native-community/cli-server-api@15.0.1)(@types/react@18.3.12)(react@18.3.1)
       web-streams-polyfill: 3.3.3
 
+  expo-file-system@18.0.12(expo@52.0.42(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@expo/metro-runtime@4.0.1(react-native@0.76.7(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@react-native-community/cli-server-api@15.0.1)(@types/react@18.3.18)(react@18.3.1)))(graphql@16.10.0)(react-native@0.76.7(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@react-native-community/cli-server-api@15.0.1)(@types/react@18.3.18)(react@18.3.1))(react@18.3.1))(react-native@0.76.7(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@react-native-community/cli-server-api@15.0.1)(@types/react@18.3.18)(react@18.3.1)):
+    dependencies:
+      expo: 52.0.42(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@expo/metro-runtime@4.0.1(react-native@0.76.7(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@react-native-community/cli-server-api@15.0.1)(@types/react@18.3.18)(react@18.3.1)))(graphql@16.10.0)(react-native@0.76.7(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@react-native-community/cli-server-api@15.0.1)(@types/react@18.3.18)(react@18.3.1))(react@18.3.1)
+      react-native: 0.76.7(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@react-native-community/cli-server-api@15.0.1)(@types/react@18.3.18)(react@18.3.1)
+      web-streams-polyfill: 3.3.3
+
   expo-file-system@18.0.12(expo@52.0.42(@babel/core@7.26.10)(@babel/preset-env@7.26.0(@babel/core@7.26.10))(@expo/metro-runtime@4.0.1(react-native@0.76.7(@babel/core@7.26.10)(@babel/preset-env@7.26.0(@babel/core@7.26.10))(@react-native-community/cli-server-api@15.0.1)(@types/react@18.3.18)(react@18.3.1)))(graphql@16.10.0)(react-native@0.76.7(@babel/core@7.26.10)(@babel/preset-env@7.26.0(@babel/core@7.26.10))(@react-native-community/cli-server-api@15.0.1)(@types/react@18.3.18)(react@18.3.1))(react@18.3.1))(react-native@0.76.7(@babel/core@7.26.10)(@babel/preset-env@7.26.0(@babel/core@7.26.10))(@react-native-community/cli-server-api@15.0.1)(@types/react@18.3.18)(react@18.3.1)):
     dependencies:
       expo: 52.0.42(@babel/core@7.26.10)(@babel/preset-env@7.26.0(@babel/core@7.26.10))(@expo/metro-runtime@4.0.1(react-native@0.76.7(@babel/core@7.26.10)(@babel/preset-env@7.26.0(@babel/core@7.26.10))(@react-native-community/cli-server-api@15.0.1)(@types/react@18.3.18)(react@18.3.1)))(graphql@16.10.0)(react-native@0.76.7(@babel/core@7.26.10)(@babel/preset-env@7.26.0(@babel/core@7.26.10))(@react-native-community/cli-server-api@15.0.1)(@types/react@18.3.18)(react@18.3.1))(react@18.3.1)
@@ -21539,6 +21580,12 @@ snapshots:
   expo-font@13.0.4(expo@52.0.42(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@expo/metro-runtime@4.0.1(react-native@0.76.7(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@react-native-community/cli-server-api@15.0.1)(@types/react@18.3.12)(react@18.3.1)))(graphql@16.10.0)(react-native@0.76.7(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@react-native-community/cli-server-api@15.0.1)(@types/react@18.3.12)(react@18.3.1))(react@18.3.1))(react@18.3.1):
     dependencies:
       expo: 52.0.42(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@expo/metro-runtime@4.0.1(react-native@0.76.7(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@react-native-community/cli-server-api@15.0.1)(@types/react@18.3.12)(react@18.3.1)))(graphql@16.10.0)(react-native@0.76.7(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@react-native-community/cli-server-api@15.0.1)(@types/react@18.3.12)(react@18.3.1))(react@18.3.1)
+      fontfaceobserver: 2.3.0
+      react: 18.3.1
+
+  expo-font@13.0.4(expo@52.0.42(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@expo/metro-runtime@4.0.1(react-native@0.76.7(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@react-native-community/cli-server-api@15.0.1)(@types/react@18.3.18)(react@18.3.1)))(graphql@16.10.0)(react-native@0.76.7(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@react-native-community/cli-server-api@15.0.1)(@types/react@18.3.18)(react@18.3.1))(react@18.3.1))(react@18.3.1):
+    dependencies:
+      expo: 52.0.42(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@expo/metro-runtime@4.0.1(react-native@0.76.7(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@react-native-community/cli-server-api@15.0.1)(@types/react@18.3.18)(react@18.3.1)))(graphql@16.10.0)(react-native@0.76.7(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@react-native-community/cli-server-api@15.0.1)(@types/react@18.3.18)(react@18.3.1))(react@18.3.1)
       fontfaceobserver: 2.3.0
       react: 18.3.1
 
@@ -21567,6 +21614,11 @@ snapshots:
   expo-keep-awake@14.0.3(expo@52.0.42(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@expo/metro-runtime@4.0.1(react-native@0.76.7(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@react-native-community/cli-server-api@15.0.1)(@types/react@18.3.12)(react@18.3.1)))(graphql@16.10.0)(react-native@0.76.7(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@react-native-community/cli-server-api@15.0.1)(@types/react@18.3.12)(react@18.3.1))(react@18.3.1))(react@18.3.1):
     dependencies:
       expo: 52.0.42(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@expo/metro-runtime@4.0.1(react-native@0.76.7(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@react-native-community/cli-server-api@15.0.1)(@types/react@18.3.12)(react@18.3.1)))(graphql@16.10.0)(react-native@0.76.7(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@react-native-community/cli-server-api@15.0.1)(@types/react@18.3.12)(react@18.3.1))(react@18.3.1)
+      react: 18.3.1
+
+  expo-keep-awake@14.0.3(expo@52.0.42(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@expo/metro-runtime@4.0.1(react-native@0.76.7(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@react-native-community/cli-server-api@15.0.1)(@types/react@18.3.18)(react@18.3.1)))(graphql@16.10.0)(react-native@0.76.7(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@react-native-community/cli-server-api@15.0.1)(@types/react@18.3.18)(react@18.3.1))(react@18.3.1))(react@18.3.1):
+    dependencies:
+      expo: 52.0.42(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@expo/metro-runtime@4.0.1(react-native@0.76.7(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@react-native-community/cli-server-api@15.0.1)(@types/react@18.3.18)(react@18.3.1)))(graphql@16.10.0)(react-native@0.76.7(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@react-native-community/cli-server-api@15.0.1)(@types/react@18.3.18)(react@18.3.1))(react@18.3.1)
       react: 18.3.1
 
   expo-keep-awake@14.0.3(expo@52.0.42(@babel/core@7.26.10)(@babel/preset-env@7.26.0(@babel/core@7.26.10))(@expo/metro-runtime@4.0.1(react-native@0.76.7(@babel/core@7.26.10)(@babel/preset-env@7.26.0(@babel/core@7.26.10))(@react-native-community/cli-server-api@15.0.1)(@types/react@18.3.18)(react@18.3.1)))(graphql@16.10.0)(react-native@0.76.7(@babel/core@7.26.10)(@babel/preset-env@7.26.0(@babel/core@7.26.10))(@react-native-community/cli-server-api@15.0.1)(@types/react@18.3.18)(react@18.3.1))(react@18.3.1))(react@18.3.1):
@@ -21784,6 +21836,41 @@ snapshots:
       whatwg-url-without-unicode: 8.0.0-3
     optionalDependencies:
       '@expo/metro-runtime': 4.0.1(react-native@0.76.7(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@react-native-community/cli-server-api@15.0.1)(@types/react@18.3.12)(react@18.3.1))
+    transitivePeerDependencies:
+      - '@babel/core'
+      - '@babel/preset-env'
+      - babel-plugin-react-compiler
+      - bufferutil
+      - encoding
+      - graphql
+      - react-compiler-runtime
+      - supports-color
+      - utf-8-validate
+
+  expo@52.0.42(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@expo/metro-runtime@4.0.1(react-native@0.76.7(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@react-native-community/cli-server-api@15.0.1)(@types/react@18.3.18)(react@18.3.1)))(graphql@16.10.0)(react-native@0.76.7(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@react-native-community/cli-server-api@15.0.1)(@types/react@18.3.18)(react@18.3.1))(react@18.3.1):
+    dependencies:
+      '@babel/runtime': 7.26.0
+      '@expo/cli': 0.22.23(graphql@16.10.0)
+      '@expo/config': 10.0.11
+      '@expo/config-plugins': 9.0.17
+      '@expo/fingerprint': 0.11.11
+      '@expo/metro-config': 0.19.12
+      '@expo/vector-icons': 14.0.4
+      babel-preset-expo: 12.0.10(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))
+      expo-asset: 11.0.5(expo@52.0.42(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@expo/metro-runtime@4.0.1(react-native@0.76.7(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@react-native-community/cli-server-api@15.0.1)(@types/react@18.3.18)(react@18.3.1)))(graphql@16.10.0)(react-native@0.76.7(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@react-native-community/cli-server-api@15.0.1)(@types/react@18.3.18)(react@18.3.1))(react@18.3.1))(react-native@0.76.7(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@react-native-community/cli-server-api@15.0.1)(@types/react@18.3.18)(react@18.3.1))(react@18.3.1)
+      expo-constants: 17.0.8(expo@52.0.42(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@expo/metro-runtime@4.0.1(react-native@0.76.7(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@react-native-community/cli-server-api@15.0.1)(@types/react@18.3.18)(react@18.3.1)))(graphql@16.10.0)(react-native@0.76.7(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@react-native-community/cli-server-api@15.0.1)(@types/react@18.3.18)(react@18.3.1))(react@18.3.1))(react-native@0.76.7(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@react-native-community/cli-server-api@15.0.1)(@types/react@18.3.18)(react@18.3.1))
+      expo-file-system: 18.0.12(expo@52.0.42(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@expo/metro-runtime@4.0.1(react-native@0.76.7(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@react-native-community/cli-server-api@15.0.1)(@types/react@18.3.18)(react@18.3.1)))(graphql@16.10.0)(react-native@0.76.7(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@react-native-community/cli-server-api@15.0.1)(@types/react@18.3.18)(react@18.3.1))(react@18.3.1))(react-native@0.76.7(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@react-native-community/cli-server-api@15.0.1)(@types/react@18.3.18)(react@18.3.1))
+      expo-font: 13.0.4(expo@52.0.42(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@expo/metro-runtime@4.0.1(react-native@0.76.7(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@react-native-community/cli-server-api@15.0.1)(@types/react@18.3.18)(react@18.3.1)))(graphql@16.10.0)(react-native@0.76.7(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@react-native-community/cli-server-api@15.0.1)(@types/react@18.3.18)(react@18.3.1))(react@18.3.1))(react@18.3.1)
+      expo-keep-awake: 14.0.3(expo@52.0.42(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@expo/metro-runtime@4.0.1(react-native@0.76.7(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@react-native-community/cli-server-api@15.0.1)(@types/react@18.3.18)(react@18.3.1)))(graphql@16.10.0)(react-native@0.76.7(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@react-native-community/cli-server-api@15.0.1)(@types/react@18.3.18)(react@18.3.1))(react@18.3.1))(react@18.3.1)
+      expo-modules-autolinking: 2.0.8
+      expo-modules-core: 2.2.3
+      fbemitter: 3.0.0
+      react: 18.3.1
+      react-native: 0.76.7(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@react-native-community/cli-server-api@15.0.1)(@types/react@18.3.18)(react@18.3.1)
+      web-streams-polyfill: 3.3.3
+      whatwg-url-without-unicode: 8.0.0-3
+    optionalDependencies:
+      '@expo/metro-runtime': 4.0.1(react-native@0.76.7(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@react-native-community/cli-server-api@15.0.1)(@types/react@18.3.18)(react@18.3.1))
     transitivePeerDependencies:
       - '@babel/core'
       - '@babel/preset-env'
@@ -25252,6 +25339,58 @@ snapshots:
       yargs: 17.7.2
     optionalDependencies:
       '@types/react': 18.3.12
+    transitivePeerDependencies:
+      - '@babel/core'
+      - '@babel/preset-env'
+      - '@react-native-community/cli-server-api'
+      - bufferutil
+      - encoding
+      - supports-color
+      - utf-8-validate
+
+  react-native@0.76.7(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@react-native-community/cli-server-api@15.0.1)(@types/react@18.3.18)(react@18.3.1):
+    dependencies:
+      '@jest/create-cache-key-function': 29.7.0
+      '@react-native/assets-registry': 0.76.7
+      '@react-native/codegen': 0.76.7(@babel/preset-env@7.26.0(@babel/core@7.26.0))
+      '@react-native/community-cli-plugin': 0.76.7(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@react-native-community/cli-server-api@15.0.1)
+      '@react-native/gradle-plugin': 0.76.7
+      '@react-native/js-polyfills': 0.76.7
+      '@react-native/normalize-colors': 0.76.7
+      '@react-native/virtualized-lists': 0.76.7(@types/react@18.3.18)(react-native@0.76.7(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@react-native-community/cli-server-api@15.0.1)(@types/react@18.3.18)(react@18.3.1))(react@18.3.1)
+      abort-controller: 3.0.0
+      anser: 1.4.10
+      ansi-regex: 5.0.1
+      babel-jest: 29.7.0(@babel/core@7.26.0)
+      babel-plugin-syntax-hermes-parser: 0.23.1
+      base64-js: 1.5.1
+      chalk: 4.1.2
+      commander: 12.1.0
+      event-target-shim: 5.0.1
+      flow-enums-runtime: 0.0.6
+      glob: 7.2.3
+      invariant: 2.2.4
+      jest-environment-node: 29.7.0
+      jsc-android: 250231.0.0
+      memoize-one: 5.2.1
+      metro-runtime: 0.81.0
+      metro-source-map: 0.81.0
+      mkdirp: 0.5.6
+      nullthrows: 1.1.1
+      pretty-format: 29.7.0
+      promise: 8.3.0
+      react: 18.3.1
+      react-devtools-core: 5.3.2
+      react-refresh: 0.14.2
+      regenerator-runtime: 0.13.11
+      scheduler: 0.24.0-canary-efb381bbf-20230505
+      semver: 7.6.3
+      stacktrace-parser: 0.1.10
+      whatwg-fetch: 3.6.20
+      ws: 6.2.3
+      yargs: 17.7.2
+    optionalDependencies:
+      '@types/react': 18.3.18
     transitivePeerDependencies:
       - '@babel/core'
       - '@babel/preset-env'


### PR DESCRIPTION
Introduces CoState and AccountCoState classes as new primitives to subscribe to Jazz state in Svelte using https://runed.dev/docs as inspiration.

It definitely looks more ergonomic, and it's easier to guess where `$derived` is required

~~Didn't manage to make reactive ids work, will move them in a separate PR to get some feedback on where I'm doing things wrong.~~