### PR TITLE
feat: add support for coMap migrations

### DIFF
--- a/.changeset/beige-geese-call.md
+++ b/.changeset/beige-geese-call.md
@@ -1,0 +1,5 @@
+---
+"jazz-tools": patch
+---
+
+Add support for per-CoMap migrations

--- a/.changeset/itchy-dancers-shop.md
+++ b/.changeset/itchy-dancers-shop.md
@@ -1,0 +1,5 @@
+---
+"jazz-tools": patch
+---
+
+Make Zod schemas compatible with castAs

--- a/examples/music-player/src/1_schema.ts
+++ b/examples/music-player/src/1_schema.ts
@@ -41,8 +41,8 @@ export const MusicTrack = co.map({
   /**
    * You can use getters for recusrive relations
    */
-  get sourceTrack(): z.ZodOptional<typeof MusicTrack> {
-    return z.optional(MusicTrack);
+  get sourceTrack() {
+    return MusicTrack.optional();
   },
 });
 export type MusicTrack = co.loaded<typeof MusicTrack>;

--- a/examples/todo/src/1_schema.ts
+++ b/examples/todo/src/1_schema.ts
@@ -1,4 +1,4 @@
-import { co, z } from "jazz-tools";
+import { CoPlainText, co, z } from "jazz-tools";
 
 /** Walkthrough: Defining the data model with CoJSON
  *
@@ -11,9 +11,30 @@ import { co, z } from "jazz-tools";
  **/
 
 /** An individual task which collaborators can tick or rename */
-export const Task = co.map({
+export const Task = co
+  .map({
+    done: z.boolean(),
+    text: co.plainText(),
+    version: z.literal(1),
+  })
+  .withMigration((task) => {
+    if (!task.version) {
+      // Cast to the v1 version
+      const task_v1 = task.castAs(Task_V1);
+
+      // Check if the task text field is a string or an id
+      // if it's a string migrate to plaintext
+      // We need to do this check because some tasks with plainText have been created before we added the version field
+      if (!task_v1.text.startsWith("co_z")) {
+        task.text = CoPlainText.create(task_v1.text, task._owner);
+      }
+      task.version = 1;
+    }
+  });
+
+const Task_V1 = co.map({
   done: z.boolean(),
-  text: co.plainText(),
+  text: z.string(),
 });
 
 /** Our top level object: a project with a title, referencing a list of tasks */

--- a/examples/todo/src/4_ProjectTodoTable.tsx
+++ b/examples/todo/src/4_ProjectTodoTable.tsx
@@ -51,6 +51,7 @@ export function ProjectTodoTable() {
         {
           done: false,
           text: CoPlainText.create(text, project._owner),
+          version: 1,
         },
         project._owner,
       );

--- a/examples/todo/src/generate.ts
+++ b/examples/todo/src/generate.ts
@@ -19,6 +19,7 @@ export function generateRandomProject(
         faker.lorem.sentence({ min: 3, max: 8 }),
         tasks._owner,
       ),
+      version: 1,
     });
     tasks.push(task);
   }

--- a/homepage/homepage/content/docs/using-covalues/comaps.mdx
+++ b/homepage/homepage/content/docs/using-covalues/comaps.mdx
@@ -314,7 +314,7 @@ Here's an example of a migration that adds the `priority` field to the `Task` Co
 
 <CodeGroup>
 ```ts twoslash
-import { co, z, CoPlainText } from "jazz-tools";
+import { co, z } from "jazz-tools";
 
 const Task = co
   .map({

--- a/homepage/homepage/content/docs/using-covalues/comaps.mdx
+++ b/homepage/homepage/content/docs/using-covalues/comaps.mdx
@@ -310,7 +310,7 @@ project.coordinator = undefined;  // Remove the reference
 
 Migrations in CoMaps are functions that run when a CoMap is loaded, not when it's created. They're useful for updating the structure of existing CoMaps to match new schema versions. Migrations are synchronous and cannot be async.
 
-Here's an example of a migration that updates a task's text field from a plain string to a `CoPlainText` type:
+Here's an example of a migration that adds the `priority` field to the `Task` CoMap:
 
 <CodeGroup>
 ```ts twoslash

