### PR TITLE
feat: enable RNQC for encrypt/decrypt

### DIFF
--- a/.changeset/proud-humans-flash.md
+++ b/.changeset/proud-humans-flash.md
@@ -1,0 +1,6 @@
+---
+"jazz-react-native-core": patch
+"cojson": patch
+---
+
+Enable react-native-quick-crypto xsalsa20 accelerated algorithm for encrypt/decrypt functions

--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,9 @@ __screenshots__
 # Playwright
 test-results
 
+# Java
+.java-version
+
 .husky
 
 .vscode/*

--- a/packages/cojson/src/crypto/PureJSCrypto.ts
+++ b/packages/cojson/src/crypto/PureJSCrypto.ts
@@ -67,7 +67,7 @@ export class PureJSCrypto extends CryptoProvider<Blake3State> {
     return this.blake3HashOnce(input).slice(0, 24);
   }
 
-  private generateJsonNonce(material: JsonValue): Uint8Array {
+  protected generateJsonNonce(material: JsonValue): Uint8Array {
     return this.generateNonce(textEncoder.encode(stableStringify(material)));
   }
 

--- a/packages/cojson/src/exports.ts
+++ b/packages/cojson/src/exports.ts
@@ -58,7 +58,7 @@ import type {
   BinaryStreamInfo,
 } from "./coValues/coStream.js";
 import type { InviteSecret } from "./coValues/group.js";
-import type { AgentSecret } from "./crypto/crypto.js";
+import { AgentSecret, textDecoder, textEncoder } from "./crypto/crypto.js";
 import type { AgentID, RawCoID, SessionID } from "./ids.js";
 import type { JsonObject, JsonValue } from "./jsonValue.js";
 import type * as Media from "./media.js";
@@ -108,6 +108,8 @@ export const cojsonInternals = {
   setCoValueLoadingRetryDelay(delay: number) {
     CO_VALUE_LOADING_CONFIG.RETRY_DELAY = delay;
   },
+  textEncoder,
+  textDecoder,
 };
 
 export {
@@ -169,18 +171,19 @@ export type {
   AccountRole,
 };
 
+// biome-ignore format: off
 // eslint-disable-next-line @typescript-eslint/no-namespace
 export namespace CojsonInternalTypes {
   export type CoValueKnownState = import("./sync.js").CoValueKnownState;
   export type CoJsonValue<T> = import("./jsonValue.js").CoJsonValue<T>;
   export type DoneMessage = import("./sync.js").DoneMessage;
+  export type Encrypted<T extends JsonValue, N extends JsonValue> = import("./crypto/crypto.js").Encrypted<T, N>;
+  export type KeySecret = import("./crypto/crypto.js").KeySecret;
   export type KnownStateMessage = import("./sync.js").KnownStateMessage;
   export type LoadMessage = import("./sync.js").LoadMessage;
   export type NewContentMessage = import("./sync.js").NewContentMessage;
   export type SessionNewContent = import("./sync.js").SessionNewContent;
-  // biome-ignore format: inserts spurious trialing comma that breaks some parsers
   export type CoValueHeader = import("./coValueCore/verifiedState.js").CoValueHeader;
-  // biome-ignore format: inserts spurious trialing comma that breaks some parsers
   export type Transaction = import("./coValueCore/verifiedState.js").Transaction;
   export type TransactionID = import("./ids.js").TransactionID;
   export type Signature = import("./crypto/crypto.js").Signature;
@@ -191,3 +194,4 @@ export namespace CojsonInternalTypes {
   export type SignerSecret = import("./crypto/crypto.js").SignerSecret;
   export type JsonObject = import("./jsonValue.js").JsonObject;
 }
+// biome-ignore format: on

--- a/packages/jazz-react-native-core/package.json
+++ b/packages/jazz-react-native-core/package.json
@@ -40,6 +40,7 @@
     "cojson-transport-ws": "workspace:*",
     "jazz-react-core": "workspace:*",
     "jazz-tools": "workspace:*",
+    "react-native-fast-encoder": "^0.2.0",
     "react-native-nitro-modules": "0.25.2",
     "react-native-quick-crypto": "1.0.0-beta.16"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2616,6 +2616,9 @@ importers:
       jazz-tools:
         specifier: workspace:*
         version: link:../jazz-tools
+      react-native-fast-encoder:
+        specifier: ^0.2.0
+        version: 0.2.0(react-native@0.79.2(@babel/core@7.27.1)(@react-native-community/cli@15.0.1(typescript@5.6.2))(@types/react@19.0.0)(react@19.0.0))(react@19.0.0)
       react-native-nitro-modules:
         specifier: 0.25.2
         version: 0.25.2(react-native@0.79.2(@babel/core@7.27.1)(@react-native-community/cli@15.0.1(typescript@5.6.2))(@types/react@19.0.0)(react@19.0.0))(react@19.0.0)
@@ -9641,6 +9644,9 @@ packages:
     resolution: {integrity: sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==}
     engines: {node: '>=16'}
 
+  flatbuffers@2.0.6:
+    resolution: {integrity: sha512-QTTZTXTbVfuOVQu2X6eLOw4vefUxnFJZxAKeN3rEPhjEzBtIbehimJLfVGHPM8iX0Na+9i76SBEg0skf0c0sCA==}
+
   flatted@3.3.2:
     resolution: {integrity: sha512-AiwGJM8YcNOaobumgtng+6NHuOqC3A7MixFeDafM3X9cIUM+xUXoS5Vfgf+OihAYe20fxqNM9yPBXJzRtZ/4eA==}
 
@@ -12523,6 +12529,13 @@ packages:
 
   react-native-edge-to-edge@1.6.0:
     resolution: {integrity: sha512-2WCNdE3Qd6Fwg9+4BpbATUxCLcouF6YRY7K+J36KJ4l3y+tWN6XCqAC4DuoGblAAbb2sLkhEDp4FOlbOIot2Og==}
+    peerDependencies:
+      react: 19.0.0
+      react-native: '*'
+
+  react-native-fast-encoder@0.2.0:
+    resolution: {integrity: sha512-E4mx81fRMVs0qq8is3cZTrbuEJdsDo8Nfe7qTxKZwsCianpYpA2QfyH6cEYumSOEht6l+KeRJ4RqcyfxMDyesg==}
+    engines: {node: '>= 18.0.0'}
     peerDependencies:
       react: 19.0.0
       react-native: '*'
@@ -19144,7 +19157,7 @@ snapshots:
       eslint: 8.57.1
       eslint-config-prettier: 8.10.0(eslint@8.57.1)
       eslint-plugin-eslint-comments: 3.2.0(eslint@8.57.1)
-      eslint-plugin-ft-flow: 2.0.3(@babel/eslint-parser@7.27.0(@babel/core@7.26.0)(eslint@8.57.1))(eslint@8.57.1)
+      eslint-plugin-ft-flow: 2.0.3(@babel/eslint-parser@7.27.0(@babel/core@7.27.1)(eslint@8.57.1))(eslint@8.57.1)
       eslint-plugin-jest: 27.9.0(@typescript-eslint/eslint-plugin@7.18.0(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.6.2))(eslint@8.57.1)(typescript@5.6.2))(eslint@8.57.1)(jest@29.7.0(@types/node@22.15.18)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.10.1(@swc/helpers@0.5.15))(@types/node@22.15.18)(typescript@5.6.2)))(typescript@5.6.2)
       eslint-plugin-react: 7.37.4(eslint@8.57.1)
       eslint-plugin-react-hooks: 4.6.2(eslint@8.57.1)
@@ -22600,7 +22613,7 @@ snapshots:
       eslint: 8.57.1
       ignore: 5.3.2
 
-  eslint-plugin-ft-flow@2.0.3(@babel/eslint-parser@7.27.0(@babel/core@7.26.0)(eslint@8.57.1))(eslint@8.57.1):
+  eslint-plugin-ft-flow@2.0.3(@babel/eslint-parser@7.27.0(@babel/core@7.27.1)(eslint@8.57.1))(eslint@8.57.1):
     dependencies:
       '@babel/eslint-parser': 7.27.0(@babel/core@7.27.1)(eslint@8.57.1)
       eslint: 8.57.1
@@ -23508,6 +23521,8 @@ snapshots:
     dependencies:
       flatted: 3.3.2
       keyv: 4.5.4
+
+  flatbuffers@2.0.6: {}
 
   flatted@3.3.2: {}
 
@@ -26867,6 +26882,13 @@ snapshots:
 
   react-native-edge-to-edge@1.6.0(react-native@0.79.2(@babel/core@7.27.1)(@react-native-community/cli@15.0.1(typescript@5.6.2))(@types/react@19.0.0)(react@19.0.0))(react@19.0.0):
     dependencies:
+      react: 19.0.0
+      react-native: 0.79.2(@babel/core@7.27.1)(@react-native-community/cli@15.0.1(typescript@5.6.2))(@types/react@19.0.0)(react@19.0.0)
+
+  react-native-fast-encoder@0.2.0(react-native@0.79.2(@babel/core@7.27.1)(@react-native-community/cli@15.0.1(typescript@5.6.2))(@types/react@19.0.0)(react@19.0.0))(react@19.0.0):
+    dependencies:
+      big-integer: 1.6.52
+      flatbuffers: 2.0.6
       react: 19.0.0
       react-native: 0.79.2(@babel/core@7.27.1)(@react-native-community/cli@15.0.1(typescript@5.6.2))(@types/react@19.0.0)(react@19.0.0)
 


### PR DESCRIPTION
`react-native-quick-crypto` just got support for `xsalsa20` so this PR adds `encrypt()` and `decryptRaw()` accelerated functions to `RNQuickCrypto` provider.

There are expo plugins coming for RNQC 🤞 - so for now we don't have an app that uses this in the monorepo.