### PR TITLE
feat: improve missing deps recovery & parallelize storage reads

### DIFF
--- a/.changeset/poor-taxis-help.md
+++ b/.changeset/poor-taxis-help.md
@@ -1,0 +1,5 @@
+---
+"cojson": patch
+---
+
+Improve the missing dependencies recovery & management

--- a/.changeset/seven-crabs-shake.md
+++ b/.changeset/seven-crabs-shake.md
@@ -1,0 +1,6 @@
+---
+"cojson-storage-indexeddb": patch
+"cojson-storage": patch
+---
+
+Read in parallel up to 10 values on the async storage adapters to improve loading perf

--- a/examples/todo/src/2_main.tsx
+++ b/examples/todo/src/2_main.tsx
@@ -121,7 +121,7 @@ export default function App() {
 
 function HomeScreen() {
   const { me } = useAccount(TodoAccount, {
-    resolve: { root: { projects: { $each: true } } },
+    resolve: { root: { projects: { $each: { $onError: null } } } },
   });
   const navigate = useNavigate();
 
@@ -129,6 +129,8 @@ function HomeScreen() {
     <>
       {me?.root.projects.length ? <h1>My Projects</h1> : null}
       {me?.root.projects.map((project) => {
+        if (!project) return null;
+
         return (
           <Button
             key={project.id}

--- a/examples/todo/src/4_ProjectTodoTable.tsx
+++ b/examples/todo/src/4_ProjectTodoTable.tsx
@@ -37,7 +37,11 @@ export function ProjectTodoTable() {
   // It also recursively resolves and subsribes to all referenced CoValues.
   const project = useCoState(TodoProject, projectId, {
     resolve: {
-      tasks: true,
+      tasks: {
+        $each: {
+          text: true,
+        },
+      },
     },
   });
 
@@ -88,7 +92,7 @@ export function ProjectTodoTable() {
           </TableRow>
         </TableHeader>
         <TableBody>
-          {project?.tasks?.map(
+          {project?.tasks.map(
             (task) => task && <TaskRow key={task.id} task={task} />,
           )}
           <NewTaskInputRow createTask={createTask} disabled={!project} />

--- a/examples/todo/src/components/TaskGenerator.tsx
+++ b/examples/todo/src/components/TaskGenerator.tsx
@@ -26,9 +26,11 @@ export function TaskGenerator() {
       },
     });
 
-    root.projects.push(project);
+    root.projects.push(project.value);
 
-    navigate(`/project/${project.id}`);
+    await project.done;
+
+    navigate(`/project/${project.value.id}`);
   };
 
   return (

--- a/examples/todo/src/generate.ts
+++ b/examples/todo/src/generate.ts
@@ -1,32 +1,40 @@
 import { faker } from "@faker-js/faker";
-import { CoPlainText, Loaded, co } from "jazz-tools";
+import { CoPlainText } from "jazz-tools";
 import { Task, TodoProject } from "./1_schema";
 
-export function generateRandomProject(
-  numTasks: number,
-): Loaded<typeof TodoProject> {
+export function generateRandomProject(numTasks: number) {
   // Generate a random project title
   const projectTitle = faker.company.catchPhrase();
 
   // Create a list of tasks
-  const tasks = co.list(Task).create([]);
+  const tasks = TodoProject.def.shape.tasks.create([]);
 
   // Generate random tasks
-  for (let i = 0; i < numTasks; i++) {
-    const task = Task.create({
-      done: faker.datatype.boolean(),
-      text: CoPlainText.create(
-        faker.lorem.sentence({ min: 3, max: 8 }),
-        tasks._owner,
-      ),
-      version: 1,
-    });
-    tasks.push(task);
+  function populateTasks() {
+    for (let i = 0; i < numTasks; i++) {
+      const task = Task.create({
+        done: faker.datatype.boolean(),
+        text: CoPlainText.create(
+          faker.lorem.sentence({ min: 3, max: 8 }),
+          tasks._owner,
+        ),
+        version: 1,
+      });
+      tasks.push(task);
+    }
   }
 
   // Create and return the project
-  return TodoProject.create({
-    title: projectTitle,
-    tasks: tasks,
-  });
+  return {
+    value: TodoProject.create({
+      title: projectTitle,
+      tasks: tasks,
+    }),
+    done: new Promise((resolve) => {
+      setTimeout(() => {
+        populateTasks();
+        resolve(true);
+      }, 10);
+    }),
+  };
 }

--- a/packages/cojson-storage-indexeddb/src/CoJsonIDBTransaction.ts
+++ b/packages/cojson-storage-indexeddb/src/CoJsonIDBTransaction.ts
@@ -39,7 +39,7 @@ export class CoJsonIDBTransaction {
   startedAt = performance.now();
   isReusable() {
     const delta = performance.now() - this.startedAt;
-    return !this.done && delta <= 20;
+    return !this.done && !this.failed && delta <= 100;
   }
 
   getObjectStore(name: StoreName) {

--- a/packages/cojson-storage-indexeddb/src/tests/storage.indexeddb.test.ts
+++ b/packages/cojson-storage-indexeddb/src/tests/storage.indexeddb.test.ts
@@ -103,7 +103,9 @@ test("should sync and load data from storage", async () => {
     [
       "client -> LOAD Map sessions: empty",
       "storage -> CONTENT Group header: true new: After: 0 New: 3",
+      "client -> KNOWN Group sessions: header/3",
       "storage -> CONTENT Map header: true new: After: 0 New: 1",
+      "client -> KNOWN Map sessions: header/1",
     ]
   `);
 });
@@ -174,7 +176,9 @@ test("should send an empty content message if there is no content", async () => 
     [
       "client -> LOAD Map sessions: empty",
       "storage -> CONTENT Group header: true new: After: 0 New: 3",
+      "client -> KNOWN Group sessions: header/3",
       "storage -> CONTENT Map header: true new: ",
+      "client -> KNOWN Map sessions: header/0",
     ]
   `);
 });
@@ -255,8 +259,11 @@ test("should load dependencies correctly (group inheritance)", async () => {
     [
       "client -> LOAD Map sessions: empty",
       "storage -> CONTENT ParentGroup header: true new: After: 0 New: 4",
+      "client -> KNOWN ParentGroup sessions: header/4",
       "storage -> CONTENT Group header: true new: After: 0 New: 5",
+      "client -> KNOWN Group sessions: header/5",
       "storage -> CONTENT Map header: true new: After: 0 New: 1",
+      "client -> KNOWN Map sessions: header/1",
     ]
   `);
 });
@@ -322,13 +329,14 @@ test("should not send the same dependency value twice", async () => {
     [
       "client -> LOAD Map sessions: empty",
       "storage -> CONTENT ParentGroup header: true new: After: 0 New: 4",
-      "storage -> CONTENT Group header: true new: After: 0 New: 5",
-      "storage -> CONTENT Map header: true new: After: 0 New: 1",
       "client -> KNOWN ParentGroup sessions: header/4",
+      "storage -> CONTENT Group header: true new: After: 0 New: 5",
       "client -> KNOWN Group sessions: header/5",
+      "storage -> CONTENT Map header: true new: After: 0 New: 1",
       "client -> KNOWN Map sessions: header/1",
       "client -> LOAD MapFromParent sessions: empty",
       "storage -> CONTENT MapFromParent header: true new: After: 0 New: 1",
+      "client -> KNOWN MapFromParent sessions: header/1",
     ]
   `);
 });
@@ -428,7 +436,9 @@ test("should recover from data loss", async () => {
     [
       "client -> LOAD Map sessions: empty",
       "storage -> CONTENT Group header: true new: After: 0 New: 3",
+      "client -> KNOWN Group sessions: header/3",
       "storage -> CONTENT Map header: true new: After: 0 New: 4",
+      "client -> KNOWN Map sessions: header/4",
     ]
   `);
 });
@@ -504,7 +514,9 @@ test("should sync multiple sessions in a single content message", async () => {
     [
       "client -> LOAD Map sessions: empty",
       "storage -> CONTENT Group header: true new: After: 0 New: 3",
+      "client -> KNOWN Group sessions: header/3",
       "storage -> CONTENT Map header: true new: After: 0 New: 1 | After: 0 New: 1",
+      "client -> KNOWN Map sessions: header/2",
     ]
   `);
 });
@@ -576,12 +588,12 @@ test("large coValue upload streaming", async () => {
       "client -> LOAD Map sessions: empty",
       "storage -> KNOWN Map sessions: header/200",
       "storage -> CONTENT Group header: true new: After: 0 New: 3",
-      "storage -> CONTENT Map header: true new: After: 0 New: 97",
-      "storage -> CONTENT Map header: true new: After: 97 New: 97",
-      "storage -> CONTENT Map header: true new: After: 194 New: 6",
       "client -> KNOWN Group sessions: header/3",
+      "storage -> CONTENT Map header: true new: After: 0 New: 97",
       "client -> KNOWN Map sessions: header/97",
+      "storage -> CONTENT Map header: true new: After: 97 New: 97",
       "client -> KNOWN Map sessions: header/194",
+      "storage -> CONTENT Map header: true new: After: 194 New: 6",
       "client -> KNOWN Map sessions: header/200",
     ]
   `);
@@ -655,8 +667,8 @@ test("should sync and load accounts from storage", async () => {
       "client -> KNOWN Account sessions: header/4",
       "client -> LOAD Profile sessions: empty",
       "storage -> CONTENT ProfileGroup header: true new: After: 0 New: 5",
-      "storage -> CONTENT Profile header: true new: After: 0 New: 1",
       "client -> KNOWN ProfileGroup sessions: header/5",
+      "storage -> CONTENT Profile header: true new: After: 0 New: 1",
       "client -> KNOWN Profile sessions: header/1",
     ]
   `);

--- a/packages/cojson-storage/src/managerAsync.ts
+++ b/packages/cojson-storage/src/managerAsync.ts
@@ -350,6 +350,10 @@ export class StorageManagerAsync {
       | CojsonInternalTypes.KnownStateMessage
       | CojsonInternalTypes.NewContentMessage,
   ): Promise<unknown> {
-    return this.toLocalNode.push(msg);
+    return this.toLocalNode.push(msg).catch((e) =>
+      logger.error(`Error sending ${msg.action} state, id ${msg.id}`, {
+        err: e,
+      }),
+    );
   }
 }

--- a/packages/cojson-storage/src/managerAsync.ts
+++ b/packages/cojson-storage/src/managerAsync.ts
@@ -15,6 +15,7 @@ import type {
   StoredCoValueRow,
   StoredSessionRow,
 } from "./types.js";
+
 import KnownStateMessage = CojsonInternalTypes.KnownStateMessage;
 import RawCoID = CojsonInternalTypes.RawCoID;
 
@@ -74,14 +75,20 @@ export class StorageManagerAsync {
     >();
 
     let contentStreaming = false;
-    for (const sessionRow of allCoValueSessions) {
-      const signatures = await this.dbClient.getSignatures(sessionRow.rowID, 0);
 
-      if (signatures.length > 0) {
-        contentStreaming = true;
-        signaturesBySession.set(sessionRow.sessionID, signatures);
-      }
-    }
+    await Promise.all(
+      allCoValueSessions.map(async (sessionRow) => {
+        const signatures = await this.dbClient.getSignatures(
+          sessionRow.rowID,
+          0,
+        );
+
+        if (signatures.length > 0) {
+          contentStreaming = true;
+          signaturesBySession.set(sessionRow.sessionID, signatures);
+        }
+      }),
+    );
 
     /**
      * If we are going to send the content in streaming, we send before a known state message
@@ -343,10 +350,6 @@ export class StorageManagerAsync {
       | CojsonInternalTypes.KnownStateMessage
       | CojsonInternalTypes.NewContentMessage,
   ): Promise<unknown> {
-    return this.toLocalNode.push(msg).catch((e) =>
-      logger.error(`Error sending ${msg.action} state, id ${msg.id}`, {
-        err: e,
-      }),
-    );
+    return this.toLocalNode.push(msg);
   }
 }

--- a/packages/cojson-storage/src/managerSync.ts
+++ b/packages/cojson-storage/src/managerSync.ts
@@ -15,14 +15,9 @@ import type {
   StoredCoValueRow,
   StoredSessionRow,
 } from "./types.js";
-import NewContentMessage = CojsonInternalTypes.NewContentMessage;
+
 import KnownStateMessage = CojsonInternalTypes.KnownStateMessage;
 import RawCoID = CojsonInternalTypes.RawCoID;
-
-type OutputMessageMap = Record<
-  RawCoID,
-  { knownMessage: KnownStateMessage; contentMessages?: NewContentMessage[] }
->;
 
 export class StorageManagerSync {
   private readonly toLocalNode: OutgoingSyncQueue;
@@ -35,7 +30,7 @@ export class StorageManagerSync {
     this.dbClient = dbClient;
   }
 
-  async handleSyncMessage(msg: SyncMessage) {
+  handleSyncMessage(msg: SyncMessage) {
     switch (msg.action) {
       case "load":
         this.handleLoad(msg);
@@ -353,10 +348,6 @@ export class StorageManagerSync {
       | CojsonInternalTypes.KnownStateMessage
       | CojsonInternalTypes.NewContentMessage,
   ) {
-    this.toLocalNode.push(msg).catch((e) =>
-      logger.error(`Error sending ${msg.action} state, id ${msg.id}`, {
-        err: e,
-      }),
-    );
+    this.toLocalNode.push(msg);
   }
 }

--- a/packages/cojson-storage/src/managerSync.ts
+++ b/packages/cojson-storage/src/managerSync.ts
@@ -348,6 +348,10 @@ export class StorageManagerSync {
       | CojsonInternalTypes.KnownStateMessage
       | CojsonInternalTypes.NewContentMessage,
   ) {
-    this.toLocalNode.push(msg);
+    this.toLocalNode.push(msg).catch((e) =>
+      logger.error(`Error sending ${msg.action} state, id ${msg.id}`, {
+        err: e,
+      }),
+    );
   }
 }

--- a/packages/cojson-storage/src/sqliteAsync/node.ts
+++ b/packages/cojson-storage/src/sqliteAsync/node.ts
@@ -10,6 +10,25 @@ import { getSQLiteMigrationQueries } from "../sqlite/sqliteMigrations.js";
 import { SQLiteClientAsync } from "./client.js";
 import type { SQLiteDatabaseDriverAsync } from "./types.js";
 
+function createParallelOpsRunner() {
+  const ops = new Set<Promise<unknown>>();
+
+  return {
+    add: (op: Promise<unknown>) => {
+      ops.add(op);
+      op.finally(() => {
+        ops.delete(op);
+      });
+    },
+    wait() {
+      return Promise.race(ops);
+    },
+    get size() {
+      return ops.size;
+    },
+  };
+}
+
 export class SQLiteNodeBaseAsync {
   private readonly syncManager: StorageManagerAsync;
   private readonly dbClient: SQLiteClientAsync;
@@ -23,13 +42,23 @@ export class SQLiteNodeBaseAsync {
     this.syncManager = new StorageManagerAsync(this.dbClient, toLocalNode);
 
     const processMessages = async () => {
+      const batch = createParallelOpsRunner();
+
       for await (const msg of fromLocalNode) {
         try {
           if (msg === "Disconnected" || msg === "PingTimeout") {
             throw new Error("Unexpected Disconnected message");
           }
 
-          await this.syncManager.handleSyncMessage(msg);
+          if (msg.action === "content") {
+            await this.syncManager.handleSyncMessage(msg);
+          } else {
+            batch.add(this.syncManager.handleSyncMessage(msg));
+          }
+
+          if (batch.size > 10) {
+            await batch.wait();
+          }
         } catch (e) {
           logger.error("Error reading from localNode, handling msg", {
             msg,

--- a/packages/cojson-storage/src/syncUtils.ts
+++ b/packages/cojson-storage/src/syncUtils.ts
@@ -1,16 +1,9 @@
 import {
   type CojsonInternalTypes,
-  type JsonValue,
   type SessionID,
-  type Stringified,
   cojsonInternals,
 } from "cojson";
-import type { RawCoID } from "cojson";
-import type {
-  StoredCoValueRow,
-  StoredSessionRow,
-  TransactionRow,
-} from "./types.js";
+import type { StoredSessionRow, TransactionRow } from "./types.js";
 
 export function collectNewTxs({
   newTxsInSession,
@@ -47,60 +40,16 @@ export function getDependedOnCoValues(
   header: CojsonInternalTypes.CoValueHeader,
   contentMessage: CojsonInternalTypes.NewContentMessage,
 ) {
-  const deps = new Set<RawCoID>();
+  const id = contentMessage.id;
+  const sessionIDs = Object.keys(contentMessage.new) as SessionID[];
+  const transactions = Object.values(contentMessage.new).map(
+    (entry) => entry.newTransactions,
+  );
 
-  for (const sessionID of Object.keys(contentMessage.new) as SessionID[]) {
-    const accountId = cojsonInternals.accountOrAgentIDfromSessionID(sessionID);
-
-    if (
-      cojsonInternals.isAccountID(accountId) &&
-      accountId !== contentMessage.id
-    ) {
-      deps.add(accountId);
-    }
-  }
-
-  if (header.ruleset.type === "group") {
-    /**
-     * Collect all the signing keys inside the transactions to list all the
-     * dependencies required to correctly access the CoValue.
-     */
-    for (const sessionEntry of Object.values(contentMessage.new)) {
-      for (const tx of sessionEntry.newTransactions) {
-        if (tx.privacy !== "trusting") continue;
-
-        const changes = safeParseChanges(tx.changes);
-        for (const change of changes) {
-          if (
-            change &&
-            typeof change === "object" &&
-            "op" in change &&
-            change.op === "set" &&
-            "key" in change &&
-            change.key
-          ) {
-            const key = cojsonInternals.getGroupDependentKey(change.key);
-
-            if (key) {
-              deps.add(key);
-            }
-          }
-        }
-      }
-    }
-  }
-
-  if (header.ruleset.type === "ownedByGroup") {
-    deps.add(header.ruleset.group);
-  }
-
-  return deps;
-}
-
-function safeParseChanges(changes: Stringified<JsonValue[]>) {
-  try {
-    return cojsonInternals.parseJSON(changes);
-  } catch (e) {
-    return [];
-  }
+  return cojsonInternals.getDependedOnCoValuesFromRawData(
+    id,
+    header,
+    sessionIDs,
+    transactions,
+  );
 }

--- a/packages/cojson-storage/src/tests/storage.sqliteAsync.test.ts
+++ b/packages/cojson-storage/src/tests/storage.sqliteAsync.test.ts
@@ -163,7 +163,9 @@ test("should sync and load data from storage", async () => {
     [
       "client -> LOAD Map sessions: empty",
       "storage -> CONTENT Group header: true new: After: 0 New: 3",
+      "client -> KNOWN Group sessions: header/3",
       "storage -> CONTENT Map header: true new: After: 0 New: 1",
+      "client -> KNOWN Map sessions: header/1",
     ]
   `);
 
@@ -239,7 +241,9 @@ test("should send an empty content message if there is no content", async () => 
     [
       "client -> LOAD Map sessions: empty",
       "storage -> CONTENT Group header: true new: After: 0 New: 3",
+      "client -> KNOWN Group sessions: header/3",
       "storage -> CONTENT Map header: true new: ",
+      "client -> KNOWN Map sessions: header/0",
     ]
   `);
 
@@ -325,8 +329,11 @@ test("should load dependencies correctly (group inheritance)", async () => {
     [
       "client -> LOAD Map sessions: empty",
       "storage -> CONTENT ParentGroup header: true new: After: 0 New: 4",
+      "client -> KNOWN ParentGroup sessions: header/4",
       "storage -> CONTENT Group header: true new: After: 0 New: 5",
+      "client -> KNOWN Group sessions: header/5",
       "storage -> CONTENT Map header: true new: After: 0 New: 1",
+      "client -> KNOWN Map sessions: header/1",
     ]
   `);
 });
@@ -395,13 +402,14 @@ test("should not send the same dependency value twice", async () => {
     [
       "client -> LOAD Map sessions: empty",
       "storage -> CONTENT ParentGroup header: true new: After: 0 New: 4",
-      "storage -> CONTENT Group header: true new: After: 0 New: 5",
-      "storage -> CONTENT Map header: true new: After: 0 New: 1",
       "client -> KNOWN ParentGroup sessions: header/4",
+      "storage -> CONTENT Group header: true new: After: 0 New: 5",
       "client -> KNOWN Group sessions: header/5",
+      "storage -> CONTENT Map header: true new: After: 0 New: 1",
       "client -> KNOWN Map sessions: header/1",
       "client -> LOAD MapFromParent sessions: empty",
       "storage -> CONTENT MapFromParent header: true new: After: 0 New: 1",
+      "client -> KNOWN MapFromParent sessions: header/1",
     ]
   `);
 });
@@ -504,7 +512,9 @@ test("should recover from data loss", async () => {
     [
       "client -> LOAD Map sessions: empty",
       "storage -> CONTENT Group header: true new: After: 0 New: 3",
+      "client -> KNOWN Group sessions: header/3",
       "storage -> CONTENT Map header: true new: After: 0 New: 4",
+      "client -> KNOWN Map sessions: header/4",
     ]
   `);
 });
@@ -671,7 +681,9 @@ test("should sync multiple sessions in a single content message", async () => {
     [
       "client -> LOAD Map sessions: empty",
       "storage -> CONTENT Group header: true new: After: 0 New: 3",
+      "client -> KNOWN Group sessions: header/3",
       "storage -> CONTENT Map header: true new: After: 0 New: 1 | After: 0 New: 1",
+      "client -> KNOWN Map sessions: header/2",
     ]
   `);
 
@@ -748,12 +760,12 @@ test("large coValue upload streaming", async () => {
       "client -> LOAD Map sessions: empty",
       "storage -> KNOWN Map sessions: header/200",
       "storage -> CONTENT Group header: true new: After: 0 New: 3",
-      "storage -> CONTENT Map header: true new: After: 0 New: 97",
-      "storage -> CONTENT Map header: true new: After: 97 New: 97",
-      "storage -> CONTENT Map header: true new: After: 194 New: 6",
       "client -> KNOWN Group sessions: header/3",
+      "storage -> CONTENT Map header: true new: After: 0 New: 97",
       "client -> KNOWN Map sessions: header/97",
+      "storage -> CONTENT Map header: true new: After: 97 New: 97",
       "client -> KNOWN Map sessions: header/194",
+      "storage -> CONTENT Map header: true new: After: 194 New: 6",
       "client -> KNOWN Map sessions: header/200",
     ]
   `);

--- a/packages/cojson/src/coValueCore/coValueCore.ts
+++ b/packages/cojson/src/coValueCore/coValueCore.ts
@@ -114,8 +114,6 @@ export class CoValueCore {
   private _cachedDependentOn?: Set<RawCoID>;
   private counter: UpDownCounter;
 
-  correctionsRequested = new Set<SessionID>();
-
   private constructor(
     init: { header: CoValueHeader } | { id: RawCoID },
     node: LocalNode,

--- a/packages/cojson/src/coValueCore/utils.ts
+++ b/packages/cojson/src/coValueCore/utils.ts
@@ -23,10 +23,6 @@ export function getDependedOnCoValuesFromRawData(
   }
 
   if (header.ruleset.type === "group") {
-    if (isAccountID(header.ruleset.initialAdmin)) {
-      deps.add(header.ruleset.initialAdmin);
-    }
-
     for (const txs of transactions) {
       for (const tx of txs) {
         if (tx.privacy !== "trusting") continue;

--- a/packages/cojson/src/coValueCore/utils.ts
+++ b/packages/cojson/src/coValueCore/utils.ts
@@ -1,0 +1,68 @@
+import { getGroupDependentKey } from "../ids.js";
+import { RawCoID, SessionID } from "../ids.js";
+import { Stringified, parseJSON } from "../jsonStringify.js";
+import { JsonValue } from "../jsonValue.js";
+import { accountOrAgentIDfromSessionID } from "../typeUtils/accountOrAgentIDfromSessionID.js";
+import { isAccountID } from "../typeUtils/isAccountID.js";
+import { CoValueHeader, Transaction } from "./verifiedState.js";
+
+export function getDependedOnCoValuesFromRawData(
+  id: RawCoID,
+  header: CoValueHeader,
+  sessions: Iterable<SessionID>,
+  transactions: Iterable<Iterable<Transaction>>,
+): Set<RawCoID> {
+  const deps = new Set<RawCoID>();
+
+  for (const session of sessions) {
+    const accountId = accountOrAgentIDfromSessionID(session);
+
+    if (isAccountID(accountId) && accountId !== id) {
+      deps.add(accountId);
+    }
+  }
+
+  if (header.ruleset.type === "group") {
+    if (isAccountID(header.ruleset.initialAdmin)) {
+      deps.add(header.ruleset.initialAdmin);
+    }
+
+    for (const txs of transactions) {
+      for (const tx of txs) {
+        if (tx.privacy !== "trusting") continue;
+
+        const changes = safeParseChanges(tx.changes);
+        for (const change of changes) {
+          if (
+            change &&
+            typeof change === "object" &&
+            "op" in change &&
+            change.op === "set" &&
+            "key" in change &&
+            change.key
+          ) {
+            const key = getGroupDependentKey(change.key);
+
+            if (key && key !== id) {
+              deps.add(key);
+            }
+          }
+        }
+      }
+    }
+  }
+
+  if (header.ruleset.type === "ownedByGroup") {
+    deps.add(header.ruleset.group);
+  }
+
+  return deps;
+}
+
+function safeParseChanges(value: Stringified<JsonValue[]>): JsonValue[] {
+  try {
+    return parseJSON(value);
+  } catch (e) {
+    return [];
+  }
+}

--- a/packages/cojson/src/exports.ts
+++ b/packages/cojson/src/exports.ts
@@ -78,6 +78,7 @@ import {
 
 type Value = JsonValue | AnyRawCoValue;
 
+import { getDependedOnCoValuesFromRawData } from "./coValueCore/utils.js";
 import { logger } from "./logger.js";
 import { getPriorityFromHeader } from "./priority.js";
 
@@ -93,6 +94,7 @@ export const cojsonInternals = {
   bytesToBase64url,
   parseJSON,
   stableStringify,
+  getDependedOnCoValuesFromRawData,
   accountOrAgentIDfromSessionID,
   isAccountID,
   accountHeaderForInitialAgentSecret,

--- a/packages/cojson/src/sync.ts
+++ b/packages/cojson/src/sync.ts
@@ -544,6 +544,11 @@ export class SyncManager {
       if (isAccountID(accountId)) {
         const account = this.local.getCoValue(accountId);
 
+        // New transaction with a missing account on an already loaded coValue
+        if (!coValue.missingDependencies.has(accountId)) {
+          account.loadFromPeers(this.getServerAndStoragePeers());
+        }
+
         // We can't verify the transaction without the account, so we skip it and ask for a correction
         if (!account.isAvailable()) {
           if (!coValue.correctionsRequested.has(sessionID)) {

--- a/packages/cojson/src/tests/coValueCoreLoadingState.test.ts
+++ b/packages/cojson/src/tests/coValueCoreLoadingState.test.ts
@@ -195,7 +195,7 @@ describe("CoValueCore loading state", () => {
         role: "storage",
       },
       async () => {
-        state.markAvailable({} as CoValueHeader, "peer1");
+        state.provideHeader({} as CoValueHeader, "peer1");
       },
     );
     const peer2 = createMockPeerState(
@@ -248,7 +248,7 @@ describe("CoValueCore loading state", () => {
         role: "server",
       },
       async () => {
-        state.markAvailable({} as CoValueHeader, "peer2");
+        state.provideHeader({} as CoValueHeader, "peer2");
       },
     );
 

--- a/packages/cojson/src/tests/sync.load.test.ts
+++ b/packages/cojson/src/tests/sync.load.test.ts
@@ -1,15 +1,20 @@
-import { beforeEach, describe, expect, test } from "vitest";
+import { beforeEach, describe, expect, onTestFinished, test, vi } from "vitest";
 
 import { expectMap } from "../coValue";
-import { toSimplifiedMessages } from "./messagesTestUtils";
+import { CO_VALUE_LOADING_CONFIG } from "../coValueCore/coValueCore";
 import {
   SyncMessagesLog,
+  blockMessageTypeOnOutgoingPeer,
   loadCoValueOrFail,
+  setupTestAccount,
   setupTestNode,
   waitFor,
 } from "./testUtils";
 
 let jazzCloud = setupTestNode({ isSyncServer: true });
+
+// Set a short timeout to make the tests on unavailable complete faster
+CO_VALUE_LOADING_CONFIG.RETRY_DELAY = 100;
 
 beforeEach(async () => {
   SyncMessagesLog.clear();
@@ -403,6 +408,210 @@ describe("loading coValues from server", () => {
         "client -> server | LOAD Map sessions: empty",
         "server -> client | CONTENT Group header: true new: After: 0 New: 5",
         "server -> client | CONTENT Map header: true new: After: 0 New: 1",
+      ]
+    `);
+  });
+
+  test("coValue with a delayed group loading", async () => {
+    const client = setupTestNode();
+
+    const { peerOnServer } = client.connectToSyncServer();
+
+    const group = jazzCloud.node.createGroup();
+    const parentGroup = jazzCloud.node.createGroup();
+    parentGroup.addMember("everyone", "reader");
+
+    const blocker = blockMessageTypeOnOutgoingPeer(peerOnServer, "content", {
+      id: group.id,
+      once: true,
+    });
+
+    group.extend(parentGroup);
+
+    const map = group.createMap();
+    map.set("hello", "world");
+
+    const mapOnClient = await loadCoValueOrFail(client.node, map.id);
+    expect(mapOnClient.get("hello")).toEqual("world");
+
+    expect(
+      SyncMessagesLog.getMessages({
+        ParentGroup: parentGroup.core,
+        Group: group.core,
+        Map: map.core,
+      }),
+    ).toMatchInlineSnapshot(`
+      [
+        "client -> server | LOAD Map sessions: empty",
+        "server -> client | CONTENT ParentGroup header: true new: After: 0 New: 6",
+        "client -> server | KNOWN ParentGroup sessions: header/6",
+        "server -> client | CONTENT Map header: true new: After: 0 New: 1",
+        "client -> server | LOAD Group sessions: empty",
+        "client -> server | KNOWN Map sessions: empty",
+        "server -> client | CONTENT Group header: true new: After: 0 New: 5",
+        "client -> server | KNOWN Group sessions: header/5",
+      ]
+    `);
+
+    blocker.unblock();
+  });
+
+  test("coValue with a delayed parent group loading", async () => {
+    const client = setupTestNode();
+
+    const { peerOnServer } = client.connectToSyncServer();
+
+    const group = jazzCloud.node.createGroup();
+    const parentGroup = jazzCloud.node.createGroup();
+    parentGroup.addMember("everyone", "reader");
+
+    const blocker = blockMessageTypeOnOutgoingPeer(peerOnServer, "content", {
+      id: parentGroup.id,
+      once: true,
+    });
+
+    group.extend(parentGroup);
+
+    const map = group.createMap();
+    map.set("hello", "world");
+
+    const mapOnClient = await loadCoValueOrFail(client.node, map.id);
+    expect(mapOnClient.get("hello")).toEqual("world");
+
+    expect(
+      SyncMessagesLog.getMessages({
+        ParentGroup: parentGroup.core,
+        Group: group.core,
+        Map: map.core,
+      }),
+    ).toMatchInlineSnapshot(`
+      [
+        "client -> server | LOAD Map sessions: empty",
+        "server -> client | CONTENT Group header: true new: After: 0 New: 5",
+        "client -> server | LOAD ParentGroup sessions: empty",
+        "client -> server | KNOWN Group sessions: empty",
+        "server -> client | CONTENT ParentGroup header: true new: After: 0 New: 6",
+        "client -> server | KNOWN ParentGroup sessions: header/6",
+        "server -> client | CONTENT Map header: true new: After: 0 New: 1",
+        "client -> server | KNOWN Map sessions: header/1",
+      ]
+    `);
+
+    blocker.unblock();
+  });
+
+  test("coValue with a delayed account loading (block once)", async () => {
+    const client = setupTestNode();
+    const syncServer = await setupTestAccount({ isSyncServer: true });
+
+    const { peerOnServer } = client.connectToSyncServer({
+      syncServer: syncServer.node,
+    });
+
+    const group = syncServer.node.createGroup();
+    group.addMember("everyone", "writer");
+    const blocker = blockMessageTypeOnOutgoingPeer(peerOnServer, "content", {
+      id: syncServer.accountID,
+      once: true,
+    });
+
+    const account = syncServer.node.expectCurrentAccount(syncServer.accountID);
+
+    const map = group.createMap();
+    map.set("hello", "world");
+
+    const mapOnClient = await loadCoValueOrFail(client.node, map.id);
+    expect(mapOnClient.get("hello")).toEqual("world");
+
+    // ParentGroup sent twice, once because the server pushed it and another time because the client requested the missing dependency
+    expect(
+      SyncMessagesLog.getMessages({
+        Account: account.core,
+        Group: group.core,
+        Map: map.core,
+      }),
+    ).toMatchInlineSnapshot(`
+      [
+        "client -> server | LOAD Map sessions: empty",
+        "server -> client | CONTENT Group header: true new: After: 0 New: 5",
+        "client -> server | LOAD Account sessions: empty",
+        "client -> server | KNOWN CORRECTION Group sessions: empty",
+        "server -> client | CONTENT Account header: true new: After: 0 New: 4",
+        "client -> server | KNOWN Account sessions: header/4",
+        "server -> client | CONTENT Group header: true new: After: 0 New: 5",
+        "client -> server | KNOWN Group sessions: header/5",
+        "server -> client | CONTENT Map header: true new: After: 0 New: 1",
+        "client -> server | KNOWN Map sessions: header/1",
+      ]
+    `);
+
+    blocker.unblock();
+  });
+
+  test("coValue with a delayed account loading (block for 100ms)", async () => {
+    const client = setupTestNode();
+    const syncServer = await setupTestAccount({ isSyncServer: true });
+
+    const { peerOnServer } = client.connectToSyncServer({
+      syncServer: syncServer.node,
+    });
+
+    const group = syncServer.node.createGroup();
+    group.addMember("everyone", "writer");
+
+    const blocker = blockMessageTypeOnOutgoingPeer(peerOnServer, "content", {
+      id: syncServer.accountID,
+      once: true,
+    });
+
+    const account = syncServer.node.expectCurrentAccount(syncServer.accountID);
+
+    const map = group.createMap();
+    map.set("hello", "world");
+
+    const core = client.node.getCoValue(map.id);
+    const promise = client.node.loadCoValueCore(map.id);
+
+    const spy = vi.fn();
+
+    core.subscribe(spy);
+    spy.mockClear(); // Reset the first call
+
+    await new Promise((resolve) => setTimeout(resolve, 100));
+
+    console.log("sending blocked messages");
+    blocker.sendBlockedMessages();
+    blocker.unblock();
+
+    await promise;
+
+    expect(spy).toHaveBeenCalled();
+    expect(core.isAvailable()).toBe(true);
+
+    const mapOnClient = expectMap(core.getCurrentContent());
+    expect(mapOnClient.get("hello")).toEqual("world");
+
+    // ParentGroup sent twice, once because the server pushed it and another time because the client requested the missing dependency
+    expect(
+      SyncMessagesLog.getMessages({
+        Account: account.core,
+        Group: group.core,
+        Map: map.core,
+      }),
+    ).toMatchInlineSnapshot(`
+      [
+        "client -> server | LOAD Map sessions: empty",
+        "server -> client | CONTENT Group header: true new: After: 0 New: 5",
+        "client -> server | LOAD Account sessions: empty",
+        "client -> server | KNOWN CORRECTION Group sessions: empty",
+        "server -> client | CONTENT Account header: true new: After: 0 New: 4",
+        "client -> server | KNOWN Account sessions: header/4",
+        "server -> client | CONTENT Group header: true new: After: 0 New: 5",
+        "client -> server | KNOWN Group sessions: header/5",
+        "server -> client | CONTENT Map header: true new: After: 0 New: 1",
+        "client -> server | KNOWN Map sessions: header/1",
+        "server -> client | CONTENT Account header: true new: After: 0 New: 4",
+        "client -> server | KNOWN Account sessions: header/4",
       ]
     `);
   });

--- a/packages/cojson/src/tests/sync.mesh.test.ts
+++ b/packages/cojson/src/tests/sync.mesh.test.ts
@@ -380,7 +380,7 @@ describe("multiple clients syncing with the a cloud-like server mesh", () => {
     map.set("hello", "updated", "trusting");
 
     // Block the content message from the core peer to simulate the delay on response
-    blockMessageTypeOnOutgoingPeer(peerOnServer, "content");
+    blockMessageTypeOnOutgoingPeer(peerOnServer, "content", {});
 
     const mapOnClient = await loadCoValueOrFail(client.node, map.id);
 
@@ -431,7 +431,7 @@ describe("multiple clients syncing with the a cloud-like server mesh", () => {
       },
     });
 
-    blockMessageTypeOnOutgoingPeer(peerToCoreServer, "load");
+    blockMessageTypeOnOutgoingPeer(peerToCoreServer, "load", {});
 
     client.node.syncManager.addPeer(peer1);
     anotherServer.node.syncManager.addPeer(peer2);

--- a/packages/cojson/src/tests/sync.peerReconciliation.test.ts
+++ b/packages/cojson/src/tests/sync.peerReconciliation.test.ts
@@ -1,9 +1,9 @@
 import { assert, beforeEach, describe, expect, test } from "vitest";
 import { expectMap } from "../coValue";
+import { CO_VALUE_LOADING_CONFIG } from "../coValueCore/coValueCore";
 import { WasmCrypto } from "../crypto/WasmCrypto";
 import {
   SyncMessagesLog,
-  loadCoValueOrFail,
   setupTestAccount,
   setupTestNode,
   waitFor,
@@ -193,16 +193,13 @@ describe("peer reconciliation", () => {
         "client -> server | CONTENT Map header: false new: After: 1 New: 1",
         "server -> client | KNOWN CORRECTION Map sessions: empty",
         "client -> server | CONTENT Map header: true new: After: 0 New: 2",
-        "server -> client | LOAD Group sessions: empty",
-        "client -> server | CONTENT Group header: true new: After: 0 New: 3",
-        "server -> client | KNOWN CORRECTION Map sessions: empty",
-        "client -> server | CONTENT Map header: true new: After: 0 New: 2",
-        "server -> client | KNOWN Group sessions: header/3",
-        "server -> client | KNOWN Map sessions: header/2",
+        "server -> client | KNOWN Map sessions: empty",
         "client -> server | LOAD Group sessions: header/3",
-        "server -> client | KNOWN Group sessions: header/3",
+        "server -> client | KNOWN Group sessions: empty",
         "client -> server | LOAD Map sessions: header/2",
-        "server -> client | KNOWN Map sessions: header/2",
+        "server -> client | KNOWN Map sessions: empty",
+        "client -> server | CONTENT Map header: true new: After: 0 New: 2",
+        "server -> client | KNOWN Map sessions: empty",
       ]
     `);
   });
@@ -254,30 +251,26 @@ describe("peer reconciliation", () => {
         "server -> client | KNOWN Profile sessions: empty",
         "client -> server | LOAD Group sessions: header/3",
         "server -> client | KNOWN Group sessions: empty",
-        "client -> server | LOAD Map sessions: header/2",
+        "client -> server | LOAD Map sessions: header/1",
         "server -> client | KNOWN Map sessions: empty",
         "client -> server | CONTENT Map header: false new: After: 1 New: 1",
         "server -> client | KNOWN CORRECTION Map sessions: empty",
         "client -> server | CONTENT Map header: true new: After: 0 New: 2",
-        "server -> client | LOAD Account sessions: empty",
-        "client -> server | CONTENT Account header: true new: After: 0 New: 4",
-        "server -> client | LOAD Group sessions: empty",
-        "client -> server | CONTENT Group header: true new: After: 0 New: 3",
         "server -> client | KNOWN CORRECTION Map sessions: empty",
         "client -> server | CONTENT Map header: true new: After: 0 New: 2",
-        "server -> client | KNOWN Account sessions: header/4",
-        "server -> client | KNOWN Group sessions: header/3",
-        "server -> client | KNOWN Map sessions: header/2",
+        "server -> client | KNOWN Map sessions: empty",
         "client -> server | LOAD Account sessions: header/4",
-        "server -> client | KNOWN Account sessions: header/4",
+        "server -> client | KNOWN Account sessions: empty",
         "client -> server | LOAD ProfileGroup sessions: header/5",
         "server -> client | KNOWN ProfileGroup sessions: empty",
         "client -> server | LOAD Profile sessions: header/1",
         "server -> client | KNOWN Profile sessions: empty",
         "client -> server | LOAD Group sessions: header/3",
-        "server -> client | KNOWN Group sessions: header/3",
+        "server -> client | KNOWN Group sessions: empty",
         "client -> server | LOAD Map sessions: header/2",
-        "server -> client | KNOWN Map sessions: header/2",
+        "server -> client | KNOWN Map sessions: empty",
+        "client -> server | CONTENT Map header: true new: After: 0 New: 2",
+        "server -> client | KNOWN Map sessions: empty",
       ]
     `);
   });

--- a/packages/cojson/src/tests/sync.peerReconciliation.test.ts
+++ b/packages/cojson/src/tests/sync.peerReconciliation.test.ts
@@ -2,6 +2,7 @@ import { assert, beforeEach, describe, expect, test } from "vitest";
 import { expectMap } from "../coValue";
 import { CO_VALUE_LOADING_CONFIG } from "../coValueCore/coValueCore";
 import { WasmCrypto } from "../crypto/WasmCrypto";
+import { RawCoMap } from "../exports";
 import {
   SyncMessagesLog,
   setupTestAccount,
@@ -193,13 +194,14 @@ describe("peer reconciliation", () => {
         "client -> server | CONTENT Map header: false new: After: 1 New: 1",
         "server -> client | KNOWN CORRECTION Map sessions: empty",
         "client -> server | CONTENT Map header: true new: After: 0 New: 2",
+        "server -> client | LOAD Group sessions: empty",
+        "client -> server | CONTENT Group header: true new: After: 0 New: 3",
         "server -> client | KNOWN Map sessions: empty",
+        "server -> client | KNOWN Group sessions: header/3",
         "client -> server | LOAD Group sessions: header/3",
-        "server -> client | KNOWN Group sessions: empty",
+        "server -> client | KNOWN Group sessions: header/3",
         "client -> server | LOAD Map sessions: header/2",
-        "server -> client | KNOWN Map sessions: empty",
-        "client -> server | CONTENT Map header: true new: After: 0 New: 2",
-        "server -> client | KNOWN Map sessions: empty",
+        "server -> client | KNOWN Map sessions: header/2",
       ]
     `);
   });
@@ -229,7 +231,9 @@ describe("peer reconciliation", () => {
     await waitFor(() => {
       const mapOnSyncServer = jazzCloud.node.getCoValue(map.id);
 
-      expect(mapOnSyncServer.loadingState).toBe("available");
+      expect(mapOnSyncServer.isAvailable()).toBe(true);
+      const content = mapOnSyncServer.getCurrentContent() as RawCoMap;
+      expect(content.get("hello")).toBe("updated");
     });
 
     expect(
@@ -251,26 +255,29 @@ describe("peer reconciliation", () => {
         "server -> client | KNOWN Profile sessions: empty",
         "client -> server | LOAD Group sessions: header/3",
         "server -> client | KNOWN Group sessions: empty",
-        "client -> server | LOAD Map sessions: header/1",
+        "client -> server | LOAD Map sessions: header/2",
         "server -> client | KNOWN Map sessions: empty",
         "client -> server | CONTENT Map header: false new: After: 1 New: 1",
         "server -> client | KNOWN CORRECTION Map sessions: empty",
         "client -> server | CONTENT Map header: true new: After: 0 New: 2",
-        "server -> client | KNOWN CORRECTION Map sessions: empty",
-        "client -> server | CONTENT Map header: true new: After: 0 New: 2",
+        "server -> client | LOAD Account sessions: empty",
+        "client -> server | CONTENT Account header: true new: After: 0 New: 4",
+        "server -> client | LOAD Group sessions: empty",
+        "client -> server | CONTENT Group header: true new: After: 0 New: 3",
         "server -> client | KNOWN Map sessions: empty",
+        "server -> client | KNOWN Account sessions: header/4",
+        "server -> client | KNOWN Map sessions: empty",
+        "server -> client | KNOWN Group sessions: header/3",
         "client -> server | LOAD Account sessions: header/4",
-        "server -> client | KNOWN Account sessions: empty",
+        "server -> client | KNOWN Account sessions: header/4",
         "client -> server | LOAD ProfileGroup sessions: header/5",
         "server -> client | KNOWN ProfileGroup sessions: empty",
         "client -> server | LOAD Profile sessions: header/1",
         "server -> client | KNOWN Profile sessions: empty",
         "client -> server | LOAD Group sessions: header/3",
-        "server -> client | KNOWN Group sessions: empty",
+        "server -> client | KNOWN Group sessions: header/3",
         "client -> server | LOAD Map sessions: header/2",
-        "server -> client | KNOWN Map sessions: empty",
-        "client -> server | CONTENT Map header: true new: After: 0 New: 2",
-        "server -> client | KNOWN Map sessions: empty",
+        "server -> client | KNOWN Map sessions: header/2",
       ]
     `);
   });

--- a/packages/cojson/src/tests/sync.test.ts
+++ b/packages/cojson/src/tests/sync.test.ts
@@ -601,7 +601,7 @@ describe("SyncManager - knownStates vs optimisticKnownStates", () => {
     // optimisticKnownStates is updated when the content messages are sent,
     // while knownStates is only updated when we receive the "known" messages
     // that are acknowledging the receipt of the content messages
-    const outgoing = blockMessageTypeOnOutgoingPeer(peer, "content");
+    const outgoing = blockMessageTypeOnOutgoingPeer(peer, "content", {});
 
     map.set("key2", "value2", "trusting");
 

--- a/packages/cojson/src/tests/testUtils.ts
+++ b/packages/cojson/src/tests/testUtils.ts
@@ -287,15 +287,25 @@ export async function loadCoValueOrFail<V extends RawCoValue>(
 export function blockMessageTypeOnOutgoingPeer(
   peer: Peer,
   messageType: SyncMessage["action"],
+  opts: {
+    id?: string;
+    once?: boolean;
+  },
 ) {
   const push = peer.outgoing.push;
   const pushSpy = vi.spyOn(peer.outgoing, "push");
 
   const blockedMessages: SyncMessage[] = [];
+  const blockedIds = new Set<string>();
 
   pushSpy.mockImplementation(async (msg) => {
-    if (msg.action === messageType) {
+    if (
+      msg.action === messageType &&
+      (!opts.id || msg.id === opts.id) &&
+      (!opts.once || !blockedIds.has(msg.id))
+    ) {
       blockedMessages.push(msg);
+      blockedIds.add(msg.id);
       return Promise.resolve();
     }
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -597,17 +597,17 @@ importers:
         version: link:../../packages/jazz-tools
       tailwindcss:
         specifier: ^4.1.7
-        version: 4.1.8
+        version: 4.1.10
     devDependencies:
       '@sveltejs/adapter-auto':
         specifier: ^3.3.1
-        version: 3.3.1(@sveltejs/kit@2.21.4(@sveltejs/vite-plugin-svelte@5.1.0(svelte@5.33.19)(vite@6.0.11(@types/node@22.15.18)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.37.0)(tsx@4.19.3)(yaml@2.6.1)))(svelte@5.33.19)(vite@6.0.11(@types/node@22.15.18)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.37.0)(tsx@4.19.3)(yaml@2.6.1)))
+        version: 3.3.1(@sveltejs/kit@2.21.5(@sveltejs/vite-plugin-svelte@5.1.0(svelte@5.34.1)(vite@6.0.11(@types/node@22.15.18)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.37.0)(tsx@4.19.3)(yaml@2.6.1)))(svelte@5.34.1)(vite@6.0.11(@types/node@22.15.18)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.37.0)(tsx@4.19.3)(yaml@2.6.1)))
       '@sveltejs/kit':
         specifier: ^2.21.1
-        version: 2.21.4(@sveltejs/vite-plugin-svelte@5.1.0(svelte@5.33.19)(vite@6.0.11(@types/node@22.15.18)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.37.0)(tsx@4.19.3)(yaml@2.6.1)))(svelte@5.33.19)(vite@6.0.11(@types/node@22.15.18)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.37.0)(tsx@4.19.3)(yaml@2.6.1))
+        version: 2.21.5(@sveltejs/vite-plugin-svelte@5.1.0(svelte@5.34.1)(vite@6.0.11(@types/node@22.15.18)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.37.0)(tsx@4.19.3)(yaml@2.6.1)))(svelte@5.34.1)(vite@6.0.11(@types/node@22.15.18)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.37.0)(tsx@4.19.3)(yaml@2.6.1))
       '@sveltejs/vite-plugin-svelte':
         specifier: ^5.0.3
-        version: 5.1.0(svelte@5.33.19)(vite@6.0.11(@types/node@22.15.18)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.37.0)(tsx@4.19.3)(yaml@2.6.1))
+        version: 5.1.0(svelte@5.34.1)(vite@6.0.11(@types/node@22.15.18)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.37.0)(tsx@4.19.3)(yaml@2.6.1))
       '@types/eslint':
         specifier: ^9.6.1
         version: 9.6.1
@@ -619,7 +619,7 @@ importers:
         version: 9.1.0(eslint@9.28.0(jiti@2.4.2))
       eslint-plugin-svelte:
         specifier: ^2.46.1
-        version: 2.46.1(eslint@9.28.0(jiti@2.4.2))(svelte@5.33.19)(ts-node@10.9.2(@swc/core@1.11.29)(@types/node@22.15.18)(typescript@5.6.2))
+        version: 2.46.1(eslint@9.28.0(jiti@2.4.2))(svelte@5.34.1)(ts-node@10.9.2(@swc/core@1.11.29)(@types/node@22.15.18)(typescript@5.6.2))
       globals:
         specifier: ^15.15.0
         version: 15.15.0
@@ -631,13 +631,13 @@ importers:
         version: 3.5.3
       prettier-plugin-svelte:
         specifier: ^3.4.0
-        version: 3.4.0(prettier@3.5.3)(svelte@5.33.19)
+        version: 3.4.0(prettier@3.5.3)(svelte@5.34.1)
       svelte:
         specifier: ^5.31.1
-        version: 5.33.19
+        version: 5.34.1
       svelte-check:
         specifier: ^4.2.1
-        version: 4.2.1(picomatch@4.0.2)(svelte@5.33.19)(typescript@5.6.2)
+        version: 4.2.1(picomatch@4.0.2)(svelte@5.34.1)(typescript@5.6.2)
       typescript:
         specifier: 5.6.2
         version: 5.6.2
@@ -1796,7 +1796,7 @@ importers:
         version: link:../../packages/jazz-tools
       prosekit:
         specifier: ^0.13.3
-        version: 0.13.4(@shikijs/types@3.5.0)(@types/hast@3.0.4)(preact@10.25.3)(prosemirror-model@1.25.1)(prosemirror-state@1.4.3)(prosemirror-transform@1.10.4)(prosemirror-view@1.39.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(solid-js@1.9.5)(svelte@5.33.19)(vue@3.5.13(typescript@5.6.2))
+        version: 0.13.4(@shikijs/types@3.5.0)(@types/hast@3.0.4)(preact@10.25.3)(prosemirror-model@1.25.1)(prosemirror-state@1.4.3)(prosemirror-transform@1.10.4)(prosemirror-view@1.39.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(solid-js@1.9.5)(svelte@5.34.1)(vue@3.5.13(typescript@5.6.2))
       react:
         specifier: 19.0.0
         version: 19.0.0
@@ -3191,28 +3191,28 @@ importers:
         version: 1.50.1
       '@sveltejs/adapter-auto':
         specifier: ^6.0.1
-        version: 6.0.1(@sveltejs/kit@2.21.4(@sveltejs/vite-plugin-svelte@5.1.0(svelte@5.33.19)(vite@6.3.5(@types/node@22.15.18)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.37.0)(tsx@4.19.3)(yaml@2.6.1)))(svelte@5.33.19)(vite@6.3.5(@types/node@22.15.18)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.37.0)(tsx@4.19.3)(yaml@2.6.1)))
+        version: 6.0.1(@sveltejs/kit@2.21.5(@sveltejs/vite-plugin-svelte@5.1.0(svelte@5.34.1)(vite@6.3.5(@types/node@22.15.18)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.37.0)(tsx@4.19.3)(yaml@2.6.1)))(svelte@5.34.1)(vite@6.3.5(@types/node@22.15.18)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.37.0)(tsx@4.19.3)(yaml@2.6.1)))
       '@sveltejs/kit':
         specifier: ^2.21.4
-        version: 2.21.4(@sveltejs/vite-plugin-svelte@5.1.0(svelte@5.33.19)(vite@6.3.5(@types/node@22.15.18)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.37.0)(tsx@4.19.3)(yaml@2.6.1)))(svelte@5.33.19)(vite@6.3.5(@types/node@22.15.18)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.37.0)(tsx@4.19.3)(yaml@2.6.1))
+        version: 2.21.5(@sveltejs/vite-plugin-svelte@5.1.0(svelte@5.34.1)(vite@6.3.5(@types/node@22.15.18)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.37.0)(tsx@4.19.3)(yaml@2.6.1)))(svelte@5.34.1)(vite@6.3.5(@types/node@22.15.18)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.37.0)(tsx@4.19.3)(yaml@2.6.1))
       '@sveltejs/vite-plugin-svelte':
         specifier: ^5.1.0
