### PR TITLE
Worker group tools in jazz-run

### DIFF
--- a/.changeset/cool-dodos-raise.md
+++ b/.changeset/cool-dodos-raise.md
@@ -1,0 +1,5 @@
+---
+"jazz-run": patch
+---
+
+Add group create and group create-with-admin commands

--- a/packages/jazz-run/src/createWorkerAccount.ts
+++ b/packages/jazz-run/src/createWorkerAccount.ts
@@ -33,5 +33,6 @@ export const createWorkerAccount = async ({
   return {
     accountID: account.id,
     agentSecret: account._raw.core.node.getCurrentAgent().agentSecret,
+    account,
   };
 };

--- a/packages/jazz-run/src/createWorkerGroupWithAdmin.ts
+++ b/packages/jazz-run/src/createWorkerGroupWithAdmin.ts
@@ -1,0 +1,33 @@
+import { createWorkerAccount } from "./createWorkerAccount.js";
+import { createWorkerGroup } from "./greateWorkerGroup.js";
+
+export async function createWorkerGroupWithAdmin({
+  name,
+  peer,
+}: { name: string; peer: string }) {
+  const { accountID: adminAccountID, agentSecret: adminAgentSecret } =
+    await createWorkerAccount({ name: name + "_admin", peer });
+
+  const { groupID, groupAsOwner } = await createWorkerGroup({
+    owner: adminAccountID,
+    ownerSecret: adminAgentSecret,
+    peer,
+  });
+
+  const { account, accountID, agentSecret } = await createWorkerAccount({
+    name: name + "_0",
+    peer,
+  });
+
+  groupAsOwner.addMember(account, "writer");
+
+  await account.waitForAllCoValuesSync({ timeout: 4_000 });
+
+  return {
+    adminAccountID,
+    adminAgentSecret,
+    groupID,
+    accountID,
+    agentSecret,
+  };
+}

--- a/packages/jazz-run/src/greateWorkerGroup.ts
+++ b/packages/jazz-run/src/greateWorkerGroup.ts
@@ -1,0 +1,42 @@
+import { AgentSecret } from "cojson";
+import { createWebSocketPeer } from "cojson-transport-ws";
+import { WasmCrypto } from "cojson/crypto/WasmCrypto";
+import {
+  Account,
+  Group,
+  createJazzContextFromExistingCredentials,
+  randomSessionProvider,
+} from "jazz-tools";
+import { WebSocket } from "ws";
+
+export const createWorkerGroup = async ({
+  owner,
+  ownerSecret,
+  peer: peerAddr,
+}: { owner: string; ownerSecret: string; peer: string }) => {
+  const crypto = await WasmCrypto.create();
+
+  const peer = createWebSocketPeer({
+    id: "upstream",
+    websocket: new WebSocket(peerAddr),
+    role: "server",
+  });
+
+  const context = await createJazzContextFromExistingCredentials({
+    credentials: {
+      accountID: owner,
+      secret: ownerSecret as AgentSecret,
+    },
+    AccountSchema: Account,
+    sessionProvider: randomSessionProvider,
+    peersToLoadFrom: [peer],
+    crypto,
+  });
+
+  const group = Group.create({ owner: context.account });
+  await context.account.waitForAllCoValuesSync();
+
+  return {
+    groupID: group.id,
+  };
+};

--- a/packages/jazz-run/src/greateWorkerGroup.ts
+++ b/packages/jazz-run/src/greateWorkerGroup.ts
@@ -38,5 +38,6 @@ export const createWorkerGroup = async ({
 
   return {
     groupID: group.id,
+    groupAsOwner: group,
   };
 };

--- a/packages/jazz-run/src/tests/createWorkerGroup.test.ts
+++ b/packages/jazz-run/src/tests/createWorkerGroup.test.ts
@@ -1,0 +1,88 @@
+import { LocalNode } from "cojson";
+import { createWebSocketPeer } from "cojson-transport-ws";
+import { WasmCrypto } from "cojson/crypto/WasmCrypto";
+import { describe, expect, it, onTestFinished } from "vitest";
+import { WebSocket } from "ws";
+import { createWorkerAccount } from "../createWorkerAccount.js";
+import { createWorkerGroup } from "../greateWorkerGroup.js";
+import { startSyncServer } from "../startSyncServer.js";
+
+describe("createWorkerGroup - integration tests", () => {
+  it("should create a worker group using the local sync server", async () => {
+    // Pass port: undefined to let the server choose a random port
+    const server = await startSyncServer({
+      port: undefined,
+      inMemory: true,
+      db: "",
+    });
+
+    onTestFinished(() => {
+      server.close();
+    });
+
+    const address = server.address();
+
+    if (typeof address !== "object" || address === null) {
+      throw new Error("Server address is not an object");
+    }
+
+    const { accountID, agentSecret } = await createWorkerAccount({
+      name: "test",
+      peer: `ws://localhost:${address.port}`,
+    });
+
+    const { groupID } = await createWorkerGroup({
+      owner: accountID,
+      ownerSecret: agentSecret,
+      peer: `ws://localhost:${address.port}`,
+    });
+
+    expect(groupID).toBeDefined();
+
+    const peer = createWebSocketPeer({
+      id: "upstream",
+      websocket: new WebSocket(`ws://localhost:${address.port}`),
+      role: "server",
+    });
+
+    const crypto = await WasmCrypto.create();
+    const { node } = await LocalNode.withNewlyCreatedAccount({
+      creationProps: { name: "test" },
+      peersToLoadFrom: [peer],
+      crypto,
+    });
+
+    expect(await node.load(groupID as any)).not.toBe("unavailable");
+  });
+
+  it("should create a worker group using the Jazz cloud", async () => {
+    const { accountID, agentSecret } = await createWorkerAccount({
+      name: "test",
+      peer: `wss://cloud.jazz.tools`,
+    });
+
+    const { groupID } = await createWorkerGroup({
+      owner: accountID,
+      ownerSecret: agentSecret,
+      peer: `wss://cloud.jazz.tools`,
+    });
+
+    expect(accountID).toBeDefined();
+    expect(agentSecret).toBeDefined();
+
+    const peer = createWebSocketPeer({
+      id: "upstream",
+      websocket: new WebSocket(`wss://cloud.jazz.tools`),
+      role: "server",
+    });
+
+    const crypto = await WasmCrypto.create();
+    const { node } = await LocalNode.withNewlyCreatedAccount({
+      creationProps: { name: "test" },
+      peersToLoadFrom: [peer],
+      crypto,
+    });
+
+    expect(await node.load(groupID as any)).not.toBe("unavailable");
+  });
+});

--- a/packages/jazz-run/src/tests/createWorkerGroupWithAdmin.test.ts
+++ b/packages/jazz-run/src/tests/createWorkerGroupWithAdmin.test.ts
@@ -1,0 +1,100 @@
+import { RawGroup } from "cojson";
+import { createWebSocketPeer } from "cojson-transport-ws";
+import { WasmCrypto } from "cojson/crypto/WasmCrypto";
+import { LocalNode } from "cojson/dist/localNode.js";
+import { describe, expect, it, onTestFinished } from "vitest";
+import { createWorkerGroupWithAdmin } from "../createWorkerGroupWithAdmin.js";
+import { startSyncServer } from "../startSyncServer.js";
+
+describe("createWorkerGroupWithAdmin - integration tests", () => {
+  it("should create a worker group with admin using the local sync server", async () => {
+    // Pass port: undefined to let the server choose a random port
+    const server = await startSyncServer({
+      port: undefined,
+      inMemory: true,
+      db: "",
+    });
+
+    onTestFinished(() => {
+      server.close();
+    });
+
+    const address = server.address();
+
+    if (typeof address !== "object" || address === null) {
+      throw new Error("Server address is not an object");
+    }
+
+    const {
+      adminAccountID,
+      adminAgentSecret,
+      groupID,
+      accountID,
+      agentSecret,
+    } = await createWorkerGroupWithAdmin({
+      name: "test",
+      peer: `ws://localhost:${address.port}`,
+    });
+
+    expect(adminAccountID).toBeDefined();
+    expect(adminAgentSecret).toBeDefined();
+    expect(groupID).toBeDefined();
+    expect(accountID).toBeDefined();
+    expect(agentSecret).toBeDefined();
+
+    const peer = createWebSocketPeer({
+      id: "upstream",
+      websocket: new WebSocket(`ws://localhost:${address.port}`),
+      role: "server",
+    });
+
+    const crypto = await WasmCrypto.create();
+    const { node } = await LocalNode.withNewlyCreatedAccount({
+      creationProps: { name: "test" },
+      peersToLoadFrom: [peer],
+      crypto,
+    });
+
+    const loadedGroup = await node.load(groupID as any);
+
+    expect(loadedGroup).not.toBe("unavailable");
+    expect((loadedGroup as RawGroup).get(accountID as any)).toBe("writer");
+  });
+
+  it("should create a worker group with admin using the Jazz cloud", async () => {
+    const {
+      adminAccountID,
+      adminAgentSecret,
+      groupID,
+      accountID,
+      agentSecret,
+    } = await createWorkerGroupWithAdmin({
+      name: "test",
+      peer: `wss://cloud.jazz.tools`,
+    });
+
+    expect(adminAccountID).toBeDefined();
+    expect(adminAgentSecret).toBeDefined();
+    expect(groupID).toBeDefined();
+    expect(accountID).toBeDefined();
+    expect(agentSecret).toBeDefined();
+
+    const peer = createWebSocketPeer({
+      id: "upstream",
+      websocket: new WebSocket(`wss://cloud.jazz.tools`),
+      role: "server",
+    });
+
+    const crypto = await WasmCrypto.create();
+    const { node } = await LocalNode.withNewlyCreatedAccount({
+      creationProps: { name: "test" },
+      peersToLoadFrom: [peer],
+      crypto,
+    });
+
+    const loadedGroup = await node.load(groupID as any);
+
+    expect(loadedGroup).not.toBe("unavailable");
+    expect((loadedGroup as RawGroup).get(accountID as any)).toBe("writer");
+  });
+});


### PR DESCRIPTION
Adds two commands:

`npx jazz-run group create -o OWNER_ID -s OWNER_SECRET`

And

`npx jazz-run group create-with-admin --name "MyApp"`

- creates an admin account to manage members
- creates group with admin as owner
- adds a first member account to use as actual worker account ("writer" rights)