### PR TITLE
Closes GCO-581 - Create pull_request_template.md

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,24 @@
+### What this Does
+Brief summary of the change, ideally framed in user or product terms.
+
+### Why Are We Doing This?
+Link to the shaped pitch or explain what problem it solves.
+
+### Scope / Boundaries
+Includes:
+- [x] Core feature functionality
+- [x] Tests or validation steps
+
+Do NOT include:
+- [ ] Related stretch features or follow-ups
+
+### Testing Instructions
+How a reviewer or QA can verify behavior, offer step-by-step instructions if possible. Screenshots or recordings are welcome.
+
+### Known Issues / Open Questions (if any)
+- [ ] Note anything you’d like review on or decided async
+
+### Related Links
+- GitHub issue
+- Linear pitch
+- Design links or references


### PR DESCRIPTION
### What this Does
Adds a PR template to github, using the format in this PR

### Why Are We Doing This?
Adding this to ensure more consistency and details in PR's 

### Scope / Boundaries
Includes:
- [x] Adding a PR file to the hidden `.github` folder in the jazz monorepo

Do NOT include:
- [x] Does not add multiple templates or an extra directory folder within the .github file structure

### Testing 
Proof that magic words are working:
<img width="800" alt="Screenshot 2025-06-23 at 3 02 34 PM" src="https://github.com/user-attachments/assets/861de587-8788-42a2-ada7-8b8f7092de82" />



### Related Links
- [Github documentation](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/creating-a-pull-request-template-for-your-repository)
- [PR guide in Linear](https://linear.app/garden-co/document/pr-guide-c26b2188fab2)