--- a/homepage/homepage/content/docs/using-covalues/comaps.mdx
+++ b/homepage/homepage/content/docs/using-covalues/comaps.mdx
@@ -306,6 +306,82 @@ project.coordinator = undefined;  // Remove the reference
 ```
 </CodeGroup>
 
+## Running migrations on CoMaps
+
+Migrations in CoMaps are functions that run when a CoMap is loaded, not when it's created. They're useful for updating the structure of existing CoMaps to match new schema versions. Migrations are synchronous and cannot be async.
+
+Here's an example of a migration that updates a task's text field from a plain string to a `CoPlainText` type:
+
+<CodeGroup>
+```ts twoslash
+import { co, z, CoPlainText } from "jazz-tools";
+
+const Task = co
+  .map({
+    done: z.boolean(),
+    text: co.plainText(),
+    version: z.literal([1, 2]),
+    priority: z.enum(["low", "medium", "high"]), // new field
+  })
+  .withMigration((task) => {
+    if (task.version === 1) {
+      task.priority = "medium";
+      task.version = 2; // Upgrade the version so the migration won't run again
+    }
+  });
+```
+</CodeGroup>
+
+### Migrations best practices
+
+It's always a good idea to keep the schema backward & forward compatible when possible.
+
+This means that you should:
+- Only add new fields, never rename or change the type of existing fields
+- The new fields should be optional if possible
+
+### Migration & reader permissions
+
+Migrations need to modify the CoMap's structure, so they are not allowed if you only have read permissions on the CoMap.
+
+If some users might have only read permissions, you should be more careful about how you handle migrations.
+
+If your schemas are forward compatible, good news! They should still be able to use your app even if the migration has not been run yet.
+This means that you won't need to do manage both versions of the CoMap in your app.
+
+If they are not forward compatible, you will need to handle both versions of the CoMap in your app using a discriminated union:
+
+<CodeGroup>
+```ts twoslash
+import { co, z } from "jazz-tools";
+
+const TaskV1 = co.map({
+  version: z.literal(1),
+  done: z.boolean(),
+  text: z.string(),
+});
+
+const TaskV2 = co.map({
+  version: z.literal(2), // This time we need to be more strict about the version to make the discriminated union work
+  done: z.boolean(),
+  text: z.string(),
+  priority: z.enum(["low", "medium", "high"]),
+}).withMigration((task) => {
+  // @ts-expect-error - we are checking the version field to see if we need to run the migration
+  if (task.version === 1) {
+    task.version = 2;
+    task.priority = "medium";
+  }
+});
+
+// Export the discriminated union because some users might not be able to run the migration
+export const Task = z.discriminatedUnion("version", [
+  TaskV1,
+  TaskV2,
+]);
+```
+</CodeGroup>
+
 ## Best Practices
 
 ### Structuring Data

--- a/packages/jazz-tools/src/coValues/CoValueBase.ts
+++ b/packages/jazz-tools/src/coValues/CoValueBase.ts
@@ -61,7 +61,6 @@ export class CoValueBase implements CoValue {
   static fromRaw<V extends CoValue>(this: CoValueClass<V>, raw: RawCoValue): V {
     return new this({ fromRaw: raw });
   }
-
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   toJSON(): object | any[] | string {
     return {

--- a/packages/jazz-tools/src/coValues/coMap.ts
+++ b/packages/jazz-tools/src/coValues/coMap.ts
@@ -45,7 +45,6 @@ import {
   subscribeToCoValueWithoutMe,
   subscribeToExistingCoValue,
 } from "../internal.js";
-import { applyCoValueMigrations } from "../lib/migration.js";
 
 type CoMapEdit<V> = {
   value?: V;
@@ -316,8 +315,6 @@ export class CoMap extends CoValueBase implements CoValue {
       },
       _raw: { value: raw, enumerable: false },
     });
-
-    applyCoValueMigrations(instance);
 
     return instance;
   }

--- a/packages/jazz-tools/src/coValues/coMap.ts
+++ b/packages/jazz-tools/src/coValues/coMap.ts
@@ -35,7 +35,6 @@ import {
   accessChildById,
   accessChildByKey,
   activeAccountContext,
-  anySchemaToCoSchema,
   ensureCoValueLoaded,
   inspect,
   isRefEncoded,
@@ -46,6 +45,7 @@ import {
   subscribeToCoValueWithoutMe,
   subscribeToExistingCoValue,
 } from "../internal.js";
+import { applyCoValueMigrations } from "../lib/migration.js";
 
 type CoMapEdit<V> = {
   value?: V;
@@ -316,6 +316,8 @@ export class CoMap extends CoValueBase implements CoValue {
       },
       _raw: { value: raw, enumerable: false },
     });
+
+    applyCoValueMigrations(instance);
 
     return instance;
   }

--- a/packages/jazz-tools/src/implementation/zodSchema/runtimeConverters/zodSchemaToCoSchema.ts
+++ b/packages/jazz-tools/src/implementation/zodSchema/runtimeConverters/zodSchemaToCoSchema.ts
@@ -61,19 +61,6 @@ export function tryZodSchemaToCoSchema<S extends z.core.$ZodType>(
         }
       };
 
-      if ("migration" in schema) {
-        const migration = schema.migration;
-        if (typeof migration !== "function") {
-          throw new Error("migration must be a function");
-        }
-        (coSchema.prototype as Account).migrate = async function (
-          this,
-          creationProps,
-        ) {
-          await migration(this, creationProps);
-        };
-      }
-
       coSchemasForZodSchemas.set(schema, coSchema as unknown as CoValueClass);
       return coSchema as unknown as CoValueClassFromZodSchema<S>;
     } else if (isZodArray(schema)) {
@@ -175,9 +162,11 @@ export function anySchemaToCoSchema<
     : never {
   if (isCoValueClass(schema)) {
     return schema as any;
-  } else {
-    return zodSchemaToCoSchema(schema as any) as any;
+  } else if ("getCoSchema" in schema) {
+    return (schema as any).getCoSchema() as any;
   }
+
+  throw new Error(`Unsupported schema: ${schema}`);
 }
 
 export function zodSchemaToCoSchemaOrKeepPrimitive<S extends z.core.$ZodType>(

--- a/packages/jazz-tools/src/implementation/zodSchema/schemaTypes/AccountSchema.ts
+++ b/packages/jazz-tools/src/implementation/zodSchema/schemaTypes/AccountSchema.ts
@@ -64,6 +64,8 @@ export type AccountSchema<
       creationProps?: { name: string },
     ) => void,
   ): AccountSchema<Shape>;
+
+  getCoSchema: () => typeof Account;
 };
 
 export type DefaultProfileShape = {

--- a/packages/jazz-tools/src/implementation/zodSchema/schemaTypes/AccountSchema.ts
+++ b/packages/jazz-tools/src/implementation/zodSchema/schemaTypes/AccountSchema.ts
@@ -33,7 +33,7 @@ export type AccountSchema<
     }>;
     root: CoMapSchema<{}>;
   },
-> = Omit<CoMapSchema<Shape>, "create" | "load"> & {
+> = Omit<CoMapSchema<Shape>, "create" | "load" | "withMigration"> & {
   builtin: "Account";
 
   create: (options: {

--- a/packages/jazz-tools/src/implementation/zodSchema/schemaTypes/CoFeedSchema.ts
+++ b/packages/jazz-tools/src/implementation/zodSchema/schemaTypes/CoFeedSchema.ts
@@ -57,6 +57,8 @@ export type CoFeedSchema<T extends z.core.$ZodType> = z.core.$ZodCustom<
       unsubscribe: () => void,
     ) => void,
   ): () => void;
+
+  getCoSchema: () => typeof CoFeed;
 };
 
 // less precise verion to avoid circularity issues and allow matching against

--- a/packages/jazz-tools/src/implementation/zodSchema/schemaTypes/CoListSchema.ts
+++ b/packages/jazz-tools/src/implementation/zodSchema/schemaTypes/CoListSchema.ts
@@ -51,6 +51,8 @@ export type CoListSchema<T extends z.core.$ZodType> = z.core.$ZodArray<T> & {
     this: S,
     helpers: (Self: S) => T,
   ): WithHelpers<S, T>;
+
+  getCoSchema: () => typeof CoList;
 };
 
 // less precise verion to avoid circularity issues and allow matching against

--- a/packages/jazz-tools/src/implementation/zodSchema/schemaTypes/CoMapSchema.ts
+++ b/packages/jazz-tools/src/implementation/zodSchema/schemaTypes/CoMapSchema.ts
@@ -97,6 +97,15 @@ export type CoMapSchema<
       this: S,
       helpers: (Self: S) => T,
     ): WithHelpers<S, T>;
+
+    withMigration(
+      migration: (
+        value: Resolved<
+          Simplify<CoMapInstanceCoValuesNullable<Shape>> & CoMap,
+          true
+        >,
+      ) => undefined,
+    ): CoMapSchema<Shape, Config, Owner>;
   };
 
 export type optionalKeys<Shape extends z.core.$ZodLooseShape> = {

--- a/packages/jazz-tools/src/implementation/zodSchema/schemaTypes/CoMapSchema.ts
+++ b/packages/jazz-tools/src/implementation/zodSchema/schemaTypes/CoMapSchema.ts
@@ -106,6 +106,8 @@ export type CoMapSchema<
         >,
       ) => undefined,
     ): CoMapSchema<Shape, Config, Owner>;
+
+    getCoSchema: () => typeof CoMap;
   };
 
 export type optionalKeys<Shape extends z.core.$ZodLooseShape> = {

--- a/packages/jazz-tools/src/implementation/zodSchema/schemaTypes/CoRecordSchema.ts
+++ b/packages/jazz-tools/src/implementation/zodSchema/schemaTypes/CoRecordSchema.ts
@@ -1,7 +1,7 @@
 import { CoValueUniqueness } from "cojson";
 import {
   Account,
-  CoMap,
+  type CoMap,
   Group,
   ID,
   RefsToResolve,
@@ -83,6 +83,7 @@ export type CoRecordSchema<
     this: S,
     helpers: (Self: S) => T,
   ): WithHelpers<S, T>;
+  getCoSchema: () => typeof CoMap;
 };
 
 // less precise verion to avoid circularity issues and allow matching against

--- a/packages/jazz-tools/src/implementation/zodSchema/schemaTypes/FileStreamSchema.ts
+++ b/packages/jazz-tools/src/implementation/zodSchema/schemaTypes/FileStreamSchema.ts
@@ -40,4 +40,5 @@ export type FileStreamSchema = z.core.$ZodCustom<FileStream, unknown> & {
     id: string,
     listener: (value: FileStream, unsubscribe: () => void) => void,
   ): () => void;
+  getCoSchema: () => typeof FileStream;
 };

--- a/packages/jazz-tools/src/implementation/zodSchema/schemaTypes/PlainTextSchema.ts
+++ b/packages/jazz-tools/src/implementation/zodSchema/schemaTypes/PlainTextSchema.ts
@@ -24,4 +24,5 @@ export type PlainTextSchema = z.core.$ZodCustom<CoPlainText, unknown> & {
     listener: (value: CoPlainText, unsubscribe: () => void) => void,
   ): () => void;
   fromRaw(raw: RawCoPlainText): CoPlainText;
+  getCoSchema: () => typeof CoPlainText;
 };

--- a/packages/jazz-tools/src/implementation/zodSchema/schemaTypes/RichTextSchema.ts
+++ b/packages/jazz-tools/src/implementation/zodSchema/schemaTypes/RichTextSchema.ts
@@ -22,4 +22,5 @@ export type RichTextSchema = z.core.$ZodCustom<CoRichText, unknown> & {
     id: string,
     listener: (value: CoRichText, unsubscribe: () => void) => void,
   ): () => void;
+  getCoSchema: () => typeof CoRichText;
 };

--- a/packages/jazz-tools/src/implementation/zodSchema/zodCo.ts
+++ b/packages/jazz-tools/src/implementation/zodSchema/zodCo.ts
@@ -1,11 +1,7 @@
-import { CoValueUniqueness } from "cojson";
-import { ZodObject } from "zod/v4";
 import {
-  Account,
   AccountCreationProps,
   AccountInstance,
   AccountSchema,
-  AnonymousJazzAgent,
   AnyCoMapSchema,
   CoFeed,
   CoFeedSchema,
@@ -18,7 +14,6 @@ import {
   DefaultProfileShape,
   FileStream,
   FileStreamSchema,
-  Group,
   ImageDefinition,
   PlainTextSchema,
   Simplify,
@@ -55,10 +50,16 @@ function enrichCoMapSchema<Shape extends z.core.$ZodLooseShape>(
     withHelpers: (helpers: (Self: z.core.$ZodType) => object) => {
       return Object.assign(schema, helpers(schema));
     },
+    withMigration: (migration: (value: any) => void) => {
+      coSchema.prototype.migration = migration;
+
+      return enrichedSchema;
+    },
   }) as unknown as CoMapSchema<Shape>;
 
   // Needs to be derived from the enriched schema
   const coSchema = zodSchemaToCoSchema(enrichedSchema) as any;
+
   return enrichedSchema;
 }
 
@@ -151,7 +152,7 @@ export const coAccountDefiner = <
     this: CoMapSchema<Shape>,
     helpers: object,
   ) {
-    return { ...this, ...helpers };
+    return Object.assign(this, helpers);
   } as CoMapSchema<Shape>["withHelpers"];
 
   accountSchema.withMigration = function (

--- a/packages/jazz-tools/src/implementation/zodSchema/zodSchema.ts
+++ b/packages/jazz-tools/src/implementation/zodSchema/zodSchema.ts
@@ -80,7 +80,7 @@ type AccountClassEssentials = {
   fromNode: <A extends Account>(this: AccountClass<A>, node: LocalNode) => A;
 };
 
-type AnyCoSchema =
+export type AnyCoSchema =
   | AnyCoMapSchema
   | AnyAccountSchema
   | AnyCoRecordSchema

--- a/packages/jazz-tools/src/lib/migration.ts
+++ b/packages/jazz-tools/src/lib/migration.ts
@@ -1,0 +1,22 @@
+import type { LocalNode } from "cojson";
+import type { CoValue } from "../internal.js";
+
+export function applyCoValueMigrations(instance: CoValue) {
+  const node = instance._raw.core.node;
+
+  // @ts-expect-error _migratedCoValues is a custom expando property
+  const migratedCoValues = (node._migratedCoValues ??= new Set<string>());
+
+  if (
+    "migration" in instance &&
+    typeof instance.migration === "function" &&
+    instance._type !== "Account" &&
+    !migratedCoValues.has(instance.id)
+  ) {
+    const result = instance.migration?.(instance);
+    if (result && "then" in result) {
+      console.error("Migration function cannot be async");
+    }
+    migratedCoValues.add(instance.id);
+  }
+}

--- a/packages/jazz-tools/src/lib/migration.ts
+++ b/packages/jazz-tools/src/lib/migration.ts
@@ -1,4 +1,3 @@
-import type { LocalNode } from "cojson";
 import type { CoValue } from "../internal.js";
 
 export function applyCoValueMigrations(instance: CoValue) {
@@ -8,15 +7,17 @@ export function applyCoValueMigrations(instance: CoValue) {
   const migratedCoValues = (node._migratedCoValues ??= new Set<string>());
 
   if (
-    "migration" in instance &&
-    typeof instance.migration === "function" &&
+    "migrate" in instance &&
+    typeof instance.migrate === "function" &&
     instance._type !== "Account" &&
     !migratedCoValues.has(instance.id)
   ) {
-    const result = instance.migration?.(instance);
-    if (result && "then" in result) {
-      console.error("Migration function cannot be async");
-    }
+    // We flag this before the migration to avoid that internal loads trigger the migration again
     migratedCoValues.add(instance.id);
+
+    const result = instance.migrate?.(instance);
+    if (result && "then" in result) {
+      throw new Error("Migration function cannot be async");
+    }
   }
 }

--- a/packages/jazz-tools/src/subscribe/SubscriptionScope.ts
+++ b/packages/jazz-tools/src/subscribe/SubscriptionScope.ts
@@ -7,8 +7,10 @@ import {
   type ID,
   type RefEncoded,
   type RefsToResolve,
+  instantiateRefEncoded,
   isRefEncoded,
 } from "../internal.js";
+import { applyCoValueMigrations } from "../lib/migration.js";
 import { CoValueCoreSubscription } from "./CoValueCoreSubscription.js";
 import { JazzError, type JazzErrorIssue } from "./JazzError.js";
 import type { SubscriptionValue, Unloaded } from "./types.js";
@@ -32,6 +34,8 @@ export class SubscriptionScope<D extends CoValue> {
   autoloadedKeys = new Set<string>();
   skipInvalidKeys = new Set<string>();
   totalValidTransactions = 0;
+  migrated = false;
+  migrating = false;
 
   silenceUpdates = false;
 
@@ -43,7 +47,29 @@ export class SubscriptionScope<D extends CoValue> {
   ) {
     this.resolve = resolve;
     this.value = { type: "unloaded", id };
+
+    let lastUpdate: RawCoValue | "unavailable" | undefined;
     this.subscription = new CoValueCoreSubscription(node, id, (value) => {
+      lastUpdate = value;
+
+      // Need all these checks because the migration can trigger new syncronous updates
+      //
+      // We want to:
+      // - Run the migration only once
+      // - Skip all the updates until the migration is done
+      // - Trigger handleUpdate only with the final value
+      if (!this.migrated && value !== "unavailable") {
+        if (this.migrating) {
+          return;
+        }
+
+        this.migrating = true;
+        applyCoValueMigrations(instantiateRefEncoded(this.schema, value));
+        this.migrated = true;
+        this.handleUpdate(lastUpdate);
+        return;
+      }
+
       this.handleUpdate(value);
     });
   }

--- a/packages/jazz-tools/src/subscribe/utils.ts
+++ b/packages/jazz-tools/src/subscribe/utils.ts
@@ -7,6 +7,7 @@ import {
   instantiateRefEncoded,
 } from "../internal.js";
 import { coValuesCache } from "../lib/cache.js";
+import { applyCoValueMigrations } from "../lib/migration.js";
 import { SubscriptionScope } from "./SubscriptionScope.js";
 
 export function getOwnerFromRawValue(raw: RawCoValue) {
@@ -32,6 +33,8 @@ export function createCoValue<D extends CoValue>(
     enumerable: false,
     configurable: false,
   });
+
+  applyCoValueMigrations(freshValueInstance);
 
   return {
     type: "loaded" as const,

--- a/packages/jazz-tools/src/subscribe/utils.ts
+++ b/packages/jazz-tools/src/subscribe/utils.ts
@@ -7,7 +7,6 @@ import {
   instantiateRefEncoded,
 } from "../internal.js";
 import { coValuesCache } from "../lib/cache.js";
-import { applyCoValueMigrations } from "../lib/migration.js";
 import { SubscriptionScope } from "./SubscriptionScope.js";
 
 export function getOwnerFromRawValue(raw: RawCoValue) {
@@ -33,8 +32,6 @@ export function createCoValue<D extends CoValue>(
     enumerable: false,
     configurable: false,
   });
-
-  applyCoValueMigrations(freshValueInstance);
 
   return {
     type: "loaded" as const,

--- a/packages/jazz-tools/src/tests/coMap.test.ts
+++ b/packages/jazz-tools/src/tests/coMap.test.ts
@@ -1357,17 +1357,104 @@ describe("Creating and finding unique CoMaps", async () => {
   });
 });
 
+describe("castAs", () => {
+  test("should cast a co.map type", () => {
+    const Person = co.map({
+      name: z.string(),
+    });
+
+    const PersonWithAge = co.map({
+      name: z.string(),
+      age: z.number().optional(),
+    });
+
+    const person = Person.create({
+      name: "Alice",
+    });
+
+    const personWithAge = person.castAs(PersonWithAge);
+
+    personWithAge.age = 20;
+
+    expect(personWithAge.age).toEqual(20);
+  });
+
+  test("should still be able to autoload in-memory deps", () => {
+    const Dog = co.map({
+      name: z.string(),
+    });
+
+    const Person = co.map({
+      name: z.string(),
+      dog: Dog,
+    });
+
+    const PersonWithAge = co.map({
+      name: z.string(),
+      age: z.number().optional(),
+      dog: Dog,
+    });
+
+    const person = Person.create({
+      name: "Alice",
+      dog: Dog.create({ name: "Rex" }),
+    });
+
+    const personWithAge = person.castAs(PersonWithAge);
+
+    personWithAge.age = 20;
+
+    expect(personWithAge.age).toEqual(20);
+    expect(personWithAge.dog?.name).toEqual("Rex");
+  });
+});
+
 describe("CoMap migration", () => {
-  test("should run on creation", () => {
+  test("should run on load", async () => {
+    const PersonV1 = co.map({
+      name: z.string(),
+      version: z.literal(1),
+    });
+
     const Person = co
       .map({
         name: z.string(),
-        version: z.number(),
+        age: z.number(),
+        version: z.literal([1, 2]),
       })
       .withMigration((person) => {
         if (person.version === 1) {
-          person.name = "Alice";
+          person.age = 20;
           person.version = 2;
+        }
+      });
+
+    const person = PersonV1.create({
+      name: "Bob",
+      version: 1,
+    });
+
+    expect(person?.name).toEqual("Bob");
+    expect(person?.version).toEqual(1);
+
+    const loadedPerson = await Person.load(person.id);
+
+    expect(loadedPerson?.name).toEqual("Bob");
+    expect(loadedPerson?.age).toEqual(20);
+    expect(loadedPerson?.version).toEqual(2);
+  });
+
+  test("should handle group updates", async () => {
+    const Person = co
+      .map({
+        name: z.string(),
+        version: z.literal([1, 2]),
+      })
+      .withMigration((person) => {
+        if (person.version === 1) {
+          person.version = 2;
+
+          person._owner.castAs(Group).addMember("everyone", "reader");
         }
       });
 
@@ -1376,73 +1463,40 @@ describe("CoMap migration", () => {
       version: 1,
     });
 
-    expect(person.name).toEqual("Alice");
-    expect(person.version).toEqual(2);
-  });
+    expect(person?.name).toEqual("Bob");
+    expect(person?.version).toEqual(1);
 
-  test("should run on load", async () => {
-    const Person = co
-      .map({
-        name: z.string(),
-        version: z.number(),
-      })
-      .withMigration((person) => {
-        if (person.version === 1) {
-          person.name = "Alice";
-          person.version = 2;
-        }
-      });
+    const loadedPerson = await Person.load(person.id);
 
-    const group = Group.create();
-    group.addMember("everyone", "writer");
-
-    const person = Person.create(
-      {
-        name: "Bob",
-        version: 1,
-      },
-      group,
-    );
-    person.version = 1;
-    person.name = "Bob";
-
-    await person.waitForSync();
-
-    const account = await createJazzTestAccount();
-
-    const loadedPerson = await Person.load(person.id, {
-      loadAs: account,
-    });
-    expect(loadedPerson?.name).toEqual("Alice");
+    expect(loadedPerson?.name).toEqual("Bob");
     expect(loadedPerson?.version).toEqual(2);
+
+    const anotherAccount = await createJazzTestAccount();
+
+    const loadedPersonFromAnotherAccount = await Person.load(person.id, {
+      loadAs: anotherAccount,
+    });
+
+    expect(loadedPersonFromAnotherAccount?.name).toEqual("Bob");
   });
 
-  test("should log an error if a migration is async", () => {
+  test("should throw an error if a migration is async", async () => {
     const Person = co
       .map({
         name: z.string(),
         version: z.number(),
       })
       // @ts-expect-error async function
-      .withMigration(async (person) => {
-        if (person.version === 1) {
-          person.name = "Alice";
-          person.version = 2;
-        }
-      });
-
-    const spy = vi.spyOn(console, "error").mockImplementation(() => {});
+      .withMigration(async () => {});
 
     const person = Person.create({
       name: "Bob",
       version: 1,
     });
 
-    expect(spy).toHaveBeenCalledWith("Migration function cannot be async");
-
-    expect(person.name).toEqual("Alice");
-    expect(person.version).toEqual(2);
-    spy.mockRestore();
+    await expect(Person.load(person.id)).rejects.toThrow(
+      "Migration function cannot be async",
+    );
   });
 
   test("should run only once", async () => {
@@ -1454,10 +1508,6 @@ describe("CoMap migration", () => {
       })
       .withMigration((person) => {
         spy(person);
-        if (person.version === 1) {
-          person.name = "Alice";
-          person.version = 2;
-        }
       });
 
     const person = Person.create({
@@ -1465,116 +1515,58 @@ describe("CoMap migration", () => {
       version: 1,
     });
 
-    // First migration should run
-    expect(person.name).toEqual("Alice");
-    expect(person.version).toEqual(2);
-
-    // Second migration should not run
-    person.version = 1;
-
-    const loadedPerson = await Person.load(person.id);
-    expect(loadedPerson?.name).toEqual("Alice");
-    expect(loadedPerson?.version).toEqual(1);
+    await Person.load(person.id);
+    await Person.load(person.id);
     expect(spy).toHaveBeenCalledTimes(1);
   });
 
-  test("should not break recursive schemas", () => {
+  test("should not break recursive schemas", async () => {
+    const PersonV1 = co.map({
+      name: z.string(),
+      version: z.literal(1),
+      get friend() {
+        return PersonV1.optional();
+      },
+    });
+
     const Person = co
       .map({
         name: z.string(),
-        version: z.number(),
+        age: z.number(),
         get friend() {
           return Person.optional();
         },
+        version: z.literal([1, 2]),
       })
       .withMigration((person) => {
         if (person.version === 1) {
-          person.name = "Alice";
+          person.age = 20;
           person.version = 2;
         }
       });
 
-    const friend = Person.create({
-      name: "Bob",
+    const charlie = PersonV1.create({
+      name: "Charlie",
       version: 1,
     });
 
-    const person = Person.create({
-      name: "Charlie",
+    const bob = PersonV1.create({
+      name: "Bob",
       version: 1,
-      friend,
+      friend: charlie,
+    });
+
+    const loaded = await Person.load(bob.id, {
+      resolve: {
+        friend: true,
+      },
     });
 
     // Migration should run on both the person and their friend
-    expect(person.name).toEqual("Alice");
-    expect(person.version).toEqual(2);
-    expect(person.friend?.name).toEqual("Alice");
-    expect(person.friend?.version).toEqual(2);
-  });
-
-  test("should run on deep nested values", () => {
-    const NestedMap = co
-      .map({
-        name: z.string(),
-        version: z.number(),
-      })
-      .withMigration((nested) => {
-        if (nested.version === 1) {
-          nested.name = "Nested Alice";
-          nested.version = 2;
-        }
-      });
-
-    const MiddleMap = co
-      .map({
-        name: z.string(),
-        version: z.number(),
-        nested: NestedMap,
-      })
-      .withMigration((middle) => {
-        if (middle.version === 1) {
-          middle.name = "Middle Alice";
-          middle.version = 2;
-        }
-      });
-
-    const TopMap = co
-      .map({
-        name: z.string(),
-        version: z.number(),
-        middle: MiddleMap,
-      })
-      .withMigration((top) => {
-        if (top.version === 1) {
-          top.name = "Top Alice";
-          top.version = 2;
-        }
-      });
-
-    // Create a deeply nested structure
-    const nested = NestedMap.create({
-      name: "Nested Bob",
-      version: 1,
-    });
-
-    const middle = MiddleMap.create({
-      name: "Middle Bob",
-      version: 1,
-      nested,
-    });
-
-    const top = TopMap.create({
-      name: "Top Bob",
-      version: 1,
-      middle,
-    });
-
-    // Verify migrations ran on all levels
-    expect(top.name).toEqual("Top Alice");
-    expect(top.version).toEqual(2);
-    expect(top.middle.name).toEqual("Middle Alice");
-    expect(top.middle.version).toEqual(2);
-    expect(top.middle.nested.name).toEqual("Nested Alice");
-    expect(top.middle.nested.version).toEqual(2);
+    expect(loaded?.name).toEqual("Bob");
+    expect(loaded?.age).toEqual(20);
+    expect(loaded?.version).toEqual(2);
+    expect(loaded?.friend?.name).toEqual("Charlie");
+    expect(loaded?.friend?.version).toEqual(2);
   });
 });


### PR DESCRIPTION
Part of #1135 
Fixes #2374 

Design decisions:
- ~Running the migrations also on `.create` / this way they are applied consistently and can also be used as creation "triggers"~
- Limited the migrations to be sync. Async migrations might cause some performance issues if not managed correctly.
- Add support only for CoMap because on the others types it feels less useful and hard to track when the migration should run.

Docs: https://jazz-homepage-git-feature-co-map-migrations-gcmp.vercel.app/docs/react/using-covalues/comaps?_vercel_share=xNNVoJ49NPRFYf3zki8XnG44ySHhIhVD
