### PR TITLE
feat(docs): link to Previous and Next pages

### DIFF
--- a/homepage/design-system/src/components/atoms/Icon.tsx
+++ b/homepage/design-system/src/components/atoms/Icon.tsx
@@ -9,7 +9,9 @@ import {
   Brackets,
   CheckIcon,
   ChevronDown,
+  ChevronLeftIcon,
   ChevronRight,
+  ChevronRightIcon,
   ClipboardIcon,
   CodeIcon,
   FileLock2Icon,
@@ -89,6 +91,9 @@ const icons = {
   colist: Brackets,
   user: UserIcon,
   group: UsersIcon,
+
+  previous: ChevronLeftIcon,
+  next: ChevronRightIcon,
 
   // text editor icons
   bold: BoldIcon,

--- a/homepage/homepage/app/(docs)/docs/[framework]/[topic]/[subtopic]/page.tsx
+++ b/homepage/homepage/app/(docs)/docs/[framework]/[topic]/[subtopic]/page.tsx
@@ -1,4 +1,4 @@
-import { docNavigationItems } from "@/content/docs/docNavigationItems.js";
+import { docNavigationItems } from "@/content/docs/docNavigationItems";
 import { Framework, frameworks } from "@/content/framework";
 import { DocPage, getDocMetadata } from "@/lib/docMdxContent";
 

--- a/homepage/homepage/app/(docs)/docs/[framework]/[topic]/page.tsx
+++ b/homepage/homepage/app/(docs)/docs/[framework]/[topic]/page.tsx
@@ -1,4 +1,4 @@
-import { docNavigationItems } from "@/content/docs/docNavigationItems.js";
+import { docNavigationItems } from "@/content/docs/docNavigationItems";
 import { Framework, frameworks } from "@/content/framework";
 import { DocPage, getDocMetadata } from "@/lib/docMdxContent";
 

--- a/homepage/homepage/app/(others)/examples/page.tsx
+++ b/homepage/homepage/app/(others)/examples/page.tsx
@@ -679,13 +679,13 @@ export default function Page() {
             </div>
 
             <GappedGrid>
-              {category.examples.map((example) =>
+              {category.examples.map((example) => (
                 <ExampleCard
                   className="border bg-stone-50 shadow-sm p-3 rounded-lg dark:bg-stone-950"
                   key={example.slug}
                   example={example}
                 />
-              )}
+              ))}
             </GappedGrid>
           </div>
         ))}

--- a/homepage/homepage/components/docs/DocsNav.tsx
+++ b/homepage/homepage/components/docs/DocsNav.tsx
@@ -3,7 +3,7 @@
 import { SideNav, SideNavBody, SideNavHeader } from "@/components/SideNav";
 import { SideNavSection } from "@/components/SideNavSection";
 import { FrameworkSelect } from "@/components/docs/FrameworkSelect";
-import { docNavigationItems } from "@/content/docs/docNavigationItems.js";
+import { docNavigationItems } from "@/content/docs/docNavigationItems";
 import { useFramework } from "@/lib/use-framework";
 import React from "react";
 

