### PR TITLE
fix(react-native): close db connections and keep the same instance of storage over JazzProvider renders

### DIFF
--- a/.changeset/spotty-feet-cheat.md
+++ b/.changeset/spotty-feet-cheat.md
@@ -1,0 +1,8 @@
+---
+"cojson-storage-sqlite": patch
+"jazz-react-native": patch
+"cojson-storage": patch
+"jazz-expo": patch
+---
+
+Close the DB connection when the node/context is closed

--- a/examples/chat-rn-expo/src/chat.tsx
+++ b/examples/chat-rn-expo/src/chat.tsx
@@ -128,7 +128,11 @@ export default function ChatScreen() {
             }}
             testID="chat-id-input"
           />
-          <TouchableOpacity onPress={joinChat} style={styles.joinChatButton}>
+          <TouchableOpacity
+            testID="join-chat-button"
+            onPress={joinChat}
+            style={styles.joinChatButton}
+          >
             <Text style={styles.newChatButtonText}>Join chat</Text>
           </TouchableOpacity>
         </View>

--- a/examples/chat-rn-expo/test/e2e/flow.yml
+++ b/examples/chat-rn-expo/test/e2e/flow.yml
@@ -44,9 +44,9 @@ appId: tools.jazz.chatrnexpo
 - assertVisible: "Anonymous user"
 
 # join chat
-# - tapOn:
-#     id: "chat-id-input"
-# - inputText: "co_zFs6KFyhxPw4xtw83tcEMzeHUNv" # Use a static id because maestro doesn't have access to the system clipboard
-# - tapOn: "Join chat"
-# - assertVisible: "boorad"
-# - assertVisible: "bro, low key, it do be like that tho"
+- tapOn:
+    id: "chat-id-input"
+- inputText: "co_zFs6KFyhxPw4xtw83tcEMzeHUNv" # Use a static id because maestro doesn't have access to the system clipboard
+- tapOn: "Join chat"
+- assertVisible: "boorad"
+- assertVisible: "bro, low key, it do be like that tho"

--- a/examples/chat-rn-expo/test/e2e/flow.yml
+++ b/examples/chat-rn-expo/test/e2e/flow.yml
@@ -41,12 +41,17 @@ appId: tools.jazz.chatrnexpo
 # logout
 - tapOn: "Logout"
 - assertVisible: "Username"
-- assertVisible: "Anonymous user"
 
-# join chat
-- tapOn:
-    id: "chat-id-input"
-- inputText: "co_zFs6KFyhxPw4xtw83tcEMzeHUNv" # Use a static id because maestro doesn't have access to the system clipboard
-- tapOn: "Join chat"
-- assertVisible: "boorad"
-- assertVisible: "bro, low key, it do be like that tho"
+- extendedWaitUntil:
+    visible: "Anonymous user"
+    timeout: 10000
+# join chat 
+
+## Commented because it fails on CI
+# - tapOn:
+#     id: "chat-id-input"
+# - inputText: "co_zFs6KFyhxPw4xtw83tcEMzeHUNv" # Use a static id because maestro doesn't have access to the system clipboard
+# - tapOn:
+#     id: "join-chat-button"
+# - assertVisible: "boorad"
+# - assertVisible: "bro, low key, it do be like that tho"

--- a/examples/chat-rn-expo/test/e2e/runLocal.sh
+++ b/examples/chat-rn-expo/test/e2e/runLocal.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+# This script is necessary, because unlike ios, the android emulator action
+# accepts a script, runs it as your tests, then terminates.
+
+set -e
+
+# run the e2e tests
+export PATH="$PATH":"$HOME/.maestro/bin"
+export MAESTRO_DRIVER_STARTUP_TIMEOUT=300000 # setting to 5 mins 👀
+export MAESTRO_CLI_NO_ANALYTICS=1
+export MAESTRO_CLI_ANALYSIS_NOTIFICATION_DISABLED=true
+maestro test test/e2e/flow.yml

--- a/packages/cojson-storage-sqlite/src/betterSqliteDriver.ts
+++ b/packages/cojson-storage-sqlite/src/betterSqliteDriver.ts
@@ -25,4 +25,8 @@ export class BetterSqliteDriver implements SQLiteDatabaseDriver {
   transaction(callback: () => unknown) {
     return this.db.transaction(callback)();
   }
+
+  closeDb() {
+    this.db.close();
+  }
 }

--- a/packages/cojson-storage/src/sqlite/node.ts
+++ b/packages/cojson-storage/src/sqlite/node.ts
@@ -59,6 +59,8 @@ export class SQLiteNodeBase {
           });
         }
       }
+
+      db.closeDb();
     };
 
     processMessages().catch((e) =>

--- a/packages/cojson-storage/src/sqlite/types.ts
+++ b/packages/cojson-storage/src/sqlite/types.ts
@@ -3,4 +3,5 @@ export interface SQLiteDatabaseDriver {
   get<T>(sql: string, params: unknown[]): T | undefined;
   query<T>(sql: string, params: unknown[]): T[];
   transaction(callback: () => unknown): void;
+  closeDb(): void;
 }

--- a/packages/cojson-storage/src/sqliteAsync/node.ts
+++ b/packages/cojson-storage/src/sqliteAsync/node.ts
@@ -37,6 +37,10 @@ export class SQLiteNodeBaseAsync {
           });
         }
       }
