### PR TITLE
fix(react-19): optimize re-renders when the values are already in memory

### DIFF
--- a/.changeset/strong-apes-develop.md
+++ b/.changeset/strong-apes-develop.md
@@ -1,0 +1,5 @@
+---
+"jazz-react-core": patch
+---
+
+Adapt useCoState and useAccount to the new behavoir of useSyncExternalStore in React 19 to keep the re-renders minimal when a value is already in memory

--- a/.changeset/wicked-cycles-unite.md
+++ b/.changeset/wicked-cycles-unite.md
@@ -1,0 +1,5 @@
+---
+"jazz-tools": patch
+---
+
+Improve SubscriptionScope.getCurrentValue to be the basis of the new React integration

--- a/packages/jazz-react-core/src/tests/useAccount.test.ts
+++ b/packages/jazz-react-core/src/tests/useAccount.test.ts
@@ -121,10 +121,6 @@ describe("useAccount", () => {
         },
         {
           "accountIndex": 0,
-          "isAuthenticated": true,
-        },
-        {
-          "accountIndex": 0,
           "isAuthenticated": false,
         },
         {
@@ -183,10 +179,6 @@ describe("useAccount", () => {
 
     expect(updates).toMatchInlineSnapshot(`
       [
-        {
-          "accountIndex": 0,
-          "isAuthenticated": false,
-        },
         {
           "accountIndex": 0,
           "isAuthenticated": false,

--- a/packages/jazz-react-core/src/tests/useCoState.test.ts
+++ b/packages/jazz-react-core/src/tests/useCoState.test.ts
@@ -328,8 +328,8 @@ describe("useCoState", () => {
   it("should update when an inner coValue is updated", async () => {
     const TestMap = co.map({
       value: z.string(),
-      get nested(): z.ZodOptional<typeof TestMap> {
-        return z.optional(TestMap);
+      get nested() {
+        return TestMap.optional();
       },
     });
 
@@ -424,7 +424,7 @@ describe("useCoState", () => {
     expect(result.current?.value).toBeUndefined();
   });
 
-  it("should only render twice when loading a list of values", async () => {
+  it("should only render once when loading a list of values", async () => {
     const TestMap = co.map({
       value: z.string(),
     });
@@ -457,7 +457,7 @@ describe("useCoState", () => {
 
     await new Promise((resolve) => setTimeout(resolve, 100));
 
-    expect(renderCount).toBe(2);
+    expect(renderCount).toBe(1);
   });
 
   it("should manage correctly the group.members[number].account.profile?.name autoload", async () => {
@@ -507,7 +507,7 @@ describe("useCoState", () => {
     });
   });
 
-  it.skip("should immediately load deeploaded data when available locally", async () => {
+  it("should immediately load deeploaded data when available locally", async () => {
     const Message = co.map({
       content: CoRichText,
     });
@@ -547,6 +547,6 @@ describe("useCoState", () => {
 
     await new Promise((resolve) => setTimeout(resolve, 20));
 
-    expect(renderings).toBe([true]);
+    expect(renderings).toEqual([true]);
   });
 });

--- a/packages/jazz-react-core/src/tests/usePassPhraseAuth.test.ts
+++ b/packages/jazz-react-core/src/tests/usePassPhraseAuth.test.ts
@@ -162,10 +162,6 @@ describe("usePassphraseAuth", () => {
         },
         {
           "accountIndex": 0,
-          "state": "anonymous",
-        },
-        {
-          "accountIndex": 0,
           "state": "signedIn",
         },
         {

--- a/packages/jazz-tools/src/coValues/interfaces.ts
+++ b/packages/jazz-tools/src/coValues/interfaces.ts
@@ -294,6 +294,11 @@ export function subscribeToCoValue<
   return unsubscribe;
 }
 
+/**
+ * @deprecated Used for the React integration in the past, but we moved to use SubscriptionScope directly.
+ *
+ * Going to be removed in the next minor version.
+ */
 export function createCoValueObservable<
   S extends CoValueOrZodSchema,
   const R extends ResolveQuery<S>,

--- a/packages/jazz-tools/src/subscribe/SubscriptionScope.ts
+++ b/packages/jazz-tools/src/subscribe/SubscriptionScope.ts
@@ -249,9 +249,28 @@ export class SubscriptionScope<D extends CoValue> {
   }
 
   getCurrentValue() {
-    if (!this.shouldSendUpdates()) return;
-    if (this.errorFromChildren) return this.errorFromChildren;
-    return this.value;
+    if (
+      this.value.type === "unauthorized" ||
+      this.value.type === "unavailable"
+    ) {
+      console.error(this.value.toString());
+      return null;
+    }
+
+    if (!this.shouldSendUpdates()) {
+      return undefined;
+    }
+
+    if (this.errorFromChildren) {
+      console.error(this.errorFromChildren.toString());
+      return null;
+    }
+
+    if (this.value.type === "loaded") {
+      return this.value.value;
+    }
+
+    return undefined;
   }
 
   triggerUpdate() {


### PR DESCRIPTION
One of the breaking changes of React 19 is that useSyncExternalStore now executes the subscribe callback asyncrnously, messing with our rendering pipeline.

Before this fix we are always returning undefined in the first render, now we don't if the value is already in memory.

fixes #2402 