-        version: 5.1.0(svelte@5.33.19)(vite@6.3.5(@types/node@22.15.18)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.37.0)(tsx@4.19.3)(yaml@2.6.1))
+        version: 5.1.0(svelte@5.34.1)(vite@6.3.5(@types/node@22.15.18)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.37.0)(tsx@4.19.3)(yaml@2.6.1))
       '@types/eslint':
         specifier: ^9.6.0
         version: 9.6.1
       eslint:
         specifier: ^9.7.0
-        version: 9.17.0(jiti@2.4.2)
+        version: 9.28.0(jiti@2.4.2)
       eslint-config-prettier:
         specifier: ^9.1.0
-        version: 9.1.0(eslint@9.17.0(jiti@2.4.2))
+        version: 9.1.0(eslint@9.28.0(jiti@2.4.2))
       eslint-plugin-svelte:
         specifier: ^2.36.0
-        version: 2.46.1(eslint@9.17.0(jiti@2.4.2))(svelte@5.33.19)(ts-node@10.9.2(@swc/core@1.11.29)(@types/node@22.15.18)(typescript@5.6.2))
+        version: 2.46.1(eslint@9.28.0(jiti@2.4.2))(svelte@5.34.1)(ts-node@10.9.2(@swc/core@1.11.29)(@types/node@22.15.18)(typescript@5.6.2))
       globals:
         specifier: ^15.11.0
