### PR TITLE
fix(rn): reuse the same db connection when doing login/logout

### DIFF
--- a/.changeset/real-roses-run.md
+++ b/.changeset/real-roses-run.md
@@ -1,0 +1,6 @@
+---
+"jazz-react-native": patch
+"jazz-expo": patch
+---
+
+Reuse the same db connection when switching users instead of closing/opening a new one

--- a/packages/jazz-expo/src/storage/expo-sqlite-adapter.ts
+++ b/packages/jazz-expo/src/storage/expo-sqlite-adapter.ts
@@ -11,6 +11,10 @@ export class ExpoSQLiteAdapter implements SQLiteDatabaseDriverAsync {
   }
 
   public async initialize(): Promise<void> {
+    if (this.db) {
+      return;
+    }
+
     const db = await openDatabaseAsync(this.dbName, {
       useNewConnection: true,
     });
@@ -85,11 +89,6 @@ export class ExpoSQLiteAdapter implements SQLiteDatabaseDriverAsync {
   }
 
   public async closeDb(): Promise<void> {
-    if (!this.db) {
-      throw new Error("Database not initialized");
-    }
-
-    await this.db.closeAsync();
-    this.db = null;
+    // Keeping the database open and reusing the same connection over multiple ctx instances.
   }
 }

--- a/packages/jazz-react-native/src/storage/op-sqlite-adapter.ts
+++ b/packages/jazz-react-native/src/storage/op-sqlite-adapter.ts
@@ -18,6 +18,10 @@ export class OPSQLiteAdapter implements SQLiteDatabaseDriverAsync {
   }
 
   public async initialize(): Promise<void> {
+    if (this.db) {
+      return;
+    }
+
     const dbPath =
       Platform.OS === "ios" ? IOS_LIBRARY_PATH : ANDROID_DATABASE_PATH;
 
@@ -70,11 +74,6 @@ export class OPSQLiteAdapter implements SQLiteDatabaseDriverAsync {
   }
 
   public async closeDb(): Promise<void> {
-    if (!this.db) {
-      throw new Error("Database not initialized");
-    }
-
-    this.db.close();
-    this.db = null;
+    // Keeping the database open and reusing the same connection over multiple ctx instances.
   }
 }


### PR DESCRIPTION
The last fix on the DB connections has caused a regression for some users: https://github.com/garden-co/jazz/pull/2448

Going to switch to always reusing the same DB connection