### PR TITLE
2186-split-graphemes-with-unicode-segmenter

### DIFF
--- a/packages/cojson/package.json
+++ b/packages/cojson/package.json
@@ -38,7 +38,8 @@
     "@scure/base": "1.2.1",
     "jazz-crypto-rs": "0.0.7",
     "neverthrow": "^7.0.1",
-    "queueueue": "^4.1.2"
+    "queueueue": "^4.1.2",
+    "unicode-segmenter": "^0.12.0"
   },
   "scripts": {
     "dev": "tsc --watch --sourceMap --outDir dist",

--- a/packages/cojson/src/coValues/coPlainText.ts
+++ b/packages/cojson/src/coValues/coPlainText.ts
@@ -1,7 +1,5 @@
-import {
-  AvailableCoValueCore,
-  CoValueCore,
-} from "../coValueCore/coValueCore.js";
+import { splitGraphemes } from "unicode-segmenter/grapheme";
+import { AvailableCoValueCore } from "../coValueCore/coValueCore.js";
 import { JsonObject } from "../jsonValue.js";
 import { DeletionOpPayload, OpID, RawCoList } from "./coList.js";
 
@@ -57,8 +55,6 @@ export class RawCoPlainText<
   /** @category 6. Meta */
   type = "coplaintext" as const;
 
-  private _segmenter: Intl.Segmenter;
-
   _cachedMapping: WeakMap<
     NonNullable<typeof this._cachedEntries>,
     PlaintextIdxMapping
@@ -67,11 +63,6 @@ export class RawCoPlainText<
   constructor(core: AvailableCoValueCore) {
     super(core);
     this._cachedMapping = new WeakMap();
-    if (!Intl.Segmenter) {
-      throw new Error(
-        "Intl.Segmenter is not supported. Use a polyfill to get coPlainText support in Jazz. (eg. https://formatjs.github.io/docs/polyfills/intl-segmenter/)",
-      );
-    }
 
     // Use locale from meta if provided, fallback to browser locale, or 'en' as last resort
     const effectiveLocale =
@@ -81,10 +72,6 @@ export class RawCoPlainText<
         ? (core.verified.header.meta.locale as string)
         : undefined) ||
       (typeof navigator !== "undefined" ? navigator.language : "en");
-
-    this._segmenter = new Intl.Segmenter(effectiveLocale, {
-      granularity: "grapheme",
-    });
   }
 
   get mapping() {
@@ -138,7 +125,7 @@ export class RawCoPlainText<
     text: string,
     privacy: "private" | "trusting" = "private",
   ) {
-    const graphemes = [...this._segmenter.segment(text)].map((g) => g.segment);
+    const graphemes = [...splitGraphemes(text)];
 
     if (idx === 0) {
       // For insertions at start, prepend each character in reverse

--- a/packages/cojson/src/coValues/coPlainText.ts
+++ b/packages/cojson/src/coValues/coPlainText.ts
@@ -91,7 +91,7 @@ export class RawCoPlainText<
     let idxBefore = 0;
 
     for (const entry of entries) {
-      const idxAfter = idxBefore + entry.value.length;
+      const idxAfter = idxBefore + 1;
 
       mapping.opIDafterIdx[idxBefore] = entry.opID;
       mapping.opIDbeforeIdx[idxAfter] = entry.opID;
@@ -151,8 +151,12 @@ export class RawCoPlainText<
     text: string,
     privacy: "private" | "trusting" = "private",
   ) {
-    const graphemes = [...this._segmenter.segment(text)].map((g) => g.segment);
-    this.appendItems(graphemes, idx, privacy);
+    const graphemes = [...splitGraphemes(text)];
+    if (idx >= this.entries().length) {
+      this.appendItems(graphemes, idx - 1, privacy);
+    } else {
+      this.appendItems(graphemes, idx, privacy);
+    }
   }
 
   deleteRange(

--- a/packages/cojson/src/tests/coPlainText.test.ts
+++ b/packages/cojson/src/tests/coPlainText.test.ts
@@ -1,27 +1,11 @@
 import { afterEach, expect, test, vi } from "vitest";
 import { expectPlainText } from "../coValue.js";
 import { WasmCrypto } from "../crypto/WasmCrypto.js";
-import { LocalNode } from "../localNode.js";
-import {
-  nodeWithRandomAgentAndSessionID,
-  randomAgentAndSessionID,
-} from "./testUtils.js";
+import { nodeWithRandomAgentAndSessionID } from "./testUtils.js";
 
 const Crypto = await WasmCrypto.create();
 
 afterEach(() => void vi.unstubAllGlobals());
-
-test("should throw on creation if Intl.Segmenter is not available", () => {
-  vi.stubGlobal("Intl", {
-    Segmenter: undefined,
-  });
-
-  const node = nodeWithRandomAgentAndSessionID();
-  const group = node.createGroup();
-  expect(() => group.createPlainText()).toThrow(
-    "Intl.Segmenter is not supported. Use a polyfill to get coPlainText support in Jazz. (eg. https://formatjs.github.io/docs/polyfills/intl-segmenter/)",
-  );
-});
 
 test("Empty CoPlainText works", () => {
   const node = nodeWithRandomAgentAndSessionID();
@@ -86,7 +70,7 @@ test("Can insert and delete in CoPlainText", () => {
   content.insertBefore(2, "😍", "trusting");
   expect(content.toString()).toEqual("He😍llo, world");
 
-  content.deleteRange({ from: 2, to: 4 }, "trusting");
+  content.deleteRange({ from: 2, to: 3 }, "trusting");
   expect(content.toString()).toEqual("Hello, world");
 });
 
@@ -205,6 +189,21 @@ test("insertBefore and insertAfter work as expected", () => {
   expect(content.toString()).toEqual("!hey");
 });
 
+test("Can delete a single grapheme", () => {
+  const node = nodeWithRandomAgentAndSessionID();
+  const coValue = node.createCoValue({
+    type: "coplaintext",
+    ruleset: { type: "unsafeAllowAll" },
+    meta: null,
+    ...Crypto.createdNowUnique(),
+  });
+  const content = expectPlainText(coValue.getCurrentContent());
+
+  content.insertAfter(0, "a̐éö̲", "trusting"); // 3 graphemes
+  content.deleteRange({ from: 1, to: 2 }, "trusting"); // delete the second grapheme
+  expect(content.toString()).toEqual("a̐ö̲");
+});
+
 test("Handles complex grapheme clusters correctly", () => {
   const node = nodeWithRandomAgentAndSessionID();
   const coValue = node.createCoValue({
@@ -242,4 +241,27 @@ test("Handles complex grapheme clusters correctly", () => {
   expect(content.toString()).toEqual("a̐ö̲👍🏽");
   content.deleteRange({ from: 2, to: 3 }, "trusting");
   expect(content.toString()).toEqual("a̐ö̲");
+});
+
+test("Handle deletion of complex grapheme clusters correctly", () => {
+  const node = nodeWithRandomAgentAndSessionID();
+  const coValue = node.createCoValue({
+    type: "coplaintext",
+    ruleset: { type: "unsafeAllowAll" },
+    meta: null,
+    ...Crypto.createdNowUnique(),
+  });
+  const content = expectPlainText(coValue.getCurrentContent());
+
+  // Combining marks (should be treated as one grapheme each)
+  content.insertAfter(0, "👋 안녕!", "trusting");
+  expect(content.toString()).toEqual("👋 안녕!");
+
+  // Delete the first grapheme
+  content.deleteRange({ from: 0, to: 1 }, "trusting");
+  expect(content.toString()).toEqual(" 안녕!");
+
+  // Delete the second grapheme
+  content.deleteRange({ from: 1, to: 2 }, "trusting");
+  expect(content.toString()).toEqual(" 녕!");
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1932,6 +1932,9 @@ importers:
       queueueue:
         specifier: ^4.1.2
         version: 4.1.2
+      unicode-segmenter:
+        specifier: ^0.12.0
+        version: 0.12.0
     devDependencies:
       '@opentelemetry/sdk-metrics':
         specifier: ^2.0.0
@@ -13217,6 +13220,9 @@ packages:
   unicode-property-aliases-ecmascript@2.1.0:
     resolution: {integrity: sha512-6t3foTQI9qne+OZoVQB/8x8rk2k1eVy1gRXhV3oFQ5T6R1dqQ1xtin3XqSlx3+ATBkliTaR/hHyJBm+LVPNM8w==}
     engines: {node: '>=4'}
+
+  unicode-segmenter@0.12.0:
+    resolution: {integrity: sha512-PK6M1A1tt3ky6cFAJW/JOO9ml/sbEvim+SL75FM8slck08ACbF0TZj+tdUd3Mh8Tk5XieqUDPwmLjiyRQvb4pw==}
 
   unicorn-magic@0.3.0:
     resolution: {integrity: sha512-+QBBXBCvifc56fsbuxZQ6Sic3wqqc3WWaqxs58gvJrcOuN83HGTCwz3oS5phzU9LthRNE9VrJCFCLUgHeeFnfA==}
@@ -27662,6 +27668,8 @@ snapshots:
   unicode-match-property-value-ecmascript@2.2.0: {}
 
   unicode-property-aliases-ecmascript@2.1.0: {}
+
+  unicode-segmenter@0.12.0: {}
 
   unicorn-magic@0.3.0: {}
 


### PR DESCRIPTION
Replaces `Intl.Segmenter` with `unicode-segmenter`.
Also switches mapping to grapheme-based, rather than code-point-based (matching the string splitting).

Close #2186 