### PR TITLE
Error: Loading PostCSS Plugin failed: Cannot find module '@tailwindcss/postcss'

### DIFF
--- a/starters/svelte-passkey-auth/package.json
+++ b/starters/svelte-passkey-auth/package.json
@@ -33,6 +33,7 @@
     "svelte": "^5.33.19",
     "svelte-check": "^4.0.0",
     "tailwindcss": "^4.1.10",
+    "@tailwindcss/postcss": "^4.1.11",
     "typescript": "5.6.2",
     "typescript-eslint": "^8.0.0",
     "vite": "^6.3.5"


### PR DESCRIPTION
### What this Does

I created an example app using npm. When I ran it via `npm run dev`, I got this error:

```
Error: Loading PostCSS Plugin failed: Cannot find module '@tailwindcss/postcss'
```

This change switches the svelte starter to using '@tailwindcss/postcss' as a dependency instead of 'postcss'. Once this change is made, the example works correctly.

### Scope / Boundaries
Includes:
- [x] Core feature functionality
- [ ] Tests or validation steps

Do NOT include:
- [x ] Related stretch features or follow-ups

### Testing Instructions

Follow the instructions at https://jazz.tools/examples for svelte:

1. `npx create-jazz-app@latest --starter svelte-passkey-auth`
2. choose npm as the package manager
3. run npm run dev


