### PR TITLE
fix(storage): align groups dependencies calculation to LocalNode

### DIFF
--- a/.changeset/old-spoons-help.md
+++ b/.changeset/old-spoons-help.md
@@ -1,0 +1,6 @@
+---
+"cojson-storage": patch
+"cojson": patch
+---
+
+Align the processing of the group dependencies between LocalNode and Storage.

--- a/packages/cojson-storage/src/managerAsync.ts
+++ b/packages/cojson-storage/src/managerAsync.ts
@@ -15,14 +15,8 @@ import type {
   StoredCoValueRow,
   StoredSessionRow,
 } from "./types.js";
-import NewContentMessage = CojsonInternalTypes.NewContentMessage;
 import KnownStateMessage = CojsonInternalTypes.KnownStateMessage;
 import RawCoID = CojsonInternalTypes.RawCoID;
-
-type OutputMessageMap = Record<
-  RawCoID,
-  { knownMessage: KnownStateMessage; contentMessages?: NewContentMessage[] }
->;
 
 export class StorageManagerAsync {
   private readonly toLocalNode: OutgoingSyncQueue;
@@ -179,10 +173,10 @@ export class StorageManagerAsync {
     coValueRow: StoredCoValueRow,
     contentMessage: CojsonInternalTypes.NewContentMessage,
   ) {
-    const dependedOnCoValuesList = getDependedOnCoValues({
-      coValueRow,
-      newContentMessages: [contentMessage],
-    });
+    const dependedOnCoValuesList = getDependedOnCoValues(
+      coValueRow.header,
+      contentMessage,
+    );
 
     for (const dependedOnCoValue of dependedOnCoValuesList) {
       if (this.loadedCoValues.has(dependedOnCoValue)) {

--- a/packages/cojson-storage/src/managerSync.ts
+++ b/packages/cojson-storage/src/managerSync.ts
@@ -180,10 +180,10 @@ export class StorageManagerSync {
     coValueRow: StoredCoValueRow,
     contentMessage: CojsonInternalTypes.NewContentMessage,
   ) {
-    const dependedOnCoValuesList = getDependedOnCoValues({
-      coValueRow,
-      newContentMessages: [contentMessage],
-    });
+    const dependedOnCoValuesList = getDependedOnCoValues(
+      coValueRow.header,
+      contentMessage,
+    );
 
     for (const dependedOnCoValue of dependedOnCoValuesList) {
       if (this.loadedCoValues.has(dependedOnCoValue)) {

--- a/packages/cojson-storage/src/tests/getDependedOnCoValues.test.ts
+++ b/packages/cojson-storage/src/tests/getDependedOnCoValues.test.ts
@@ -13,7 +13,7 @@ function getMockedCoValueId() {
 function generateNewContentMessage(
   privacy: "trusting" | "private",
   changes: any[],
-  accountId?: `co_z${string}`,
+  accountId: `co_z${string}`,
 ) {
   return {
     action: "content",
@@ -46,18 +46,21 @@ describe("getDependedOnCoValues", () => {
       },
     } as any;
 
-    const result = getDependedOnCoValues({
-      coValueRow,
-      newContentMessages: [
-        generateNewContentMessage("trusting", [
+    const accountId = getMockedCoValueId();
+    const result = getDependedOnCoValues(
+      coValueRow.header,
+      generateNewContentMessage(
+        "trusting",
+        [
           { op: "set", key: "co_zabc123", value: "test" },
           { op: "set", key: "parent_co_zdef456", value: "test" },
           { op: "set", key: "normal_key", value: "test" },
-        ]),
-      ],
-    });
+        ],
+        accountId,
+      ),
+    );
 
-    expect(result).toEqual(["co_zabc123", "co_zdef456"]);
+    expect(result).toEqual(new Set([accountId, "co_zabc123", "co_zdef456"]));
   });
 
   it("should not throw on malformed JSON", () => {
@@ -70,9 +73,12 @@ describe("getDependedOnCoValues", () => {
       },
     } as any;
 
-    const message = generateNewContentMessage("trusting", [
-      { op: "set", key: "co_zabc123", value: "test" },
-    ]);
+    const accountId = getMockedCoValueId();
+    const message = generateNewContentMessage(
+      "trusting",
+      [{ op: "set", key: "co_zabc123", value: "test" }],
+      accountId,
+    );
 
     message.new["invalid_session" as SessionID] = {
       after: 0,
@@ -86,12 +92,9 @@ describe("getDependedOnCoValues", () => {
       ],
     };
 
-    const result = getDependedOnCoValues({
-      coValueRow,
-      newContentMessages: [message],
-    });
+    const result = getDependedOnCoValues(coValueRow.header, message);
 
-    expect(result).toEqual(["co_zabc123"]);
+    expect(result).toEqual(new Set([accountId, "co_zabc123"]));
   });
 
   it("should return dependencies for ownedByGroup ruleset", () => {
@@ -123,12 +126,9 @@ describe("getDependedOnCoValues", () => {
       newTransactions: [],
     };
 
-    const result = getDependedOnCoValues({
-      coValueRow,
-      newContentMessages: [message],
-    });
+    const result = getDependedOnCoValues(coValueRow.header, message);
 
-    expect(result).toEqual([groupId, accountId]);
+    expect(result).toEqual(new Set([groupId, accountId]));
   });
 
   it("should return empty array for other ruleset types", () => {
@@ -141,18 +141,21 @@ describe("getDependedOnCoValues", () => {
       },
     } as any;
 
-    const result = getDependedOnCoValues({
-      coValueRow,
-      newContentMessages: [
-        generateNewContentMessage("trusting", [
+    const accountId = getMockedCoValueId();
+    const result = getDependedOnCoValues(
+      coValueRow.header,
+      generateNewContentMessage(
+        "trusting",
+        [
           { op: "set", key: "co_zabc123", value: "test" },
           { op: "set", key: "parent_co_zdef456", value: "test" },
           { op: "set", key: "normal_key", value: "test" },
-        ]),
-      ],
-    });
+        ],
+        accountId,
+      ),
+    );
 
-    expect(result).toEqual([]);
+    expect(result).toEqual(new Set([accountId]));
   });
 
   it("should ignore non-trusting transactions in group ruleset", () => {
@@ -165,15 +168,17 @@ describe("getDependedOnCoValues", () => {
       },
     } as any;
 
-    const result = getDependedOnCoValues({
-      coValueRow,
-      newContentMessages: [
-        generateNewContentMessage("private", [
-          { op: "set", key: "co_zabc123", value: "test" },
-        ]),
-      ],
-    });
+    const accountId = getMockedCoValueId();
 
-    expect(result).toEqual([]);
+    const result = getDependedOnCoValues(
+      coValueRow.header,
+      generateNewContentMessage(
+        "private",
+        [{ op: "set", key: "co_zabc123", value: "test" }],
+        accountId,
+      ),
+    );
+
+    expect(result).toEqual(new Set([accountId]));
   });
 });

--- a/packages/cojson-storage/src/tests/syncManager.test.ts
+++ b/packages/cojson-storage/src/tests/syncManager.test.ts
@@ -21,7 +21,6 @@ import { fixtures } from "./fixtureMessages.js";
 
 type RawCoID = CojsonInternalTypes.RawCoID;
 type NewContentMessage = CojsonInternalTypes.NewContentMessage;
-type Transaction = CojsonInternalTypes.Transaction;
 vi.mock("../syncUtils");
 
 const coValueIdToLoad = "co_zKwG8NyfZ8GXqcjDHY4NS3SbU2m";
@@ -58,7 +57,7 @@ describe("DB sync manager", () => {
     syncManager.sendStateMessage = vi.fn();
 
     // No dependencies found
-    vi.mocked(getDependedOnCoValues).mockReturnValue([]);
+    vi.mocked(getDependedOnCoValues).mockReturnValue(new Set());
   });
 
   afterEach(() => {
@@ -135,7 +134,7 @@ describe("DB sync manager", () => {
 
       // Fetch dependencies of the current dependency for the future recursion iterations
       vi.mocked(getDependedOnCoValues).mockImplementation(
-        ({ coValueRow }) => dependenciesTreeWithLoop[coValueRow.id] || [],
+        (_, msg) => new Set(dependenciesTreeWithLoop[msg.id] || []),
       );
 
       await syncManager.handleSyncMessage(loadMsg);

--- a/packages/cojson/src/exports.ts
+++ b/packages/cojson/src/exports.ts
@@ -72,6 +72,7 @@ import type {
 import {
   DisconnectedError,
   PingTimeoutError,
+  SyncManager,
   emptyKnownState,
 } from "./sync.js";
 
@@ -102,6 +103,7 @@ export const cojsonInternals = {
   getGroupDependentKeyList,
   getGroupDependentKey,
   disablePermissionErrors,
+  SyncManager,
   CO_VALUE_LOADING_CONFIG,
   setCoValueLoadingRetryDelay(delay: number) {
     CO_VALUE_LOADING_CONFIG.RETRY_DELAY = delay;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2970,6 +2970,9 @@ importers:
       cojson:
         specifier: workspace:*
         version: link:../../packages/cojson
+      cojson-storage:
+        specifier: workspace:*
+        version: link:../../packages/cojson-storage
       cojson-storage-indexeddb:
         specifier: workspace:*
         version: link:../../packages/cojson-storage-indexeddb

--- a/tests/browser-integration/package.json
+++ b/tests/browser-integration/package.json
@@ -12,9 +12,10 @@
   },
   "dependencies": {
     "cojson": "workspace:*",
-    "cojson-transport-ws": "workspace:*",
+    "cojson-storage": "workspace:*",
     "cojson-storage-indexeddb": "workspace:*",
     "cojson-storage-sqlite": "workspace:*",
+    "cojson-transport-ws": "workspace:*",
     "jazz-browser": "workspace:*",
     "jazz-browser-media-images": "workspace:*",
     "jazz-tools": "workspace:*"


### PR DESCRIPTION
We found that sometimes group loading might get stuck in storage.

Debugging we found that was because of the dependencies processing.

Not all account dependencies required to verify signatures were pushed from storage, but they are expeced in LocalNode creating a lock.

This PR fixes that.