### PR TITLE
feat: add FileStream.loadAsBase64 API

### DIFF
--- a/.changeset/olive-steaks-boil.md
+++ b/.changeset/olive-steaks-boil.md
@@ -1,0 +1,5 @@
+---
+"jazz-tools": patch
+---
+
+Add FileStream.loadAsBase64 API

--- a/packages/jazz-tools/src/react-native-core/media.tsx
+++ b/packages/jazz-tools/src/react-native-core/media.tsx
@@ -26,28 +26,8 @@ export function useProgressiveImgNative({
       if (highestRes && highestRes.res !== lastHighestRes) {
         lastHighestRes = highestRes.res;
         // use the base64 data directly
-        const chunks = highestRes.stream.getChunks();
-        if (chunks?.chunks && chunks.chunks.length > 0) {
-          // convert chunks to base64
-          const totalLength = chunks.chunks.reduce(
-            (acc, chunk) => acc + chunk.length,
-            0,
-          );
-          const combinedArray = new Uint8Array(totalLength);
-          let offset = 0;
-          chunks.chunks.forEach((chunk) => {
-            combinedArray.set(chunk, offset);
-            offset += chunk.length;
-          });
-
-          // Create data URL
-          const base64 = btoa(
-            Array.from(combinedArray, (byte) => String.fromCharCode(byte)).join(
-              "",
-            ),
-          );
-          const dataUrl = `data:${chunks.mimeType};base64,${base64}`;
-
+        const dataUrl = highestRes.stream.asBase64({ dataURL: true });
+        if (dataUrl) {
           setCurrent({
             src: dataUrl,
             res: highestRes.res,

--- a/packages/jazz-tools/src/tools/coValues/coFeed.ts
+++ b/packages/jazz-tools/src/tools/coValues/coFeed.ts
@@ -774,6 +774,44 @@ export class FileStream extends CoValueBase implements CoValue {
     });
   }
 
+  static async loadAsBase64(
+    id: ID<FileStream>,
+    options?: {
+      allowUnfinished?: boolean;
+      loadAs?: Account | AnonymousJazzAgent;
+      dataURL?: boolean;
+    },
+  ): Promise<string | undefined> {
+    const stream = await this.load(id, options);
+
+    return stream?.asBase64(options);
+  }
+
+  asBase64(options?: {
+    allowUnfinished?: boolean;
+    dataURL?: boolean;
+  }): string | undefined {
+    const chunks = this.getChunks(options);
+
+    if (!chunks) return undefined;
+
+    const output = [];
+
+    for (const chunk of chunks.chunks) {
+      for (const byte of chunk) {
+        output.push(String.fromCharCode(byte));
+      }
+    }
+
+    const base64 = btoa(output.join(""));
+
+    if (options?.dataURL) {
+      return `data:${chunks.mimeType};base64,${base64}`;
+    }
+
+    return base64;
+  }
+
   /**
    * Create a `FileStream` from a `Blob` or `File`
    *


### PR DESCRIPTION
Since base64 is commonly used to handle FileStream values in React Native I've decided to make a first-class API to load a FileStream directly in base64 encoding