### PR TITLE
Add error boundary for inspector

### DIFF
--- a/examples/inspector/src/viewer/new-app.tsx
+++ b/examples/inspector/src/viewer/new-app.tsx
@@ -94,24 +94,24 @@ export default function CoJsonViewerApp() {
           },
         });
       } catch (err: any) {
-        const invalidAccountIndex = accounts.findIndex(
-          (acc) => acc.id === currentAccount.id,
-        );
-        accounts.splice(invalidAccountIndex, 1);
+        if (err.toString().includes("invalid id")) {
+          setAccounts(accounts.filter((acc) => acc.id !== currentAccount.id));
+          //remove from localStorage
+          localStorage.removeItem("lastSelectedAccountId");
+          localStorage.setItem(
+            "inspectorAccounts",
+            JSON.parse(localStorage.inspectorAccounts).filter(
+              (acc: Account) => acc.id != currentAccount.id,
+            ),
+          );
+          setCurrentAccount(null);
+          setErrors("Trying to load covalue with invalid id");
+          setLocalNode(null);
+          goToIndex(-1);
+        } else {
+          setErrors("The account could not be loaded");
+        }
 
-        setAccounts(accounts);
-        //remove from localStorage
-        localStorage.removeItem("lastSelectedAccountId");
-        localStorage.setItem(
-          "inspectorAccounts",
-          JSON.parse(localStorage.inspectorAccounts).filter(
-            (acc: Account) => acc.id != currentAccount.id,
-          ),
-        );
-        setCurrentAccount(null);
-        setErrors(err.toString());
-        setLocalNode(null);
-        goToIndex(-1);
         return;
       }
       setLocalNode(node);
@@ -340,7 +340,7 @@ function AddAccountForm({
         <div className="bg-red-100 border border-red-400 text-red-700 px-4 py-3 rounded mt-4 font-mono whitespace-pre-wrap break-words mb-8">
           <h3>Error</h3>
           <pre className="whitespace-pre-wrap break-words overflow-hidden">
-            {JSON.stringify(errors)}
+            Error: {JSON.stringify(errors)}
           </pre>
         </div>
       )}

--- a/examples/inspector/src/viewer/new-app.tsx
+++ b/examples/inspector/src/viewer/new-app.tsx
@@ -99,15 +99,13 @@ export default function CoJsonViewerApp() {
         );
         accounts.splice(invalidAccountIndex, 1);
 
-        console.log(accounts);
-        console.log("remove the account");
         setAccounts(accounts);
         //remove from localStorage
         localStorage.removeItem("lastSelectedAccountId");
         localStorage.setItem(
           "inspectorAccounts",
           JSON.parse(localStorage.inspectorAccounts).filter(
-            (acc) => acc.id != currentAccount.id,
+            (acc: Account) => acc.id != currentAccount.id,
           ),
         );
         setCurrentAccount(null);
@@ -336,10 +334,10 @@ function AddAccountForm({
   return (
     <form
       onSubmit={handleSubmit}
-      className="flex flex-col gap-3 max-w-md mx-auto h-full justify-center"
+      className={`flex flex-col max-w-[30rem] mx-auto justify-center ${errors == null ? "h-full" : ""}`}
     >
       {errors != null && (
-        <div className="bg-red-100 border border-red-400 text-red-700 px-4 py-3 rounded mt-4 font-mono whitespace-pre-wrap break-words">
+        <div className="bg-red-100 border border-red-400 text-red-700 px-4 py-3 rounded mt-4 font-mono whitespace-pre-wrap break-words mb-8">
           <h3>Error</h3>
           <pre className="whitespace-pre-wrap break-words overflow-hidden">
             {JSON.stringify(errors)}

--- a/examples/inspector/src/viewer/new-app.tsx
+++ b/examples/inspector/src/viewer/new-app.tsx
@@ -35,7 +35,7 @@ interface JazzLoggedInSecret {
 }
 
 export default function CoJsonViewerApp() {
-  const [errors, setErrors] = useState(null);
+  const [errors, setErrors] = useState<string | null>(null);
   const [accounts, setAccounts] = useState<Account[]>(() => {
     const storedAccounts = localStorage.getItem("inspectorAccounts");
     return storedAccounts ? JSON.parse(storedAccounts) : [];

--- a/examples/inspector/src/viewer/new-app.tsx
+++ b/examples/inspector/src/viewer/new-app.tsx
@@ -106,12 +106,11 @@ export default function CoJsonViewerApp() {
           );
           setCurrentAccount(null);
           setErrors("Trying to load covalue with invalid id");
-          setLocalNode(null);
-          goToIndex(-1);
         } else {
           setErrors("The account could not be loaded");
         }
-
+        setLocalNode(null);
+        goToIndex(-1);
         return;
       }
       setLocalNode(node);
@@ -340,7 +339,7 @@ function AddAccountForm({
         <div className="bg-red-100 border border-red-400 text-red-700 px-4 py-3 rounded mt-4 font-mono whitespace-pre-wrap break-words mb-8">
           <h3>Error</h3>
           <pre className="whitespace-pre-wrap break-words overflow-hidden">
-            Error: {JSON.stringify(errors)}
+            {errors}
           </pre>
         </div>
       )}


### PR DESCRIPTION
[nit] I was working with getting familiarized with the jazz inspector today and noticed that the accounts drop down would be stuck in a loading state if an account was invalid and errors were logged in the console. It's easily identifiable when you open the console, but I figured it's an easy fix that could be helpful for more visibility for a customer when things don't work as expected.

Not sure if I missed an error component in the design system but open to edits and feedback in that regard!

Before:
<img width="1511" alt="Screenshot 2025-06-10 at 5 53 36 PM" src="https://github.com/user-attachments/assets/642a6c58-ff86-424b-89b9-04de46268b94" />
After:
<img width="1512" alt="Screenshot 2025-06-10 at 5 54 20 PM" src="https://github.com/user-attachments/assets/782db18a-a924-4811-9484-5fe6d2b4de1a" />

