### PR TITLE
Add "use client" directive for Next.js

### DIFF
--- a/.changeset/witty-owls-run.md
+++ b/.changeset/witty-owls-run.md
@@ -1,0 +1,6 @@
+---
+"jazz-react-core": patch
+"jazz-react": patch
+---
+
+Add use client directives on jazz-react and jazz-react-core

--- a/packages/jazz-react-core/src/auth/DemoAuth.tsx
+++ b/packages/jazz-react-core/src/auth/DemoAuth.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import { DemoAuth } from "jazz-tools";
 import { useEffect, useMemo, useState } from "react";
 import { useAuthSecretStorage, useJazzContext } from "../hooks.js";

--- a/packages/jazz-react-core/src/auth/PassphraseAuth.tsx
+++ b/packages/jazz-react-core/src/auth/PassphraseAuth.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import { PassphraseAuth } from "jazz-tools";
 import { useCallback, useMemo, useSyncExternalStore } from "react";
 import { useAuthSecretStorage, useJazzContext } from "../hooks.js";

--- a/packages/jazz-react-core/src/hooks.ts
+++ b/packages/jazz-react-core/src/hooks.ts
@@ -1,3 +1,5 @@
+"use client";
+
 import React, {
   useCallback,
   useContext,

--- a/packages/jazz-react-core/src/provider.tsx
+++ b/packages/jazz-react-core/src/provider.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import React from "react";
 
 import { Account, JazzContextManager, JazzContextType } from "jazz-tools";

--- a/packages/jazz-react/src/auth/DemoAuth.tsx
+++ b/packages/jazz-react/src/auth/DemoAuth.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import { useDemoAuth } from "jazz-react-core";
 import { useState } from "react";
 

--- a/packages/jazz-react/src/auth/PasskeyAuth.tsx
+++ b/packages/jazz-react/src/auth/PasskeyAuth.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import { BrowserPasskeyAuth } from "jazz-browser";
 import {
   useAuthSecretStorage,

--- a/packages/jazz-react/src/auth/PassphraseAuth.tsx
+++ b/packages/jazz-react/src/auth/PassphraseAuth.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import { usePassphraseAuth } from "jazz-react-core";
 import { useState } from "react";
 

--- a/packages/jazz-react/src/hooks.tsx
+++ b/packages/jazz-react/src/hooks.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import { consumeInviteLinkFromWindowLocation } from "jazz-browser";
 import { useEffect } from "react";
 

--- a/packages/jazz-react/src/media.tsx
+++ b/packages/jazz-react/src/media.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import { ImageDefinition, Loaded } from "jazz-tools";
 import React, { useEffect, useState } from "react";
 

--- a/packages/jazz-react/src/provider.tsx
+++ b/packages/jazz-react/src/provider.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import {
   JazzBrowserContextManager,
   JazzContextManagerProps,


### PR DESCRIPTION
I haven't verified if tsc leaves this at the top of the file - but we need something like this