### PR TITLE
[Inspector] Allow pasting of full account JSON

### DIFF
--- a/examples/inspector/src/viewer/new-app.tsx
+++ b/examples/inspector/src/viewer/new-app.tsx
@@ -27,6 +27,13 @@ interface Account {
   secret: AgentSecret;
 }
 
+interface JazzLoggedInSecret {
+    accountID: string;
+    accountSecret: string;
+    secretSeed?: number[];
+    provider?: string;
+}
+
 export default function CoJsonViewerApp() {
   const [accounts, setAccounts] = useState<Account[]>(() => {
     const storedAccounts = localStorage.getItem("inspectorAccounts");
@@ -269,7 +276,26 @@ function AddAccountForm({
   const [id, setId] = useState("");
   const [secret, setSecret] = useState("");
 
-  const handleSubmit = (e: React.FormEvent) => {
+    const handleIdChange = (e: React.ChangeEvent<HTMLInputElement>): void => {
+        const value = e.target.value;
+        setId(value);
+
+        // Try to parse as JSON if it looks like a JSON object
+        if (value.trim().startsWith("{") && value.trim().endsWith("}")) {
+            try {
+                const parsed: JazzLoggedInSecret = JSON.parse(value);
+                if (parsed.accountID && parsed.accountSecret) {
+                    setId(parsed.accountID);
+                    setSecret(parsed.accountSecret);
+                }
+            } catch (error) {
+                // If parsing fails, just keep the raw value in the id field
+                console.log("Failed to parse JSON:", error);
+            }
+        }
+    };
+
+    const handleSubmit = (e: React.FormEvent): void => {
     e.preventDefault();
     addAccount(id as RawAccountID, secret as AgentSecret);
     setId("");
@@ -290,13 +316,14 @@ function AddAccountForm({
           jazz-logged-in-secret
         </code>{" "}
         local storage key from within your Jazz app for your account
-        credentials.
+                credentials. You can paste the full JSON object or enter the ID
+                and secret separately.
       </p>
       <Input
         label="Account ID"
         value={id}
-        placeholder="co_z1234567890abcdef123456789"
-        onChange={(e) => setId(e.target.value)}
+                placeholder="co_z1234567890abcdef123456789 or paste full JSON"
+                onChange={handleIdChange}
       />
       <Input
         label="Account secret"


### PR DESCRIPTION
Small quality of life improvement, to allow pasting the full JSON from local storage, into the Account ID field.

https://github.com/user-attachments/assets/e3d0394a-a804-4e14-a195-1cc113d4065c


