### PR TITLE
useForm hook

### DIFF
--- a/examples/form/index.html
+++ b/examples/form/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Jazz | Form example</title>
-    <link rel="icon" type="image/png" href="./public/favicon.ico">
+    <link rel="icon" type="image/png" href="./favicon.ico">
   </head>
   <body class="h-full flex flex-col bg-white text-stone-700 dark:text-stone-400 dark:bg-stone-925">
     <div id="root" class="align-self-center flex-1"></div>

--- a/examples/form/package.json
+++ b/examples/form/package.json
@@ -14,6 +14,7 @@
     "hash-slash": "workspace:*",
     "jazz-react": "workspace:*",
     "jazz-tools": "workspace:*",
+    "jazz-inspector": "workspace:*",
     "react": "19.0.0",
     "react-dom": "19.0.0"
   },

--- a/examples/form/src/EditOrder.tsx
+++ b/examples/form/src/EditOrder.tsx
@@ -15,7 +15,11 @@ export function EditOrder(props: { id: string }) {
     <>
       <LinkToHome />
 
-      <OrderThumbnail order={order} />
+      <div>
+        <p>Saved order:</p>
+
+        <OrderThumbnail order={order} />
+      </div>
 
       <h1 className="text-lg">
         <strong>Edit your bubble tea order 🧋</strong>

--- a/examples/form/src/EditOrder.tsx
+++ b/examples/form/src/EditOrder.tsx
@@ -1,11 +1,13 @@
 import { useCoState } from "jazz-react";
 import { LinkToHome } from "./LinkToHome.tsx";
-import { OrderForm } from "./OrderForm.tsx";
+import { OrderFormWithSaveButton } from "./OrderFormWithSaveButton.tsx";
 import { OrderThumbnail } from "./OrderThumbnail.tsx";
 import { BubbleTeaOrder } from "./schema.ts";
 
 export function EditOrder(props: { id: string }) {
-  const order = useCoState(BubbleTeaOrder, props.id);
+  const order = useCoState(BubbleTeaOrder, props.id, {
+    resolve: { addOns: true, instructions: true },
+  });
 
   if (!order) return;
 
@@ -19,7 +21,7 @@ export function EditOrder(props: { id: string }) {
         <strong>Edit your bubble tea order 🧋</strong>
       </h1>
 
-      <OrderForm order={order} />
+      <OrderFormWithSaveButton order={order} />
     </>
   );
 }

--- a/examples/form/src/OrderFormWithSaveButton.tsx
+++ b/examples/form/src/OrderFormWithSaveButton.tsx
@@ -38,7 +38,12 @@ const useOrderForm = (order: LoadedBubbleTeaOrder) => {
     value.addOns.applyDiff(order.addOns);
     order.deliveryDate = value.deliveryDate;
     order.withMilk = value.withMilk;
-    order.instructions.applyDiff(value.instructions);
+
+    const instructions = order.instructions || CoPlainText.create("");
+    if (value.instructions) {
+      instructions.applyDiff(value.instructions.toString());
+      order.instructions = instructions;
+    }
   };
 
   return { value, save };

--- a/examples/form/src/OrderFormWithSaveButton.tsx
+++ b/examples/form/src/OrderFormWithSaveButton.tsx
@@ -1,0 +1,181 @@
+import { CoPlainText, Loaded } from "jazz-tools";
+import { useEffect, useState } from "react";
+import { OrderThumbnail } from "./OrderThumbnail.tsx";
+import {
+  BubbleTeaAddOnTypes,
+  BubbleTeaBaseTeaTypes,
+  BubbleTeaOrder,
+  ListOfBubbleTeaAddOns,
+} from "./schema.ts";
+
+const useOrderForm = (
+  order: Loaded<
+    typeof BubbleTeaOrder,
+    { addOns: { $each: true }; instructions: true }
+  >,
+) => {
+  const [value, setValue] = useState<
+    | Loaded<
+        typeof BubbleTeaOrder,
+        { addOns: { $each: true }; instructions: true }
+      >
+    | undefined
+  >();
+
+  console.log("hook value id", value?.id);
+
+  useEffect(() => {
+    // deep clone order
+    setValue(
+      BubbleTeaOrder.create({
+        ...order,
+        instructions: CoPlainText.create(`${order.instructions}` || ""),
+        addOns: ListOfBubbleTeaAddOns.create([...order.addOns]),
+      }),
+    );
+  }, [order.id]);
+
+  if (!value) return { value, save: () => {} };
+
+  const save = () => {
+    order.baseTea = value.baseTea;
+    value.addOns.applyDiff(order.addOns);
+    order.deliveryDate = value.deliveryDate;
+    order.withMilk = value.withMilk;
+    order.instructions = value.instructions;
+  };
+
+  return { value, save };
+};
+
+export function OrderFormWithSaveButton({
+  order: originalOrder,
+}: {
+  order: Loaded<
+    typeof BubbleTeaOrder,
+    { addOns: { $each: true }; instructions: true }
+  >;
+}) {
+  const { value: order, save } = useOrderForm(originalOrder);
+
+  if (!order) return null;
+
+  console.log("cloned order id", order.id);
+
+  const handleInstructionsChange = (
+    e: React.ChangeEvent<HTMLTextAreaElement>,
+  ) => {
+    if (order.instructions) {
+      return order.instructions.applyDiff(e.target.value);
+    }
+    order.instructions = CoPlainText.create(e.target.value, order._owner);
+  };
+
+  const submit = (e: React.FormEvent<HTMLFormElement>) => {
+    console.log("submit form");
+    e.preventDefault();
+    save();
+  };
+
+  return (
+    <form onSubmit={submit} className="grid gap-5">
+      <h1>With save button</h1>
+
+      <div>
+        <div>original order id: {originalOrder.id}</div>
+        <div>cloned order id: {order.id}</div>
+      </div>
+
+      <OrderThumbnail order={order} />
+
+      <strong>base tea: {order.baseTea}</strong>
+
+      <div className="flex flex-col gap-2">
+        <label htmlFor="baseTea">Base tea</label>
+        <select
+          name="baseTea"
+          id="baseTea"
+          value={order.baseTea || ""}
+          className="dark:bg-transparent"
+          onChange={(e) => (order.baseTea = e.target.value as any)}
+          required
+        >
+          <option value="" disabled>
+            Please select your preferred base tea
+          </option>
+          {BubbleTeaBaseTeaTypes.map((teaType) => (
+            <option key={teaType} value={teaType}>
+              {teaType}
+            </option>
+          ))}
+        </select>
+      </div>
+
+      <fieldset>
+        <legend className="mb-2">Add-ons</legend>
+
+        {BubbleTeaAddOnTypes.map((addOn) => (
+          <div key={addOn} className="flex items-center gap-2">
+            <input
+              type="checkbox"
+              value={addOn}
+              name={addOn}
+              id={addOn}
+              checked={order.addOns?.includes(addOn) || false}
+              onChange={(e) => {
+                if (e.target.checked) {
+                  order.addOns?.push(addOn);
+                } else {
+                  order.addOns?.splice(order.addOns?.indexOf(addOn), 1);
+                }
+              }}
+            />
+            <label htmlFor={addOn}>{addOn}</label>
+          </div>
+        ))}
+      </fieldset>
+
+      <div className="flex flex-col gap-2">
+        <label htmlFor="deliveryDate">Delivery date</label>
+        <input
+          type="date"
+          name="deliveryDate"
+          id="deliveryDate"
+          className="dark:bg-transparent"
+          value={order.deliveryDate?.toISOString().split("T")[0] || ""}
+          onChange={(e) => (order.deliveryDate = new Date(e.target.value))}
+          required
+        />
+      </div>
+
+      <div className="flex items-center gap-2">
+        <input
+          type="checkbox"
+          name="withMilk"
+          id="withMilk"
+          checked={order.withMilk}
+          onChange={(e) => (order.withMilk = e.target.checked)}
+        />
+        <label htmlFor="withMilk">With milk?</label>
+      </div>
+
+      <div className="flex flex-col gap-2">
+        <label htmlFor="instructions">Special instructions</label>
+        <textarea
+          name="instructions"
+          id="instructions"
+          value={`${order.instructions}`}
+          className="dark:bg-transparent"
+          onChange={handleInstructionsChange}
+        ></textarea>
+      </div>
+
+      <button
+        type="submit"
+        className="bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded"
+      >
+        Submit
+      </button>
+    </form>
+  );
+}

--- a/examples/form/src/main.tsx
+++ b/examples/form/src/main.tsx
@@ -3,6 +3,7 @@ import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
 import App from "./App.tsx";
 import "./index.css";
+import { JazzInspector } from "jazz-inspector";
 import { apiKey } from "./apiKey";
 import { JazzAccount } from "./schema.ts";
 
@@ -15,6 +16,7 @@ createRoot(document.getElementById("root")!).render(
       AccountSchema={JazzAccount}
     >
       <App />
+      <JazzInspector />
     </JazzProvider>
   </StrictMode>,
 );

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -827,6 +827,9 @@ importers:
       hash-slash:
         specifier: workspace:*
         version: link:../../packages/hash-slash
+      jazz-inspector:
+        specifier: workspace:*
+        version: link:../../packages/jazz-inspector
       jazz-react:
         specifier: workspace:*
         version: link:../../packages/jazz-react


### PR DESCRIPTION
Preview: https://form-demo-git-feat-form-with-save-button-gcmp.vercel.app/

Pain points
- I have to specify the resolve query in the type but also in useCoState
- No obvious way to clone different types of CoValues
  - How about `BubbleTeaOrder.clone()` which does a deep clone? 
- No obvious way to copy over a CoValue's value to another CoValue (rich text and list)
  - How about `order.applyDiff(order2)`? 
- In `covalue.applyDiff(covalue2)`, it's not obvious where the value is being applied to

Todo
- Try with ImageDefinition, FileStream, CoFeed

Ideas
- We can extend this pattern to have edit drafts