### PR TITLE
fix(flake): stick with `pnpm@9.x`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -20,11 +20,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1739580444,
-        "narHash": "sha256-+/bSz4EAVbqz8/HsIGLroF8aNaO8bLRL7WfACN+24g4=",
+        "lastModified": 1746904237,
+        "narHash": "sha256-3e+AVBczosP5dCLQmMoMEogM57gmZ2qrVSrmq9aResQ=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "8bb37161a0488b89830168b81c48aed11569cb93",
+        "rev": "d89fc19e405cb2d55ce7cc114356846a0ee5e956",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -22,7 +22,7 @@
             
             # JS development
             nodejs_22
-            nodePackages.pnpm
+            pnpm_9
           ];
 
           shellHook = ''


### PR DESCRIPTION
to be in sync with `pnpm` version [defined in `package.json`](https://github.com/garden-co/jazz/blob/12e983785824c21dba29c89555aafeb16d91d13a/package.json#L6) (currently `9.15.0`). In other case
`pnpm@10` is used and `pnpm i` or other commands won't work properly