### PR TITLE
Typo that could be causing some b0rked metrics

### DIFF
--- a/packages/cojson/src/PriorityBasedMessageQueue.ts
+++ b/packages/cojson/src/PriorityBasedMessageQueue.ts
@@ -76,14 +76,14 @@ class QueueMeter {
     private attrs?: Record<string, string | number>,
   ) {
     this.pullCounter = metrics
-      .getMeter("cojosn")
+      .getMeter("cojson")
       .createCounter(`${prefix}.pulled`, {
         description: "Number of messages pulled from the queue",
         valueType: ValueType.INT,
         unit: "1",
       });
     this.pushCounter = metrics
-      .getMeter("cojosn")
+      .getMeter("cojson")
       .createCounter(`${prefix}.pushed`, {
         description: "Number of messages pushed to the queue",
         valueType: ValueType.INT,


### PR DESCRIPTION
Right now the queue size isn't correct for client, it should trend to 0. I doubt a typo is the cause of this, but this fixes a typo so we at least report properly since Pino registered cojson as a module not cojosn -> https://github.com/garden-co/job-sync/blob/3673a63561e90a55eff8a564906886c851ff94ec/src/logger.ts#L31

<img width="1491" alt="Screenshot 2025-06-18 at 4 01 46 PM" src="https://github.com/user-attachments/assets/5197ae13-e6bb-4e31-90bb-b7a1a6359e53" />
