### PR TITLE
feat: add $onError to catch errors on resolve

### DIFF
--- a/.changeset/bright-hotels-tap.md
+++ b/.changeset/bright-hotels-tap.md
@@ -1,0 +1,5 @@
+---
+"jazz-tools": patch
+---
+
+Add $skipInvalid option to resolve, to be able to catch errors inside of the deep loading

--- a/.changeset/bright-hotels-tap.md
+++ b/.changeset/bright-hotels-tap.md
@@ -2,4 +2,4 @@
 "jazz-tools": patch
 ---
 
-Add $skipInvalid option to resolve, to be able to catch errors inside of the deep loading
+Add $onError option to resolve, to be able to catch errors inside of the deep loading

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -13,7 +13,7 @@ jobs:
     continue-on-error: true
     strategy:
       matrix:
-        project: ["tests/e2e", "examples/chat",  "examples/clerk", "examples/betterauth", "examples/file-share-svelte", "examples/form", "examples/music-player", "examples/pets", "starters/react-passkey-auth"]
+        project: ["tests/e2e", "examples/chat",  "examples/clerk", "examples/betterauth", "examples/file-share-svelte", "examples/form", "examples/music-player", "examples/organization", "examples/pets", "starters/react-passkey-auth"]
 
     steps:
       - uses: actions/checkout@v4

--- a/examples/organization/.gitignore
+++ b/examples/organization/.gitignore
@@ -22,3 +22,5 @@ dist-ssr
 *.njsproj
 *.sln
 *.sw?
+
+playwright-report

--- a/examples/organization/package.json
+++ b/examples/organization/package.json
@@ -8,7 +8,9 @@
     "build": "vite build",
     "preview": "vite preview",
     "format-and-lint": "biome check .",
