### PR TITLE
fix: refresh the IndexedDB transaction when finished but not flagged as done

### DIFF
--- a/.changeset/thin-knives-lick.md
+++ b/.changeset/thin-knives-lick.md
@@ -1,0 +1,5 @@
+---
+"cojson-storage-indexeddb": patch
+---
+
+Refresh the IndexedDB transaction when getting "Failed to execute 'objectStore' on 'IDBTransaction': The transaction has finished"


### PR DESCRIPTION
### What this Does

A user reported getting "Failed to execute 'objectStore' on 'IDBTransaction': The transaction has finished." on their app.

I've also encountered the error when working on https://github.com/garden-co/jazz/pull/2575 and som I'm positive that this fixes the bug.

### Why Are We Doing This?

IndexedDB APIs are crap, and sometimes IDBTransaction finishes before triggering the `oncomplete` event.
As a workaround we create a new transaction on fly.

### Scope / Boundaries
Includes:
- [x] A bugfix

Do NOT include:
- [x] Automated tests, since the bug can't be easily reproduced

### Related Links

https://discord.com/channels/1139617727565271160/1139621689882321009/1387926178303578215