-        version: 15.14.0
+        version: 15.15.0
       is-ci:
         specifier: ^3.0.1
         version: 3.0.1
@@ -3224,13 +3224,13 @@ importers:
         version: 3.5.3
       prettier-plugin-svelte:
         specifier: ^3.2.6
-        version: 3.4.0(prettier@3.5.3)(svelte@5.33.19)
+        version: 3.4.0(prettier@3.5.3)(svelte@5.34.1)
       svelte:
         specifier: ^5.33.19
-        version: 5.33.19
+        version: 5.34.1
       svelte-check:
         specifier: ^4.0.0
-        version: 4.1.1(picomatch@4.0.2)(svelte@5.33.19)(typescript@5.6.2)
+        version: 4.2.1(picomatch@4.0.2)(svelte@5.34.1)(typescript@5.6.2)
       tailwindcss:
         specifier: ^4.1.10
         version: 4.1.10
@@ -3239,7 +3239,7 @@ importers:
         version: 5.6.2
       typescript-eslint:
         specifier: ^8.0.0
-        version: 8.18.1(eslint@9.17.0(jiti@2.4.2))(typescript@5.6.2)
+        version: 8.34.0(eslint@9.28.0(jiti@2.4.2))(typescript@5.6.2)
       vite:
         specifier: 6.3.5
         version: 6.3.5(@types/node@22.15.18)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.37.0)(tsx@4.19.3)(yaml@2.6.1)
