### PR TITLE
Set default package manager based on command runner

### DIFF
--- a/packages/create-jazz-app/src/index.ts
+++ b/packages/create-jazz-app/src/index.ts
@@ -106,7 +106,7 @@ function isInsideGitRepository(projectPath: string): boolean {
   }
 }
 
-function getPkgManager(): PackageManager {
+function getPkgManager() {
   const userAgent = process.env.npm_config_user_agent || "";
 
   if (userAgent.startsWith("yarn")) {

--- a/packages/create-jazz-app/src/index.ts
+++ b/packages/create-jazz-app/src/index.ts
@@ -106,6 +106,28 @@ function isInsideGitRepository(projectPath: string): boolean {
   }
 }
 
+function getPkgManager(): PackageManager {
+  const userAgent = process.env.npm_config_user_agent || "";
+
+  if (userAgent.startsWith("yarn")) {
+    return "yarn";
+  }
+
+  if (userAgent.startsWith("pnpm")) {
+    return "pnpm";
+  }
+
+  if (userAgent.startsWith("bun")) {
+    return "bun";
+  }
+
+  if (userAgent.startsWith("deno")) {
+    return "deno";
+  }
+
+  return "npm";
+}
+
 async function scaffoldProject({
   template,
   projectName,
@@ -443,6 +465,8 @@ async function promptUser(
   }
 
   if (!partialOptions.packageManager) {
+    const defaultPackageManager = getPkgManager();
+
     questions.push({
       type: "list",
       name: "packageManager",
@@ -454,7 +478,7 @@ async function promptUser(
         { name: chalk.white("bun"), value: "bun" },
         { name: chalk.white("deno"), value: "deno" },
       ],
-      default: "npm",
+      default: defaultPackageManager,
     });
   }
 


### PR DESCRIPTION
This PR sets the default package manager to the one used to run `create-jazz-app`.

So if you run `pnpm dlx create-jazz-app` it would select `pnpm` by default which allows you to just press enter.