### PR TITLE
fix-file-share-svelte

### DIFF
--- a/examples/file-share-svelte/package.json
+++ b/examples/file-share-svelte/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "vite dev",
-    "build": "vite build",
+    "build": "pnpm run check && vite build",
     "preview": "vite preview",
     "check": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json",
     "check:watch": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json --watch",

--- a/examples/file-share-svelte/src/lib/components/FileItem.svelte
+++ b/examples/file-share-svelte/src/lib/components/FileItem.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import { slide } from 'svelte/transition';
-  import { SharedFile } from '$lib/schema';
-  import { FileStream } from 'jazz-tools';
+  import { type SharedFile } from '$lib/schema';
+  import { FileStream, type Loaded } from 'jazz-tools';
   import { File, FileDown, Trash2, Link2 } from 'lucide-svelte';
   import { toast } from 'svelte-sonner';
   import { downloadFileBlob, formatFileSize } from '$lib/utils';
@@ -11,9 +11,9 @@
     loading = false,
     onDelete
   }: {
-    file: SharedFile;
+    file: Loaded<SharedFile>;
     loading?: boolean;
-    onDelete: (file: SharedFile) => void;
+    onDelete: (file: Loaded<SharedFile>) => void;
   } = $props();
 
   const isAdmin = $derived(file._owner?.myRole() === 'admin');
@@ -55,7 +55,7 @@
   class="flex items-center justify-between rounded-lg border border-gray-200 bg-white p-4"
   transition:slide={{ duration: 200 }}
 >
-  <div class="flex items-center space-x-4 flex-grow">
+  <div class="flex flex-grow items-center space-x-4">
     <div class="flex h-10 w-10 items-center justify-center rounded-lg bg-blue-100 text-blue-600">
       <File class="h-6 w-6" />
     </div>
@@ -64,7 +64,12 @@
         <label class="sr-only" for={`file-name-${file.id}`}>File name</label>
         <!-- Jazz values are reactive, but they are not recognized as reactive by Svelte -->
         <!-- svelte-ignore binding_property_non_reactive -->
-        <input class="font-medium text-gray-900 w-full py-1" type="text" bind:value={file.name} id={`file-name-${file.id}`} />
+        <input
+          class="w-full py-1 font-medium text-gray-900"
+          type="text"
+          bind:value={file.name}
+          id={`file-name-${file.id}`}
+        />
       {:else}
         <h3 class="font-medium text-gray-900">{file.name}</h3>
       {/if}

--- a/examples/file-share-svelte/src/lib/schema.ts
+++ b/examples/file-share-svelte/src/lib/schema.ts
@@ -8,6 +8,8 @@ export const SharedFile = co.map({
   size: z.number(),
 });
 
+export type SharedFile = typeof SharedFile;
+
 export const FileShareAccountRoot = co.map({
   type: z.literal('file-share-account'),
   sharedFiles: co.list(SharedFile),

--- a/examples/file-share-svelte/src/routes/+page.svelte
+++ b/examples/file-share-svelte/src/routes/+page.svelte
@@ -11,10 +11,12 @@
       root: {
         sharedFiles: {
           $each: true
-        },
+        }
       }
     }
   });
+
+  $inspect(me);
 
   const sharedFiles = $derived(me.current?.root.sharedFiles);
 
@@ -107,10 +109,7 @@
         {#if sharedFiles.length}
           {#each sharedFiles as file}
             {#if file}
-              <FileItem
-                {file}
-                onDelete={deleteFile}
-              />
+              <FileItem {file} onDelete={deleteFile} />
             {/if}
           {/each}
         {:else}

--- a/examples/file-share-svelte/src/routes/file/[fileId]/+page.svelte
+++ b/examples/file-share-svelte/src/routes/file/[fileId]/+page.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import { page } from '$app/stores';
-  import {  CoState } from 'jazz-svelte';
+  import { CoState } from 'jazz-svelte';
   import { SharedFile } from '$lib/schema';
   import { File, FileDown, Link2 } from 'lucide-svelte';
   import { FileStream } from 'jazz-tools';
@@ -9,7 +9,7 @@
 
   const fileId = $page.params.fileId;
 
-  const file = $derived(new CoState(SharedFile, fileId ));
+  const file = $derived(new CoState(SharedFile, fileId));
   const isAdmin = $derived(file.current?._owner?.myRole() === 'admin');
 
   const fileStreamId = $derived(file.current?._refs?.file?.id);


### PR DESCRIPTION
Follow up to 0.14, fixes the remaining type issues in the example app

Also turns on type-checking on build, to make things easier to spot next time