### PR TITLE
feat: make the SyncManager async-free, support parallel load on server peers

### DIFF
--- a/packages/cojson/src/sync.ts
+++ b/packages/cojson/src/sync.ts
@@ -298,7 +298,7 @@ export class SyncManager {
     }
   }
 
-  async addPeer(peer: Peer) {
+  addPeer(peer: Peer) {
     const prevPeer = this.peers[peer.id];
 
     if (prevPeer && !prevPeer.closed) {
@@ -379,65 +379,17 @@ export class SyncManager {
     peer.setKnownState(msg.id, knownStateIn(msg));
     const coValue = this.local.getCoValue(msg.id);
 
-    if (
-      coValue.loadingState === "unknown" ||
-      coValue.loadingState === "unavailable"
-    ) {
-      const eligiblePeers = this.getServerAndStoragePeers(peer.id);
-
-      if (eligiblePeers.length === 0) {
-        // We don't have any eligible peers to load the coValue from
-        // so we send a known state back to the sender to let it know
-        // that the coValue is unavailable
-        peer.trackToldKnownState(msg.id);
-        this.trySendToPeer(peer, {
-          action: "known",
-          id: msg.id,
-          header: false,
-          sessions: {},
-        });
-
-        return;
-      } else {
-        // Syncronously updates the state loading is possible
-        coValue
-          .loadFromPeers(this.getServerAndStoragePeers(peer.id))
-          .catch((e) => {
-            logger.error("Error loading coValue in handleLoad", { err: e });
-          });
-      }
+    if (coValue.isAvailable()) {
+      this.sendNewContentIncludingDependencies(msg.id, peer);
+      return;
     }
 
-    if (coValue.loadingState === "loading") {
-      // We need to return from handleLoad immediately and wait for the CoValue to be loaded
-      // in a new task, otherwise we might block further incoming content messages that would
-      // resolve the CoValue as available. This can happen when we receive fresh
-      // content from a client, but we are a server with our own upstream server(s)
-      coValue
-        .waitForAvailableOrUnavailable()
-        .then(async (value) => {
-          if (!value.isAvailable()) {
-            peer.trackToldKnownState(msg.id);
-            this.trySendToPeer(peer, {
-              action: "known",
-              id: msg.id,
-              header: false,
-              sessions: {},
-            });
+    const eligiblePeers = this.getServerAndStoragePeers(peer.id);
 
-            return;
-          }
-
-          this.sendNewContentIncludingDependencies(msg.id, peer);
-        })
-        .catch((e) => {
-          logger.error("Error loading coValue in handleLoad loading state", {
-            err: e,
-          });
-        });
-    } else if (coValue.isAvailable()) {
-      this.sendNewContentIncludingDependencies(msg.id, peer);
-    } else {
+    if (eligiblePeers.length === 0) {
+      // We don't have any eligible peers to load the coValue from
+      // so we send a known state back to the sender to let it know
+      // that the coValue is unavailable
       peer.trackToldKnownState(msg.id);
       this.trySendToPeer(peer, {
         action: "known",
@@ -445,7 +397,40 @@ export class SyncManager {
         header: false,
         sessions: {},
       });
+
+      return;
     }
+
+    coValue.loadFromPeers(eligiblePeers).catch((e) => {
+      logger.error("Error loading coValue in handleLoad", { err: e });
+    });
+
+    // We need to return from handleLoad immediately and wait for the CoValue to be loaded
+    // in a new task, otherwise we might block further incoming content messages that would
+    // resolve the CoValue as available. This can happen when we receive fresh
+    // content from a client, but we are a server with our own upstream server(s)
+    coValue
+      .waitForAvailableOrUnavailable()
+      .then((value) => {
+        if (!value.isAvailable()) {
+          peer.trackToldKnownState(msg.id);
+          this.trySendToPeer(peer, {
+            action: "known",
+            id: msg.id,
+            header: false,
+            sessions: {},
+          });
+
+          return;
+        }
+
+        this.sendNewContentIncludingDependencies(msg.id, peer);
+      })
+      .catch((e) => {
+        logger.error("Error loading coValue in handleLoad loading state", {
+          err: e,
+        });
+      });
   }
 
   handleKnownState(msg: KnownStateMessage, peer: PeerState) {
@@ -607,6 +592,8 @@ export class SyncManager {
         // Check if there is a inflight load operation and we
         // are waiting for other peers to send the load request
         if (state === "unknown" || state === undefined) {
+          // Sending a load message to the peer to get to know how much content is missing
+          // before sending the new content
           this.trySendToPeer(peer, {
             action: "load",
             ...coValue.knownState(),
@@ -645,7 +632,7 @@ export class SyncManager {
     this.requestedSyncs.add(coValue.id);
   }
 
-  async syncCoValue(coValue: CoValueCore) {
+  syncCoValue(coValue: CoValueCore) {
     this.requestedSyncs.delete(coValue.id);
 
     for (const peer of this.peersInPriorityOrder()) {
@@ -668,21 +655,21 @@ export class SyncManager {
     }
   }
 
-  async waitForSyncWithPeer(peerId: PeerID, id: RawCoID, timeout: number) {
+  waitForSyncWithPeer(peerId: PeerID, id: RawCoID, timeout: number) {
     const { syncState } = this;
     const currentSyncState = syncState.getCurrentSyncState(peerId, id);
 
     const isTheConditionAlreadyMet = currentSyncState.uploaded;
 
     if (isTheConditionAlreadyMet) {
-      return true;
+      return;
     }
 
     const peerState = this.peers[peerId];
 
     // The peer has been closed, so it isn't possible to sync
     if (!peerState || peerState.closed) {
-      return true;
+      return;
     }
 
     // The client isn't subscribed to the coValue, so we won't sync it
@@ -690,7 +677,7 @@ export class SyncManager {
       peerState.role === "client" &&
       !peerState.optimisticKnownStates.has(id)
     ) {
-      return true;
+      return;
     }
 
     return new Promise((resolve, reject) => {
@@ -712,25 +699,25 @@ export class SyncManager {
     });
   }
 
-  async waitForStorageSync(id: RawCoID, timeout = 30_000) {
+  waitForStorageSync(id: RawCoID, timeout = 30_000) {
     const peers = this.getPeers();
 
-    await Promise.all(
+    return Promise.all(
       peers
         .filter((peer) => peer.role === "storage")
         .map((peer) => this.waitForSyncWithPeer(peer.id, id, timeout)),
     );
   }
 
-  async waitForSync(id: RawCoID, timeout = 30_000) {
+  waitForSync(id: RawCoID, timeout = 30_000) {
     const peers = this.getPeers();
 
-    await Promise.all(
+    return Promise.all(
       peers.map((peer) => this.waitForSyncWithPeer(peer.id, id, timeout)),
     );
   }
 
-  async waitForAllCoValuesSync(timeout = 60_000) {
+  waitForAllCoValuesSync(timeout = 60_000) {
     const coValues = this.local.allCoValues();
     const validCoValues = Array.from(coValues).filter(
       (coValue) =>

--- a/packages/cojson/src/tests/SyncStateManager.test.ts
+++ b/packages/cojson/src/tests/SyncStateManager.test.ts
@@ -257,7 +257,7 @@ describe("SyncStateManager", () => {
     const group = client.node.createGroup();
     const map = group.createMap();
 
-    await expect(map.core.waitForSync()).resolves.toBeUndefined();
+    await map.core.waitForSync();
   });
 
   test("should skip client peers that are not subscribed to the coValue", async () => {

--- a/packages/cojson/src/tests/testUtils.ts
+++ b/packages/cojson/src/tests/testUtils.ts
@@ -463,6 +463,7 @@ export function createMockStoragePeer(opts: {
     },
   });
 
+  peer1.role = "storage";
   peer1.priority = 100;
 
   storage.syncManager.addPeer(peer2);

--- a/packages/jazz-tools/src/tests/patterns/requestToJoin.test.ts
+++ b/packages/jazz-tools/src/tests/patterns/requestToJoin.test.ts
@@ -72,6 +72,8 @@ async function setup() {
 
   const organizationId = organization.id;
 
+  await admin1.waitForAllCoValuesSync();
+
   return {
     admin1,
     admin2,


### PR DESCRIPTION
Adding support parallel load on server peers to make it possible to keep a server peer open while the connection is down and not block the other server peers.
