### PR TITLE
form design pattern docs: emphasize not having a save button

### DIFF
--- a/examples/form/src/schema.ts
+++ b/examples/form/src/schema.ts
@@ -77,6 +77,7 @@ export class JazzAccount extends Account {
       const draft = DraftBubbleTeaOrder.create(
         {
           addOns: ListOfBubbleTeaAddOns.create([], account),
+          instructions: CoPlainText.create("", account),
         },
         account,
       );

--- a/homepage/homepage/content/docs/design-patterns/form.mdx
+++ b/homepage/homepage/content/docs/design-patterns/form.mdx
@@ -2,23 +2,18 @@ export const metadata = { title: "Form design pattern" };
 
 import { CodeGroup } from "@/components/forMdx";
 
-# Creating and updating CoValues in a form
+# How to write autosaving forms to create and update CoValues
 
-Normally, we implement forms using
-[the onSubmit handler](https://react.dev/reference/react-dom/components/form#handle-form-submission-on-the-client),
-or by making [a controlled form with useState](https://christinakozanian.medium.com/building-controlled-forms-with-usestate-in-react-f9053ad255a0),
-or by using special libraries like [react-hook-form](https://www.react-hook-form.com).
+This guide shows you a simple and powerful way to implement forms for creating and updating CoValues.
 
-In Jazz, we can do something simpler and more powerful, because CoValues give us reactive,
-persisted state which we can use to directly edit live objects. This lets us:
-1. Remove the need for a save button on update forms.
-2. Represent auto-saved drafts.
+We'll build:
+1. An update form that saves changes as you make them, removing the need for a save button.
+2. A create form that autosaves your changes into a draft, so you can come back to it later.
 
 [See the full example here.](https://github.com/garden-co/jazz/tree/main/examples/form)
 
-**Note**: If you do need a save button on your update form, this design pattern is not for you.
-One option is to use react-hook-form, which is used in the
-[password manager example](https://github.com/garden-co/jazz/tree/main/examples/password-manager).
+**Note**: If you do need a save button on your update form, this guide is not for you. Another option
+is to use [react-hook-form](https://www.react-hook-form.com), which you can see in [this example](https://github.com/garden-co/jazz/tree/main/examples/password-manager).
 
 ## Updating a CoValue
 

--- a/homepage/homepage/content/docs/design-patterns/form.mdx
+++ b/homepage/homepage/content/docs/design-patterns/form.mdx
@@ -10,14 +10,19 @@ or by making [a controlled form with useState](https://christinakozanian.medium.
 or by using special libraries like [react-hook-form](https://www.react-hook-form.com).
 
 In Jazz, we can do something simpler and more powerful, because CoValues give us reactive,
-persisted state which we can use to directly edit live objects, and represent auto-saved drafts.
+persisted state which we can use to directly edit live objects. This lets us:
+1. Remove the need for a save button on update forms.
+2. Represent auto-saved drafts.
 
 [See the full example here.](https://github.com/garden-co/jazz/tree/main/examples/form)
 
+**Note**: If you do need a save button on your update form, this design pattern is not for you.
+One option is to use react-hook-form, which is used in the
+[password manager example](https://github.com/garden-co/jazz/tree/main/examples/password-manager).
+
 ## Updating a CoValue
 
-To update a CoValue, we simply assign the new value directly as changes happen. These changes are synced to the server, so
-we don't need to handle form submissions either.
+To update a CoValue, we simply assign the new value directly as changes happen. These changes are synced to the server.
 
 <CodeGroup>
 ```tsx
@@ -29,7 +34,7 @@ we don't need to handle form submissions either.
 ```
 </CodeGroup>
 
-This means we can write update forms in fewer lines of code.
+It's that simple!
 
 ## Creating a CoValue
 

--- a/homepage/homepage/content/docs/docNavigationItems.js
+++ b/homepage/homepage/content/docs/docNavigationItems.js
@@ -265,7 +265,7 @@ export const docNavigationItems = [
     name: "Design patterns",
     items: [
       {
-        name: "Form",
+        name: "Autosaving forms",
         href: "/docs/design-patterns/form",
         done: 100,
       },


### PR DESCRIPTION
We don't always want an auto-saving form. For example, in the dashboard, none of our forms autosave because we don't want users accidentally changing important information. 

This change emphasizes that the form design pattern is not a fit if you need that save button.

Ideally, the form example would also show how to make a form with a save button, but for now I'm just linking to the password manager example. Related: #1287

fixes #2209 