--- a/homepage/homepage/components/docs/PreviousNextLinks.tsx
+++ b/homepage/homepage/components/docs/PreviousNextLinks.tsx
@@ -23,17 +23,17 @@ export function PreviousNextLinks({ slug, framework }: PreviousNextLinksProps) {
   }
 
   return (
-    <div className="flex justify-between gap-4 not-prose">
+    <div className="flex justify-evenly gap-3 not-prose">
       {currentItem.previous && (
         <Link
           href={currentItem.previous.href.replace(
             "/docs",
             `/docs/${framework}`,
           )}
-          className="flex-1 group py-5 pr-12"
+          className="group py-5 xl:pr-12"
         >
-          <span className="text-sm block mb-1">Previous</span>
-          <div className="text-highlight font-medium inline-flex gap-2 items-center text-lg group-hover:text-blue">
+          <span className="text-xs block md:text-sm md:mb-1">Previous</span>
+          <div className="text-highlight font-medium inline-flex gap-2 items-center group-hover:text-blue">
             {currentItem.previous.name}
           </div>
         </Link>
@@ -41,10 +41,10 @@ export function PreviousNextLinks({ slug, framework }: PreviousNextLinksProps) {
       {currentItem.next && (
         <Link
           href={currentItem.next.href.replace("/docs", `/docs/${framework}`)}
-          className="flex-1 group text-right ml-auto py-5 pl-12"
+          className="group text-right ml-auto py-5 xl:pl-12"
         >
-          <span className="text-sm block mb-1">Next</span>
-          <div className="text-highlight font-medium inline-flex gap-2 items-center text-lg group-hover:text-blue">
+          <span className="text-xs block md:text-sm md:mb-1">Next</span>
+          <div className="text-highlight font-medium inline-flex gap-2 items-center group-hover:text-blue">
             {currentItem.next.name}
           </div>
         </Link>

--- a/homepage/homepage/components/docs/PreviousNextLinks.tsx
+++ b/homepage/homepage/components/docs/PreviousNextLinks.tsx
@@ -2,6 +2,7 @@ import {
   docNavigationItems,
   flatItemsWithNavLinks,
 } from "@/content/docs/docNavigationItems";
+import { Icon } from "@garden-co/design-system/src/components/atoms/Icon";
 import { Separator } from "@garden-co/design-system/src/components/atoms/Separator";
 import Link from "next/link";
 
@@ -37,8 +38,9 @@ export function PreviousNextLinks({ slug, framework }: PreviousNextLinksProps) {
             )}
             className="group py-5 xl:pr-12"
           >
-            <span className="text-xs block md:text-sm md:mb-1">Previous</span>
-            <div className="text-highlight font-medium inline-flex gap-2 items-center group-hover:text-blue">
+            <span className="hidden text-sm mb-1 sm:block">Previous</span>
+            <div className="text-sm text-highlight font-medium inline-flex gap-1 items-center group-hover:text-blue sm:text-base">
+              <Icon name="previous" size="xs" className="sm:hidden" />
               {currentItem.previous.name}
             </div>
           </Link>
@@ -48,9 +50,10 @@ export function PreviousNextLinks({ slug, framework }: PreviousNextLinksProps) {
             href={currentItem.next.href.replace("/docs", `/docs/${framework}`)}
             className="group text-right ml-auto py-5 xl:pl-12"
           >
-            <span className="text-xs block md:text-sm md:mb-1">Next</span>
-            <div className="text-highlight font-medium inline-flex gap-2 items-center group-hover:text-blue">
+            <span className="hidden text-sm mb-1 sm:block">Next</span>
+            <div className="text-sm text-highlight font-medium inline-flex gap-1 items-center group-hover:text-blue sm:text-base">
               {currentItem.next.name}
+              <Icon name="next" size="xs" className="sm:hidden" />
             </div>
           </Link>
         )}

--- a/homepage/homepage/components/docs/PreviousNextLinks.tsx
+++ b/homepage/homepage/components/docs/PreviousNextLinks.tsx
@@ -2,7 +2,6 @@
 
 import { docNavigationItems } from "@/content/docs/docNavigationItems";
 import { useFramework } from "@/lib/use-framework";
-import { Icon } from "@garden-co/design-system/src/components/atoms/Icon";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
 
@@ -27,7 +26,7 @@ export function PreviousNextLinks() {
       {currentItem.back && (
         <Link
           href={currentItem.back.href.replace("/docs", `/docs/${framework}`)}
-          className="group py-5 pr-12"
+          className="flex-1 group py-5 pr-12"
         >
           <span className="text-sm block mb-1">Previous</span>
           <div className="text-highlight font-medium inline-flex gap-2 items-center text-lg group-hover:text-blue">
@@ -38,7 +37,7 @@ export function PreviousNextLinks() {
       {currentItem.next && (
         <Link
           href={currentItem.next.href.replace("/docs", `/docs/${framework}`)}
-          className="group text-right ml-auto py-5 pl-12"
+          className="flex-1 group text-right ml-auto py-5 pl-12"
         >
           <span className="text-sm block mb-1">Next</span>
           <div className="text-highlight font-medium inline-flex gap-2 items-center text-lg group-hover:text-blue">

--- a/homepage/homepage/components/docs/PreviousNextLinks.tsx
+++ b/homepage/homepage/components/docs/PreviousNextLinks.tsx
@@ -17,20 +17,20 @@ export function PreviousNextLinks() {
       return path === itemPath;
     });
 
-  if (!currentItem?.next && !currentItem?.back) {
+  if (!currentItem?.next && !currentItem?.previous) {
     return null;
   }
 
   return (
     <div className="flex justify-between gap-4 not-prose">
-      {currentItem.back && (
+      {currentItem.previous && (
         <Link
-          href={currentItem.back.href.replace("/docs", `/docs/${framework}`)}
+          href={currentItem.previous.href.replace("/docs", `/docs/${framework}`)}
           className="flex-1 group py-5 pr-12"
         >
           <span className="text-sm block mb-1">Previous</span>
           <div className="text-highlight font-medium inline-flex gap-2 items-center text-lg group-hover:text-blue">
-            {currentItem.back.name}
+            {currentItem.previous.name}
           </div>
         </Link>
       )}

--- a/homepage/homepage/components/docs/PreviousNextLinks.tsx
+++ b/homepage/homepage/components/docs/PreviousNextLinks.tsx
@@ -2,6 +2,7 @@ import {
   docNavigationItems,
   flatItemsWithNavLinks,
 } from "@/content/docs/docNavigationItems";
+import { Separator } from "@garden-co/design-system/src/components/atoms/Separator";
 import Link from "next/link";
 
 interface PreviousNextLinksProps {
@@ -18,37 +19,42 @@ export function PreviousNextLinks({ slug, framework }: PreviousNextLinksProps) {
     return currentPath === itemPath;
   });
 
-  if (!currentItem?.next && !currentItem?.previous) {
+  if (
+    currentItem?.excludeFromNavigation ||
+    (!currentItem?.next && !currentItem?.previous)
+  ) {
     return null;
   }
 
   return (
-    <div className="flex justify-evenly gap-3 not-prose">
-      {currentItem.previous && (
-        <Link
-          href={currentItem.previous.href.replace(
-            "/docs",
-            `/docs/${framework}`,
-          )}
-          className="group py-5 xl:pr-12"
-        >
-          <span className="text-xs block md:text-sm md:mb-1">Previous</span>
-          <div className="text-highlight font-medium inline-flex gap-2 items-center group-hover:text-blue">
-            {currentItem.previous.name}
-          </div>
-        </Link>
-      )}
-      {currentItem.next && (
-        <Link
-          href={currentItem.next.href.replace("/docs", `/docs/${framework}`)}
-          className="group text-right ml-auto py-5 xl:pl-12"
-        >
-          <span className="text-xs block md:text-sm md:mb-1">Next</span>
-          <div className="text-highlight font-medium inline-flex gap-2 items-center group-hover:text-blue">
-            {currentItem.next.name}
-          </div>
-        </Link>
-      )}
-    </div>
+    <>
+      <div className="flex justify-evenly gap-3 not-prose">
+        {currentItem.previous && (
+          <Link
+            href={currentItem.previous.href.replace(
+              "/docs",
+              `/docs/${framework}`,
+            )}
+            className="group py-5 xl:pr-12"
+          >
+            <span className="text-xs block md:text-sm md:mb-1">Previous</span>
+            <div className="text-highlight font-medium inline-flex gap-2 items-center group-hover:text-blue">
+              {currentItem.previous.name}
+            </div>
+          </Link>
+        )}
+        {currentItem.next && (
+          <Link
+            href={currentItem.next.href.replace("/docs", `/docs/${framework}`)}
+            className="group text-right ml-auto py-5 xl:pl-12"
+          >
+            <span className="text-xs block md:text-sm md:mb-1">Next</span>
+            <div className="text-highlight font-medium inline-flex gap-2 items-center group-hover:text-blue">
+              {currentItem.next.name}
+            </div>
+          </Link>
+        )}
+      </div>
+    </>
   );
 }

--- a/homepage/homepage/components/docs/PreviousNextLinks.tsx
+++ b/homepage/homepage/components/docs/PreviousNextLinks.tsx
@@ -1,0 +1,51 @@
+"use client";
+
+import { docNavigationItems } from "@/content/docs/docNavigationItems";
+import { useFramework } from "@/lib/use-framework";
+import { Icon } from "@garden-co/design-system/src/components/atoms/Icon";
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+
+export function PreviousNextLinks() {
+  const path = usePathname();
+  const framework = useFramework();
+
+  // Find the current navigation item
+  const currentItem = docNavigationItems
+    .flatMap((section) => section.items)
+    .find((item) => {
+      const itemPath = item.href.replace("/docs", `/docs/${framework}`);
+      return path === itemPath;
+    });
+
+  if (!currentItem?.next && !currentItem?.back) {
+    return null;
+  }
+
+  return (
+    <div className="flex justify-between gap-4 not-prose">
+      {currentItem.back && (
+        <Link
+          href={currentItem.back.href.replace("/docs", `/docs/${framework}`)}
+          className="group py-5 pr-12"
+        >
+          <span className="text-sm block mb-1">Previous</span>
+          <div className="text-highlight font-medium inline-flex gap-2 items-center text-lg group-hover:text-blue">
+            {currentItem.back.name}
+          </div>
+        </Link>
+      )}
+      {currentItem.next && (
+        <Link
+          href={currentItem.next.href.replace("/docs", `/docs/${framework}`)}
+          className="group text-right ml-auto py-5 pl-12"
+        >
+          <span className="text-sm block mb-1">Next</span>
+          <div className="text-highlight font-medium inline-flex gap-2 items-center text-lg group-hover:text-blue">
+            {currentItem.next.name}
+          </div>
+        </Link>
+      )}
+    </div>
+  );
+}

--- a/homepage/homepage/components/docs/PreviousNextLinks.tsx
+++ b/homepage/homepage/components/docs/PreviousNextLinks.tsx
@@ -1,21 +1,22 @@
-"use client";
-
-import { docNavigationItems } from "@/content/docs/docNavigationItems";
-import { useFramework } from "@/lib/use-framework";
+import {
+  docNavigationItems,
+  flatItemsWithNavLinks,
+} from "@/content/docs/docNavigationItems";
 import Link from "next/link";
-import { usePathname } from "next/navigation";
 
-export function PreviousNextLinks() {
-  const path = usePathname();
-  const framework = useFramework();
+interface PreviousNextLinksProps {
+  slug?: string[];
+  framework: string;
+}
 
-  // Find the current navigation item
-  const currentItem = docNavigationItems
-    .flatMap((section) => section.items)
-    .find((item) => {
-      const itemPath = item.href.replace("/docs", `/docs/${framework}`);
-      return path === itemPath;
-    });
+export function PreviousNextLinks({ slug, framework }: PreviousNextLinksProps) {
+  const currentItem = flatItemsWithNavLinks.find((item) => {
+    const itemPath = item.href.replace("/docs", `/docs/${framework}`);
+    const currentPath = slug
+      ? `/docs/${framework}/${slug.join("/")}`
+      : `/docs/${framework}`;
+    return currentPath === itemPath;
+  });
 
   if (!currentItem?.next && !currentItem?.previous) {
     return null;
@@ -25,7 +26,10 @@ export function PreviousNextLinks() {
     <div className="flex justify-between gap-4 not-prose">
       {currentItem.previous && (
         <Link
-          href={currentItem.previous.href.replace("/docs", `/docs/${framework}`)}
+          href={currentItem.previous.href.replace(
+            "/docs",
+            `/docs/${framework}`,
+          )}
           className="flex-1 group py-5 pr-12"
         >
           <span className="text-sm block mb-1">Previous</span>

--- a/homepage/homepage/content/docs/docNavigationItems.ts
+++ b/homepage/homepage/content/docs/docNavigationItems.ts
@@ -11,6 +11,7 @@ export type DocNavigationItem = {
   framework?: Framework;
   next?: DocNavigationItem | null;
   previous?: DocNavigationItem | null;
+  excludeFromNavigation?: boolean;
 };
 
 export type DocNavigationSection = {
@@ -111,24 +112,21 @@ export const docNavigationItems: DocNavigationSection[] = [
         name: "0.13.0 - React Native Split",
         href: "/docs/upgrade/0-13-0",
         done: 100,
-        next: null,
-        previous: null,
+        excludeFromNavigation: true,
       },
       {
         // upgrade guides
         name: "0.12.0 - Deeply Resolved Data",
         href: "/docs/upgrade/0-12-0",
         done: 100,
-        next: null,
-        previous: null,
+        excludeFromNavigation: true,
       },
       {
         // upgrade guides
         name: "0.11.0 - Roles and permissions",
         href: "/docs/upgrade/0-11-0",
         done: 100,
-        next: null,
-        previous: null,
+        excludeFromNavigation: true,
       },
       // {
       //   // upgrade guides
@@ -155,6 +153,7 @@ export const docNavigationItems: DocNavigationSection[] = [
         href: "/docs/upgrade/react-native-local-persistence",
         done: 100,
         framework: Framework.ReactNativeExpo,
+        excludeFromNavigation: true,
       },
       // {
       //   // upgrade guides
@@ -325,16 +324,14 @@ export const docNavigationItems: DocNavigationSection[] = [
   },
 ];
 
-const flatItems = docNavigationItems.flatMap((section) => section.items);
+const flatItems = docNavigationItems
+  .flatMap((section) => section.items)
+  .filter((item) => !item.excludeFromNavigation);
 
-export const flatItemsWithNavLinks = flatItems.map((item) => {
-  const currentIndex = flatItems.findIndex(
-    (flatItem) => flatItem.href === item.href,
-  );
+export const flatItemsWithNavLinks = flatItems.map((item, index) => {
   return {
     ...item,
-    next: item.next === null ? null : flatItems[currentIndex + 1] || undefined,
-    previous:
-      item.previous === null ? null : flatItems[currentIndex - 1] || undefined,
+    next: item.next === null ? null : flatItems[index + 1],
+    previous: item.previous === null ? null : flatItems[index - 1],
   };
 });

--- a/homepage/homepage/content/docs/docNavigationItems.ts
+++ b/homepage/homepage/content/docs/docNavigationItems.ts
@@ -10,7 +10,7 @@ export type DocNavigationItem = {
   done: DoneStatus;
   framework?: Framework;
   next?: DocNavigationItem | null;
-  back?: DocNavigationItem | null;
+  previous?: DocNavigationItem | null;
 };
 
 export type DocNavigationSection = {
@@ -112,7 +112,7 @@ const items: DocNavigationSection[] = [
         href: "/docs/upgrade/0-13-0",
         done: 100,
         next: null,
-        back: null,
+        previous: null,
       },
       {
         // upgrade guides
@@ -120,7 +120,7 @@ const items: DocNavigationSection[] = [
         href: "/docs/upgrade/0-12-0",
         done: 100,
         next: null,
-        back: null,
+        previous: null,
       },
       {
         // upgrade guides
@@ -128,7 +128,7 @@ const items: DocNavigationSection[] = [
         href: "/docs/upgrade/0-11-0",
         done: 100,
         next: null,
-        back: null,
+        previous: null,
       },
       // {
       //   // upgrade guides
@@ -337,8 +337,8 @@ export const docNavigationItems = items.map((section) => ({
       ...item,
       next:
         item.next === null ? null : flatItems[currentIndex + 1] || undefined,
-      back:
-        item.back === null ? null : flatItems[currentIndex - 1] || undefined,
+      previous:
+        item.previous === null ? null : flatItems[currentIndex - 1] || undefined,
     };
   }),
 }));

--- a/homepage/homepage/content/docs/docNavigationItems.ts
+++ b/homepage/homepage/content/docs/docNavigationItems.ts
@@ -1,4 +1,26 @@
-export const docNavigationItems = [
+import { Framework } from "../framework";
+
+export type DoneStatus =
+  | number // represents percentage done
+  | Partial<Record<Framework, number>>;
+
+export type DocNavigationItem = {
+  name: string;
+  href: string;
+  done: DoneStatus;
+  framework?: Framework;
+  next?: DocNavigationItem;
+  back?: DocNavigationItem;
+};
+
+export type DocNavigationSection = {
+  name: string;
+  items: DocNavigationItem[];
+  collapse?: boolean;
+  prefix?: string;
+};
+
+export const docNavigationItems: DocNavigationSection[] = [
   {
     // welcome to jazz
     name: "Getting started",
@@ -126,7 +148,7 @@ export const docNavigationItems = [
         name: "0.9.2 - Local persistence on React Native Expo",
         href: "/docs/upgrade/react-native-local-persistence",
         done: 100,
-        framework: "react-native-expo",
+        framework: Framework.ReactNativeExpo,
       },
       // {
       //   // upgrade guides
@@ -295,4 +317,13 @@ export const docNavigationItems = [
       },
     ],
   },
-];
+].map((section) => ({
+  ...section,
+  items: section.items.map((item, index, items) => ({
+    ...item,
+    next: items[index + 1] || undefined,
+    back: items[index - 1] || undefined,
+  })),
+}));
+
+console.log(docNavigationItems);

--- a/homepage/homepage/content/docs/docNavigationItems.ts
+++ b/homepage/homepage/content/docs/docNavigationItems.ts
@@ -20,7 +20,7 @@ export type DocNavigationSection = {
   prefix?: string;
 };
 
-export const docNavigationItems: DocNavigationSection[] = [
+const items: DocNavigationSection[] = [
   {
     // welcome to jazz
     name: "Getting started",
@@ -317,13 +317,18 @@ export const docNavigationItems: DocNavigationSection[] = [
       },
     ],
   },
-].map((section) => ({
-  ...section,
-  items: section.items.map((item, index, items) => ({
-    ...item,
-    next: items[index + 1] || undefined,
-    back: items[index - 1] || undefined,
-  })),
-}));
+];
 
-console.log(docNavigationItems);
+const flatItems = items.flatMap((section) => section.items);
+
+export const docNavigationItems = items.map((section) => ({
+  ...section,
+  items: section.items.map((item) => {
+    const currentIndex = flatItems.findIndex((flatItem) => flatItem.href === item.href);
+    return {
+      ...item,
+      next: flatItems[currentIndex + 1] || undefined,
+      back: flatItems[currentIndex - 1] || undefined,
+    };
+  }),
+}))

--- a/homepage/homepage/content/docs/docNavigationItems.ts
+++ b/homepage/homepage/content/docs/docNavigationItems.ts
@@ -31,6 +31,7 @@ export const docNavigationItems: DocNavigationSection[] = [
         name: "Introduction",
         href: "/docs",
         done: 100,
+        excludeFromNavigation: true,
       },
       {
         name: "Guide",
@@ -43,6 +44,7 @@ export const docNavigationItems: DocNavigationSection[] = [
         name: "Example apps",
         href: "/examples",
         done: 30,
+        excludeFromNavigation: true,
       },
       { name: "FAQs", href: "/docs/faq", done: 100 },
     ],

--- a/homepage/homepage/content/docs/docNavigationItems.ts
+++ b/homepage/homepage/content/docs/docNavigationItems.ts
@@ -20,7 +20,7 @@ export type DocNavigationSection = {
   prefix?: string;
 };
 
-const items: DocNavigationSection[] = [
+export const docNavigationItems: DocNavigationSection[] = [
   {
     // welcome to jazz
     name: "Getting started",
@@ -325,20 +325,16 @@ const items: DocNavigationSection[] = [
   },
 ];
 
-const flatItems = items.flatMap((section) => section.items);
+const flatItems = docNavigationItems.flatMap((section) => section.items);
 
-export const docNavigationItems = items.map((section) => ({
-  ...section,
-  items: section.items.map((item) => {
-    const currentIndex = flatItems.findIndex(
-      (flatItem) => flatItem.href === item.href,
-    );
-    return {
-      ...item,
-      next:
-        item.next === null ? null : flatItems[currentIndex + 1] || undefined,
-      previous:
-        item.previous === null ? null : flatItems[currentIndex - 1] || undefined,
-    };
-  }),
-}));
+export const flatItemsWithNavLinks = flatItems.map((item) => {
+  const currentIndex = flatItems.findIndex(
+    (flatItem) => flatItem.href === item.href,
+  );
+  return {
+    ...item,
+    next: item.next === null ? null : flatItems[currentIndex + 1] || undefined,
+    previous:
+      item.previous === null ? null : flatItems[currentIndex - 1] || undefined,
+  };
+});

--- a/homepage/homepage/content/docs/docNavigationItems.ts
+++ b/homepage/homepage/content/docs/docNavigationItems.ts
@@ -9,8 +9,8 @@ export type DocNavigationItem = {
   href: string;
   done: DoneStatus;
   framework?: Framework;
-  next?: DocNavigationItem;
-  back?: DocNavigationItem;
+  next?: DocNavigationItem | null;
+  back?: DocNavigationItem | null;
 };
 
 export type DocNavigationSection = {
@@ -111,18 +111,24 @@ const items: DocNavigationSection[] = [
         name: "0.13.0 - React Native Split",
         href: "/docs/upgrade/0-13-0",
         done: 100,
+        next: null,
+        back: null,
       },
       {
         // upgrade guides
         name: "0.12.0 - Deeply Resolved Data",
         href: "/docs/upgrade/0-12-0",
         done: 100,
+        next: null,
+        back: null,
       },
       {
         // upgrade guides
         name: "0.11.0 - Roles and permissions",
         href: "/docs/upgrade/0-11-0",
         done: 100,
+        next: null,
+        back: null,
       },
       // {
       //   // upgrade guides
@@ -324,11 +330,15 @@ const flatItems = items.flatMap((section) => section.items);
 export const docNavigationItems = items.map((section) => ({
   ...section,
   items: section.items.map((item) => {
-    const currentIndex = flatItems.findIndex((flatItem) => flatItem.href === item.href);
+    const currentIndex = flatItems.findIndex(
+      (flatItem) => flatItem.href === item.href,
+    );
     return {
       ...item,
-      next: flatItems[currentIndex + 1] || undefined,
-      back: flatItems[currentIndex - 1] || undefined,
+      next:
+        item.next === null ? null : flatItems[currentIndex + 1] || undefined,
+      back:
+        item.back === null ? null : flatItems[currentIndex - 1] || undefined,
     };
   }),
-}))
+}));

--- a/homepage/homepage/generate-docs/utils/config.mjs
+++ b/homepage/homepage/generate-docs/utils/config.mjs
@@ -1,4 +1,4 @@
-import { docNavigationItems } from "../../content/docs/docNavigationItems.js";
+import { docNavigationItems } from "../../content/docs/docNavigationItems.ts";
 
 // Transform docNavigationItems into the format we need
 function transformNavItems() {

--- a/homepage/homepage/lib/docMdxContent.tsx
+++ b/homepage/homepage/lib/docMdxContent.tsx
@@ -72,11 +72,11 @@ export async function DocPage({
         <DocProse>
           <Content />
 
-          <HelpLinks className="lg:hidden mt-12" />
+          <div className="divide-y mt-12">
+            <HelpLinks className="lg:hidden pb-4" />
 
-          <Separator className="mt-4 mb-0 lg:mt-12" />
-
-          <PreviousNextLinks slug={slug} framework={framework} />
+            <PreviousNextLinks slug={slug} framework={framework} />
+          </div>
         </DocProse>
       </DocsLayout>
     );

--- a/homepage/homepage/lib/docMdxContent.tsx
+++ b/homepage/homepage/lib/docMdxContent.tsx
@@ -73,9 +73,10 @@ export async function DocPage({
           <Content />
 
           <HelpLinks className="lg:hidden mt-12" />
+
           <Separator className="mt-4 mb-0 lg:mt-12" />
 
-          <PreviousNextLinks />
+          <PreviousNextLinks slug={slug} framework={framework} />
         </DocProse>
       </DocsLayout>
     );

--- a/homepage/homepage/lib/docMdxContent.tsx
+++ b/homepage/homepage/lib/docMdxContent.tsx
@@ -1,6 +1,7 @@
 import DocsLayout from "@/components/docs/DocsLayout";
 import { DocNav } from "@/components/docs/DocsNav";
 import { HelpLinks } from "@/components/docs/HelpLinks";
+import { PreviousNextLinks } from "@/components/docs/PreviousNextLinks";
 import { Separator } from "@garden-co/design-system/src/components/atoms/Separator";
 import { Prose } from "@garden-co/design-system/src/components/molecules/Prose";
 import { Toc } from "@stefanprobst/rehype-extract-toc";
@@ -25,7 +26,10 @@ export async function getDocMetadata(framework: string, slug?: string[]) {
   try {
     const mdxSource = await getMdxSource(framework, slugPath);
 
-    const title = mdxSource.metadata.title || mdxSource.tableOfContents?.[0].value || "Documentation"
+    const title =
+      mdxSource.metadata.title ||
+      mdxSource.tableOfContents?.[0].value ||
+      "Documentation";
 
     return {
       title,
@@ -35,7 +39,7 @@ export async function getDocMetadata(framework: string, slug?: string[]) {
       },
     };
   } catch (error) {
-    const title = "Documentation"
+    const title = "Documentation";
     return {
       title,
       openGraph: {
@@ -68,9 +72,10 @@ export async function DocPage({
         <DocProse>
           <Content />
 
-          <Separator className="mt-12 mb-4 lg:hidden" />
+          <HelpLinks className="lg:hidden mt-12" />
+          <Separator className="mt-4 mb-0 lg:mt-12" />
 
-          <HelpLinks className="lg:hidden" />
+          <PreviousNextLinks />
         </DocProse>
       </DocsLayout>
     );
@@ -110,6 +115,7 @@ export async function getMdxWithToc(framework: string, slug?: string[]) {
     tocItems,
   };
 }
+
 function filterTocItemsForFramework(
   tocItems: Toc,
   framework: string,


### PR DESCRIPTION
[Test here](https://jazz-homepage-git-feat-back-next-buttons-gcmp.vercel.app/docs/react/guide)

<img width="660" alt="image" src="https://github.com/user-attachments/assets/8f3deb07-e08f-4f08-bc3a-a8d1d5ca01aa" />

The following pages are excluded from the prev/next navigation
- intro page - because this is going to be more intentional, and we'll have more than one "next" link
- example apps - because this takes you outside of the docs
- upgrade guides - because they're not part of the sequence

I'll take another look at this after the restructuring of the docs.



fixes #2249