+
+      db.closeDb().catch((e) =>
+        logger.error("Error closing sqlite", { err: e }),
+      );
     };
 
     processMessages().catch((e) =>

--- a/packages/cojson-storage/src/sqliteAsync/types.ts
+++ b/packages/cojson-storage/src/sqliteAsync/types.ts
@@ -4,4 +4,5 @@ export interface SQLiteDatabaseDriverAsync {
   query<T>(sql: string, params: unknown[]): Promise<T[]>;
   get<T>(sql: string, params: unknown[]): Promise<T | undefined>;
   transaction(callback: () => unknown): Promise<unknown>;
+  closeDb(): Promise<unknown>;
 }

--- a/packages/jazz-expo/src/provider.tsx
+++ b/packages/jazz-expo/src/provider.tsx
@@ -5,7 +5,7 @@ import {
   AnyAccountSchema,
   CoValueFromRaw,
 } from "jazz-tools";
-import React from "react";
+import React, { useMemo } from "react";
 import { ExpoSecureStoreAdapter } from "./storage/expo-secure-store-adapter.js";
 import { ExpoSQLiteAdapter } from "./storage/expo-sqlite-adapter.js";
 
@@ -14,14 +14,13 @@ export function JazzProvider<
     | (AccountClass<Account> & CoValueFromRaw<Account>)
     | AnyAccountSchema,
 >(props: JazzProviderProps<S>) {
-  // Destructure kvStore and pass everything else via rest
-  const { kvStore, storage, ...rest } = props;
+  const storage = useMemo(() => {
+    return props.storage ?? new ExpoSQLiteAdapter();
+  }, [props.storage]);
 
-  return (
-    <JazzProviderCore
-      {...rest}
-      storage={storage ?? new ExpoSQLiteAdapter()}
-      kvStore={kvStore ?? new ExpoSecureStoreAdapter()}
-    />
-  );
+  const kvStore = useMemo(() => {
+    return props.kvStore ?? new ExpoSecureStoreAdapter();
+  }, [props.kvStore]);
+
+  return <JazzProviderCore {...props} storage={storage} kvStore={kvStore} />;
 }

--- a/packages/jazz-expo/src/storage/expo-sqlite-adapter.ts
+++ b/packages/jazz-expo/src/storage/expo-sqlite-adapter.ts
@@ -83,4 +83,12 @@ export class ExpoSQLiteAdapter implements SQLiteDatabaseDriverAsync {
     this.db = null;
     await this.initialize();
   }
+
+  public async closeDb(): Promise<void> {
+    if (!this.db) {
+      throw new Error("Database not initialized");
+    }
+
+    await this.db.closeAsync();
+  }
 }

--- a/packages/jazz-expo/src/storage/expo-sqlite-adapter.ts
+++ b/packages/jazz-expo/src/storage/expo-sqlite-adapter.ts
@@ -90,5 +90,6 @@ export class ExpoSQLiteAdapter implements SQLiteDatabaseDriverAsync {
     }
 
     await this.db.closeAsync();
+    this.db = null;
   }
 }

--- a/packages/jazz-react-native/src/provider.tsx
+++ b/packages/jazz-react-native/src/provider.tsx
@@ -5,7 +5,7 @@ import {
   AnyAccountSchema,
   CoValueFromRaw,
 } from "jazz-tools";
-import React from "react";
+import React, { useMemo } from "react";
 import { MMKVStore } from "./storage/mmkv-store-adapter.js";
 import { OPSQLiteAdapter } from "./storage/op-sqlite-adapter.js";
 
@@ -15,13 +15,13 @@ export function JazzProvider<
     | AnyAccountSchema,
 >(props: JazzProviderProps<S>) {
   // Destructure kvStore and pass everything else via rest
-  const { kvStore, storage, ...rest } = props;
+  const storage = useMemo(() => {
+    return props.storage ?? new OPSQLiteAdapter();
+  }, [props.storage]);
 
-  return (
-    <JazzProviderCore
-      {...rest}
-      storage={storage ?? new OPSQLiteAdapter()}
-      kvStore={kvStore ?? new MMKVStore()}
-    />
-  );
+  const kvStore = useMemo(() => {
+    return props.kvStore ?? new MMKVStore();
+  }, [props.kvStore]);
+
+  return <JazzProviderCore {...props} storage={storage} kvStore={kvStore} />;
 }

--- a/packages/jazz-react-native/src/storage/op-sqlite-adapter.ts
+++ b/packages/jazz-react-native/src/storage/op-sqlite-adapter.ts
@@ -75,5 +75,6 @@ export class OPSQLiteAdapter implements SQLiteDatabaseDriverAsync {
     }
 
     this.db.close();
+    this.db = null;
   }
 }

--- a/packages/jazz-react-native/src/storage/op-sqlite-adapter.ts
+++ b/packages/jazz-react-native/src/storage/op-sqlite-adapter.ts
@@ -68,4 +68,12 @@ export class OPSQLiteAdapter implements SQLiteDatabaseDriverAsync {
       throw error;
     }
   }
+
+  public async closeDb(): Promise<void> {
+    if (!this.db) {
+      throw new Error("Database not initialized");
+    }
+
+    this.db.close();
+  }
 }


### PR DESCRIPTION
This PR brings two fixes:
- Initialize storage inside a `useMemo` / the changes on storage trigger a Jazz ctx reset generating stiability issues when the JazzProvider re-renders (especially on StrictMode/dev where the render happens twice)
- Close the dbs when the ctx is closed. Keeping the connection open was probably what was causing random errors on `expo-sqlite` on dev.