### PR TITLE
fix: fixes InvalidSignature errors that could happen during streaming

### DIFF
--- a/packages/cojson/src/storage/storageAsync.ts
+++ b/packages/cojson/src/storage/storageAsync.ts
@@ -298,6 +298,10 @@ export class StorageApiAsync implements StorageAPI {
 
     const actuallyNewTransactions = newTransactions.slice(actuallyNewOffset);
 
+    if (actuallyNewTransactions.length === 0) {
+      return sessionRow?.lastIdx || 0;
+    }
+
     let newBytesSinceLastSignature =
       (sessionRow?.bytesSinceLastSignature || 0) +
       actuallyNewTransactions.reduce(

--- a/packages/cojson/src/storage/storageSync.ts
+++ b/packages/cojson/src/storage/storageSync.ts
@@ -279,6 +279,10 @@ export class StorageApiSync implements StorageAPI {
 
     const actuallyNewTransactions = newTransactions.slice(actuallyNewOffset);
 
+    if (actuallyNewTransactions.length === 0) {
+      return sessionRow?.lastIdx || 0;
+    }
+
     let newBytesSinceLastSignature =
       (sessionRow?.bytesSinceLastSignature || 0) +
       actuallyNewTransactions.reduce(

--- a/packages/cojson/src/storage/syncUtils.ts
+++ b/packages/cojson/src/storage/syncUtils.ts
@@ -23,17 +23,17 @@ export function collectNewTxs({
   if (!sessionEntry) {
     sessionEntry = {
       after: firstNewTxIdx,
-      lastSignature: "WILL_BE_REPLACED" as Signature,
+      lastSignature: signature,
       newTransactions: [],
     };
     contentMessage.new[sessionRow.sessionID] = sessionEntry;
+  } else {
+    sessionEntry.lastSignature = signature;
   }
 
   for (const tx of newTxsInSession) {
     sessionEntry.newTransactions.push(tx.tx);
   }
-
-  sessionEntry.lastSignature = signature;
 }
 
 export function getDependedOnCoValues(


### PR DESCRIPTION
# Description

Found that when stale content is reiceved on storage we still update the lastSignature, leading to overriding the valid lastSignature with one that is referred to an old transaction.

## Manual testing instructions

Reproduced the InvalidSignature bug using `tests/stress-test` app, restarting the sync server while having a page with 10k tasks open.

In practice, we may still send non-required content when both the client and the sync-server are loading a coValue in streaming.

This can cause one of the two nodes to send some content blocks, which leads to updating the lastSignature with one of the chunk signatures.

In production this bug can be reproduced in a similar way.

## Tests

- [x] Tests have been added and/or updated
- [ ] Tests have not been updated, because: <!-- Insert reason for not updating tests here -->
- [ ] I need help with writing tests


## Checklist

- [x] I've updated the part of the docs that are affected the PR changes
- [x] I've generated a changeset, if a version bump is required
- [x] I've updated the jsDoc comments to the public APIs I've modified, or added them when missing