### PR TITLE
chore: avoid running the quality GHA twice on PRs

### DIFF
--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -2,11 +2,14 @@ name: Code quality
 
 on:
   push:
+    branches: 
+      - "main"
   pull_request:
+
 
 jobs:
   quality:
-    runs-on: blacksmith-4vcpu-ubuntu-2204
+    runs-on: blacksmith-2vcpu-ubuntu-2404-arm
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
Also updates the images to ubuntu 24, and uses a less powerful one (based on arm) to save some $$ ($0.0025 per run vs  $0.008). it's not like we had any issue, but the previous runner was unnecassarily powerful. 

with the new runner:
Checked 1092 files in 316ms. No fixes applied.

old one:
Checked 1092 files in 193ms. No fixes applied.
