### PR TITLE
fix(inspector): colist shows too many items after navigating from a longer colist

### DIFF
--- a/.changeset/hot-jars-bow.md
+++ b/.changeset/hot-jars-bow.md
@@ -1,0 +1,5 @@
+---
+"jazz-inspector": patch
+---
+
+fix: colist shows too many items after navigating from a longer colist

--- a/packages/jazz-inspector/src/ui/global-styles.tsx
+++ b/packages/jazz-inspector/src/ui/global-styles.tsx
@@ -43,7 +43,6 @@ export const GlobalStyles = styled("div")`
 
   @media (prefers-color-scheme: dark) {
     --j-text-color: var(--j-neutral-400);
-    --j-link-color: #5870f1;
     --j-border-color: var(--j-neutral-900);
     --j-background: var(--j-neutral-950);
     --j-foreground: var(--j-neutral-925);

--- a/packages/jazz-inspector/src/viewer/use-resolve-covalue.ts
+++ b/packages/jazz-inspector/src/viewer/use-resolve-covalue.ts
@@ -195,7 +195,7 @@ export function useResolvedCoValues(
       const unsubscribe = subscribeToCoValue(coValueId, node, (newResult) => {
         if (isMounted) {
           setResults((prevResults) => {
-            const newResults = [...prevResults];
+            const newResults = prevResults.slice(0, coValueIds.length);
             newResults[index] = newResult;
             return newResults;
           });


### PR DESCRIPTION
closes #2193