@@ -7179,8 +7179,8 @@ packages:
       svelte: ^4.0.0 || ^5.0.0-next.0
       vite: ^5.0.3 || ^6.0.0
 
-  '@sveltejs/kit@2.21.4':
-    resolution: {integrity: sha512-683kl4BBnORaYn3vktH01HAHYep8FaiRA21LVY7d6uAX+1D/1gK4WYHRJq90vA01Cz/k6rU3n6vpf4fAn9ipkA==}
+  '@sveltejs/kit@2.21.5':
+    resolution: {integrity: sha512-P5m7yZtvD1Kx/Z6JcjgJtdMqef/tCGMDrd9B9S2q8j+FMnkeKTMxW1nidnjVzk4HEDRGf4IlBI94/niy6t3hLA==}
     engines: {node: '>=18.13'}
     hasBin: true
     peerDependencies:
@@ -12647,6 +12647,11 @@ packages:
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
+  nanoid@5.0.9:
+    resolution: {integrity: sha512-Aooyr6MXU6HpvvWXKoVoXwKMs/KyVakWwg7xQfv5/S/RIgJMy0Ifa45H9qqYy7pTCszrHzP21Uk4PZq2HpEM8Q==}
+    engines: {node: ^18 || >=20}
+    hasBin: true
+
   nanoid@5.1.5:
     resolution: {integrity: sha512-Ir/+ZpE9fDsNH0hQ3C68uyThDXzYcim2EqcZ8zn8Chtt1iylPT9xXJB0kPCnqzgcEGikO9RxSrh63MsmVCU7Fw==}
     engines: {node: ^18 || >=20}
