### PR TITLE
Fix: `applyDiff` out of bounds for strings with emoji

### DIFF
--- a/.changeset/polite-bulldogs-train.md
+++ b/.changeset/polite-bulldogs-train.md
@@ -1,0 +1,5 @@
+---
+"cojson": patch
+---
+
+Adds grapheme split helpers for coText

--- a/.changeset/short-peaches-smell.md
+++ b/.changeset/short-peaches-smell.md
@@ -1,0 +1,5 @@
+---
+"jazz-tools": patch
+---
+
+Fixs coText applyDiff out of bounds insertion with emoji

--- a/packages/cojson/src/coValues/coPlainText.ts
+++ b/packages/cojson/src/coValues/coPlainText.ts
@@ -182,4 +182,14 @@ export class RawCoPlainText<
     this.core.makeTransaction(ops, privacy);
     this.processNewTransactions();
   }
+
+  /** @internal Helper method to split text into graphemes */
+  toGraphemes(text: string): string[] {
+    return [...splitGraphemes(text)];
+  }
+
+  /** @internal Helper method to join graphemes into a string */
+  fromGraphemes(graphemes: string[]): string {
+    return graphemes.join("");
+  }
 }

--- a/packages/cojson/src/coValues/coPlainText.ts
+++ b/packages/cojson/src/coValues/coPlainText.ts
@@ -3,12 +3,6 @@ import { AvailableCoValueCore } from "../coValueCore/coValueCore.js";
 import { JsonObject } from "../jsonValue.js";
 import { DeletionOpPayload, OpID, RawCoList } from "./coList.js";
 
-declare const navigator:
-  | {
-      language: string;
-    }
-  | undefined;
-
 export type StringifiedOpID = string & { __stringifiedOpID: true };
 
 export function stringifyOpID(opID: OpID): StringifiedOpID {
@@ -63,15 +57,6 @@ export class RawCoPlainText<
   constructor(core: AvailableCoValueCore) {
     super(core);
     this._cachedMapping = new WeakMap();
-
-    // Use locale from meta if provided, fallback to browser locale, or 'en' as last resort
-    const effectiveLocale =
-      (core.verified.header.meta &&
-      typeof core.verified.header.meta === "object" &&
-      "locale" in core.verified.header.meta
-        ? (core.verified.header.meta.locale as string)
-        : undefined) ||
-      (typeof navigator !== "undefined" ? navigator.language : "en");
   }
 
   get mapping() {

--- a/packages/cojson/src/tests/coPlainText.test.ts
+++ b/packages/cojson/src/tests/coPlainText.test.ts
@@ -265,3 +265,24 @@ test("Handle deletion of complex grapheme clusters correctly", () => {
   content.deleteRange({ from: 1, to: 2 }, "trusting");
   expect(content.toString()).toEqual(" 녕!");
 });
+
+test("Splits into and from grapheme string arrays", () => {
+  const node = nodeWithRandomAgentAndSessionID();
+  const coValue = node.createCoValue({
+    type: "coplaintext",
+    ruleset: { type: "unsafeAllowAll" },
+    meta: null,
+    ...Crypto.createdNowUnique(),
+  });
+
+  const content = expectPlainText(coValue.getCurrentContent());
+
+  content.insertAfter(0, "👋 안녕!", "trusting");
+  expect(content.toString()).toEqual("👋 안녕!");
+
+  const graphemes = content.toGraphemes("👋 안녕!");
+  expect(graphemes).toEqual(["👋", " ", "안", "녕", "!"]);
+
+  const text = content.fromGraphemes(graphemes);
+  expect(text).toEqual("👋 안녕!");
+});

--- a/packages/jazz-tools/src/coValues/coPlainText.ts
+++ b/packages/jazz-tools/src/coValues/coPlainText.ts
@@ -178,12 +178,22 @@ export class CoPlainText extends String implements CoValue {
    */
   applyDiff(other: string) {
     const current = this._raw.toString();
-    for (const [from, to, insert] of [...calcPatch(current, other)].reverse()) {
+
+    // Split both strings into grapheme arrays for proper comparison
+    const currentGraphemes = this._raw.toGraphemes(current);
+    const otherGraphemes = this._raw.toGraphemes(other);
+
+    // Calculate the diff on grapheme arrays
+    const patches = [...calcPatch(currentGraphemes, otherGraphemes)];
+
+    // Apply patches in reverse order to avoid index shifting issues
+    for (const [from, to, insert] of patches.reverse()) {
       if (to > from) {
         this.deleteRange({ from, to });
       }
       if (insert.length > 0) {
-        this.insertBefore(from, insert);
+        // Join the graphemes back into a string for insertion
+        this.insertBefore(from, this._raw.fromGraphemes(insert));
       }
     }
   }

--- a/packages/jazz-tools/src/tests/coPlainText.test.ts
+++ b/packages/jazz-tools/src/tests/coPlainText.test.ts
@@ -85,6 +85,14 @@ describe("CoPlainText", () => {
         text.applyDiff("hello cruel world");
         expect(text.toString()).toEqual("hello cruel world");
       });
+
+      test("applyDiff with complex grapheme clusters", () => {
+        const text = co.plainText().create(`😊`, { owner: me });
+        text.applyDiff(`😊안녕!`);
+        expect(text.toString()).toEqual(`😊안녕!`);
+        text.applyDiff(`😊👋 안녕!`);
+        expect(text.toString()).toEqual(`😊👋 안녕!`);
+      });
     });
 
     describe("Properties", () => {


### PR DESCRIPTION
`coText.applyDiff` uses string index for comparison, which with emoji is incorrect. This PR adds splitting into grapheme string array first, then calculating the difference.