### PR TITLE
fix: `RNQuickCrypto` type error

### DIFF
--- a/.changeset/hungry-spiders-turn.md
+++ b/.changeset/hungry-spiders-turn.md
@@ -1,0 +1,5 @@
+---
+"jazz-tools": patch
+---
+
+Fix type error with `RNQuickCrypto` that prevented using it as a `CryptoProvider`

--- a/packages/jazz-tools/src/react-native-core/crypto/index.ts
+++ b/packages/jazz-tools/src/react-native-core/crypto/index.ts
@@ -1,1 +1,1 @@
-export { RNQuickCrypto } from "./RNQuickCrypto";
+export { RNQuickCrypto } from "./RNQuickCrypto.js";

--- a/packages/jazz-tools/src/react-native-core/crypto/index.ts
+++ b/packages/jazz-tools/src/react-native-core/crypto/index.ts
@@ -1,1 +1,1 @@
-export { RNQuickCrypto } from "./RNQuickCrypto.js";
+export { RNQuickCrypto } from "./RNQuickCrypto";

--- a/packages/jazz-tools/src/react-native-core/platform.ts
+++ b/packages/jazz-tools/src/react-native-core/platform.ts
@@ -27,7 +27,7 @@ import { SQLiteReactNative } from "./storage/sqlite-react-native.js";
 
 import { SQLiteDatabaseDriverAsync } from "cojson-storage";
 import { WebSocketPeerWithReconnection } from "cojson-transport-ws";
-import type { RNQuickCrypto } from "./crypto/RNQuickCrypto.js";
+import type { RNQuickCrypto } from "./crypto/RNQuickCrypto";
 
 export type BaseReactNativeContextOptions = {
   sync: SyncConfig;

--- a/packages/jazz-tools/src/react-native-core/platform.ts
+++ b/packages/jazz-tools/src/react-native-core/platform.ts
@@ -27,7 +27,7 @@ import { SQLiteReactNative } from "./storage/sqlite-react-native.js";
 
 import { SQLiteDatabaseDriverAsync } from "cojson-storage";
 import { WebSocketPeerWithReconnection } from "cojson-transport-ws";
-import type { RNQuickCrypto } from "./crypto/RNQuickCrypto";
+import type { RNQuickCrypto } from "jazz-tools/react-native-core/crypto";
 
 export type BaseReactNativeContextOptions = {
   sync: SyncConfig;


### PR DESCRIPTION
### Why Are We Doing This?

While working on https://github.com/garden-co/jazz/issues/2576, I tried adding a `CryptoProvider` to the `chat-rn-expo` example following [the docs](https://jazz.tools/docs/react-native-expo/project-setup/providers#quick-crypto), but ran into the following type error:
![image](https://github.com/user-attachments/assets/4fff8ed3-7e51-4c05-b159-bc504282dacd)

Replacing the relative `.js` import with an absolute import solves the type error.

### Testing Instructions
Confirmed it's now possible to add `RNQuickCrypto` as a `CrytoProvider` in `JazzExpoProvider` following [the docs](https://jazz.tools/docs/react-native-expo/project-setup/providers#quick-crypto):
- check out https://github.com/garden-co/jazz/tree/fix-RNQuickCrypto-type-error-TEST
- run `pnpm check` in `example/chat-rn-expo` and notice the type error
- run `pnpm build` in `package/jazz-tools`
- run `pnpm check` in `example/chat-rn-expo` again and notice the type error is gone ✨ 

I also manually tested the `chat-rn-expo` example with the `RNQuickCrypto` provider to confirm it works correctly with this change.