### PR TITLE
Add URL's to live demos in all readme files in examples

### DIFF
--- a/examples/clerk/README.md
+++ b/examples/clerk/README.md
@@ -2,7 +2,7 @@
 
 This is an example of how to use clerk authentication with Jazz.
 
-Live version: https://clerk-demo.jazz.tools
+Live version: [https://clerk-demo.jazz.tools](https://clerk-demo.jazz.tools)
 
 ## Getting started
 

--- a/examples/filestream/README.md
+++ b/examples/filestream/README.md
@@ -2,7 +2,7 @@
 
 This is an example of how to upload and render images with Jazz.
 
-Live version: https://file-upload-demo.jazz.tools
+Live version: [https://file-upload-demo.jazz.tools](https://file-upload-demo.jazz.tools)
 
 ## Getting started
 

--- a/examples/image-upload/README.md
+++ b/examples/image-upload/README.md
@@ -2,7 +2,7 @@
 
 This is an example of how to upload and render images with Jazz.
 
-Live version: https://image-upload-demo.jazz.tools
+Live version: [https://image-upload-demo.jazz.tools](https://image-upload-demo.jazz.tools)
 
 ## Getting started
 

--- a/examples/inspector/README.md
+++ b/examples/inspector/README.md
@@ -1,6 +1,6 @@
 # Jazz Inspector
 
-Live address: https://inspector.jazz.tools
+Live address: [https://inspector.jazz.tools](https://inspector.jazz.tools)
 
 Use this to visually inspect a Jazz account or other CoValue.
 

--- a/examples/multi-cursors/README.md
+++ b/examples/multi-cursors/README.md
@@ -1,6 +1,7 @@
 # Jazz Multi-Cursors Example
 
 Track user presence on a canvas with multiple cursors and out of bounds indicators.
+Live version: [https://multi-cursors-demo.jazz.tools/](https://multi-cursors-demo.jazz.tools/)
 
 ## Getting started
 

--- a/examples/music-player/README.md
+++ b/examples/music-player/README.md
@@ -1,6 +1,6 @@
 # Music player example with Jazz and React
 
-Live version: https://music-demo.jazz.tools
+Live version: [https://music-demo.jazz.tools](https://music-demo.jazz.tools)
 
 ## Getting started
 

--- a/examples/organization/README.md
+++ b/examples/organization/README.md
@@ -2,7 +2,7 @@
 
 This is an example of how to share a set of data between users through a CoMap called Organization. 
 Different apps have different names for this concept, such as "teams" or "workspaces".
-
+Live version: [https://jazz-organization.vercel.app/](https://jazz-organization.vercel.app/)
 Refer to the [documentation](https://jazz.tools/docs/react/design-patterns/organization)  for more information.
 
 ## Getting started

--- a/examples/passkey/README.md
+++ b/examples/passkey/README.md
@@ -2,7 +2,7 @@
 
 This is an example of how to use passkey authentication with Jazz.
 
-Live version: https://passkey-demo.jazz.tools
+Live version: [https://passkey-demo.jazz.tools](https://passkey-demo.jazz.tools)
 
 ## Getting started
 

--- a/examples/password-manager/README.md
+++ b/examples/password-manager/README.md
@@ -1,6 +1,6 @@
 # Password manager example with Jazz and React
 
-Live version: https://passwords-demo.jazz.tools
+Live version: [https://passwords-demo.jazz.tools](https://passwords-demo.jazz.tools)
 
 ![Password Manager Screenshot](demo.png "Screenshot")
 

--- a/examples/pets/README.md
+++ b/examples/pets/README.md
@@ -1,6 +1,6 @@
 # Rate My Pets example with Jazz and React
 
-Live version: https://pets-demo.jazz.tools/
+Live version: [https://pets-demo.jazz.tools/](https://pets-demo.jazz.tools/)
 
 ## Getting started
 

--- a/examples/todo/README.md
+++ b/examples/todo/README.md
@@ -1,6 +1,6 @@
 # Todo list example with Jazz and React
 
-Live version: https://todo-demo.jazz.tools/
+Live version: [https://todo-demo.jazz.tools/](https://todo-demo.jazz.tools/)
 
 ## Getting started
 

--- a/examples/version-history/README.md
+++ b/examples/version-history/README.md
@@ -1,6 +1,7 @@
 # Jazz Version History Example
 
 A minimal example showing how to use Jazz's built-in version history to show and restore changes.
+Live Version: [https://jazz-version-history.vercel.app/](https://jazz-version-history.vercel.app/)
 
 ## Getting started
 


### PR DESCRIPTION
Closes [#2345 ](https://github.com/garden-co/jazz/issues/2345)

Adds links to live demos in all example README files 
Updates all existing links to use consistent markdown syntax 