@@ -13126,9 +13131,6 @@ packages:
 
   pathe@1.1.2:
     resolution: {integrity: sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==}
-
-  pathe@2.0.2:
-    resolution: {integrity: sha512-15Ztpk+nov8DR524R4BF7uEuzESgzUEAV4Ah7CUMNGXdE5ELuvxElxGXndBl32vMSsWa1jpNf22Z+Er3sKwq+w==}
 
   pathe@2.0.3:
     resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
@@ -14900,8 +14902,8 @@ packages:
     resolution: {integrity: sha512-kRlbhIlMTijbFmVDQFDeKXPLlX1/ovXwV0I162wRqQhRcygaqDIcu1d/Ese3H2uI+yt3uT8E7ndgDthQv5v5BA==}
     engines: {node: '>=18'}
 
-  svelte@5.33.19:
-    resolution: {integrity: sha512-udmgc1nnGeAgnfVJjOMfSOAqPAKv8N65MWN2kDuxo6BZthTaUcsLh4vP8bdZC0bMXLGn69smSZXgQOeuZBOn4Q==}
+  svelte@5.34.1:
+    resolution: {integrity: sha512-jWNnN2hZFNtnzKPptCcJHBWrD9CtbHPDwIRIODufOYaWkR0kLmAIlM384lMt4ucwuIRX4hCJwD2D8ZtEcGJQ0Q==}
     engines: {node: '>=18'}
 
   svg-tags@1.0.0:
@@ -14950,9 +14952,6 @@ packages:
 
   tailwindcss@4.1.6:
     resolution: {integrity: sha512-j0cGLTreM6u4OWzBeLBpycK0WIh8w7kSwcUsQZoGLHZ7xDTdM69lN64AgoIEEwFi0tnhs4wSykUa5YWxAzgFYg==}
-
-  tailwindcss@4.1.8:
-    resolution: {integrity: sha512-kjeW8gjdxasbmFKpVGrGd5T4i40mV5J2Rasw48QARfYeQ8YS9x02ON9SFWax3Qf616rt4Cp3nVNIj6Hd1mP3og==}
 
   tapable@2.2.1:
     resolution: {integrity: sha512-GNzQvQTOIP6RyTfE2Qxb8ZVlNmw0n88vp1szwWRimP02mnTsx3Wtn5qRdqY9w2XduFNUgvOwhNnQsjwCp+kqaQ==}
@@ -16385,7 +16384,7 @@ snapshots:
       '@babel/traverse': 7.27.0
       '@babel/types': 7.27.0
       convert-source-map: 2.0.0
-      debug: 4.4.1
+      debug: 4.4.0
       gensync: 1.0.0-beta.2
       json5: 2.2.3
       semver: 6.3.1
@@ -17842,7 +17841,7 @@ snapshots:
       '@babel/parser': 7.26.3
       '@babel/template': 7.25.9
       '@babel/types': 7.26.3
-      debug: 4.4.1
+      debug: 4.4.0
       globals: 11.12.0
     transitivePeerDependencies:
       - supports-color
@@ -17854,7 +17853,7 @@ snapshots:
       '@babel/parser': 7.27.0
       '@babel/template': 7.27.0
       '@babel/types': 7.27.0
-      debug: 4.4.1
+      debug: 4.4.0
       globals: 11.12.0
     transitivePeerDependencies:
       - supports-color
@@ -17981,7 +17980,7 @@ snapshots:
       outdent: 0.5.0
       prettier: 2.8.8
       resolve-from: 5.0.0
-      semver: 7.6.3
+      semver: 7.7.2
 
   '@changesets/assemble-release-plan@6.0.5':
     dependencies:
@@ -17990,7 +17989,7 @@ snapshots:
       '@changesets/should-skip-package': 0.1.1
       '@changesets/types': 6.0.0
       '@manypkg/get-packages': 1.1.3
-      semver: 7.6.3
+      semver: 7.7.2
 
   '@changesets/changelog-git@0.2.0':
     dependencies:
@@ -18046,7 +18045,7 @@ snapshots:
       '@changesets/types': 6.0.0
       '@manypkg/get-packages': 1.1.3
       picocolors: 1.1.1
-      semver: 7.6.3
+      semver: 7.7.2
 
   '@changesets/get-release-plan@4.0.6':
     dependencies:
@@ -18523,7 +18522,7 @@ snapshots:
   '@eslint/eslintrc@2.1.4':
     dependencies:
       ajv: 6.12.6
-      debug: 4.4.1
+      debug: 4.4.0
       espree: 9.6.1
       globals: 13.24.0
       ignore: 5.3.2
@@ -18814,7 +18813,7 @@ snapshots:
       require-from-string: 2.0.2
       resolve-from: 5.0.0
       resolve-workspace-root: 2.0.0
-      semver: 7.7.2
+      semver: 7.6.3
       slugify: 1.6.6
       sucrase: 3.35.0
     transitivePeerDependencies:
@@ -18850,7 +18849,7 @@ snapshots:
   '@expo/env@1.0.5':
     dependencies:
       chalk: 4.1.2
-      debug: 4.4.1
+      debug: 4.4.0
       dotenv: 16.4.7
       dotenv-expand: 11.0.7
       getenv: 1.0.0
@@ -18962,9 +18961,9 @@ snapshots:
       '@expo/image-utils': 0.7.4
       '@expo/json-file': 9.1.4
       '@react-native/normalize-colors': 0.79.2
-      debug: 4.4.1
+      debug: 4.4.0
       resolve-from: 5.0.0
-      semver: 7.7.2
+      semver: 7.6.3
       xml2js: 0.6.0
     transitivePeerDependencies:
       - supports-color
@@ -18974,7 +18973,7 @@ snapshots:
   '@expo/server@0.6.2':
     dependencies:
       abort-controller: 3.0.0
-      debug: 4.4.1
+      debug: 4.4.0
       source-map-support: 0.5.21
       undici: 6.21.0
     transitivePeerDependencies:
@@ -19073,7 +19072,7 @@ snapshots:
   '@humanwhocodes/config-array@0.13.0':
     dependencies:
       '@humanwhocodes/object-schema': 2.0.3
-      debug: 4.4.1
+      debug: 4.4.0
       minimatch: 3.1.2
     transitivePeerDependencies:
       - supports-color
@@ -20114,15 +20113,15 @@ snapshots:
       - y-prosemirror
       - yjs
 
-  '@prosekit/svelte@0.6.9(@shikijs/types@3.5.0)(@types/hast@3.0.4)(prosemirror-model@1.25.1)(prosemirror-state@1.4.3)(prosemirror-transform@1.10.4)(prosemirror-view@1.39.2)(svelte@5.33.19)':
+  '@prosekit/svelte@0.6.9(@shikijs/types@3.5.0)(@types/hast@3.0.4)(prosemirror-model@1.25.1)(prosemirror-state@1.4.3)(prosemirror-transform@1.10.4)(prosemirror-view@1.39.2)(svelte@5.34.1)':
     dependencies:
       '@prosekit/core': 0.8.1(prosemirror-model@1.25.1)(prosemirror-state@1.4.3)(prosemirror-transform@1.10.4)
       '@prosekit/pm': 0.1.10
       '@prosekit/web': 0.5.9(@shikijs/types@3.5.0)(@types/hast@3.0.4)(prosemirror-model@1.25.1)(prosemirror-state@1.4.3)(prosemirror-transform@1.10.4)(prosemirror-view@1.39.2)
       '@prosemirror-adapter/core': 0.4.0
