### PR TITLE
Post 0.15 docs fixes

### DIFF
--- a/homepage/homepage/content/docs/index.mdx
+++ b/homepage/homepage/content/docs/index.mdx
@@ -1,4 +1,4 @@
-import { CodeGroup, ContentByFramework, JazzLogo } from '@/components/forMdx'
+import { CodeGroup, ContentByFramework, JazzLogo } from "@/components/forMdx";
 
 export const metadata = {
   title: "Documentation",
@@ -12,20 +12,17 @@ Instead of wrestling with databases, APIs, and server infrastructure, you work w
 
 ---
 
-**Note:** We just released [Jazz 0.14.0](/docs/upgrade/0-14-0) with a bunch of breaking changes and are still cleaning the docs up - see the [upgrade guide](/docs/upgrade/0-14-0) for details.
-
 ## Quickstart
 
 You can use [`create-jazz-app`](/docs/tools/create-jazz-app) to create a new Jazz project from one of our starter templates or example apps:
 
 <CodeGroup>
-```sh
-npx create-jazz-app@latest --api-key you@example.com
-```
+  ```sh npx create-jazz-app@latest --api-key you@example.com ```
 </CodeGroup>
 
-{/* <ContentByFramework framework="react">
-  Or you can follow this [React step-by-step guide](/docs/react/guide) where we walk you through building an issue tracker app.
+{/\* <ContentByFramework framework="react">
+Or you can follow this [React step-by-step guide](/docs/react/guide) where we walk you through building an issue tracker app.
+
 </ContentByFramework> */}
 
 ## Why Jazz is different
@@ -33,7 +30,7 @@ npx create-jazz-app@latest --api-key you@example.com
 Most apps rebuild the same thing: shared state that syncs between users and devices. Jazz starts from that shared state, giving you:
 
 - **No backend required** — Focus on building features, not infrastructure
-- **Real-time sync** — Changes appear everywhere immediately  
+- **Real-time sync** — Changes appear everywhere immediately
 - **Multiplayer by default** — Collaboration just works
 - **Local-first** — Your app works offline and feels instant
 

--- a/homepage/homepage/content/docs/index.mdx
+++ b/homepage/homepage/content/docs/index.mdx
@@ -1,4 +1,5 @@
 import { CodeGroup, ContentByFramework, JazzLogo } from "@/components/forMdx";
+import { Alert } from "@garden-co/design-system/src/components/atoms/Alert";
 
 export const metadata = {
   title: "Documentation",
@@ -17,10 +18,14 @@ Instead of wrestling with databases, APIs, and server infrastructure, you work w
 You can use [`create-jazz-app`](/docs/tools/create-jazz-app) to create a new Jazz project from one of our starter templates or example apps:
 
 <CodeGroup>
-  ```sh npx create-jazz-app@latest --api-key you@example.com ```
+  ```sh
+    npx create-jazz-app@latest --api-key you@example.com 
+  ```
 </CodeGroup>
 
-{/\* <ContentByFramework framework="react">
+<Alert variant="info" className="mt-4 flex gap-2 items-center">Requires at least Node.js v20.</Alert>
+
+{/* <ContentByFramework framework="react">
 Or you can follow this [React step-by-step guide](/docs/react/guide) where we walk you through building an issue tracker app.
 
 </ContentByFramework> */}

--- a/homepage/homepage/content/docs/project-setup/react-native-expo.mdx
+++ b/homepage/homepage/content/docs/project-setup/react-native-expo.mdx
@@ -3,6 +3,7 @@ export const metadata = {
 };
 
 import { CodeGroup } from "@/components/forMdx";
+import { Alert } from "@garden-co/design-system/src/components/atoms/Alert";
 
 # React Native (Expo) Installation and Setup
 
@@ -49,7 +50,10 @@ npm i -S jazz-tools
 ```
 </CodeGroup>
 
-**Note**: Hermes has added support for `atob` and `btoa` in React Native 0.74. If you are using earlier versions, you may also need to polyfill `atob` and `btoa` in your `package.json`. Packages to try include: `text-encoding`, `base-64`, and you can drop `@bacons/text-decoder`.
+<Alert variant="info" className="mt-4" title="Note">
+  - Requires at least Node.js v20. 
+  - Hermes has added support for `atob` and `btoa` in React Native 0.74. If you are using earlier versions, you may also need to polyfill `atob` and `btoa` in your `package.json`. Packages to try include `text-encoding` and `base-64`, and you can drop `@bacons/text-decoder`.
+</Alert>
 
 #### Fix incompatible dependencies
 

--- a/homepage/homepage/content/docs/project-setup/react-native.mdx
+++ b/homepage/homepage/content/docs/project-setup/react-native.mdx
@@ -3,6 +3,7 @@ export const metadata = {
 };
 
 import { CodeGroup } from "@/components/forMdx";
+import { Alert } from "@garden-co/design-system/src/components/atoms/Alert";
 
 # React Native Installation and Setup
 
@@ -49,7 +50,10 @@ npm i -S jazz-tools
 ```
 </CodeGroup>
 
-**Note**: Hermes has added support for `atob` and `btoa` in React Native 0.74. If you are using earlier versions, you may also need to polyfill `atob` and `btoa` in your `package.json`. Packages to try include `text-encoding` and `base-64`, and you can drop `@bacons/text-decoder`.
+<Alert variant="info" className="mt-4" title="Note">
+  - Requires at least Node.js v20. 
+  - Hermes has added support for `atob` and `btoa` in React Native 0.74. If you are using earlier versions, you may also need to polyfill `atob` and `btoa` in your `package.json`. Packages to try include `text-encoding` and `base-64`, and you can drop `@bacons/text-decoder`.
+</Alert>
 
 ### Configure Metro
 

--- a/homepage/homepage/content/docs/project-setup/react.mdx
+++ b/homepage/homepage/content/docs/project-setup/react.mdx
@@ -3,6 +3,7 @@ export const metadata = {
 };
 
 import { CodeGroup } from "@/components/forMdx";
+import { Alert } from "@garden-co/design-system/src/components/atoms/Alert";
 
 # React Installation and Setup
 
@@ -25,6 +26,8 @@ First, install the required packages:
 pnpm install jazz-tools
 ```
 </CodeGroup>
+
+<Alert variant="info" className="mt-4 flex gap-2 items-center">Requires at least Node.js v20.</Alert>
 
 ## Write your schema
 

--- a/homepage/homepage/content/docs/project-setup/server-side.mdx
+++ b/homepage/homepage/content/docs/project-setup/server-side.mdx
@@ -3,6 +3,7 @@ export const metadata = {
 };
 
 import { CodeGroup } from "@/components/forMdx";
+import { Alert } from "@garden-co/design-system/src/components/atoms/Alert";
 
 # Node.JS / server workers
 
@@ -11,6 +12,8 @@ The main detail to understand when using Jazz server-side is that Server Workers
 This lets you share CoValues with Server Workers, having precise access control by adding the Worker to `Groups` with specific roles just like you would with other users.
 
 [See the full example here.](https://github.com/garden-co/jazz/tree/main/examples/jazz-paper-scissors)
+
+<Alert variant="info" className="mt-4 flex gap-2 items-center">Requires at least Node.js v20.</Alert>
 
 ## Generating credentials
 

--- a/homepage/homepage/content/docs/project-setup/svelte.mdx
+++ b/homepage/homepage/content/docs/project-setup/svelte.mdx
@@ -3,6 +3,7 @@ export const metadata = {
 };
 
 import { CodeGroup } from "@/components/forMdx";
+import { Alert } from "@garden-co/design-system/src/components/atoms/Alert";
 
 # Svelte Installation and Setup
 
@@ -10,7 +11,7 @@ Jazz can be used with Svelte or in a SvelteKit app.
 
 To add some Jazz to your Svelte app, you can use the following steps:
 
-1. Install Jazz dependencies
+## Install Jazz dependencies
 
 <CodeGroup>
 ```sh
@@ -18,7 +19,9 @@ pnpm install jazz-tools
 ```
 </CodeGroup>
 
-2. Write your schema
+<Alert variant="info" className="mt-4 flex gap-2 items-center">Requires at least Node.js v20.</Alert>
+
+## Write your schema
 
 See the [schema docs](/docs/schemas/covalues) for more information.
 
@@ -40,7 +43,7 @@ export class MyAccount extends Account {
 ```
 </CodeGroup>
 
-3. Set up the Provider in your root layout
+## Set up the Provider in your root layout
 
 <CodeGroup>
 ```svelte
@@ -60,7 +63,7 @@ export class MyAccount extends Account {
 ```
 </CodeGroup>
 
-4. Use Jazz hooks in your components
+## Use Jazz hooks in your components
 
 <CodeGroup>
 ```svelte

--- a/homepage/homepage/content/docs/tools/create-jazz-app.mdx
+++ b/homepage/homepage/content/docs/tools/create-jazz-app.mdx
@@ -89,5 +89,5 @@ When you run `create-jazz-app`, we'll:
 
 ## Requirements
 
-- Node.js 14.0.0 or later
+- Node.js 20.0.0 or later
 - Your preferred package manager (npm, yarn, pnpm, bun, or deno)

--- a/homepage/homepage/content/docs/upgrade/0-14-0.mdx
+++ b/homepage/homepage/content/docs/upgrade/0-14-0.mdx
@@ -1,4 +1,5 @@
 import { ContentByFramework, CodeGroup } from '@/components/forMdx'
+import { Alert } from "@garden-co/design-system/src/components/atoms/Alert";
 
 # Jazz 0.14.0 Introducing Zod-based schemas
 
@@ -220,6 +221,10 @@ const person = new CoState(Person, id);
 We have removed the Typescript AccountSchema registration.
 
 It was causing some deal of confusion to new adopters so we have decided to replace the magic inference with a more explicit approach.
+
+<Alert variant="warning" className="flex gap-2 items-center my-4">
+You still need to pass your custom AccountSchema to your provider!
+</Alert>
 
 <ContentByFramework framework={["react", "react-native", "vue", "vanilla", "react-native-expo"]}>
 <CodeGroup>


### PR DESCRIPTION
Fixes a few minor docs issues:

1. References to v0.14 being the most recent release removed
2. Adds a warning that AccountSchema still needs to be passed to the provider (this part of the upgrade guide was misunderstood by quite a few people, myself included)
3. Adds notes clarifying the requirement to use Node.js v20 in the installation guides for all frameworks and the create-jazz-app doc.