-    "format-and-lint:fix": "biome check . --write"
+    "format-and-lint:fix": "biome check . --write",
+    "test:e2e": "playwright test",
+    "test:e2e:ui": "playwright test --ui"
   },
   "dependencies": {
     "jazz-react": "workspace:*",
@@ -20,6 +22,7 @@
     "react-router-dom": "^6.16.0"
   },
   "devDependencies": {
+    "@playwright/test": "^1.50.1",
     "@biomejs/biome": "1.9.4",
     "@tailwindcss/forms": "^0.5.9",
     "@types/react": "^18.3.12",

--- a/examples/organization/playwright.config.ts
+++ b/examples/organization/playwright.config.ts
@@ -1,0 +1,53 @@
+import { defineConfig, devices } from "@playwright/test";
+import isCI from "is-ci";
+
+/**
+ * Read environment variables from file.
+ * https://github.com/motdotla/dotenv
+ */
+// import dotenv from 'dotenv';
+// dotenv.config({ path: path.resolve(__dirname, '.env') });
+
+/**
+ * See https://playwright.dev/docs/test-configuration.
+ */
+export default defineConfig({
+  testDir: "./tests",
+  /* Run tests in files in parallel */
+  fullyParallel: true,
+  /* Fail the build on CI if you accidentally left test.only in the source code. */
+  forbidOnly: isCI,
+  /* Retry on CI only */
+  retries: isCI ? 2 : 0,
+  /* Opt out of parallel tests on CI. */
+  workers: isCI ? 1 : undefined,
+  /* Reporter to use. See https://playwright.dev/docs/test-reporters */
+  reporter: "html",
+
+  /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
+  use: {
+    /* Base URL to use in actions like `await page.goto('/')`. */
+    baseURL: "http://localhost:5173/",
+
+    /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
+    trace: "on-first-retry",
+    permissions: ["clipboard-read", "clipboard-write"],
+  },
+
+  /* Configure projects for major browsers */
+  projects: [
+    {
+      name: "chromium",
+      use: { ...devices["Desktop Chrome"] },
+    },
+  ],
+
+  /* Run your local dev server before starting the tests */
+  webServer: [
+    {
+      command: "pnpm preview --port 5173",
+      url: "http://localhost:5173/",
+      reuseExistingServer: !isCI,
+    },
+  ],
+});

--- a/examples/organization/src/HomePage.tsx
+++ b/examples/organization/src/HomePage.tsx
@@ -5,7 +5,14 @@ import { Heading } from "./components/Heading.tsx";
 
 export function HomePage() {
   const { me } = useAccount({
-    resolve: { root: { organizations: true } },
+    resolve: {
+      root: {
+        organizations: {
+          $each: true,
+          $skipInvalid: true,
+        },
+      },
+    },
   });
 
   if (!me?.root.organizations) return;

--- a/examples/organization/src/HomePage.tsx
+++ b/examples/organization/src/HomePage.tsx
@@ -8,8 +8,7 @@ export function HomePage() {
     resolve: {
       root: {
         organizations: {
-          $each: true,
-          $skipInvalid: true,
+          $each: { $onError: null },
         },
       },
     },

--- a/examples/organization/src/Layout.tsx
+++ b/examples/organization/src/Layout.tsx
@@ -3,7 +3,7 @@ import { UserIcon } from "lucide-react";
 
 export function Layout({ children }: { children: React.ReactNode }) {
   const { me, logOut } = useAccount({
-    resolve: { root: { draftOrganization: true } },
+    resolve: { profile: true },
   });
 
   return (
@@ -16,7 +16,20 @@ export function Layout({ children }: { children: React.ReactNode }) {
             <span className="bg-stone-500 pt-1 size-6 flex items-center justify-center rounded-full">
               <UserIcon size={20} className="stroke-white" />
             </span>
-            {me?.profile?.name}
+            <label htmlFor="profile-name" className="sr-only">
+              Profile name
+            </label>
+            <input
+              id="profile-name"
+              type="text"
+              value={me?.profile.name ?? ""}
+              className="rounded-md shadow-sm dark:bg-transparent text-sm py-1.5 px-3"
+              onChange={(e) => {
+                if (me) {
+                  me.profile.name = e.target.value;
+                }
+              }}
+            />
           </span>
 
           <button

--- a/examples/organization/src/OrganizationPage.tsx
+++ b/examples/organization/src/OrganizationPage.tsx
@@ -16,7 +16,21 @@ export function OrganizationPage() {
     resolve: { projects: true },
   });
 
-  if (!organization) return <p>Loading organization...</p>;
+  if (organization === undefined) return <p>Loading organization...</p>;
+  if (organization === null) {
+    return (
+      <div className="h-full flex items-center justify-center">
+        <div className="text-center">
+          <h1 className="text-2xl font-bold">
+            You don't have access to this organization
+          </h1>
+          <a href="/#" className="text-blue-500">
+            Go back to home
+          </a>
+        </div>
+      </div>
+    );
+  }
 
   return (
     <Layout>

--- a/examples/organization/src/components/OrganizationForm.tsx
+++ b/examples/organization/src/components/OrganizationForm.tsx
@@ -27,7 +27,7 @@ export function OrganizationForm({
           type="submit"
           className="bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded"
         >
-          Submit
+          Create
         </button>
       )}
     </form>

--- a/examples/organization/src/components/OrganizationMembers.tsx
+++ b/examples/organization/src/components/OrganizationMembers.tsx
@@ -1,4 +1,5 @@
-import { Group } from "jazz-tools";
+import { useAccount, useCoState } from "jazz-react";
+import { Account, Group, ID } from "jazz-tools";
 import { Organization } from "../schema.ts";
 
 export function OrganizationMembers({
@@ -9,13 +10,51 @@ export function OrganizationMembers({
   return (
     <>
       {group.members.map((member) => (
-        <div key={member.id} className="px-4 py-5 sm:px-6">
-          <strong className="font-medium">
-            {member.account.profile?.name}
-          </strong>{" "}
-          ({member.role})
-        </div>
+        <MemberItem
+          key={member.id}
+          accountId={member.account.id}
+          role={member.role}
+          group={group}
+        />
       ))}
     </>
+  );
+}
+
+function MemberItem({
+  accountId,
+  role,
+  group,
+}: { accountId: ID<Account>; role: string; group: Group }) {
+  const account = useCoState(Account, accountId, {
+    resolve: {
+      profile: true,
+    },
+  });
+  const { me } = useAccount();
+
+  const canRemoveMember = group.myRole() === "admin" && accountId !== me?.id;
+
+  function handleRemoveMember() {
+    if (canRemoveMember && account) {
+      group.removeMember(account);
+    }
+  }
+
+  return (
+    <div className="px-4 py-5 sm:px-6 flex justify-between items-center">
+      <div>
+        <strong className="font-medium">{account?.profile.name}</strong> ({role}
+        )
+      </div>
+      {canRemoveMember && (
+        <button
+          className="bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded"
+          onClick={handleRemoveMember}
+        >
+          Remove member
+        </button>
+      )}
+    </div>
   );
 }

--- a/examples/organization/src/components/OrganizationSelector.tsx
+++ b/examples/organization/src/components/OrganizationSelector.tsx
@@ -7,7 +7,7 @@ import { Organization } from "../schema.ts";
 
 export function OrganizationSelector({ className }: { className?: string }) {
   const { me } = useAccount({
-    resolve: { root: { organizations: { $each: true } } },
+    resolve: { root: { organizations: { $each: true, $skipInvalid: true } } },
   });
 
   const navigate = useNavigate();
@@ -48,6 +48,10 @@ export function OrganizationSelector({ className }: { className?: string }) {
         className="rounded-md shadow-sm dark:bg-transparent w-full"
       >
         {me?.root.organizations.map((organization) => {
+          if (!organization) {
+            return null;
+          }
+
           return (
             <option key={organization.id} value={organization.id}>
               {organization.name}

--- a/examples/organization/src/components/OrganizationSelector.tsx
+++ b/examples/organization/src/components/OrganizationSelector.tsx
@@ -7,7 +7,7 @@ import { Organization } from "../schema.ts";
 
 export function OrganizationSelector({ className }: { className?: string }) {
   const { me } = useAccount({
-    resolve: { root: { organizations: { $each: true, $skipInvalid: true } } },
+    resolve: { root: { organizations: { $each: { $onError: null } } } },
   });
 
   const navigate = useNavigate();

--- a/examples/organization/src/util.ts
+++ b/examples/organization/src/util.ts
@@ -1,0 +1,16 @@
+const animals = [
+  "elephant",
+  "penguin",
+  "giraffe",
+  "octopus",
+  "kangaroo",
+  "dolphin",
+  "cheetah",
+  "koala",
+  "platypus",
+  "pangolin",
+];
+
+export function getRandomUsername() {
+  return `Anonymous ${animals[Math.floor(Math.random() * animals.length)]}`;
+}

--- a/examples/organization/tests/createAndShare.spec.ts
+++ b/examples/organization/tests/createAndShare.spec.ts
@@ -1,0 +1,65 @@
+import { BrowserContext, expect, test } from "@playwright/test";
+
+test("create a new organization and share", async ({
+  page: marioPage,
+  browser,
+}) => {
+  await marioPage.goto("/");
+
+  const luigiContext = await browser.newContext();
+  const luigiPage = await luigiContext.newPage();
+  await luigiPage.goto("/");
+
+  await test.step("Set the profile names", async () => {
+    await marioPage
+      .getByRole("textbox", { name: "Profile name" })
+      .fill("Mario");
+    await luigiPage
+      .getByRole("textbox", { name: "Profile name" })
+      .fill("Luigi");
+  });
+
+  await test.step("Create a new organization", async () => {
+    await marioPage
+      .getByRole("textbox", { name: "Organization name" })
+      .fill("Mario's organization");
+    await marioPage.getByRole("button", { name: "Create" }).click();
+
+    await expect(
+      marioPage.getByRole("heading", { name: "Mario's organization" }),
+    ).toBeVisible();
+  });
+
+  await test.step("Invite Luigi to the organization", async () => {
+    await marioPage.getByRole("button", { name: "Copy invite link" }).click();
+
+    const inviteUrl = await marioPage.evaluate(() =>
+      navigator.clipboard.readText(),
+    );
+
+    await luigiPage.goto(inviteUrl);
+
+    await expect(
+      luigiPage.getByRole("heading", { name: "Mario's organization" }),
+    ).toBeVisible();
+    await expect(marioPage.getByText("Luigi")).toBeVisible();
+  });
+
+  await test.step("Kick out Luigi from the organization", async () => {
+    await marioPage.getByRole("button", { name: "Remove" }).click();
+
+    await expect(marioPage.getByText("Luigi")).not.toBeVisible();
+
+    await expect(
+      luigiPage.getByRole("heading", {
+        name: "You don't have access to this organization",
+      }),
+    ).toBeVisible();
+
+    await luigiPage.getByRole("link", { name: "Go back to home" }).click();
+
+    await expect(
+      luigiPage.getByRole("heading", { name: "Organizations example app" }),
+    ).toBeVisible();
+  });
+});

--- a/homepage/homepage/content/docs/design-patterns/organization.mdx
+++ b/homepage/homepage/content/docs/design-patterns/organization.mdx
@@ -151,11 +151,11 @@ declare module "jazz-react" {
 // ---cut---
 export function AcceptInvitePage() {
   const { me } = useAccount({
-    resolve: { root: { organizations: { $each: true, $skipInvalid: true } } },
+    resolve: { root: { organizations: { $each: { $onError: null } } } },
   });
 
   const onAccept = (organizationId: ID<Organization>) => {
-    if (me?.root?.organizations) {
+    if (me) {
       Organization.load(organizationId).then((organization) => {
         if (organization) {
           // avoid duplicates

--- a/homepage/homepage/content/docs/design-patterns/organization.mdx
+++ b/homepage/homepage/content/docs/design-patterns/organization.mdx
@@ -150,7 +150,9 @@ declare module "jazz-react" {
 }
 // ---cut---
 export function AcceptInvitePage() {
-  const { me } = useAccount({ resolve: { root: { organizations: true } } });
+  const { me } = useAccount({
+    resolve: { root: { organizations: { $each: true, $skipInvalid: true } } },
+  });
 
   const onAccept = (organizationId: ID<Organization>) => {
     if (me?.root?.organizations) {

--- a/homepage/homepage/content/docs/using-covalues/subscription-and-loading.mdx
+++ b/homepage/homepage/content/docs/using-covalues/subscription-and-loading.mdx
@@ -455,57 +455,23 @@ const project = await Project.load(projectId, {
   resolve: true
 });
 
-project // => Project is null if the user doesn't have access
+project // => Project
+
+// The user doesn't have access to the owner
+project?.owner // => always null
 ```
 </CodeGroup>
 
 The load operation will succeed and return the object, but the inaccessible reference will always be `null`.
 
-The same behavoir applies when one of the deeply loaded items is inaccessible.
 
-<CodeGroup>
-```typescript twoslash
-import { ID, CoMap, co, CoList } from "jazz-tools";
-
-class Project extends CoMap {
-  name = co.string;
-  tasks = co.ref(ListOfTasks);
-  owner = co.ref(TeamMember);
-}
-
-class Task extends CoMap {
-  title = co.string;
-  subtasks = co.ref(ListOfTasks);
-  assignee = co.optional.ref(TeamMember);
-}
-
-class TeamMember extends CoMap {
-  name = co.string;
-}
-
-class ListOfTasks extends CoList.Of(co.ref(Task)) {}
-
-const projectId = "co_123" as ID<Project>;
-// ---cut-before---
-const project = await Project.load(projectId, {
-  resolve: { tasks: { $each: true } }
-});
-
-/**
- * Project is null if the user doesn't have access
- * to project or to any of the tasks
-*/ 
-project 
-```
-</CodeGroup>
-
-## Deep loading lists with shared items
+#### Deep loading lists with shared items
 
 When loading a list with shared items, you can use the `$skipInvalid` to safely load the list skipping any inaccessible items.
 
 This is especially useful when in your app access to these items might be revoked.
 
-This way, when encountering an inaccessible item, the inaccessible items are replaced with `null` in the returned list.
+This way the inaccessible items are replaced with `null` in the returned list.
 
 <CodeGroup>
 ```typescript twoslash
@@ -537,14 +503,14 @@ const project = await Project.load(projectId, {
 
 assert(project);
 
-const [task1, task2] = project.tasks ?? [];
+const [task1, task2] = project.tasks;
 
 task1 // => Task
 task2 // => null because the task is inaccessible
 ```
 </CodeGroup>
 
-The `$skipInvalid` works as a "catch" clause option to block any error in the childs resolve.
+The `$skipInvalid` works as a "catch" clause option to block any error in the resolved childs.
 
 <CodeGroup>
 ```typescript twoslash
@@ -582,7 +548,7 @@ const project = await Project.load(projectId, {
 
 assert(project);
 
-const [task1, task2] = project.tasks ?? [];
+const [task1, task2] = project.tasks;
 
 task1 // => Task, everything inside is loaded
 task2 // => null because the one of the task2 subtasks is inaccessible

--- a/homepage/homepage/content/docs/using-covalues/subscription-and-loading.mdx
+++ b/homepage/homepage/content/docs/using-covalues/subscription-and-loading.mdx
@@ -476,7 +476,7 @@ This way the inaccessible items are replaced with `null` in the returned list.
 <CodeGroup>
 ```typescript twoslash
 import { ID, CoMap, CoList, co, Group, Account } from "jazz-tools";
-import { expect, assert } from "vitest";
+import { assert } from "vitest";
 
 class Person extends CoMap {
   name = co.string;
@@ -515,16 +515,17 @@ const friends = await Friends.load(source.id, {
 
 // Thanks to $onError catching the errors, the list is loaded
 // because we have access to friends
-expect(friends).not.toBeNull();
+friends // => Friends
 
 assert(friends);
 
 // Jane is null because we lack access rights
 // and we have used $onError to catch the error on the list items
-expect(friends[0]).toBeNull();
+friends[0] // => null
+
 // Alice is not null because we have access
 // the type is nullable because we have used $onError
-expect(friends[1]?.name).toBe("Alice");
+friends[1] // => Person
 ```
 </CodeGroup>
 
@@ -533,7 +534,7 @@ The `$onError` works as a "catch" clause option to block any error in the resolv
 <CodeGroup>
 ```typescript twoslash
 import { ID, CoMap, CoList, co, Group, Account } from "jazz-tools";
-import { expect, assert } from "vitest";
+import { assert } from "vitest";
 
 class Person extends CoMap {
   name = co.string;
@@ -581,7 +582,7 @@ assert(friends);
 
 // Jane is null because we don't have access to Rex
 // and we have used $onError to catch the error on the list items
-expect(friends[0]).toBeNull();
+friends[0] // => null
 ```
 </CodeGroup>
 
@@ -590,7 +591,7 @@ We can actually use `$onError` everywhere in the resolve query, so we can use it
 <CodeGroup>
 ```typescript twoslash
 import { ID, CoMap, CoList, co, Group, Account } from "jazz-tools";
-import { expect, assert } from "vitest";
+import { assert } from "vitest";
 
 class Person extends CoMap {
   name = co.string;
@@ -641,11 +642,11 @@ assert(friends);
 //
 // This also means that if we don't have access to Jane
 // the entire friends list will be null
-expect(friends[0].name).toBe("Jane");
+friends[0] // => Person
 
 // Jane's dog is null because we don't have access to Rex
 // and we have used $onError to catch the error
-expect(friends[0]?.dog).toBeNull();
+friends[0].dog // => null
 ```
 </CodeGroup>
 

--- a/homepage/homepage/content/docs/using-covalues/subscription-and-loading.mdx
+++ b/homepage/homepage/content/docs/using-covalues/subscription-and-loading.mdx
@@ -455,15 +455,139 @@ const project = await Project.load(projectId, {
   resolve: true
 });
 
-project // => Project
-
-// The user doesn't have access to the owner
-project?.owner // => always null
+project // => Project is null if the user doesn't have access
 ```
 </CodeGroup>
 
 The load operation will succeed and return the object, but the inaccessible reference will always be `null`.
 
+The same behavoir applies when one of the deeply loaded items is inaccessible.
+
+<CodeGroup>
+```typescript twoslash
+import { ID, CoMap, co, CoList } from "jazz-tools";
+
+class Project extends CoMap {
+  name = co.string;
+  tasks = co.ref(ListOfTasks);
+  owner = co.ref(TeamMember);
+}
+
+class Task extends CoMap {
+  title = co.string;
+  subtasks = co.ref(ListOfTasks);
+  assignee = co.optional.ref(TeamMember);
+}
+
+class TeamMember extends CoMap {
+  name = co.string;
+}
+
+class ListOfTasks extends CoList.Of(co.ref(Task)) {}
+
+const projectId = "co_123" as ID<Project>;
+// ---cut-before---
+const project = await Project.load(projectId, {
+  resolve: { tasks: { $each: true } }
+});
+
+/**
+ * Project is null if the user doesn't have access
+ * to project or to any of the tasks
+*/ 
+project 
+```
+</CodeGroup>
+
+## Deep loading lists with shared items
+
+When loading a list with shared items, you can use the `$skipInvalid` to safely load the list skipping any inaccessible items.
+
+This is especially useful when in your app access to these items might be revoked.
+
+This way, when encountering an inaccessible item, the inaccessible items are replaced with `null` in the returned list.
+
+<CodeGroup>
+```typescript twoslash
+import { ID, CoMap, co, CoList } from "jazz-tools";
+
+class Project extends CoMap {
+  name = co.string;
+  tasks = co.ref(ListOfTasks);
+}
+
+class Task extends CoMap {
+  title = co.string;
+}
+
+class ListOfTasks extends CoList.Of(co.ref(Task)) {}  
+
+const projectId = "co_123" as ID<Project>;
+
+function assert<T>(value: T | null | undefined): asserts value is T {
+  if (!value) {
+    throw new Error("Value is null or undefined");
+  }
+}
+
+// ---cut-before---
+const project = await Project.load(projectId, {
+  resolve: { tasks: { $each: true, $skipInvalid: true } }
+});
+
+assert(project);
+
+const [task1, task2] = project.tasks ?? [];
+
+task1 // => Task
+task2 // => null because the task is inaccessible
+```
+</CodeGroup>
+
+The `$skipInvalid` works as a "catch" clause option to block any error in the childs resolve.
+
+<CodeGroup>
+```typescript twoslash
+import { ID, CoMap, co, CoList } from "jazz-tools";
+
+class Project extends CoMap {
+  name = co.string;
+  tasks = co.ref(ListOfTasks);
+  owner = co.ref(TeamMember);
+}
+
+class Task extends CoMap {
+  title = co.string;
+  subtasks = co.ref(ListOfTasks);
+  assignee = co.optional.ref(TeamMember);
+}
+
+class TeamMember extends CoMap {
+  name = co.string;
+}
+
+class ListOfTasks extends CoList.Of(co.ref(Task)) {}
+
+function assert<T>(value: T | null | undefined): asserts value is T {
+  if (!value) {
+    throw new Error("Value is null or undefined");
+  }
+}
+
+const projectId = "co_123" as ID<Project>;
+// ---cut-before---
+const project = await Project.load(projectId, {
+  resolve: { tasks: { $each: { subtasks: { $each: true } }, $skipInvalid: true } }
+});
+
+assert(project);
+
+const [task1, task2] = project.tasks ?? [];
+
+task1 // => Task, everything inside is loaded
+task2 // => null because the one of the task2 subtasks is inaccessible
+```
+</CodeGroup>
 
 ## Type Safety with Resolved Type
 

--- a/homepage/homepage/content/docs/using-covalues/subscription-and-loading.mdx
+++ b/homepage/homepage/content/docs/using-covalues/subscription-and-loading.mdx
@@ -467,7 +467,7 @@ The load operation will succeed and return the object, but the inaccessible refe
 
 #### Deep loading lists with shared items
 
-When loading a list with shared items, you can use the `$skipInvalid` to safely load the list skipping any inaccessible items.
+When loading a list with shared items, you can use the `$onError` option to safely load the list skipping any inaccessible items.
 
 This is especially useful when in your app access to these items might be revoked.
 
@@ -475,7 +475,64 @@ This way the inaccessible items are replaced with `null` in the returned list.
 
 <CodeGroup>
 ```typescript twoslash
-import { ID, CoMap, co, Group, Account } from "jazz-tools";
+import { ID, CoMap, CoList, co, Group, Account } from "jazz-tools";
+import { expect, assert } from "vitest";
+
+class Person extends CoMap {
+  name = co.string;
+}
+class Friends extends CoList.Of(co.ref(Person)) {}
+
+const privateGroup = Group.create();
+const publicGroup = Group.create();
+const me = {} as unknown as Account;
+
+// ---cut-before---
+const source = Friends.create(
+  [
+    Person.create(
+      {
+        name: "Jane",
+      },
+      privateGroup, // We don't have access to Jane
+    ),
+    Person.create(
+      {
+        name: "Alice",
+      },
+      publicGroup, // We have access to Alice
+    ),
+  ],
+  publicGroup,
+);
+
+const friends = await Friends.load(source.id, {
+  resolve: {
+    $each: { $onError: null }
+  },
+  loadAs: me,
+});
+
+// Thanks to $onError catching the errors, the list is loaded
+// because we have access to friends
+expect(friends).not.toBeNull();
+
+assert(friends);
+
+// Jane is null because we lack access rights
+// and we have used $onError to catch the error on the list items
+expect(friends[0]).toBeNull();
+// Alice is not null because we have access
+// the type is nullable because we have used $onError
+expect(friends[1]?.name).toBe("Alice");
+```
+</CodeGroup>
+
+The `$onError` works as a "catch" clause option to block any error in the resolved childs.
+
+<CodeGroup>
+```typescript twoslash
+import { ID, CoMap, CoList, co, Group, Account } from "jazz-tools";
 import { expect, assert } from "vitest";
 
 class Person extends CoMap {
@@ -485,104 +542,110 @@ class Person extends CoMap {
 class Dog extends CoMap {
   name = co.string;
 }
-class Friends extends CoMap.Record(co.ref(Person)) {}
+class Friends extends CoList.Of(co.ref(Person)) {}
 
 class User extends CoMap {
   name = co.string;
   friends = co.ref(Friends);
 }
 
-const onlyVisibleToBob = Group.create();
-const visibleToMe = Group.create();
+const privateGroup = Group.create();
+const publicGroup = Group.create();
 const me = {} as unknown as Account;
 
 // ---cut-before---
-const map = User.create(
-  {
-    name: "John",
-    friends: Friends.create(
+const source = Friends.create(
+  [
+    Person.create(
       {
-        jane: Person.create(
-          {
-            name: "Jane",
-            dog: Dog.create(
-              { name: "Rex" },
-              onlyVisibleToBob,
-            ), // Jane dog is not accessible by us
-          },
-          visibleToMe,
-        ),
+        name: "Jane",
+        dog: Dog.create(
+          { name: "Rex" },
+          privateGroup,
+        ), // We don't have access to Rex
       },
-      visibleToMe,
+      publicGroup,
     ),
-  },
-  visibleToMe,
+  ],
+  publicGroup,
 );
 
-const user = await User.load(map.id, {
+const friends = await Friends.load(source.id, {
   resolve: {
-    friends: { $each: { dog: true }, $skipInvalid: true },
+    $each: { dog: true, $onError: null }
   },
   loadAs: me,
 });
 
-assert(user);
+assert(friends);
 
-expect(user.friends.jane).toBeNull(); // jane is null because her dog is not accessible
+// Jane is null because we don't have access to Rex
+// and we have used $onError to catch the error on the list items
+expect(friends[0]).toBeNull();
 ```
 </CodeGroup>
 
-The `$skipInvalid` works as a "catch" clause option to block any error in the resolved childs.
+We can actually use `$onError` everywhere in the resolve query, so we can use it to catch the error on dog:
 
 <CodeGroup>
 ```typescript twoslash
-import { ID, CoMap, co, CoList } from "jazz-tools";
+import { ID, CoMap, CoList, co, Group, Account } from "jazz-tools";
+import { expect, assert } from "vitest";
 
-class Project extends CoMap {
+class Person extends CoMap {
   name = co.string;
-  tasks = co.ref(ListOfTasks);
-  owner = co.ref(TeamMember);
+  dog = co.ref(Dog);
 }
-
-class Task extends CoMap {
-  title = co.string;
-  subtasks = co.ref(ListOfTasks);
-  assignee = co.optional.ref(TeamMember);
-}
-
-class TeamMember extends CoMap {
+class Dog extends CoMap {
   name = co.string;
 }
+class Friends extends CoList.Of(co.ref(Person)) {}
 
-class ListOfTasks extends CoList.Of(co.ref(Task)) {}
-
-function assert<T>(value: T | null | undefined): asserts value is T {
-  if (!value) {
-    throw new Error("Value is null or undefined");
-  }
+class User extends CoMap {
+  name = co.string;
+  friends = co.ref(Friends);
 }
 
-const projectId = "co_123" as ID<Project>;
-// ---cut-before---
-const project = await Project.load(projectId, {
-  resolve: {
-    tasks: {
-      $each: {
-        subtasks: {
-          $each: true,
-        },
+const privateGroup = Group.create();
+const publicGroup = Group.create();
+const me = {} as unknown as Account;
+
+const source = Friends.create(
+  [
+    Person.create(
+      {
+        name: "Jane",
+        dog: Dog.create(
+          { name: "Rex" },
+          privateGroup,
+        ), // We don't have access to Rex
       },
-      $skipInvalid: true,
-    },
+      publicGroup,
+    ),
+  ],
+  publicGroup,
+);
+
+// ---cut-before---
+const friends = await Friends.load(source.id, {
+  resolve: {
+    $each: { dog: { $onError: null } }
   },
+  loadAs: me,
 });
 
-assert(project);
+assert(friends);
 
-const [task1, task2] = project.tasks;
+// Jane now is not-nullable at type level because
+// we have moved $onError down to the dog field
+//
+// This also means that if we don't have access to Jane
+// the entire friends list will be null
+expect(friends[0].name).toBe("Jane");
 
-task1 // => Task, everything inside is loaded
-task2 // => null because one of the subtasks in task2 is not accessible
+// Jane's dog is null because we don't have access to Rex
+// and we have used $onError to catch the error
+expect(friends[0]?.dog).toBeNull();
 ```
 </CodeGroup>
 

--- a/homepage/homepage/content/docs/using-covalues/subscription-and-loading.mdx
+++ b/homepage/homepage/content/docs/using-covalues/subscription-and-loading.mdx
@@ -475,38 +475,60 @@ This way the inaccessible items are replaced with `null` in the returned list.
 
 <CodeGroup>
 ```typescript twoslash
-import { ID, CoMap, co, CoList } from "jazz-tools";
+import { ID, CoMap, co, Group, Account } from "jazz-tools";
+import { expect, assert } from "vitest";
 
-class Project extends CoMap {
+class Person extends CoMap {
   name = co.string;
-  tasks = co.ref(ListOfTasks);
+  dog = co.ref(Dog);
+}
+class Dog extends CoMap {
+  name = co.string;
+}
+class Friends extends CoMap.Record(co.ref(Person)) {}
+
+class User extends CoMap {
+  name = co.string;
+  friends = co.ref(Friends);
 }
 
-class Task extends CoMap {
-  title = co.string;
-}
-
-class ListOfTasks extends CoList.Of(co.ref(Task)) {}  
-
-const projectId = "co_123" as ID<Project>;
-
-function assert<T>(value: T | null | undefined): asserts value is T {
-  if (!value) {
-    throw new Error("Value is null or undefined");
-  }
-}
+const onlyVisibleToBob = Group.create();
+const visibleToMe = Group.create();
+const me = {} as unknown as Account;
 
 // ---cut-before---
-const project = await Project.load(projectId, {
-  resolve: { tasks: { $each: true, $skipInvalid: true } }
+const map = User.create(
+  {
+    name: "John",
+    friends: Friends.create(
+      {
+        jane: Person.create(
+          {
+            name: "Jane",
+            dog: Dog.create(
+              { name: "Rex" },
+              onlyVisibleToBob,
+            ), // Jane dog is not accessible by us
+          },
+          visibleToMe,
+        ),
+      },
+      visibleToMe,
+    ),
+  },
+  visibleToMe,
+);
+
+const user = await User.load(map.id, {
+  resolve: {
+    friends: { $each: { dog: true }, $skipInvalid: true },
+  },
+  loadAs: me,
 });
 
-assert(project);
+assert(user);
 
-const [task1, task2] = project.tasks;
-
-task1 // => Task
-task2 // => null because the task is inaccessible
+expect(user.friends.jane).toBeNull(); // jane is null because her dog is not accessible
 ```
 </CodeGroup>
 
@@ -543,7 +565,16 @@ function assert<T>(value: T | null | undefined): asserts value is T {
 const projectId = "co_123" as ID<Project>;
 // ---cut-before---
 const project = await Project.load(projectId, {
-  resolve: { tasks: { $each: { subtasks: { $each: true } }, $skipInvalid: true } }
+  resolve: {
+    tasks: {
+      $each: {
+        subtasks: {
+          $each: true,
+        },
+      },
+      $skipInvalid: true,
+    },
+  },
 });
 
 assert(project);
@@ -551,7 +582,7 @@ assert(project);
 const [task1, task2] = project.tasks;
 
 task1 // => Task, everything inside is loaded
-task2 // => null because the one of the task2 subtasks is inaccessible
+task2 // => null because one of the subtasks in task2 is not accessible
 ```
 </CodeGroup>
 

--- a/packages/cojson/src/coValueCore/coValueCore.ts
+++ b/packages/cojson/src/coValueCore/coValueCore.ts
@@ -1044,11 +1044,6 @@ export class CoValueCore {
     });
     peer.trackLoadRequestSent(this.id);
 
-    const timeoutDuration =
-      peer.role === "storage"
-        ? CO_VALUE_LOADING_CONFIG.TIMEOUT * 10
-        : CO_VALUE_LOADING_CONFIG.TIMEOUT;
-
     return new Promise<void>((resolve) => {
       const markNotFound = () => {
         if (this.peers.get(peer.id)?.type === "pending") {
@@ -1060,7 +1055,7 @@ export class CoValueCore {
         }
       };
 
-      const timeout = setTimeout(markNotFound, timeoutDuration);
+      const timeout = setTimeout(markNotFound, CO_VALUE_LOADING_CONFIG.TIMEOUT);
       const removeCloseListener = peer.addCloseListener(markNotFound);
 
       const listener = (state: CoValueCore) => {

--- a/packages/jazz-tools/.gitignore
+++ b/packages/jazz-tools/.gitignore
@@ -169,3 +169,4 @@ dist
 .pnp.\*
 
 .DS_Store
+tsconfig.vitest-temp.json

--- a/packages/jazz-tools/src/coValues/deepLoading.ts
+++ b/packages/jazz-tools/src/coValues/deepLoading.ts
@@ -26,7 +26,7 @@ export type RefsToResolve<
                   DepthLimit,
                   [0, ...CurrentDepth]
                 >;
-                $skipInvalid?: true;
+                $skipInvalid?: boolean;
               }
             | boolean
         : // Basically V extends CoMap | Group | Account - but if we used that we'd introduce circularity into the definition of CoMap itself
@@ -48,7 +48,7 @@ export type RefsToResolve<
                         DepthLimit,
                         [0, ...CurrentDepth]
                       >;
-                      $skipInvalid?: true;
+                      $skipInvalid?: boolean;
                     }
                   : never)
               | boolean
@@ -63,7 +63,7 @@ export type RefsToResolve<
                       DepthLimit,
                       [0, ...CurrentDepth]
                     >;
-                    $skipInvalid?: true;
+                    $skipInvalid?: boolean;
                   }
                 | boolean
             : boolean);

--- a/packages/jazz-tools/src/subscribe/SubscriptionScope.ts
+++ b/packages/jazz-tools/src/subscribe/SubscriptionScope.ts
@@ -28,6 +28,7 @@ export class SubscriptionScope<D extends CoValue> {
   idsSubscribed = new Set<string>();
   autoloaded = new Set<string>();
   autoloadedKeys = new Set<string>();
+  skipInvalidEnabled = false;
   totalValidTransactions = 0;
 
   silenceUpdates = false;
@@ -43,6 +44,9 @@ export class SubscriptionScope<D extends CoValue> {
     this.subscription = new CoValueCoreSubscription(node, id, (value) => {
       this.handleUpdate(value);
     });
+    this.skipInvalidEnabled = Boolean(
+      (resolve as unknown as Record<string, any>)?.$skipInvalid,
+    );
   }
 
   updateValue(value: SubscriptionValue<D, any>) {
@@ -220,7 +224,7 @@ export class SubscriptionScope<D extends CoValue> {
     const error = this.errorFromChildren;
     const value = this.value;
 
-    if (error) {
+    if (error && !this.skipInvalidEnabled) {
       this.subscribers.forEach((listener) => listener(error));
     } else if (value.type !== "unloaded") {
       this.subscribers.forEach((listener) => listener(value));

--- a/packages/jazz-tools/src/tests/deepLoading.test-d.ts
+++ b/packages/jazz-tools/src/tests/deepLoading.test-d.ts
@@ -1,0 +1,318 @@
+import { cojsonInternals } from "cojson";
+import { WasmCrypto } from "cojson/crypto/WasmCrypto";
+import { assert, describe, expect, expectTypeOf, test, vi } from "vitest";
+import {
+  Account,
+  CoFeed,
+  CoList,
+  CoMap,
+  Group,
+  ID,
+  Profile,
+  SessionID,
+  co,
+  createJazzContextFromExistingCredentials,
+  isControlledAccount,
+} from "../index.js";
+import { randomSessionProvider } from "../internal.js";
+import { createJazzTestAccount } from "../testing.js";
+
+const Crypto = await WasmCrypto.create();
+const { connectedPeers } = cojsonInternals;
+
+class TestMap extends CoMap {
+  list = co.ref(TestList);
+  optionalRef = co.ref(InnermostMap, { optional: true });
+}
+
+class TestList extends CoList.Of(co.ref(() => InnerMap)) {}
+
+class InnerMap extends CoMap {
+  stream = co.ref(TestStream);
+}
+
+class TestStream extends CoFeed.Of(co.ref(() => InnermostMap)) {}
+
+class InnermostMap extends CoMap {
+  value = co.string;
+}
+
+const me = await createJazzTestAccount({});
+const map = TestMap.create({
+  list: TestList.create([], { owner: me }),
+});
+
+describe("Deep loading with depth arg", async () => {
+  test("load without resolve", async () => {
+    const map1 = await TestMap.load(map.id);
+
+    function validateType(map: TestMap | null) {
+      map;
+    }
+
+    validateType(map1);
+  });
+
+  test("load with resolve { list: true }", async () => {
+    const map2 = await TestMap.load(map.id, {
+      resolve: { list: true },
+    });
+    expectTypeOf(map2).toEqualTypeOf<
+      | (TestMap & {
+          list: TestList;
+        })
+      | null
+    >();
+  });
+
+  test("load with resolve { list: { $each: true } }", async () => {
+    const map3 = await TestMap.load(map.id, {
+      resolve: { list: { $each: true } },
+    });
+    expectTypeOf(map3).toEqualTypeOf<
+      | (TestMap & {
+          list: TestList & InnerMap[];
+        })
+      | null
+    >();
+  });
+
+  test("load with resolve { optionalRef: true }", async () => {
+    const map3a = await TestMap.load(map.id, {
+      resolve: { optionalRef: true } as const,
+    });
+    expectTypeOf(map3a).toEqualTypeOf<
+      | (TestMap & {
+          optionalRef: InnermostMap | undefined;
+        })
+      | null
+    >();
+  });
+
+  test("load with resolve { list: { $each: { stream: true } } }", async () => {
+    const map4 = await TestMap.load(map.id, {
+      resolve: { list: { $each: { stream: true } } },
+    });
+    expectTypeOf(map4).toEqualTypeOf<
+      | (TestMap & {
+          list: TestList & (InnerMap & { stream: TestStream })[];
+        })
+      | null
+    >();
+  });
+
+  test("load with resolve { list: { $each: { stream: { $each: true } } } }", async () => {
+    const map5 = await TestMap.load(map.id, {
+      resolve: { list: { $each: { stream: { $each: true } } } },
+    });
+    type ExpectedMap5 =
+      | (TestMap & {
+          list: TestList &
+            (InnerMap & {
+              stream: TestStream & {
+                byMe?: { value: InnermostMap };
+                inCurrentSession?: { value: InnermostMap };
+                perSession: {
+                  [sessionID: SessionID]: {
+                    value: InnermostMap;
+                  };
+                };
+              } & {
+                [key: ID<Account>]: { value: InnermostMap };
+              };
+            })[];
+        })
+      | null;
+    expectTypeOf(map5).toEqualTypeOf<ExpectedMap5>();
+  });
+
+  test("should handle $skipInvalid on CoList", async () => {
+    class List extends CoList.Of(co.ref(() => InnerMap)) {}
+
+    const result = await List.load("x" as ID<List>, {
+      resolve: { $each: true, $skipInvalid: true },
+    });
+    function validateType(map: ((InnerMap | null)[] & List) | null) {
+      map;
+    }
+
+    validateType(result);
+    expectTypeOf(result).toEqualTypeOf<((InnerMap | null)[] & List) | null>();
+  });
+
+  test("should handle $skipInvalid on CoMap.Record", async () => {
+    class Record extends CoMap.Record(co.ref(() => InnerMap)) {}
+
+    const result = await Record.load("x" as ID<Record>, {
+      resolve: { $each: true, $skipInvalid: true },
+    });
+
+    type ExpectedResult =
+      | ({
+          [key: string]: InnerMap | null;
+        } & Record)
+      | null;
+
+    function validateType(map: ExpectedResult) {
+      map;
+    }
+
+    validateType(result);
+    expectTypeOf(result).toEqualTypeOf<ExpectedResult>();
+  });
+});
+
+class CustomProfile extends Profile {
+  stream = co.ref(TestStream);
+}
+
+class CustomAccount extends Account {
+  profile = co.ref(CustomProfile);
+  root = co.ref(TestMap);
+
+  async migrate(
+    this: CustomAccount,
+    creationProps?: { name: string } | undefined,
+  ) {
+    if (creationProps) {
+      const profileGroup = Group.create(this);
+      this.profile = CustomProfile.create(
+        {
+          name: creationProps.name,
+          stream: TestStream.create([], this),
+        },
+        profileGroup,
+      );
+      this.root = TestMap.create({ list: TestList.create([], this) }, this);
+    }
+
+    const thisLoaded = await this.ensureLoaded({
+      resolve: {
+        profile: { stream: true },
+        root: { list: true },
+      },
+    });
+    expectTypeOf(thisLoaded).toEqualTypeOf<
+      CustomAccount & {
+        profile: CustomProfile & {
+          stream: TestStream;
+        };
+        root: TestMap & {
+          list: TestList;
+        };
+      }
+    >();
+  }
+}
+
+test("Deep loading within account", async () => {
+  const me = await CustomAccount.create({
+    creationProps: { name: "Hermes Puggington" },
+    crypto: Crypto,
+  });
+
+  const meLoaded = await me.ensureLoaded({
+    resolve: {
+      profile: { stream: true },
+      root: { list: true },
+    },
+  });
+  expectTypeOf(meLoaded).toEqualTypeOf<
+    CustomAccount & {
+      profile: CustomProfile & {
+        stream: TestStream;
+      };
+      root: TestMap & {
+        list: TestList;
+      };
+    }
+  >();
+});
+
+class RecordLike extends CoMap.Record(co.ref(TestMap)) {}
+
+test("Deep loading a record-like coMap", async () => {
+  const me = await Account.create({
+    creationProps: { name: "Hermes Puggington" },
+    crypto: Crypto,
+  });
+
+  const [initialAsPeer, secondPeer] = connectedPeers("initial", "second", {
+    peer1role: "server",
+    peer2role: "client",
+  });
+
+  if (!isControlledAccount(me)) {
+    throw "me is not a controlled account";
+  }
+
+  me._raw.core.node.syncManager.addPeer(secondPeer);
+  const { account: meOnSecondPeer } =
+    await createJazzContextFromExistingCredentials({
+      credentials: {
+        accountID: me.id,
+        secret: me._raw.core.node.agentSecret,
+      },
+      sessionProvider: randomSessionProvider,
+      peersToLoadFrom: [initialAsPeer],
+      crypto: Crypto,
+    });
+
+  const record = RecordLike.create(
+    {
+      key1: TestMap.create(
+        { list: TestList.create([], { owner: me }) },
+        { owner: me },
+      ),
+      key2: TestMap.create(
+        { list: TestList.create([], { owner: me }) },
+        { owner: me },
+      ),
+    },
+    { owner: me },
+  );
+
+  const recordLoaded = await RecordLike.load(record.id, {
+    loadAs: meOnSecondPeer,
+    resolve: {
+      $each: { list: { $each: true } },
+    },
+  });
+  expectTypeOf(recordLoaded).toEqualTypeOf<
+    | (RecordLike & {
+        [key: string]: TestMap & {
+          list: TestList & InnerMap[];
+        };
+      })
+    | null
+  >();
+});
+
+test("The resolve type doesn't accept extra keys", async () => {
+  const me = await CustomAccount.create({
+    creationProps: { name: "Hermes Puggington" },
+    crypto: Crypto,
+  });
+
+  const meLoaded = await me.ensureLoaded({
+    resolve: {
+      // @ts-expect-error
+      profile: { stream: true, extraKey: true },
+      // @ts-expect-error
+      root: { list: true, extraKey: true },
+    },
+  });
+
+  expectTypeOf(meLoaded).toEqualTypeOf<
+    CustomAccount & {
+      profile: CustomProfile & {
+        stream: TestStream;
+        extraKey: never;
+      };
+      root: TestMap & {
+        list: TestList;
+        extraKey: never;
+      };
+    }
+  >();
+});

--- a/packages/jazz-tools/src/tests/deepLoading.test.ts
+++ b/packages/jazz-tools/src/tests/deepLoading.test.ts
@@ -613,7 +613,7 @@ describe("Deep loading with unauthorized account", async () => {
     expect(loadedMap?.id).toBe(map.id);
   });
 
-  test("unaccessible record element with $skipInvalid", async () => {
+  test("unaccessible record element with $onError", async () => {
     class Person extends CoMap {
       name = co.string;
     }
@@ -628,7 +628,7 @@ describe("Deep loading with unauthorized account", async () => {
     );
 
     const friendsOnAlice = await Friends.load(map.id, {
-      resolve: { $each: true, $skipInvalid: true },
+      resolve: { $each: { $onError: null } },
       loadAs: alice,
     });
 
@@ -638,7 +638,7 @@ describe("Deep loading with unauthorized account", async () => {
     expect(friendsOnAlice.alice).not.toBeNull();
   });
 
-  test("unaccessible nested record element with $skipInvalid", async () => {
+  test("unaccessible nested record element with $onError", async () => {
     class Person extends CoMap {
       name = co.string;
     }
@@ -664,7 +664,7 @@ describe("Deep loading with unauthorized account", async () => {
     );
 
     const user = await User.load(map.id, {
-      resolve: { friends: { $each: true, $skipInvalid: true } },
+      resolve: { friends: { $each: { $onError: null } } },
       loadAs: alice,
     });
 
@@ -674,7 +674,7 @@ describe("Deep loading with unauthorized account", async () => {
     expect(user.friends.alice).not.toBeNull();
   });
 
-  test("unaccessible element down the chain with $skipInvalid on a record", async () => {
+  test("unaccessible element down the chain with $onError on a record", async () => {
     class Person extends CoMap {
       name = co.string;
       dog = co.ref(Dog);
@@ -713,7 +713,7 @@ describe("Deep loading with unauthorized account", async () => {
     );
 
     const user = await User.load(map.id, {
-      resolve: { friends: { $each: { dog: true }, $skipInvalid: true } },
+      resolve: { friends: { $each: { dog: true, $onError: null } } },
       loadAs: alice,
     });
 
@@ -723,7 +723,7 @@ describe("Deep loading with unauthorized account", async () => {
     expect(user.friends.alice?.dog).not.toBeNull(); // alice is not null because we have read access to her and her dog
   });
 
-  test("unaccessible list element with $skipInvalid and $each with depth", async () => {
+  test("unaccessible list element with $onError and $each with depth", async () => {
     class Person extends CoMap {
       name = co.string;
       friends = co.optional.ref(Friends);
@@ -759,7 +759,7 @@ describe("Deep loading with unauthorized account", async () => {
     // The error List -> Jane -> Bob should be propagated to the list element Jane
     // and we should have [null, Alice]
     const listOnAlice = await Friends.load(list.id, {
-      resolve: { $each: { friends: { $each: true } }, $skipInvalid: true },
+      resolve: { $each: { friends: { $each: true }, $onError: null } },
       loadAs: alice,
     });
 
@@ -773,7 +773,7 @@ describe("Deep loading with unauthorized account", async () => {
     expect(listOnAlice).toHaveLength(2);
   });
 
-  test("unaccessible record element with $skipInvalid", async () => {
+  test("unaccessible record element with $onError", async () => {
     class Person extends CoMap {
       name = co.string;
     }
@@ -788,7 +788,7 @@ describe("Deep loading with unauthorized account", async () => {
     );
 
     const friendsOnAlice = await Friend.load(map.id, {
-      resolve: { $each: true, $skipInvalid: true },
+      resolve: { $each: { $onError: null } },
       loadAs: alice,
     });
 
@@ -874,6 +874,7 @@ test("throw when calling ensureLoaded on a ref that is not defined in the schema
 
   await expect(
     root.ensureLoaded({
+      // @ts-expect-error missing required ref
       resolve: { profile: true },
     }),
   ).rejects.toThrow("Failed to deeply load CoValue " + root.id);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1286,6 +1286,9 @@ importers:
       '@biomejs/biome':
         specifier: 1.9.4
         version: 1.9.4
+      '@playwright/test':
+        specifier: ^1.50.1
+        version: 1.50.1
       '@tailwindcss/forms':
         specifier: ^0.5.9
         version: 0.5.9(tailwindcss@3.4.17(ts-node@10.9.2(@swc/core@1.10.1(@swc/helpers@0.5.15))(@types/node@22.10.2)(typescript@5.6.2)))


### PR DESCRIPTION
fixes #1806 

We have a big pain point now.

When deep loading values, if anything in the tree has an error (due to access rights or load issues) the whole loading returns an error. (usually results in `null` returned)

We do this to keep Jazz type-safe. When the types say that something is not-nullable we keep that promise.

Now we are trying to come up with an API that helps to deal with this problem, especially when working with shared values which access can be revoked.

Our first idea has been to add a `$skipInvalid` option to resolve, but after adding the docs we've realized that language-wise it might be misleading:

```ts
const user = await User.load(map.id, {
  resolve: {
    friends: { $each: { dog: true }, $skipInvalid: true },
  },
});
```

So we are coming up with a new idea:
```ts
const user = await User.load(map.id, {
  resolve: {
    friends: { $each: { dog: true, $onError: null } },
  },
});
```

These two would do the same thing, which is replace any list item inside of `friends` that have errors with `null`

This means that even if we don't have access to a `dog` the dog owner is going to be `null` for us.

We are going to use `$onError: null` because in the future we want to support also `$onError: "skip"` to skip elements in the lists/records instead of setting them to `null` and `$onError: (err) => value` to let the user handle error values and manually recover from errors.

[Link to the docs](https://jazz-homepage-git-feat-skipinvalid-gcmp.vercel.app/docs/react/using-covalues/subscription-and-loading?_vercel_share=sqSpt7FmSGk3aOlx8HkoMXYteo2hn90H)