-      '@prosemirror-adapter/svelte': 0.4.1(svelte@5.33.19)
+      '@prosemirror-adapter/svelte': 0.4.1(svelte@5.34.1)
     optionalDependencies:
-      svelte: 5.33.19
+      svelte: 5.34.1
     transitivePeerDependencies:
       - '@shikijs/types'
       - '@types/hast'
@@ -20217,13 +20216,13 @@ snapshots:
     optionalDependencies:
       solid-js: 1.9.5
 
-  '@prosemirror-adapter/svelte@0.4.1(svelte@5.33.19)':
+  '@prosemirror-adapter/svelte@0.4.1(svelte@5.34.1)':
     dependencies:
       '@prosemirror-adapter/core': 0.4.0
       nanoid: 5.1.5
       tslib: 2.8.1
     optionalDependencies:
-      svelte: 5.33.19
+      svelte: 5.34.1
 
   '@prosemirror-adapter/vue@0.4.1(vue@3.5.13(typescript@5.6.2))':
     dependencies:
@@ -20717,7 +20716,7 @@ snapshots:
       execa: 5.1.1
       node-stream-zip: 1.15.0
       ora: 5.4.1
-      semver: 7.7.2
+      semver: 7.6.3
       strip-ansi: 5.2.0
       wcwidth: 1.0.1
       yaml: 2.6.1
@@ -20738,7 +20737,7 @@ snapshots:
       execa: 5.1.1
       node-stream-zip: 1.15.0
       ora: 5.4.1
-      semver: 7.7.2
+      semver: 7.6.3
       strip-ansi: 5.2.0
       wcwidth: 1.0.1
       yaml: 2.6.1
@@ -20793,7 +20792,7 @@ snapshots:
       open: 6.4.0
       ora: 5.4.1
       prompts: 2.4.2
-      semver: 7.7.2
+      semver: 7.6.3
       shell-quote: 1.8.2
       sudo-prompt: 9.1.1
 
@@ -21662,14 +21661,14 @@ snapshots:
       '@sveltejs/kit': 2.17.1(@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.33.14)(vite@6.3.5(@types/node@22.15.18)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.37.0)(tsx@4.19.3)(yaml@2.6.1)))(svelte@5.33.14)(vite@6.3.5(@types/node@22.15.18)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.37.0)(tsx@4.19.3)(yaml@2.6.1))
       import-meta-resolve: 4.1.0
 
-  '@sveltejs/adapter-auto@3.3.1(@sveltejs/kit@2.21.4(@sveltejs/vite-plugin-svelte@5.1.0(svelte@5.33.19)(vite@6.0.11(@types/node@22.15.18)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.37.0)(tsx@4.19.3)(yaml@2.6.1)))(svelte@5.33.19)(vite@6.0.11(@types/node@22.15.18)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.37.0)(tsx@4.19.3)(yaml@2.6.1)))':
+  '@sveltejs/adapter-auto@3.3.1(@sveltejs/kit@2.21.5(@sveltejs/vite-plugin-svelte@5.1.0(svelte@5.34.1)(vite@6.0.11(@types/node@22.15.18)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.37.0)(tsx@4.19.3)(yaml@2.6.1)))(svelte@5.34.1)(vite@6.0.11(@types/node@22.15.18)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.37.0)(tsx@4.19.3)(yaml@2.6.1)))':
     dependencies:
-      '@sveltejs/kit': 2.21.4(@sveltejs/vite-plugin-svelte@5.1.0(svelte@5.33.19)(vite@6.0.11(@types/node@22.15.18)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.37.0)(tsx@4.19.3)(yaml@2.6.1)))(svelte@5.33.19)(vite@6.0.11(@types/node@22.15.18)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.37.0)(tsx@4.19.3)(yaml@2.6.1))
+      '@sveltejs/kit': 2.21.5(@sveltejs/vite-plugin-svelte@5.1.0(svelte@5.34.1)(vite@6.0.11(@types/node@22.15.18)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.37.0)(tsx@4.19.3)(yaml@2.6.1)))(svelte@5.34.1)(vite@6.0.11(@types/node@22.15.18)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.37.0)(tsx@4.19.3)(yaml@2.6.1))
       import-meta-resolve: 4.1.0
 
-  '@sveltejs/adapter-auto@6.0.1(@sveltejs/kit@2.21.4(@sveltejs/vite-plugin-svelte@5.1.0(svelte@5.33.19)(vite@6.3.5(@types/node@22.15.18)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.37.0)(tsx@4.19.3)(yaml@2.6.1)))(svelte@5.33.19)(vite@6.3.5(@types/node@22.15.18)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.37.0)(tsx@4.19.3)(yaml@2.6.1)))':
+  '@sveltejs/adapter-auto@6.0.1(@sveltejs/kit@2.21.5(@sveltejs/vite-plugin-svelte@5.1.0(svelte@5.34.1)(vite@6.3.5(@types/node@22.15.18)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.37.0)(tsx@4.19.3)(yaml@2.6.1)))(svelte@5.34.1)(vite@6.3.5(@types/node@22.15.18)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.37.0)(tsx@4.19.3)(yaml@2.6.1)))':
     dependencies:
-      '@sveltejs/kit': 2.21.4(@sveltejs/vite-plugin-svelte@5.1.0(svelte@5.33.19)(vite@6.3.5(@types/node@22.15.18)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.37.0)(tsx@4.19.3)(yaml@2.6.1)))(svelte@5.33.19)(vite@6.3.5(@types/node@22.15.18)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.37.0)(tsx@4.19.3)(yaml@2.6.1))
+      '@sveltejs/kit': 2.21.5(@sveltejs/vite-plugin-svelte@5.1.0(svelte@5.34.1)(vite@6.3.5(@types/node@22.15.18)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.37.0)(tsx@4.19.3)(yaml@2.6.1)))(svelte@5.34.1)(vite@6.3.5(@types/node@22.15.18)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.37.0)(tsx@4.19.3)(yaml@2.6.1))
 
   '@sveltejs/adapter-vercel@5.5.2(@sveltejs/kit@2.17.1(@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.33.14)(vite@6.3.5(@types/node@22.15.18)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.37.0)(tsx@4.19.3)(yaml@2.6.1)))(svelte@5.33.14)(vite@6.3.5(@types/node@22.15.18)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.37.0)(tsx@4.19.3)(yaml@2.6.1)))(rollup@4.41.1)':
     dependencies:
@@ -21698,10 +21697,10 @@ snapshots:
       svelte: 5.33.14
       vite: 6.3.5(@types/node@22.15.18)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.37.0)(tsx@4.19.3)(yaml@2.6.1)
 
-  '@sveltejs/kit@2.21.4(@sveltejs/vite-plugin-svelte@5.1.0(svelte@5.33.19)(vite@6.0.11(@types/node@22.15.18)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.37.0)(tsx@4.19.3)(yaml@2.6.1)))(svelte@5.33.19)(vite@6.0.11(@types/node@22.15.18)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.37.0)(tsx@4.19.3)(yaml@2.6.1))':
+  '@sveltejs/kit@2.21.5(@sveltejs/vite-plugin-svelte@5.1.0(svelte@5.34.1)(vite@6.0.11(@types/node@22.15.18)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.37.0)(tsx@4.19.3)(yaml@2.6.1)))(svelte@5.34.1)(vite@6.0.11(@types/node@22.15.18)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.37.0)(tsx@4.19.3)(yaml@2.6.1))':
     dependencies:
       '@sveltejs/acorn-typescript': 1.0.5(acorn@8.14.1)
-      '@sveltejs/vite-plugin-svelte': 5.1.0(svelte@5.33.19)(vite@6.0.11(@types/node@22.15.18)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.37.0)(tsx@4.19.3)(yaml@2.6.1))
+      '@sveltejs/vite-plugin-svelte': 5.1.0(svelte@5.34.1)(vite@6.0.11(@types/node@22.15.18)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.37.0)(tsx@4.19.3)(yaml@2.6.1))
       '@types/cookie': 0.6.0
       acorn: 8.14.1
       cookie: 0.6.0
@@ -21713,14 +21712,14 @@ snapshots:
       sade: 1.8.1
       set-cookie-parser: 2.7.1
       sirv: 3.0.1
-      svelte: 5.33.19
+      svelte: 5.34.1
       vite: 6.0.11(@types/node@22.15.18)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.37.0)(tsx@4.19.3)(yaml@2.6.1)
       vitefu: 1.0.6(vite@6.0.11(@types/node@22.15.18)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.37.0)(tsx@4.19.3)(yaml@2.6.1))
 
-  '@sveltejs/kit@2.21.4(@sveltejs/vite-plugin-svelte@5.1.0(svelte@5.33.19)(vite@6.3.5(@types/node@22.15.18)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.37.0)(tsx@4.19.3)(yaml@2.6.1)))(svelte@5.33.19)(vite@6.3.5(@types/node@22.15.18)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.37.0)(tsx@4.19.3)(yaml@2.6.1))':
+  '@sveltejs/kit@2.21.5(@sveltejs/vite-plugin-svelte@5.1.0(svelte@5.34.1)(vite@6.3.5(@types/node@22.15.18)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.37.0)(tsx@4.19.3)(yaml@2.6.1)))(svelte@5.34.1)(vite@6.3.5(@types/node@22.15.18)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.37.0)(tsx@4.19.3)(yaml@2.6.1))':
     dependencies:
       '@sveltejs/acorn-typescript': 1.0.5(acorn@8.14.1)
-      '@sveltejs/vite-plugin-svelte': 5.1.0(svelte@5.33.19)(vite@6.3.5(@types/node@22.15.18)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.37.0)(tsx@4.19.3)(yaml@2.6.1))
+      '@sveltejs/vite-plugin-svelte': 5.1.0(svelte@5.34.1)(vite@6.3.5(@types/node@22.15.18)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.37.0)(tsx@4.19.3)(yaml@2.6.1))
       '@types/cookie': 0.6.0
       acorn: 8.14.1
       cookie: 0.6.0
@@ -21732,7 +21731,7 @@ snapshots:
       sade: 1.8.1
       set-cookie-parser: 2.7.1
       sirv: 3.0.1
-      svelte: 5.33.19
+      svelte: 5.34.1
       vite: 6.3.5(@types/node@22.15.18)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.37.0)(tsx@4.19.3)(yaml@2.6.1)
       vitefu: 1.0.6(vite@6.3.5(@types/node@22.15.18)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.37.0)(tsx@4.19.3)(yaml@2.6.1))
 
@@ -21756,20 +21755,20 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@sveltejs/vite-plugin-svelte-inspector@4.0.1(@sveltejs/vite-plugin-svelte@5.1.0(svelte@5.33.19)(vite@6.0.11(@types/node@22.15.18)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.37.0)(tsx@4.19.3)(yaml@2.6.1)))(svelte@5.33.19)(vite@6.0.11(@types/node@22.15.18)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.37.0)(tsx@4.19.3)(yaml@2.6.1))':
+  '@sveltejs/vite-plugin-svelte-inspector@4.0.1(@sveltejs/vite-plugin-svelte@5.1.0(svelte@5.34.1)(vite@6.0.11(@types/node@22.15.18)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.37.0)(tsx@4.19.3)(yaml@2.6.1)))(svelte@5.34.1)(vite@6.0.11(@types/node@22.15.18)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.37.0)(tsx@4.19.3)(yaml@2.6.1))':
     dependencies:
-      '@sveltejs/vite-plugin-svelte': 5.1.0(svelte@5.33.19)(vite@6.0.11(@types/node@22.15.18)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.37.0)(tsx@4.19.3)(yaml@2.6.1))
+      '@sveltejs/vite-plugin-svelte': 5.1.0(svelte@5.34.1)(vite@6.0.11(@types/node@22.15.18)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.37.0)(tsx@4.19.3)(yaml@2.6.1))
       debug: 4.4.1
-      svelte: 5.33.19
+      svelte: 5.34.1
       vite: 6.0.11(@types/node@22.15.18)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.37.0)(tsx@4.19.3)(yaml@2.6.1)
     transitivePeerDependencies:
       - supports-color
 
-  '@sveltejs/vite-plugin-svelte-inspector@4.0.1(@sveltejs/vite-plugin-svelte@5.1.0(svelte@5.33.19)(vite@6.3.5(@types/node@22.15.18)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.37.0)(tsx@4.19.3)(yaml@2.6.1)))(svelte@5.33.19)(vite@6.3.5(@types/node@22.15.18)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.37.0)(tsx@4.19.3)(yaml@2.6.1))':
+  '@sveltejs/vite-plugin-svelte-inspector@4.0.1(@sveltejs/vite-plugin-svelte@5.1.0(svelte@5.34.1)(vite@6.3.5(@types/node@22.15.18)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.37.0)(tsx@4.19.3)(yaml@2.6.1)))(svelte@5.34.1)(vite@6.3.5(@types/node@22.15.18)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.37.0)(tsx@4.19.3)(yaml@2.6.1))':
     dependencies:
