### PR TITLE
fix(ci): prevent Android emulator from hanging during e2e-tests gh workflow

### DIFF
--- a/.github/workflows/e2e-rn-test.yml
+++ b/.github/workflows/e2e-rn-test.yml
@@ -60,7 +60,8 @@ jobs:
           emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none -no-metrics
           disable-animations: true
           working-directory: ./examples/chat-rn-expo/
-          script: ./test/e2e/run.sh
+          # killall due to this issue: https://github.com/ReactiveCircus/android-emulator-runner/issues/385
+          script: ./test/e2e/run.sh && killall -INT crashpad_handler || true
 
       - name: Copy Maestro Output
         if: steps.e2e_test.outcome != 'success'


### PR DESCRIPTION
Since June 13th e2e-tests workflow hangs while shutting down the Android emulator. 

Official issue: https://github.com/ReactiveCircus/android-emulator-runner/issues/385

```diff
-          script: ./test/e2e/run.sh
+          script: ./test/e2e/run.sh && killall -INT crashpad_handler || true
```

Keeping the Android API version to 29, the current workaround is to force the shutdown of the Android emulator as suggested in https://github.com/ReactiveCircus/android-emulator-runner/issues/385#issuecomment-2492035091 and adopted by various GH Action's users.