### PR TITLE
feat: allow to get only the direct members of a group

### DIFF
--- a/.changeset/fresh-tips-provide.md
+++ b/.changeset/fresh-tips-provide.md
@@ -1,0 +1,5 @@
+---
+"jazz-tools": patch
+---
+
+add Group.getDirectMembers to get only direct members of a group

--- a/packages/jazz-tools/src/tools/coValues/group.ts
+++ b/packages/jazz-tools/src/tools/coValues/group.ts
@@ -186,6 +186,7 @@ export class Group extends CoValueBase implements CoValue {
     accountIDs: Iterable<RawAccountID | AgentID>,
   ): Array<{
     id: string;
+    role: AccountRole;
     ref: Ref<Account>;
     account: Account;
   }> {

--- a/packages/jazz-tools/src/tools/tests/groupsAndAccounts.test.ts
+++ b/packages/jazz-tools/src/tools/tests/groupsAndAccounts.test.ts
@@ -651,7 +651,7 @@ describe("Group.members", () => {
   });
 });
 
-describe("Group.directMembers", () => {
+describe("Group.getDirectMembers", () => {
   test("should return only the direct members of the group", async () => {
     const parentGroup = Group.create();
     const childGroup = Group.create();
@@ -680,7 +680,7 @@ describe("Group.directMembers", () => {
     ]);
 
     // directMembers should only show the admin, not the inherited bob
-    expect(childGroup.directMembers).toEqual([
+    expect(childGroup.getDirectMembers()).toEqual([
       expect.objectContaining({
         account: expect.objectContaining({
           id: co.account().getMe().id,
@@ -689,7 +689,7 @@ describe("Group.directMembers", () => {
     ]);
 
     // Explicitly verify bob is not in directMembers
-    expect(childGroup.directMembers).not.toContainEqual(
+    expect(childGroup.getDirectMembers()).not.toContainEqual(
       expect.objectContaining({
         account: expect.objectContaining({
           id: bob.id,
@@ -698,7 +698,7 @@ describe("Group.directMembers", () => {
     );
 
     // Parent group's direct members should include both admin and bob
-    expect(parentGroup.directMembers).toEqual([
+    expect(parentGroup.getDirectMembers()).toEqual([
       expect.objectContaining({
         account: expect.objectContaining({
           id: co.account().getMe().id,

--- a/packages/jazz-tools/src/tools/tests/groupsAndAccounts.test.ts
+++ b/packages/jazz-tools/src/tools/tests/groupsAndAccounts.test.ts
@@ -650,3 +650,43 @@ describe("Group.members", () => {
     ]);
   });
 });
+
+describe("Group.directMembers", () => {
+  test("should return only the direct members of the group", async () => {
+    const groupWithBob = Group.create();
+
+    const bob = await createJazzTestAccount({});
+    await bob.waitForAllCoValuesSync();
+
+    groupWithBob.addMember(bob, "reader");
+
+    const childGroup = Group.create();
+    groupWithBob.addMember(childGroup, "reader");
+
+    expect(childGroup.directMembers).not.toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          account: expect.objectContaining({
+            id: bob.id,
+          }),
+          role: "reader",
+        }),
+      ]),
+    );
+
+    expect(groupWithBob.directMembers).toEqual([
+      expect.objectContaining({
+        account: expect.objectContaining({
+          id: co.account().getMe().id,
+        }),
+        role: "admin",
+      }),
+      expect.objectContaining({
+        account: expect.objectContaining({
+          id: bob.id,
+        }),
+        role: "reader",
+      }),
+    ]);
+  });
+});


### PR DESCRIPTION
### What this Does
Adds a `getDirectMembers` to groups to returns only the direct members of a given group.

### Why Are We Doing This?
N/A
### Scope / Boundaries
Includes:
- [x] Core feature functionality
- [x] Tests or validation steps

### Testing Instructions
The test should be self descriptive
