### PR TITLE
fix: mark AccountSchema as required prop

### DIFF
--- a/.changeset/curly-needles-visit.md
+++ b/.changeset/curly-needles-visit.md
@@ -1,0 +1,10 @@
+---
+"jazz-browser": minor
+"jazz-vue": minor
+"jazz-expo": minor
+"jazz-react": minor
+"jazz-react-native": minor
+"jazz-svelte": minor
+---
+
+Mark AccountSchema as required prop

--- a/examples/betterauth/src/components/JazzAndAuth.tsx
+++ b/examples/betterauth/src/components/JazzAndAuth.tsx
@@ -2,6 +2,7 @@
 
 import { JazzProvider } from "jazz-react";
 import { AuthProvider } from "jazz-react-auth-betterauth";
+import { Account } from "jazz-tools";
 import { type ReactNode, lazy } from "react";
 
 const JazzDevTools =
@@ -16,6 +17,7 @@ const JazzDevTools =
 export function JazzAndAuth({ children }: { children: ReactNode }) {
   return (
     <JazzProvider
+      AccountSchema={Account}
       sync={{
         peer: "wss://cloud.jazz.tools/?key=betterauth-example@garden.co",
       }}

--- a/examples/chat-rn-expo/src/App.tsx
+++ b/examples/chat-rn-expo/src/App.tsx
@@ -1,4 +1,5 @@
 import { JazzProvider } from "jazz-expo";
+import { Account } from "jazz-tools";
 import React, { StrictMode } from "react";
 import { apiKey } from "./apiKey";
 import ChatScreen from "./chat";
@@ -7,6 +8,7 @@ export default function App() {
   return (
     <StrictMode>
       <JazzProvider
+        AccountSchema={Account}
         sync={{
           peer: `wss://cloud.jazz.tools/?key=${apiKey}`,
         }}

--- a/examples/chat-rn/src/App.tsx
+++ b/examples/chat-rn/src/App.tsx
@@ -4,6 +4,7 @@ import {
 } from "@react-navigation/native";
 import { createNativeStackNavigator } from "@react-navigation/native-stack";
 import { JazzProvider } from "jazz-react-native";
+import { Account } from "jazz-tools";
 import React, { StrictMode, useEffect, useState } from "react";
 import { Linking } from "react-native";
 import { apiKey } from "./apiKey";
@@ -50,6 +51,7 @@ function App() {
   return (
     <StrictMode>
       <JazzProvider
+        AccountSchema={Account}
         sync={{
           peer: `wss://cloud.jazz.tools/?key=${apiKey}`,
         }}

--- a/examples/chat-vue/src/main.ts
+++ b/examples/chat-vue/src/main.ts
@@ -3,6 +3,7 @@ import { createApp, defineComponent, h } from "vue";
 import App from "./App.vue";
 import "./index.css";
 import { apiKey } from "@/apiKey";
+import { Account } from "jazz-tools";
 import router from "./router";
 
 const RootComponent = defineComponent({
@@ -12,6 +13,7 @@ const RootComponent = defineComponent({
       h(
         JazzProvider,
         {
+          AccountSchema: Account,
           sync: {
             peer: `wss://cloud.jazz.tools/?key=${apiKey}`,
           },

--- a/examples/chat/src/app.tsx
+++ b/examples/chat/src/app.tsx
@@ -3,7 +3,7 @@ import { getRandomUsername, inIframe, onChatLoad } from "@/util.ts";
 import { useIframeHashRouter } from "hash-slash";
 import { JazzInspector } from "jazz-inspector";
 import { JazzProvider, useAccount } from "jazz-react";
-import { Group } from "jazz-tools";
+import { Account, Group } from "jazz-tools";
 import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
 import { ChatScreen } from "./chatScreen.tsx";
@@ -56,6 +56,7 @@ createRoot(document.getElementById("root")!).render(
   <ThemeProvider>
     <StrictMode>
       <JazzProvider
+        AccountSchema={Account}
         sync={{
           peer: `wss://cloud.jazz.tools/?key=${apiKey}`,
         }}

--- a/examples/clerk/src/main.tsx
+++ b/examples/clerk/src/main.tsx
@@ -5,6 +5,7 @@ import App from "./App.tsx";
 import "./index.css";
 import { JazzInspector } from "jazz-inspector";
 import { JazzProviderWithClerk } from "jazz-react-auth-clerk";
+import { Account } from "jazz-tools";
 import { ReactNode } from "react";
 import { apiKey } from "./apiKey";
 
@@ -20,6 +21,7 @@ function JazzProvider({ children }: { children: ReactNode }) {
 
   return (
     <JazzProviderWithClerk
+      AccountSchema={Account}
       clerk={clerk}
       sync={{
         peer: `wss://cloud.jazz.tools/?key=${apiKey}`,

--- a/examples/jazz-nextjs/src/jazz.tsx
+++ b/examples/jazz-nextjs/src/jazz.tsx
@@ -2,10 +2,12 @@
 
 import { JazzInspector } from "jazz-inspector";
 import { JazzProvider } from "jazz-react";
+import { Account } from "jazz-tools";
 
 export function Jazz({ children }: { children: React.ReactNode }) {
   return (
     <JazzProvider
+      AccountSchema={Account}
       experimental_enableSSR
       sync={{
         peer: `wss://cloud.jazz.tools/`,

--- a/examples/jazz-paper-scissors/src/components/ui/jazz-and-auth.tsx
+++ b/examples/jazz-paper-scissors/src/components/ui/jazz-and-auth.tsx
@@ -1,8 +1,10 @@
 import { JazzProvider } from "jazz-react";
+import { Account } from "jazz-tools";
 
 export function JazzAndAuth({ children }: { children: React.ReactNode }) {
   return (
     <JazzProvider
+      AccountSchema={Account}
       sync={{
         peer: "wss://cloud.jazz.tools/?key=jazz-paper-scissors@garden.co",
       }}

--- a/examples/jazz-paper-scissors/src/main.tsx
+++ b/examples/jazz-paper-scissors/src/main.tsx
@@ -5,6 +5,7 @@ import ReactDOM from "react-dom/client";
 import "./index.css";
 import { apiKey } from "@/apiKey.ts";
 import { JazzProvider } from "jazz-react";
+import { Account } from "jazz-tools";
 import { App } from "./app";
 
 const rootElement = document.getElementById("app");
@@ -13,6 +14,7 @@ if (rootElement && !rootElement.innerHTML) {
   root.render(
     <StrictMode>
       <JazzProvider
+        AccountSchema={Account}
         sync={{
           peer: `wss://cloud.jazz.tools/?key=${apiKey}`,
         }}

--- a/examples/passkey-svelte/src/routes/+layout.svelte
+++ b/examples/passkey-svelte/src/routes/+layout.svelte
@@ -1,11 +1,13 @@
 <script lang="ts">
   import { JazzProvider, PasskeyAuthBasicUI } from 'jazz-svelte';
   import { apiKey } from '../apiKey';
+  import { Account } from 'jazz-tools';
 
   let { children } = $props();
 </script>
 
 <JazzProvider
+  AccountSchema={Account}
   sync={{
     peer: `wss://cloud.jazz.tools/?key=${apiKey}`
   }}

--- a/examples/passkey/src/main.tsx
+++ b/examples/passkey/src/main.tsx
@@ -4,11 +4,13 @@ import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
 import App from "./App.tsx";
 import "./index.css";
+import { Account } from "jazz-tools";
 import { apiKey } from "./apiKey.ts";
 
 function JazzAndAuth({ children }: { children: React.ReactNode }) {
   return (
     <JazzProvider
+      AccountSchema={Account}
       sync={{
         peer: `wss://cloud.jazz.tools/?key=${apiKey}`,
       }}

--- a/examples/passphrase/src/main.tsx
+++ b/examples/passphrase/src/main.tsx
@@ -4,6 +4,7 @@ import { StrictMode, useState } from "react";
 import { createRoot } from "react-dom/client";
 import App from "./App.tsx";
 import "./index.css";
+import { Account } from "jazz-tools";
 import { wordlist } from "./wordlist.ts";
 
 function PassphraseAuthBasicUI(props: {
@@ -141,6 +142,7 @@ function PassphraseAuthBasicUI(props: {
 function JazzAndAuth({ children }: { children: React.ReactNode }) {
   return (
     <JazzProvider
+      AccountSchema={Account}
       sync={{
         peer: "wss://cloud.jazz.tools/?key=minimal-auth-passphrase-example@garden.co",
       }}

--- a/examples/reactions/src/main.tsx
+++ b/examples/reactions/src/main.tsx
@@ -4,11 +4,13 @@ import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
 import App from "./App.tsx";
 import "./index.css";
+import { Account } from "jazz-tools";
 import { apiKey } from "./apiKey";
 
 createRoot(document.getElementById("root")!).render(
   <StrictMode>
     <JazzProvider
+      AccountSchema={Account}
       sync={{
         peer: `wss://cloud.jazz.tools/?key=${apiKey}`,
       }}

--- a/examples/version-history/src/main.tsx
+++ b/examples/version-history/src/main.tsx
@@ -4,11 +4,13 @@ import { createRoot } from "react-dom/client";
 import App from "./App.tsx";
 import "./index.css";
 import { JazzInspector } from "jazz-inspector";
+import { Account } from "jazz-tools";
 import { apiKey } from "./apiKey.ts";
 
 createRoot(document.getElementById("root")!).render(
   <StrictMode>
     <JazzProvider
+      AccountSchema={Account}
       sync={{
         peer: `wss://cloud.jazz.tools/?key=${apiKey}`,
       }}

--- a/packages/jazz-browser/src/BrowserContextManager.ts
+++ b/packages/jazz-browser/src/BrowserContextManager.ts
@@ -29,7 +29,7 @@ export type JazzContextManagerProps<
     anonymousAccount: InstanceOfSchema<S>,
   ) => Promise<void>;
   storage?: BaseBrowserContextOptions["storage"];
-  AccountSchema?: S;
+  AccountSchema: S;
   defaultProfileName?: string;
 };
 

--- a/packages/jazz-vue/src/provider.ts
+++ b/packages/jazz-vue/src/provider.ts
@@ -50,7 +50,7 @@ export const JazzProvider = defineComponent({
       type: Function as unknown as PropType<
         (AccountClass<Account> & CoValueFromRaw<Account>) | AnyAccountSchema
       >,
-      required: false,
+      required: true,
     },
     storage: {
       type: String as PropType<"indexedDB">,


### PR DESCRIPTION
fixes #2489 

Passing the Account schema to the JazzProvider is necessary to run the migrations and fill the account root.

Users that forgot to setup that usually belive that there is something wrong with Jazz migrations.

Since most use cases would need a custom account schema for anything more than a trivial example we think that it's ok to make AccountSchema required in order to prevent users to fall in the "no migrations" issue.