-      '@sveltejs/vite-plugin-svelte': 5.1.0(svelte@5.33.19)(vite@6.3.5(@types/node@22.15.18)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.37.0)(tsx@4.19.3)(yaml@2.6.1))
+      '@sveltejs/vite-plugin-svelte': 5.1.0(svelte@5.34.1)(vite@6.3.5(@types/node@22.15.18)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.37.0)(tsx@4.19.3)(yaml@2.6.1))
       debug: 4.4.1
-      svelte: 5.33.19
+      svelte: 5.34.1
       vite: 6.3.5(@types/node@22.15.18)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.37.0)(tsx@4.19.3)(yaml@2.6.1)
     transitivePeerDependencies:
       - supports-color
@@ -21787,27 +21786,27 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@sveltejs/vite-plugin-svelte@5.1.0(svelte@5.33.19)(vite@6.0.11(@types/node@22.15.18)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.37.0)(tsx@4.19.3)(yaml@2.6.1))':
+  '@sveltejs/vite-plugin-svelte@5.1.0(svelte@5.34.1)(vite@6.0.11(@types/node@22.15.18)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.37.0)(tsx@4.19.3)(yaml@2.6.1))':
     dependencies:
-      '@sveltejs/vite-plugin-svelte-inspector': 4.0.1(@sveltejs/vite-plugin-svelte@5.1.0(svelte@5.33.19)(vite@6.0.11(@types/node@22.15.18)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.37.0)(tsx@4.19.3)(yaml@2.6.1)))(svelte@5.33.19)(vite@6.0.11(@types/node@22.15.18)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.37.0)(tsx@4.19.3)(yaml@2.6.1))
+      '@sveltejs/vite-plugin-svelte-inspector': 4.0.1(@sveltejs/vite-plugin-svelte@5.1.0(svelte@5.34.1)(vite@6.0.11(@types/node@22.15.18)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.37.0)(tsx@4.19.3)(yaml@2.6.1)))(svelte@5.34.1)(vite@6.0.11(@types/node@22.15.18)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.37.0)(tsx@4.19.3)(yaml@2.6.1))
       debug: 4.4.1
       deepmerge: 4.3.1
       kleur: 4.1.5
       magic-string: 0.30.17
-      svelte: 5.33.19
+      svelte: 5.34.1
       vite: 6.0.11(@types/node@22.15.18)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.37.0)(tsx@4.19.3)(yaml@2.6.1)
       vitefu: 1.0.6(vite@6.0.11(@types/node@22.15.18)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.37.0)(tsx@4.19.3)(yaml@2.6.1))
     transitivePeerDependencies:
       - supports-color
 
-  '@sveltejs/vite-plugin-svelte@5.1.0(svelte@5.33.19)(vite@6.3.5(@types/node@22.15.18)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.37.0)(tsx@4.19.3)(yaml@2.6.1))':
+  '@sveltejs/vite-plugin-svelte@5.1.0(svelte@5.34.1)(vite@6.3.5(@types/node@22.15.18)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.37.0)(tsx@4.19.3)(yaml@2.6.1))':
     dependencies:
-      '@sveltejs/vite-plugin-svelte-inspector': 4.0.1(@sveltejs/vite-plugin-svelte@5.1.0(svelte@5.33.19)(vite@6.3.5(@types/node@22.15.18)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.37.0)(tsx@4.19.3)(yaml@2.6.1)))(svelte@5.33.19)(vite@6.3.5(@types/node@22.15.18)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.37.0)(tsx@4.19.3)(yaml@2.6.1))
+      '@sveltejs/vite-plugin-svelte-inspector': 4.0.1(@sveltejs/vite-plugin-svelte@5.1.0(svelte@5.34.1)(vite@6.3.5(@types/node@22.15.18)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.37.0)(tsx@4.19.3)(yaml@2.6.1)))(svelte@5.34.1)(vite@6.3.5(@types/node@22.15.18)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.37.0)(tsx@4.19.3)(yaml@2.6.1))
       debug: 4.4.1
       deepmerge: 4.3.1
       kleur: 4.1.5
       magic-string: 0.30.17
-      svelte: 5.33.19
+      svelte: 5.34.1
       vite: 6.3.5(@types/node@22.15.18)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.37.0)(tsx@4.19.3)(yaml@2.6.1)
       vitefu: 1.0.6(vite@6.3.5(@types/node@22.15.18)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.37.0)(tsx@4.19.3)(yaml@2.6.1))
     transitivePeerDependencies:
@@ -23354,7 +23353,7 @@ snapshots:
       '@vue/devtools-kit': 7.6.8
       '@vue/devtools-shared': 7.6.8
       mitt: 3.0.1
-      nanoid: 5.1.5
+      nanoid: 5.0.9
       pathe: 1.1.2
       vite-hot-client: 0.2.4(vite@6.3.5(@types/node@22.10.2)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.37.0)(tsx@4.19.3)(yaml@2.6.1))
       vue: 3.5.13(typescript@5.6.2)
@@ -23514,10 +23513,6 @@ snapshots:
   acorn-jsx@5.3.2(acorn@8.14.0):
     dependencies:
       acorn: 8.14.0
-
-  acorn-jsx@5.3.2(acorn@8.14.1):
-    dependencies:
-      acorn: 8.14.1
 
   acorn-walk@8.3.2: {}
 
@@ -25218,33 +25213,14 @@ snapshots:
       postcss-load-config: 3.1.4(postcss@8.5.4)(ts-node@10.9.2(@swc/core@1.11.29)(@types/node@22.15.18)(typescript@5.6.2))
       postcss-safe-parser: 6.0.0(postcss@8.5.4)
       postcss-selector-parser: 6.1.2
-      semver: 7.6.3
+      semver: 7.7.2
       svelte-eslint-parser: 0.43.0(svelte@5.33.14)
     optionalDependencies:
       svelte: 5.33.14
     transitivePeerDependencies:
       - ts-node
 
-  eslint-plugin-svelte@2.46.1(eslint@9.17.0(jiti@2.4.2))(svelte@5.33.19)(ts-node@10.9.2(@swc/core@1.11.29)(@types/node@22.15.18)(typescript@5.6.2)):
-    dependencies:
-      '@eslint-community/eslint-utils': 4.4.1(eslint@9.17.0(jiti@2.4.2))
-      '@jridgewell/sourcemap-codec': 1.5.0
-      eslint: 9.17.0(jiti@2.4.2)
-      eslint-compat-utils: 0.5.1(eslint@9.17.0(jiti@2.4.2))
-      esutils: 2.0.3
-      known-css-properties: 0.35.0
-      postcss: 8.5.4
-      postcss-load-config: 3.1.4(postcss@8.5.4)(ts-node@10.9.2(@swc/core@1.11.29)(@types/node@22.15.18)(typescript@5.6.2))
-      postcss-safe-parser: 6.0.0(postcss@8.5.4)
-      postcss-selector-parser: 6.1.2
-      semver: 7.6.3
-      svelte-eslint-parser: 0.43.0(svelte@5.33.19)
-    optionalDependencies:
-      svelte: 5.33.19
-    transitivePeerDependencies:
-      - ts-node
-
-  eslint-plugin-svelte@2.46.1(eslint@9.28.0(jiti@2.4.2))(svelte@5.33.19)(ts-node@10.9.2(@swc/core@1.11.29)(@types/node@22.15.18)(typescript@5.6.2)):
+  eslint-plugin-svelte@2.46.1(eslint@9.28.0(jiti@2.4.2))(svelte@5.34.1)(ts-node@10.9.2(@swc/core@1.11.29)(@types/node@22.15.18)(typescript@5.6.2)):
     dependencies:
       '@eslint-community/eslint-utils': 4.4.1(eslint@9.28.0(jiti@2.4.2))
       '@jridgewell/sourcemap-codec': 1.5.0
@@ -25256,10 +25232,10 @@ snapshots:
       postcss-load-config: 3.1.4(postcss@8.5.4)(ts-node@10.9.2(@swc/core@1.11.29)(@types/node@22.15.18)(typescript@5.6.2))
       postcss-safe-parser: 6.0.0(postcss@8.5.4)
       postcss-selector-parser: 6.1.2
-      semver: 7.6.3
-      svelte-eslint-parser: 0.43.0(svelte@5.33.19)
+      semver: 7.7.2
+      svelte-eslint-parser: 0.43.0(svelte@5.34.1)
     optionalDependencies:
-      svelte: 5.33.19
+      svelte: 5.34.1
     transitivePeerDependencies:
       - ts-node
 
@@ -25439,8 +25415,8 @@ snapshots:
 
   espree@9.6.1:
     dependencies:
-      acorn: 8.14.1
-      acorn-jsx: 5.3.2(acorn@8.14.1)
+      acorn: 8.14.0
+      acorn-jsx: 5.3.2(acorn@8.14.0)
       eslint-visitor-keys: 3.4.3
 
   esprima@4.0.1: {}
@@ -28499,6 +28475,8 @@ snapshots:
 
   nanoid@3.3.8: {}
 
+  nanoid@5.0.9: {}
+
   nanoid@5.1.5: {}
 
   nanostores@0.11.4: {}
@@ -29016,8 +28994,6 @@ snapshots:
 
   pathe@1.1.2: {}
 
-  pathe@2.0.2: {}
-
   pathe@2.0.3: {}
 
   pathval@2.0.0: {}
@@ -29076,7 +29052,7 @@ snapshots:
     dependencies:
       confbox: 0.1.8
       mlly: 1.7.4
-      pathe: 2.0.2
+      pathe: 2.0.3
 
   pkg-types@2.1.0:
     dependencies:
@@ -29106,12 +29082,24 @@ snapshots:
 
   possible-typed-array-names@1.0.0: {}
 
+  postcss-import@15.1.0(postcss@8.5.3):
+    dependencies:
+      postcss: 8.5.3
+      postcss-value-parser: 4.2.0
+      read-cache: 1.0.0
+      resolve: 1.22.10
+
   postcss-import@15.1.0(postcss@8.5.4):
     dependencies:
       postcss: 8.5.4
       postcss-value-parser: 4.2.0
       read-cache: 1.0.0
       resolve: 1.22.10
+
+  postcss-js@4.0.1(postcss@8.5.3):
+    dependencies:
+      camelcase-css: 2.0.1
+      postcss: 8.5.3
 
   postcss-js@4.0.1(postcss@8.5.4):
     dependencies:
@@ -29126,13 +29114,21 @@ snapshots:
       postcss: 8.5.4
       ts-node: 10.9.2(@swc/core@1.11.29)(@types/node@22.15.18)(typescript@5.6.2)
 
-  postcss-load-config@4.0.2(postcss@8.5.4)(ts-node@10.9.2(@swc/core@1.11.29)(@types/node@22.15.18)(typescript@5.6.2)):
+  postcss-load-config@4.0.2(postcss@8.5.3)(ts-node@10.9.2(@swc/core@1.11.29)(@types/node@22.15.18)(typescript@5.6.2)):
     dependencies:
       lilconfig: 3.1.3
       yaml: 2.6.1
     optionalDependencies:
-      postcss: 8.5.4
+      postcss: 8.5.3
       ts-node: 10.9.2(@swc/core@1.11.29)(@types/node@22.15.18)(typescript@5.6.2)
+
+  postcss-load-config@4.0.2(postcss@8.5.3)(ts-node@10.9.2(@swc/core@1.11.29)(@types/node@22.15.18)(typescript@5.8.3)):
+    dependencies:
+      lilconfig: 3.1.3
+      yaml: 2.6.1
+    optionalDependencies:
+      postcss: 8.5.3
+      ts-node: 10.9.2(@swc/core@1.11.29)(@types/node@22.15.18)(typescript@5.8.3)
 
   postcss-load-config@4.0.2(postcss@8.5.4)(ts-node@10.9.2(@swc/core@1.11.29)(@types/node@22.15.18)(typescript@5.8.3)):
     dependencies:
@@ -29150,6 +29146,11 @@ snapshots:
       postcss: 8.5.4
       tsx: 4.19.3
       yaml: 2.6.1
+
+  postcss-nested@6.2.0(postcss@8.5.3):
+    dependencies:
+      postcss: 8.5.3
+      postcss-selector-parser: 6.1.2
 
   postcss-nested@6.2.0(postcss@8.5.4):
     dependencies:
@@ -29224,10 +29225,10 @@ snapshots:
       prettier: 3.4.2
       svelte: 5.33.14
 
-  prettier-plugin-svelte@3.4.0(prettier@3.5.3)(svelte@5.33.19):
+  prettier-plugin-svelte@3.4.0(prettier@3.5.3)(svelte@5.34.1):
     dependencies:
       prettier: 3.5.3
-      svelte: 5.33.19
+      svelte: 5.34.1
 
   prettier-plugin-tailwindcss@0.6.9(prettier-plugin-svelte@3.3.2(prettier@3.4.2)(svelte@5.33.14))(prettier@3.4.2):
     dependencies:
@@ -29297,7 +29298,7 @@ snapshots:
 
   property-information@7.1.0: {}
 
