### PR TITLE
 persist embedded inspector's state on reload through local storage

### DIFF
--- a/packages/jazz-tools/src/inspector/viewer/new-app.tsx
+++ b/packages/jazz-tools/src/inspector/viewer/new-app.tsx
@@ -12,6 +12,7 @@ import { Account } from "jazz-tools";
 import { GlobalStyles } from "../ui/global-styles.js";
 import { Heading } from "../ui/heading.js";
 import { InspectorButton, type Position } from "./inpsector-button.js";
+import { useOpenInspector } from "./use-open-inspector.js";
 
 const InspectorContainer = styled("div")`
   position: fixed;
@@ -85,7 +86,7 @@ export function JazzInspectorInternal({
   localNode?: LocalNode;
   accountId?: CoID<RawAccount>;
 }) {
-  const [open, setOpen] = useState(false);
+  const [open, setOpen] = useOpenInspector();
   const [coValueId, setCoValueId] = useState<CoID<RawCoValue> | "">("");
   const { path, addPages, goToIndex, goBack, setPage } = usePagePath();
 

--- a/packages/jazz-tools/src/inspector/viewer/use-open-inspector.ts
+++ b/packages/jazz-tools/src/inspector/viewer/use-open-inspector.ts
@@ -1,0 +1,18 @@
+import { useEffect, useState } from "react";
+
+const STORAGE_KEY = "jazz-inspector-open";
+
+export function useOpenInspector() {
+  const [open, setOpen] = useState(() => {
+    // Initialize from localStorage if available
+    const stored = localStorage.getItem(STORAGE_KEY);
+    return stored ? JSON.parse(stored) : false;
+  });
+
+  // Update localStorage when open state changes
+  useEffect(() => {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(open));
+  }, [open]);
+
+  return [open, setOpen];
+}

--- a/packages/jazz-tools/src/inspector/viewer/use-page-path.ts
+++ b/packages/jazz-tools/src/inspector/viewer/use-page-path.ts
@@ -2,11 +2,24 @@ import { CoID, RawCoValue } from "cojson";
 import { useCallback, useEffect, useState } from "react";
 import { PageInfo } from "./types.js";
 
+const STORAGE_KEY = "jazz-inspector-paths";
+
 export function usePagePath(defaultPath?: PageInfo[]) {
-  const [path, setPath] = useState<PageInfo[]>([]);
+  const [path, setPath] = useState<PageInfo[]>(() => {
+    const stored = localStorage.getItem(STORAGE_KEY);
+    if (stored) {
+      try {
+        return JSON.parse(stored);
+      } catch (e) {
+        console.warn("Failed to parse stored path:", e);
+      }
+    }
+    return defaultPath || [];
+  });
 
   const updatePath = useCallback((newPath: PageInfo[]) => {
     setPath(newPath);
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(newPath));
   }, []);
 
   useEffect(() => {


### PR DESCRIPTION
When reloading your app, you lose your state on the inspector. This change stores your state in local storage.

closes #1957