### PR TITLE
User age calc fix

### DIFF
--- a/starters/svelte-passkey-auth/src/lib/schema.ts
+++ b/starters/svelte-passkey-auth/src/lib/schema.ts
@@ -31,9 +31,12 @@ export function getUserAge(root: co.loaded<typeof AccountRoot> | undefined) {
 
   let age = today.getFullYear() - birthDate.getFullYear();
 
-  // Check if the birthday has not occurred yet this year
-  const monthDiff = today.getMonth() - birthDate.getMonth();
-  if (monthDiff < 0 || (monthDiff === 0 && today.getDate() < birthDate.getDate())) {
+  // Check if the birthday hasn't occurred yet this year
+  const hasBirthdayPassed =
+    today.getMonth() > birthDate.getMonth() ||
+    (today.getMonth() === birthDate.getMonth() && today.getDate() > birthDate.getDate());
+
+  if (!hasBirthdayPassed) {
     age--;
   }
 

--- a/starters/svelte-passkey-auth/src/lib/schema.ts
+++ b/starters/svelte-passkey-auth/src/lib/schema.ts
@@ -25,7 +25,19 @@ export const AccountRoot = co.map({
 
 export function getUserAge(root: co.loaded<typeof AccountRoot> | undefined) {
   if (!root) return null;
-  return new Date().getFullYear() - root.dateOfBirth.getFullYear();
+
+  const today = new Date();
+  const birthDate = root.dateOfBirth;
+
+  let age = today.getFullYear() - birthDate.getFullYear();
+
+  // Check if the birthday has not occurred yet this year
+  const monthDiff = today.getMonth() - birthDate.getMonth();
+  if (monthDiff < 0 || (monthDiff === 0 && today.getDate() < birthDate.getDate())) {
+    age--;
+  }
+
+  return age;
 }
 
 export const JazzAccount = co


### PR DESCRIPTION
### What this Does

In the svelte example, the function getUserAge calculates the user's age by only comparing years, meaning the answer will be wrong for most of the year for people born late in the year. This new implementation should be more accurate.

### Scope / Boundaries
Includes:
- [x] Core feature functionality

### Testing Instructions

Create a svelte app, then enter your birthday as Dec 31, 1995. The app will say you are 30 years old when in fact you would sitll be 29.