### PR TITLE
fix: remove RN Buffer polyfill for ProgressiveImg

### DIFF
--- a/.changeset/nice-cars-notice.md
+++ b/.changeset/nice-cars-notice.md
@@ -1,0 +1,6 @@
+---
+"jazz-react-native-media-images": patch
+"jazz-react-native-core": patch
+---
+
+remove React Native `Buffer` polyfill

--- a/examples/chat-rn-expo-clerk/package.json
+++ b/examples/chat-rn-expo-clerk/package.json
@@ -16,7 +16,6 @@
     "@bacons/text-decoder": "0.0.0",
     "@bam.tech/react-native-image-resizer": "^3.0.11",
     "@clerk/clerk-expo": "^2.2.21",
-    "@craftzdog/react-native-buffer": "6.0.5",
     "@expo/vector-icons": "^14.1.0",
     "@react-native-community/netinfo": "11.4.1",
     "@react-navigation/native": "7.0.19",

--- a/examples/chat-rn-expo-clerk/polyfills.js
+++ b/examples/chat-rn-expo-clerk/polyfills.js
@@ -3,9 +3,6 @@
 // @ts-expect-error - @types/react-native doesn't cover this file
 import { polyfillGlobal } from "react-native/Libraries/Utilities/PolyfillFunctions";
 
-import { Buffer } from "@craftzdog/react-native-buffer";
-polyfillGlobal("Buffer", () => Buffer);
-
 // @ts-expect-error - @types/readable-stream doesn't have ReadableStream type
 import { ReadableStream } from "readable-stream";
 polyfillGlobal("ReadableStream", () => ReadableStream);

