### PR TITLE
fix: make `react-native-nitro-modules` and `react-native-quick-crypto` optional peer dependencies

### DIFF
--- a/packages/jazz-tools/package.json
+++ b/packages/jazz-tools/package.json
@@ -165,7 +165,6 @@
     "prosemirror-transform": "^1.9.0",
     "react-native-fast-encoder": "^0.2.0",
     "react-native-mmkv": "^3.2.0",
-    "react-native-quick-crypto": "1.0.0-beta.16",
     "zod": "3.25.28"
   },
   "scripts": {
@@ -202,6 +201,7 @@
     "react-dom": "*",
     "react-native": "*",
     "react-native-nitro-modules": "0.25.2",
+    "react-native-quick-crypto": "1.0.0-beta.16",
     "svelte": "^5.0.0"
   },
   "peerDependenciesMeta": {
@@ -227,6 +227,9 @@
       "optional": true
     },
     "react-native-nitro-modules": {
+      "optional": true
+    },
+    "react-native-quick-crypto": {
       "optional": true
     },
     "svelte": {

--- a/packages/jazz-tools/package.json
+++ b/packages/jazz-tools/package.json
@@ -165,7 +165,6 @@
     "prosemirror-transform": "^1.9.0",
     "react-native-fast-encoder": "^0.2.0",
     "react-native-mmkv": "^3.2.0",
-    "react-native-nitro-modules": "0.25.2",
     "react-native-quick-crypto": "1.0.0-beta.16",
     "zod": "3.25.28"
   },
@@ -202,6 +201,7 @@
     "react": "*",
     "react-dom": "*",
     "react-native": "*",
+    "react-native-nitro-modules": "0.25.2",
     "svelte": "^5.0.0"
   },
   "peerDependenciesMeta": {
@@ -224,6 +224,9 @@
       "optional": true
     },
     "react-native": {
+      "optional": true
+    },
+    "react-native-nitro-modules": {
       "optional": true
     },
     "svelte": {


### PR DESCRIPTION
### What this Does
Converts `react-native-nitro-modules` and `react-native-quick-crypto` into optional peer dependencies, since these dependencies are already required to be installed in the host project in order to use Quick Crypto ([see docs](https://jazz.tools/docs/react-native-expo/project-setup/providers#quick-crypto)).

### Why Are We Doing This?
A user reported issues when using jazz-tools in a [onestack](https://onestack.dev/) project that didn't require this feature.

### Testing Instructions
I added `RNQuickCrypto` as a `CrytoProvider` to the `chat-rn-expo` example to confirm everything works as expected when the host project includes `react-native-nitro-modules` and `react-native-quick-crypto` as dependencies.

When the dependencies are not present, the following error is thrown:
```
ERROR  Error: Failed to get NitroModules: The native "NitroModules" Turbo/Native-Module could not be found.
* Make sure react-native-nitro-modules/NitroModules is correctly autolinked (run `npx react-native config` to verify)
* Make sure you enabled the new architecture (TurboModules) and CodeGen properly generated the "NativeNitroModules"/NitroModules specs. See https://github.com/reactwg/react-native-new-architecture/blob/main/docs/enable-apps.md
* Make sure you are using react-native 0.75.0 or higher.
* Make sure you rebuilt the app.
* Make sure you ran `expo prebuild`.
* Make sure you ran `pod install` in the ios/ directory., js engine: hermes
```

### Open Questions
- [ ] Should we provide a clearer error message when a user tries to use `RNQuickCrypto` but the required deps have not been included? Or is the one that's currently being shown good enough?
- [ ] @gdorsi suggested making other RN dependencies like `op-sqlite` and `expo-sqlite` (https://github.com/garden-co/jazz/issues/2576#issuecomment-3007660502) peer dependencies as well. The difference with these dependencies is that they are used by default on all expo apps, and we don't require host projects to install them (see [Expo project setup docs](https://jazz.tools/docs/react-native-expo/project-setup)). Should we change our policy here and require them to? In any case, I think we could address this in a follow-up PR.

### Related Links
- GitHub issue: https://github.com/garden-co/jazz/issues/2576
