### PR TITLE
add get started button to drive engagement to docs

### DIFF
--- a/homepage/design-system/src/components/organisms/Nav.tsx
+++ b/homepage/design-system/src/components/organisms/Nav.tsx
@@ -13,6 +13,7 @@ import { usePathname } from "next/navigation";
 import { ComponentType, ReactNode, useEffect, useState } from "react";
 import React from "react";
 import { isActive } from "../../utils/nav";
+import { Button } from "../atoms/Button";
 import { Icon } from "../atoms/Icon";
 import type { IconName } from "../atoms/Icon";
 import { BreadCrumb } from "../molecules/Breadcrumb";
@@ -146,7 +147,7 @@ export function MobileNav({
     icon: "menu",
     content: (
       <>
-        <div className="flex items-center justify-between border-b p-3">
+        <div className="flex items-center justify-between border-b p-3 position-sticky top-0 left-0 right-0 bg-white dark:bg-stone-950 z-50">
           <Link href="/" className="flex items-center">
             {mainLogo}
           </Link>
@@ -170,6 +171,10 @@ export function MobileNav({
               </NavLink>
             ))}
         </div>
+
+        <Button variant="primary" size="sm" className="mb-3 ml-4">
+          <Link href="/docs">Get started</Link>
+        </Button>
       </>
     ),
   };
@@ -199,7 +204,11 @@ export function MobileNav({
         <NavLinkLogo prominent href="/" className="mr-auto">
           {mainLogo}
         </NavLinkLogo>
-        <button
+        <Button variant="primary" size="sm" className="mr-3">
+          <Link href="/docs">Get started</Link>
+        </Button>
+        <Button
+          variant="plain"
           className="flex gap-2 p-3 rounded-xl items-center"
           onClick={() => {
             setActive("Menu");
@@ -208,7 +217,7 @@ export function MobileNav({
         >
           <Icon name="menu" />
           <BreadCrumb items={items} />
-        </button>
+        </Button>
       </div>
 
       <div
@@ -361,6 +370,10 @@ export function Nav(props: NavProps) {
               className={i == items.length - 1 ? "mr-3" : ""}
             />
           ))}
+
+          <Button variant="primary" size="sm" className="mr-3">
+            <Link href="/docs">Get started</Link>
+          </Button>
 
           <SocialLinks
             {...props.socials}

--- a/homepage/design-system/src/components/organisms/Nav.tsx
+++ b/homepage/design-system/src/components/organisms/Nav.tsx
@@ -147,7 +147,7 @@ export function MobileNav({
     icon: "menu",
     content: (
       <>
-        <div className="flex items-center justify-between border-b p-3 position-sticky top-0 left-0 right-0 bg-white dark:bg-stone-950 z-50">
+        <div className="flex items-center justify-between border-b p-3">
           <Link href="/" className="flex items-center">
             {mainLogo}
           </Link>

--- a/homepage/homepage/components/home/HeroSection.tsx
+++ b/homepage/homepage/components/home/HeroSection.tsx
@@ -6,6 +6,7 @@ import {
   type IconName,
 } from "@garden-co/design-system/src/components/atoms/Icon";
 import { Kicker } from "@garden-co/design-system/src/components/atoms/Kicker";
+import { Button } from "@garden-co/design-system/src/components/atoms/Button";
 import { CopyButton } from "@garden-co/design-system/src/components/molecules/CodeGroup";
 import { Prose } from "@garden-co/design-system/src/components/molecules/Prose";
 import { SectionHeader } from "@garden-co/design-system/src/components/molecules/SectionHeader";
@@ -89,6 +90,14 @@ export function HeroSection() {
               <p>{title}</p>
             </div>
           ))}
+          <div className="mt-5">
+            <Button
+              variant="primary"
+              size="md"
+            >
+              <Link href="/docs">Get started</Link>
+            </Button>
+          </div>
         </div>
       </div>
 


### PR DESCRIPTION
to be merged after https://github.com/garden-co/jazz/issues/2463

Adding get started now buttons to drive engagement, as per feedback from Ali

<img width="826" alt="Screenshot 2025-06-02 at 11 27 03" src="https://github.com/user-attachments/assets/95d2472c-b4a7-4974-ab90-3b03e6dac6ce" />


<img width="612" alt="Screenshot 2025-06-02 at 11 27 15" src="https://github.com/user-attachments/assets/2fb87908-b33f-4b59-bb35-9f9dfc43431b" />


<img width="1081" alt="Screenshot 2025-06-02 at 11 10 44" src="https://github.com/user-attachments/assets/c8ae5682-6821-443b-86f0-ac2ad005bf9c" />