--- a/examples/chat-rn-expo/package.json
+++ b/examples/chat-rn-expo/package.json
@@ -11,7 +11,7 @@
   "dependencies": {
     "@azure/core-asynciterator-polyfill": "^1.0.2",
     "@bacons/text-decoder": "^0.0.0",
-    "@craftzdog/react-native-buffer": "^6.0.5",
+    "@bam.tech/react-native-image-resizer": "^3.0.11",
     "@react-native-community/netinfo": "11.4.1",
     "expo": "~53.0.9",
     "expo-clipboard": "^7.1.4",

--- a/examples/chat-rn-expo/polyfills.ts
+++ b/examples/chat-rn-expo/polyfills.ts
@@ -3,9 +3,6 @@
 // @ts-expect-error - @types/react-native doesn't cover this file
 import { polyfillGlobal } from "react-native/Libraries/Utilities/PolyfillFunctions";
 
-import { Buffer } from "@craftzdog/react-native-buffer";
-polyfillGlobal("Buffer", () => Buffer);
-
 // @ts-expect-error - @types/readable-stream doesn't have ReadableStream type
 import { ReadableStream } from "readable-stream";
 polyfillGlobal("ReadableStream", () => ReadableStream);

--- a/examples/chat-rn/package.json
+++ b/examples/chat-rn/package.json
@@ -12,7 +12,6 @@
   "dependencies": {
     "@azure/core-asynciterator-polyfill": "^1.0.2",
     "@bacons/text-decoder": "0.0.0",
-    "@craftzdog/react-native-buffer": "6.0.5",
     "@op-engineering/op-sqlite": "^11.4.8",
     "@react-native-clipboard/clipboard": "1.16.1",
     "@react-native-community/netinfo": "11.4.1",

--- a/examples/chat-rn/src/polyfills.ts
+++ b/examples/chat-rn/src/polyfills.ts
@@ -4,9 +4,6 @@
 import { polyfillGlobal } from "react-native/Libraries/Utilities/PolyfillFunctions";
 // import 'react-native-polyfill-globals/auto';
 
-import { Buffer } from "@craftzdog/react-native-buffer";
-polyfillGlobal("Buffer", () => Buffer);
-
 // @ts-expect-error - @types/readable-stream doesn't have ReadableStream type
 import { ReadableStream } from "readable-stream";
 polyfillGlobal("ReadableStream", () => ReadableStream);

--- a/homepage/homepage/content/docs/project-setup/react-native-expo.mdx
+++ b/homepage/homepage/content/docs/project-setup/react-native-expo.mdx
@@ -42,7 +42,7 @@ npx expo prebuild
 npx expo install expo-linking expo-secure-store expo-file-system @react-native-community/netinfo @bam.tech/react-native-image-resizer
 
 # React Native polyfills
-npm i -S @azure/core-asynciterator-polyfill react-native-url-polyfill readable-stream react-native-get-random-values @craftzdog/react-native-buffer
+npm i -S @azure/core-asynciterator-polyfill react-native-url-polyfill readable-stream react-native-get-random-values
 
 # Jazz dependencies
 npm i -S jazz-tools jazz-expo jazz-react-native-media-images
@@ -141,8 +141,6 @@ Create a file `polyfills.js` at the project root with the following content:
 // @noErrors: 7016
 // polyfills.js
 import { polyfillGlobal } from 'react-native/Libraries/Utilities/PolyfillFunctions';
-import { Buffer } from "@craftzdog/react-native-buffer";
-polyfillGlobal("Buffer", () => Buffer); // polyfill Buffer
 
 import { ReadableStream } from "readable-stream";
 polyfillGlobal("ReadableStream", () => ReadableStream); // polyfill ReadableStream

--- a/homepage/homepage/content/docs/project-setup/react-native.mdx
+++ b/homepage/homepage/content/docs/project-setup/react-native.mdx
@@ -42,7 +42,7 @@ If you intend to build for iOS, you can accept the invitation to install CocoaPo
 npm install @react-native-community/netinfo @bam.tech/react-native-image-resizer
 
 # React Native polyfills
-npm i -S @azure/core-asynciterator-polyfill react-native-url-polyfill readable-stream react-native-get-random-values @craftzdog/react-native-buffer @op-engineering/op-sqlite react-native-mmkv
+npm i -S @azure/core-asynciterator-polyfill react-native-url-polyfill readable-stream react-native-get-random-values @op-engineering/op-sqlite react-native-mmkv
 
 # Jazz dependencies
 npm i -S jazz-tools jazz-react-native jazz-react-native-media-images
@@ -143,9 +143,6 @@ Create a file `polyfills.js` at the project root with the following content:
 // @noErrors: 7016
 // polyfills.js
 import { polyfillGlobal } from 'react-native/Libraries/Utilities/PolyfillFunctions';
-import { Buffer } from "@craftzdog/react-native-buffer";
-polyfillGlobal("Buffer", () => Buffer); // polyfill Buffer
-
 import { ReadableStream } from "readable-stream";
 polyfillGlobal("ReadableStream", () => ReadableStream); // polyfill ReadableStream
 

--- a/packages/jazz-expo/README.md
+++ b/packages/jazz-expo/README.md
@@ -29,7 +29,7 @@ npx expo prebuild
 ```bash
 npx expo install expo-linking expo-secure-store expo-file-system @react-native-community/netinfo @bam.tech/react-native-image-resizer
 
-  npm i -S @azure/core-asynciterator-polyfill react-native-url-polyfill readable-stream react-native-get-random-values @craftzdog/react-native-buffer
+  npm i -S @azure/core-asynciterator-polyfill react-native-url-polyfill readable-stream react-native-get-random-values
 
 
 npm i -D @babel/plugin-transform-class-static-block
@@ -139,9 +139,6 @@ Create a file `polyfills.js` at the project root with the following content:
 
 ```js
 import { polyfillGlobal } from 'react-native/Libraries/Utilities/PolyfillFunctions';
-
-import { Buffer } from '@craftzdog/react-native-buffer';
-polyfillGlobal('Buffer', () => Buffer);
 
 import { ReadableStream } from 'readable-stream';
 polyfillGlobal('ReadableStream', () => ReadableStream);

--- a/packages/jazz-react-native-core/src/media.tsx
+++ b/packages/jazz-react-native-core/src/media.tsx
@@ -41,7 +41,11 @@ export function useProgressiveImg({
           });
 
           // Create data URL
-          const base64 = Buffer.from(combinedArray).toString("base64");
+          const base64 = btoa(
+            Array.from(combinedArray, (byte) => String.fromCharCode(byte)).join(
+              "",
+            ),
+          );
           const dataUrl = `data:${chunks.mimeType};base64,${base64}`;
 
           setCurrent({

--- a/packages/jazz-react-native-media-images/src/index.ts
+++ b/packages/jazz-react-native-media-images/src/index.ts
@@ -73,9 +73,8 @@ async function base64DataURIToBlob(base64Data: string) {
   }
   const byteArray = new Uint8Array(byteNumbers);
 
-  const buffer = Buffer.from(byteArray);
-  // @ts-expect-error buffer has data
-  const blob = new Blob([buffer.data], { type: contentType });
+  // @ts-expect-error byteArray has data
+  const blob = new Blob(byteArray, { type: contentType });
   blob.arrayBuffer = () => arrayBuffer(blob);
   return blob;
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -259,9 +259,6 @@ importers:
       '@bacons/text-decoder':
         specifier: 0.0.0
         version: 0.0.0(react-native@0.79.2(@babel/core@7.26.0)(@react-native-community/cli@15.0.1(typescript@5.6.2))(@types/react@19.0.0)(react@19.0.0))
-      '@craftzdog/react-native-buffer':
-        specifier: 6.0.5
-        version: 6.0.5(react-native@0.79.2(@babel/core@7.26.0)(@react-native-community/cli@15.0.1(typescript@5.6.2))(@types/react@19.0.0)(react@19.0.0))(react@19.0.0)
       '@op-engineering/op-sqlite':
         specifier: ^11.4.8
         version: 11.4.8(react-native@0.79.2(@babel/core@7.26.0)(@react-native-community/cli@15.0.1(typescript@5.6.2))(@types/react@19.0.0)(react@19.0.0))(react@19.0.0)
@@ -386,9 +383,9 @@ importers:
       '@bacons/text-decoder':
         specifier: ^0.0.0
         version: 0.0.0(react-native@0.79.2(@babel/core@7.26.0)(@react-native-community/cli@15.0.1(typescript@5.8.3))(@types/react@19.0.0)(react@19.0.0))
-      '@craftzdog/react-native-buffer':
-        specifier: ^6.0.5
-        version: 6.0.5(react-native@0.79.2(@babel/core@7.26.0)(@react-native-community/cli@15.0.1(typescript@5.8.3))(@types/react@19.0.0)(react@19.0.0))(react@19.0.0)
+      '@bam.tech/react-native-image-resizer':
+        specifier: ^3.0.11
+        version: 3.0.11(react-native@0.79.2(@babel/core@7.26.0)(@react-native-community/cli@15.0.1(typescript@5.8.3))(@types/react@19.0.0)(react@19.0.0))(react@19.0.0)
       '@react-native-community/netinfo':
         specifier: 11.4.1
         version: 11.4.1(react-native@0.79.2(@babel/core@7.26.0)(@react-native-community/cli@15.0.1(typescript@5.8.3))(@types/react@19.0.0)(react@19.0.0))
@@ -450,9 +447,6 @@ importers:
       '@clerk/clerk-expo':
         specifier: ^2.2.21
         version: 2.6.5(6wmqyfiepq3qqevv5wnhfabybe)
-      '@craftzdog/react-native-buffer':
-        specifier: 6.0.5
-        version: 6.0.5(react-native@0.79.2(@babel/core@7.26.0)(@react-native-community/cli@15.0.1(typescript@5.8.3))(@types/react@19.0.0)(react@19.0.0))(react@19.0.0)
       '@expo/vector-icons':
         specifier: ^14.1.0
         version: 14.1.0(expo-font@13.3.1(expo@53.0.8(@babel/core@7.26.0)(@expo/metro-runtime@5.0.4(react-native@0.79.2(@babel/core@7.26.0)(@react-native-community/cli@15.0.1(typescript@5.8.3))(@types/react@19.0.0)(react@19.0.0)))(graphql@16.11.0)(react-native@0.79.2(@babel/core@7.26.0)(@react-native-community/cli@15.0.1(typescript@5.8.3))(@types/react@19.0.0)(react@19.0.0))(react@19.0.0))(react@19.0.0))(react-native@0.79.2(@babel/core@7.26.0)(@react-native-community/cli@15.0.1(typescript@5.8.3))(@types/react@19.0.0)(react@19.0.0))(react@19.0.0)
@@ -3372,9 +3366,6 @@ importers:
       '@bacons/text-decoder':
         specifier: 0.0.0
         version: 0.0.0(react-native@0.79.2(@babel/core@7.26.0)(@react-native-community/cli@15.0.1(typescript@5.8.3))(@types/react@19.0.0)(react@19.0.0))
-      '@craftzdog/react-native-buffer':
-        specifier: 6.0.5
-        version: 6.0.5(react-native@0.79.2(@babel/core@7.26.0)(@react-native-community/cli@15.0.1(typescript@5.8.3))(@types/react@19.0.0)(react@19.0.0))(react@19.0.0)
       '@op-engineering/op-sqlite':
         specifier: ^11.2.12
         version: 11.4.8(react-native@0.79.2(@babel/core@7.26.0)(@react-native-community/cli@15.0.1(typescript@5.8.3))(@types/react@19.0.0)(react@19.0.0))(react@19.0.0)
@@ -18214,22 +18205,6 @@ snapshots:
       preact: 10.25.3
       sha.js: 2.4.11
 
-  '@craftzdog/react-native-buffer@6.0.5(react-native@0.79.2(@babel/core@7.26.0)(@react-native-community/cli@15.0.1(typescript@5.6.2))(@types/react@19.0.0)(react@19.0.0))(react@19.0.0)':
-    dependencies:
-      ieee754: 1.2.1
-      react-native-quick-base64: 2.1.2(react-native@0.79.2(@babel/core@7.26.0)(@react-native-community/cli@15.0.1(typescript@5.6.2))(@types/react@19.0.0)(react@19.0.0))(react@19.0.0)
-    transitivePeerDependencies:
-      - react
-      - react-native
-
-  '@craftzdog/react-native-buffer@6.0.5(react-native@0.79.2(@babel/core@7.26.0)(@react-native-community/cli@15.0.1(typescript@5.8.3))(@types/react@19.0.0)(react@19.0.0))(react@19.0.0)':
-    dependencies:
-      ieee754: 1.2.1
-      react-native-quick-base64: 2.1.2(react-native@0.79.2(@babel/core@7.26.0)(@react-native-community/cli@15.0.1(typescript@5.8.3))(@types/react@19.0.0)(react@19.0.0))(react@19.0.0)
-    transitivePeerDependencies:
-      - react
-      - react-native
-
   '@craftzdog/react-native-buffer@6.0.5(react-native@0.79.2(@babel/core@7.27.1)(@react-native-community/cli@15.0.1(typescript@5.6.2))(@types/react@19.0.0)(react@19.0.0))(react@19.0.0)':
     dependencies:
       ieee754: 1.2.1
@@ -29782,18 +29757,6 @@ snapshots:
       react-native-url-polyfill: 2.0.0(react-native@0.79.2(@babel/core@7.26.0)(@react-native-community/cli@15.0.1(typescript@5.6.2))(@types/react@19.0.0)(react@19.0.0))
       text-encoding: 0.7.0
       web-streams-polyfill: 3.3.3
-
-  react-native-quick-base64@2.1.2(react-native@0.79.2(@babel/core@7.26.0)(@react-native-community/cli@15.0.1(typescript@5.6.2))(@types/react@19.0.0)(react@19.0.0))(react@19.0.0):
-    dependencies:
-      base64-js: 1.5.1
-      react: 19.0.0
-      react-native: 0.79.2(@babel/core@7.26.0)(@react-native-community/cli@15.0.1(typescript@5.6.2))(@types/react@19.0.0)(react@19.0.0)
-
-  react-native-quick-base64@2.1.2(react-native@0.79.2(@babel/core@7.26.0)(@react-native-community/cli@15.0.1(typescript@5.8.3))(@types/react@19.0.0)(react@19.0.0))(react@19.0.0):
-    dependencies:
-      base64-js: 1.5.1
-      react: 19.0.0
-      react-native: 0.79.2(@babel/core@7.26.0)(@react-native-community/cli@15.0.1(typescript@5.8.3))(@types/react@19.0.0)(react@19.0.0)
 
   react-native-quick-base64@2.1.2(react-native@0.79.2(@babel/core@7.27.1)(@react-native-community/cli@15.0.1(typescript@5.6.2))(@types/react@19.0.0)(react@19.0.0))(react@19.0.0):
     dependencies:

--- a/tests/e2e-rn-expo/package.json
+++ b/tests/e2e-rn-expo/package.json
@@ -13,7 +13,6 @@
   "dependencies": {
     "@azure/core-asynciterator-polyfill": "^1.0.2",
     "@bacons/text-decoder": "0.0.0",
-    "@craftzdog/react-native-buffer": "6.0.5",
     "@op-engineering/op-sqlite": "^11.2.12",
     "@react-native-community/netinfo": "11.4.1",
     "@react-navigation/native": "7.0.19",

--- a/tests/e2e-rn-expo/polyfills.js
+++ b/tests/e2e-rn-expo/polyfills.js
@@ -3,9 +3,6 @@
 // @ts-expect-error - @types/react-native doesn't cover this file
 import { polyfillGlobal } from "react-native/Libraries/Utilities/PolyfillFunctions";
 
-import { Buffer } from "@craftzdog/react-native-buffer";
-polyfillGlobal("Buffer", () => Buffer);
-
 // @ts-expect-error - @types/readable-stream doesn't have ReadableStream type
 import { ReadableStream } from "readable-stream";
 polyfillGlobal("ReadableStream", () => ReadableStream);


### PR DESCRIPTION
There is a [new error](https://github.com/craftzdog/react-native-buffer/issues/14) with a RN `Buffer` polyfill, not sure if it was a change in Hermes or RN or what...  However, Jazz `<ProgressiveImg>` was affected.

The workaround removed one use of `Buffer`, and so I chose to remove the others, reducing polyfills and making setup at least a little easier.

fixes GCO-570