### PR TITLE
Add docs for accept invite

### DIFF
--- a/homepage/homepage/content/docs/groups/sharing.mdx
+++ b/homepage/homepage/content/docs/groups/sharing.mdx
@@ -99,8 +99,7 @@ const Organization = co.map({
 });
 const account = {} as unknown as Account;
 const organizationId = "";
-const inviteSecret ="";
-
+const inviteSecret = "inviteSecret_z";
 // ---cut---
 await account.acceptInvite(
   organizationId,

--- a/homepage/homepage/content/docs/groups/sharing.mdx
+++ b/homepage/homepage/content/docs/groups/sharing.mdx
@@ -86,7 +86,8 @@ useAcceptInvite({
 });
 ```
 
-You can also accept the invite programmatically, using the `acceptInvite` method on an account by passing the ID of the CoValue you're being invited to, the secret from the invite link, and the schema of the CoValue.
+You can accept an invitation programmatically by using the `acceptInvite` method on an account.
+Pass the ID of the CoValue you're being invited to, the secret from the invite link, and the schema of the CoValue.
 
 <CodeGroup>
 ```ts twoslash

--- a/homepage/homepage/content/docs/groups/sharing.mdx
+++ b/homepage/homepage/content/docs/groups/sharing.mdx
@@ -85,11 +85,8 @@ useAcceptInvite({
   },
 });
 ```
-</CodeGroup>
 
-### Accepting Invites Programmatically
-
-While the `useAcceptInvite` hook is convenient for React applications, you can also accept invites programmatically using the `acceptInvite` method on an account:
+You can also accept the invite programmatically, using the `acceptInvite` method on an account by passing the ID of the CoValue you're being invited to, the secret from the invite link, and the schema of the CoValue.
 
 <CodeGroup>
 ```ts twoslash
@@ -99,17 +96,13 @@ const Organization = co.map({
   name: z.string(),
 });
 
-// ---cut---
-// Assuming you have an account and invite details
 await account.acceptInvite(
-  organizationId, // The ID of the CoValue you're being invited to
-  inviteSecret,   // The secret from the invite link
-  Organization    // The schema of the CoValue
+  organizationId,
+  inviteSecret,
+  Organization
 );
 ```
 </CodeGroup>
-
-This is useful when you need to accept invites outside of React components or want more control over the invite acceptance process.
 
 ### Requesting Invites
 

--- a/homepage/homepage/content/docs/groups/sharing.mdx
+++ b/homepage/homepage/content/docs/groups/sharing.mdx
@@ -91,12 +91,16 @@ Pass the ID of the CoValue you're being invited to, the secret from the invite l
 
 <CodeGroup>
 ```ts twoslash
-import { co, z } from "jazz-tools";
+import { co, z, Account } from "jazz-tools";
 
 const Organization = co.map({
   name: z.string(),
 });
+const account = {} as unknown as Account;
+const organizationId = "";
+const inviteSecret ="";
 
+// ---cut---
 await account.acceptInvite(
   organizationId,
   inviteSecret,

--- a/homepage/homepage/content/docs/groups/sharing.mdx
+++ b/homepage/homepage/content/docs/groups/sharing.mdx
@@ -2,7 +2,7 @@ export const metadata = {
   description: "Share CoValues in Jazz through public sharing and invite links. Enable collaboration by granting access to everyone or specific users with different permission levels."
 };
 
-import { ContentByFramework, CodeGroup } from '@/components/forMdx'
+import { CodeGroup, ContentByFramework } from '@/components/forMdx';
 
 # Public sharing and invites
 
@@ -87,6 +87,29 @@ useAcceptInvite({
 ```
 </CodeGroup>
 
+### Accepting Invites Programmatically
+
+While the `useAcceptInvite` hook is convenient for React applications, you can also accept invites programmatically using the `acceptInvite` method on an account:
+
+<CodeGroup>
+```ts twoslash
+import { co, z } from "jazz-tools";
+
+const Organization = co.map({
+  name: z.string(),
+});
+
+// ---cut---
+// Assuming you have an account and invite details
+await account.acceptInvite(
+  organizationId, // The ID of the CoValue you're being invited to
+  inviteSecret,   // The secret from the invite link
+  Organization    // The schema of the CoValue
+);
+```
+</CodeGroup>
+
+This is useful when you need to accept invites outside of React components or want more control over the invite acceptance process.
 
 ### Requesting Invites
 

--- a/homepage/homepage/content/docs/groups/sharing.mdx
+++ b/homepage/homepage/content/docs/groups/sharing.mdx
@@ -85,6 +85,7 @@ useAcceptInvite({
   },
 });
 ```
+</CodeGroup>
 
 You can accept an invitation programmatically by using the `acceptInvite` method on an account.
 Pass the ID of the CoValue you're being invited to, the secret from the invite link, and the schema of the CoValue.


### PR DESCRIPTION
I was searching for a way to handle invites programatically until I found the `acceptInvite` method. I thought it wouldn't hurt to include this in  the docs.