### PR TITLE
feat(load): increase retry delay and immediately resolve on available

### DIFF
--- a/.changeset/heavy-dolphins-kiss.md
+++ b/.changeset/heavy-dolphins-kiss.md
@@ -1,0 +1,5 @@
+---
+"cojson": patch
+---
+
+Load: increase the coValue retry delay and stop waiting as soon as the value becomes available

--- a/packages/cojson/src/coValueCore/coValueCore.ts
+++ b/packages/cojson/src/coValueCore/coValueCore.ts
@@ -67,7 +67,7 @@ export type AvailableCoValueCore = CoValueCore & { verified: VerifiedState };
 export const CO_VALUE_LOADING_CONFIG = {
   MAX_RETRIES: 1,
   TIMEOUT: 30_000,
-  RETRY_DELAY: 300,
+  RETRY_DELAY: 3000,
 };
 
 export class CoValueCore {
@@ -183,6 +183,20 @@ export class CoValueCore {
     return new Promise<CoValueCore>((resolve) => {
       const listener = (core: CoValueCore) => {
         if (core.isAvailable() || core.loadingState === "unavailable") {
+          resolve(core);
+          this.listeners.delete(listener);
+        }
+      };
+
+      this.listeners.add(listener);
+      listener(this);
+    });
+  }
+
+  waitForAvailable(): Promise<CoValueCore> {
+    return new Promise<CoValueCore>((resolve) => {
+      const listener = (core: CoValueCore) => {
+        if (core.isAvailable()) {
           resolve(core);
           this.listeners.delete(listener);
         }

--- a/packages/cojson/src/exports.ts
+++ b/packages/cojson/src/exports.ts
@@ -103,6 +103,9 @@ export const cojsonInternals = {
   getGroupDependentKey,
   disablePermissionErrors,
   CO_VALUE_LOADING_CONFIG,
+  setCoValueLoadingRetryDelay(delay: number) {
+    CO_VALUE_LOADING_CONFIG.RETRY_DELAY = delay;
+  },
 };
 
 export {

--- a/packages/cojson/src/tests/testUtils.ts
+++ b/packages/cojson/src/tests/testUtils.ts
@@ -8,12 +8,12 @@ import {
 import { expect, onTestFinished, vi } from "vitest";
 import { ControlledAccount, ControlledAgent } from "../coValues/account.js";
 import { WasmCrypto } from "../crypto/WasmCrypto.js";
-import type {
-  AgentSecret,
-  CoID,
-  CoValueCore,
-  RawAccount,
-  RawCoValue,
+import {
+  type AgentSecret,
+  type CoID,
+  type CoValueCore,
+  type RawAccount,
+  type RawCoValue,
 } from "../exports.js";
 import type { SessionID } from "../ids.js";
 import { LocalNode } from "../localNode.js";

--- a/packages/jazz-react-core/src/tests/useCoState.test.ts
+++ b/packages/jazz-react-core/src/tests/useCoState.test.ts
@@ -19,10 +19,7 @@ beforeEach(async () => {
   });
 });
 
-beforeEach(() => {
-  cojsonInternals.CO_VALUE_LOADING_CONFIG.MAX_RETRIES = 1;
-  cojsonInternals.CO_VALUE_LOADING_CONFIG.TIMEOUT = 1;
-});
+cojsonInternals.setCoValueLoadingRetryDelay(300);
 
 describe("useCoState", () => {
   it("should return the correct value", async () => {

--- a/packages/jazz-svelte/src/lib/tests/useCoState.svelte.test.ts
+++ b/packages/jazz-svelte/src/lib/tests/useCoState.svelte.test.ts
@@ -16,10 +16,7 @@ beforeEach(async () => {
   await setupJazzTestSync();
 });
 
-beforeEach(() => {
-  cojsonInternals.CO_VALUE_LOADING_CONFIG.MAX_RETRIES = 1;
-  cojsonInternals.CO_VALUE_LOADING_CONFIG.TIMEOUT = 1;
-});
+cojsonInternals.setCoValueLoadingRetryDelay(300);
 
 function setup<T extends CoValue>(options: { account: Account; map: T; resolve?: RefsToResolve<T> }) {
   const result = { current: undefined } as { current: T | undefined };

--- a/packages/jazz-tools/src/tests/subscribe.test.ts
+++ b/packages/jazz-tools/src/tests/subscribe.test.ts
@@ -30,6 +30,8 @@ import {
 } from "../testing.js";
 import { setupAccount, waitFor } from "./utils.js";
 
+cojsonInternals.setCoValueLoadingRetryDelay(300);
+
 class ChatRoom extends CoMap {
   messages = co.ref(MessagesList);
   name = co.string;

--- a/packages/jazz-vue/src/tests/useCoState.test.ts
+++ b/packages/jazz-vue/src/tests/useCoState.test.ts
@@ -11,10 +11,7 @@ beforeEach(async () => {
   await setupJazzTestSync();
 });
 
-beforeEach(() => {
-  cojsonInternals.CO_VALUE_LOADING_CONFIG.MAX_RETRIES = 1;
-  cojsonInternals.CO_VALUE_LOADING_CONFIG.TIMEOUT = 1;
-});
+cojsonInternals.setCoValueLoadingRetryDelay(300);
 
 describe("useCoState", () => {
   it("should return the correct value", async () => {


### PR DESCRIPTION
The `unavailable` state in Jazz should be considered a transient error state, but for the `load` function is a one-time call, so we can return only a "final" result.

Very often a value is declared `unavailable` either because:
- when requested it haven't reached yet the sync server / current edge
- when requested the connection is down

For both cases the current delay of 300ms is often not enough, so I'm increasing the delay to 3s.

To keep the `load` API responsive, I've added a race condition check on `isAvailable` so we can interrupt the timeout and immediately resolve when the value becomes available.
