### PR TITLE
Prevent submitting form if account id isn't accompanied by a secret

### DIFF
--- a/examples/inspector/src/viewer/new-app.tsx
+++ b/examples/inspector/src/viewer/new-app.tsx
@@ -370,23 +370,21 @@ function AddAccountForm({
         secret separately.
       </p>
       <Input
+        required
         label="Account ID"
         value={id}
         placeholder="co_z1234567890abcdef123456789 or paste full JSON"
         onChange={handleIdChange}
       />
       <Input
+        required
         label="Account secret"
         type="password"
         value={secret}
         onChange={(e) => setSecret(e.target.value)}
         placeholder="sealerSecret_ziz7NA12340abcdef123789..."
       />
-      <Button
-        className="mt-3"
-        type="submit"
-        disabled={secret.length == 0 || id.length == 0}
-      >
+      <Button className="mt-3" type="submit">
         Add account
       </Button>
     </form>

--- a/examples/inspector/src/viewer/new-app.tsx
+++ b/examples/inspector/src/viewer/new-app.tsx
@@ -106,7 +106,8 @@ export default function CoJsonViewerApp() {
           KNOWN_ERRORS.filter((e) =>
             normalizeError(err.message).includes(e),
           )[0] || "";
-        if (KNOWN_ERRORS.indexOf(matchError) >= 0) {
+        const knownErrorIndex: number = KNOWN_ERRORS.indexOf(matchError);
+        if (knownErrorIndex >= 0) {
           setAccounts(accounts.filter((acc) => acc.id !== currentAccount.id));
           //remove from localStorage
           localStorage.removeItem("lastSelectedAccountId");
@@ -117,7 +118,7 @@ export default function CoJsonViewerApp() {
             ),
           );
           setCurrentAccount(null);
-          setErrors(KNOWN_ERRORS[KNOWN_ERRORS.indexOf(matchError)]);
+          setErrors(KNOWN_ERRORS[knownErrorIndex]);
         } else {
           setErrors("Something went wrong, the account could not be loaded");
         }


### PR DESCRIPTION
Noticed that the console was blowing up an error when I tried to load an invalid secret and/or I submitted the form with only an account id and not secret. This adds an extra check so we prevent this from happening

<img width="1504" alt="Screenshot 2025-06-12 at 11 15 04 AM" src="https://github.com/user-attachments/assets/bc0c93ad-e5a3-4d4f-853e-c4a7044819a0" />