-  prosekit@0.13.4(@shikijs/types@3.5.0)(@types/hast@3.0.4)(preact@10.25.3)(prosemirror-model@1.25.1)(prosemirror-state@1.4.3)(prosemirror-transform@1.10.4)(prosemirror-view@1.39.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(solid-js@1.9.5)(svelte@5.33.19)(vue@3.5.13(typescript@5.6.2)):
+  prosekit@0.13.4(@shikijs/types@3.5.0)(@types/hast@3.0.4)(preact@10.25.3)(prosemirror-model@1.25.1)(prosemirror-state@1.4.3)(prosemirror-transform@1.10.4)(prosemirror-view@1.39.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(solid-js@1.9.5)(svelte@5.34.1)(vue@3.5.13(typescript@5.6.2)):
     dependencies:
       '@prosekit/basic': 0.5.1(@shikijs/types@3.5.0)(@types/hast@3.0.4)(prosemirror-model@1.25.1)(prosemirror-state@1.4.3)(prosemirror-transform@1.10.4)(prosemirror-view@1.39.2)
       '@prosekit/core': 0.8.1(prosemirror-model@1.25.1)(prosemirror-state@1.4.3)(prosemirror-transform@1.10.4)
@@ -29307,7 +29308,7 @@ snapshots:
       '@prosekit/preact': 0.4.14(@shikijs/types@3.5.0)(@types/hast@3.0.4)(preact@10.25.3)(prosemirror-model@1.25.1)(prosemirror-state@1.4.3)(prosemirror-transform@1.10.4)(prosemirror-view@1.39.2)
       '@prosekit/react': 0.5.0(@shikijs/types@3.5.0)(@types/hast@3.0.4)(prosemirror-model@1.25.1)(prosemirror-state@1.4.3)(prosemirror-transform@1.10.4)(prosemirror-view@1.39.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       '@prosekit/solid': 0.4.14(@shikijs/types@3.5.0)(@types/hast@3.0.4)(prosemirror-model@1.25.1)(prosemirror-state@1.4.3)(prosemirror-transform@1.10.4)(prosemirror-view@1.39.2)(solid-js@1.9.5)
-      '@prosekit/svelte': 0.6.9(@shikijs/types@3.5.0)(@types/hast@3.0.4)(prosemirror-model@1.25.1)(prosemirror-state@1.4.3)(prosemirror-transform@1.10.4)(prosemirror-view@1.39.2)(svelte@5.33.19)
+      '@prosekit/svelte': 0.6.9(@shikijs/types@3.5.0)(@types/hast@3.0.4)(prosemirror-model@1.25.1)(prosemirror-state@1.4.3)(prosemirror-transform@1.10.4)(prosemirror-view@1.39.2)(svelte@5.34.1)
       '@prosekit/vue': 0.4.14(@shikijs/types@3.5.0)(@types/hast@3.0.4)(prosemirror-model@1.25.1)(prosemirror-state@1.4.3)(prosemirror-transform@1.10.4)(prosemirror-view@1.39.2)(vue@3.5.13(typescript@5.6.2))
       '@prosekit/web': 0.5.9(@shikijs/types@3.5.0)(@types/hast@3.0.4)(prosemirror-model@1.25.1)(prosemirror-state@1.4.3)(prosemirror-transform@1.10.4)(prosemirror-view@1.39.2)
     optionalDependencies:
@@ -29315,7 +29316,7 @@ snapshots:
       react: 19.0.0
       react-dom: 19.0.0(react@19.0.0)
       solid-js: 1.9.5
-      svelte: 5.33.19
+      svelte: 5.34.1
       vue: 3.5.13(typescript@5.6.2)
     transitivePeerDependencies:
       - '@shikijs/types'
@@ -29681,12 +29682,12 @@ snapshots:
       '@babel/helper-module-imports': 7.25.9
       '@babel/traverse': 7.26.4
       '@babel/types': 7.26.3
-      debug: 4.4.1
+      debug: 4.4.0
       lightningcss: 1.29.1
       react: 19.0.0
       react-native: 0.79.2(@babel/core@7.26.0)(@react-native-community/cli@15.0.1(typescript@5.8.3))(@types/react@19.0.0)(react@19.0.0)
       react-native-reanimated: 3.17.5(@babel/core@7.26.0)(react-native@0.79.2(@babel/core@7.26.0)(@react-native-community/cli@15.0.1(typescript@5.8.3))(@types/react@19.0.0)(react@19.0.0))(react@19.0.0)
-      semver: 7.7.2
+      semver: 7.6.3
       tailwindcss: 3.3.2(ts-node@10.9.2(@swc/core@1.11.29)(@types/node@22.15.18)(typescript@5.8.3))
     optionalDependencies:
       react-native-safe-area-context: 5.4.0(react-native@0.79.2(@babel/core@7.26.0)(@react-native-community/cli@15.0.1(typescript@5.8.3))(@types/react@19.0.0)(react@19.0.0))(react@19.0.0)
@@ -29698,12 +29699,12 @@ snapshots:
       '@babel/helper-module-imports': 7.25.9
       '@babel/traverse': 7.26.4
       '@babel/types': 7.26.3
-      debug: 4.4.1
+      debug: 4.4.0
       lightningcss: 1.29.1
       react: 19.0.0
       react-native: 0.79.2(@babel/core@7.26.0)(@react-native-community/cli@15.0.1(typescript@5.8.3))(@types/react@19.0.0)(react@19.0.0)
       react-native-reanimated: 3.17.5(@babel/core@7.26.0)(react-native@0.79.2(@babel/core@7.26.0)(@react-native-community/cli@15.0.1(typescript@5.8.3))(@types/react@19.0.0)(react@19.0.0))(react@19.0.0)
-      semver: 7.7.2
+      semver: 7.6.3
       tailwindcss: 3.4.17(ts-node@10.9.2(@swc/core@1.11.29)(@types/node@22.15.18)(typescript@5.8.3))
     optionalDependencies:
       react-native-safe-area-context: 5.4.0(react-native@0.79.2(@babel/core@7.26.0)(@react-native-community/cli@15.0.1(typescript@5.8.3))(@types/react@19.0.0)(react@19.0.0))(react@19.0.0)
@@ -30618,7 +30619,7 @@ snapshots:
     dependencies:
       color: 4.2.3
       detect-libc: 2.0.3
-      semver: 7.7.2
+      semver: 7.6.3
     optionalDependencies:
       '@img/sharp-darwin-arm64': 0.33.5
       '@img/sharp-darwin-x64': 0.33.5
@@ -31150,26 +31151,14 @@ snapshots:
     transitivePeerDependencies:
       - picomatch
 
-  svelte-check@4.1.1(picomatch@4.0.2)(svelte@5.33.19)(typescript@5.6.2):
-    dependencies:
-      '@jridgewell/trace-mapping': 0.3.25
-      chokidar: 4.0.3
-      fdir: 6.4.2(picomatch@4.0.2)
-      picocolors: 1.1.1
-      sade: 1.8.1
-      svelte: 5.33.19
-      typescript: 5.6.2
-    transitivePeerDependencies:
-      - picomatch
-
-  svelte-check@4.2.1(picomatch@4.0.2)(svelte@5.33.19)(typescript@5.6.2):
+  svelte-check@4.2.1(picomatch@4.0.2)(svelte@5.34.1)(typescript@5.6.2):
     dependencies:
       '@jridgewell/trace-mapping': 0.3.25
       chokidar: 4.0.3
       fdir: 6.4.5(picomatch@4.0.2)
       picocolors: 1.1.1
       sade: 1.8.1
-      svelte: 5.33.19
+      svelte: 5.34.1
       typescript: 5.6.2
     transitivePeerDependencies:
       - picomatch
@@ -31184,7 +31173,7 @@ snapshots:
     optionalDependencies:
       svelte: 5.33.14
 
-  svelte-eslint-parser@0.43.0(svelte@5.33.19):
+  svelte-eslint-parser@0.43.0(svelte@5.34.1):
     dependencies:
       eslint-scope: 7.2.2
       eslint-visitor-keys: 3.4.3
@@ -31192,7 +31181,7 @@ snapshots:
       postcss: 8.5.4
       postcss-scss: 4.0.9(postcss@8.5.4)
     optionalDependencies:
-      svelte: 5.33.19
+      svelte: 5.34.1
 
   svelte-sonner@0.3.28(svelte@5.33.14):
     dependencies:
@@ -31222,7 +31211,7 @@ snapshots:
       magic-string: 0.30.17
       zimmerframe: 1.1.2
 
-  svelte@5.33.19:
+  svelte@5.34.1:
     dependencies:
       '@ampproject/remapping': 2.3.0
       '@jridgewell/sourcemap-codec': 1.5.0
@@ -31305,11 +31294,11 @@ snapshots:
       normalize-path: 3.0.0
       object-hash: 3.0.0
       picocolors: 1.1.1
-      postcss: 8.5.4
-      postcss-import: 15.1.0(postcss@8.5.4)
-      postcss-js: 4.0.1(postcss@8.5.4)
-      postcss-load-config: 4.0.2(postcss@8.5.4)(ts-node@10.9.2(@swc/core@1.11.29)(@types/node@22.15.18)(typescript@5.6.2))
-      postcss-nested: 6.2.0(postcss@8.5.4)
+      postcss: 8.5.3
+      postcss-import: 15.1.0(postcss@8.5.3)
+      postcss-js: 4.0.1(postcss@8.5.3)
+      postcss-load-config: 4.0.2(postcss@8.5.3)(ts-node@10.9.2(@swc/core@1.11.29)(@types/node@22.15.18)(typescript@5.6.2))
+      postcss-nested: 6.2.0(postcss@8.5.3)
       postcss-selector-parser: 6.1.2
       resolve: 1.22.10
       sucrase: 3.35.0
@@ -31332,11 +31321,11 @@ snapshots:
       normalize-path: 3.0.0
       object-hash: 3.0.0
       picocolors: 1.1.1
-      postcss: 8.5.4
-      postcss-import: 15.1.0(postcss@8.5.4)
-      postcss-js: 4.0.1(postcss@8.5.4)
-      postcss-load-config: 4.0.2(postcss@8.5.4)(ts-node@10.9.2(@swc/core@1.11.29)(@types/node@22.15.18)(typescript@5.8.3))
-      postcss-nested: 6.2.0(postcss@8.5.4)
+      postcss: 8.5.3
+      postcss-import: 15.1.0(postcss@8.5.3)
+      postcss-js: 4.0.1(postcss@8.5.3)
+      postcss-load-config: 4.0.2(postcss@8.5.3)(ts-node@10.9.2(@swc/core@1.11.29)(@types/node@22.15.18)(typescript@5.8.3))
+      postcss-nested: 6.2.0(postcss@8.5.3)
       postcss-selector-parser: 6.1.2
       resolve: 1.22.10
       sucrase: 3.35.0
@@ -31348,8 +31337,6 @@ snapshots:
   tailwindcss@4.1.4: {}
 
   tailwindcss@4.1.6: {}
-
-  tailwindcss@4.1.8: {}
 
   tapable@2.2.1: {}
 
@@ -31990,7 +31977,7 @@ snapshots:
   vite-node@3.1.1(@types/node@22.15.18)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.37.0)(tsx@4.19.3)(yaml@2.6.1):
     dependencies:
       cac: 6.7.14
-      debug: 4.4.1
+      debug: 4.4.0
       es-module-lexer: 1.6.0
       pathe: 2.0.3
       vite: 6.3.5(@types/node@22.15.18)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.37.0)(tsx@4.19.3)(yaml@2.6.1)
@@ -32052,13 +32039,13 @@ snapshots:
     dependencies:
       '@antfu/utils': 0.7.10
       '@rollup/pluginutils': 5.1.4(rollup@4.41.1)
-      debug: 4.4.1
+      debug: 4.4.0
       error-stack-parser-es: 0.1.5
       fs-extra: 11.2.0
       open: 10.1.0
       perfect-debounce: 1.0.0
       picocolors: 1.1.1
-      sirv: 3.0.1
+      sirv: 3.0.0
       vite: 6.3.5(@types/node@22.10.2)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.37.0)(tsx@4.19.3)(yaml@2.6.1)
     transitivePeerDependencies:
       - rollup
@@ -32303,14 +32290,14 @@ snapshots:
 
   vue-eslint-parser@9.4.3(eslint@9.17.0(jiti@2.4.2)):
     dependencies:
-      debug: 4.4.1
+      debug: 4.4.0
       eslint: 9.17.0(jiti@2.4.2)
       eslint-scope: 7.2.2
       eslint-visitor-keys: 3.4.3
       espree: 9.6.1
       esquery: 1.6.0
       lodash: 4.17.21
-      semver: 7.7.2
+      semver: 7.6.3
     transitivePeerDependencies:
       - supports-color
 


### PR DESCRIPTION
Started by working on improving performance by parallelizing read operations on storage, while working I've found some gaps in the current deps recovery system.

Now we handle correctly missing parent groups (was breaking the app before) and a coValue is marked as available only after all their required deps are loaded.

fixes #1917

The storage reads parallelization is bringing around 1s gain when loading 1k tasks

Before:
<img width="1482" alt="Screenshot 2025-06-12 at 17 10 53" src="https://github.com/user-attachments/assets/609649cc-5d0f-41d4-82ec-3c60966393e6" />

After:
<img width="876" alt="Screenshot 2025-06-12 at 17 08 55" src="https://github.com/user-attachments/assets/e1bafc32-7351-4104-b413-69240a620b91" />
