### PR TITLE
Turbo just builds deps now

### DIFF
--- a/turbo.json
+++ b/turbo.json
@@ -14,7 +14,7 @@
     "dev": {
       "cache": false,
       "persistent": true,
-      "dependsOn": ["build"]
+      "dependsOn": ["^build"]
     },
     "test": {
       "env": ["CI"],


### PR DESCRIPTION
Just run `turbo dev` from any package and you'll get all the dependencies built before spinning up the dev server.