### PR TITLE
fix: fake pull all items in queue when shutting down a peer

### DIFF
--- a/packages/cojson/src/PeerState.ts
+++ b/packages/cojson/src/PeerState.ts
@@ -207,6 +207,7 @@ export class PeerState {
     this.peer.crashOnClose = false;
     this.peer.outgoing.close();
     this.closed = true;
+    this.queue.clearMetrics();
     this.emitClose();
   }
 

--- a/packages/cojson/src/PriorityBasedMessageQueue.ts
+++ b/packages/cojson/src/PriorityBasedMessageQueue.ts
@@ -112,7 +112,7 @@ class QueueMeter {
   }
 
   public clear(items: number) {
-    this.pullCounter.add(-items, this.attrs);
+    this.pullCounter.add(items, this.attrs);
   }
 }
 

--- a/packages/cojson/src/PriorityBasedMessageQueue.ts
+++ b/packages/cojson/src/PriorityBasedMessageQueue.ts
@@ -65,6 +65,10 @@ export class LinkedList<T> {
     this.meter?.pull();
     return value;
   }
+
+  clearMetrics() {
+    this.meter?.clear(this.length);
+  }
 }
 
 class QueueMeter {
@@ -105,6 +109,10 @@ class QueueMeter {
 
   public push() {
     this.pushCounter.add(1, this.attrs);
+  }
+
+  public clear(items: number) {
+    this.pullCounter.add(-items, this.attrs);
   }
 }
 
@@ -150,5 +158,9 @@ export class PriorityBasedMessageQueue {
     const priority = this.queues.findIndex((queue) => queue.length > 0);
 
     return this.queues[priority]?.shift();
+  }
+
+  public clearMetrics() {
+    this.queues.forEach((queue) => queue.clearMetrics());
   }
 }

--- a/packages/cojson/src/tests/PriorityBasedMessageQueue.test.ts
+++ b/packages/cojson/src/tests/PriorityBasedMessageQueue.test.ts
@@ -19,6 +19,38 @@ describe("PriorityBasedMessageQueue", () => {
   });
 
   describe("meteredQueue", () => {
+    test("should corretly clear metrics", async () => {
+      const { queue, metricReader } = setup();
+      const message: SyncMessage = {
+        action: "load",
+        id: "co_ztest-id",
+        header: false,
+        sessions: {},
+      };
+
+      expect(
+        await metricReader.getMetricValue("jazz.messagequeue.pushed", {
+          priority: CO_VALUE_PRIORITY.MEDIUM,
+        }),
+      ).toBe(0);
+
+      void queue.push(message);
+      void queue.push(message);
+      void queue.push(message);
+      expect(
+        await metricReader.getMetricValue("jazz.messagequeue.pushed", {
+          priority: CO_VALUE_PRIORITY.MEDIUM,
+        }),
+      ).toBe(3);
+
+      queue.clearMetrics();
+      expect(
+        await metricReader.getMetricValue("jazz.messagequeue.pulled", {
+          priority: CO_VALUE_PRIORITY.MEDIUM,
+        }),
+      ).toBe(0);
+    });
+
     test("should corretly count pushes", async () => {
       const { queue, metricReader } = setup();
       const message: SyncMessage = {

--- a/packages/cojson/src/tests/PriorityBasedMessageQueue.test.ts
+++ b/packages/cojson/src/tests/PriorityBasedMessageQueue.test.ts
@@ -48,7 +48,11 @@ describe("PriorityBasedMessageQueue", () => {
         await metricReader.getMetricValue("jazz.messagequeue.pulled", {
           priority: CO_VALUE_PRIORITY.MEDIUM,
         }),
-      ).toBe(0);
+      ).toBe(
+        await metricReader.getMetricValue("jazz.messagequeue.pushed", {
+          priority: CO_VALUE_PRIORITY.MEDIUM,
+        }),
+      );
     });
 
     test("should corretly count pushes", async () => {


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed -->
<!-- Please also include relevant motivation and context -->
<!-- Include any links to documentation like RFC’s if necessary -->
<!-- Add a link to to relevant preview environments or anything that would simplify visual review process -->
<!-- Supplemental screenshots and video are encouraged, but the primary description should be in text -->

## Manual testing instructions

<!-- Add any actions required to manually test the changes -->

## Tests

- [ ] Tests have been added and/or updated
- [ ] Tests have not been updated, because: <!-- Insert reason for not updating tests here -->
- [ ] I need help with writing tests


## Checklist

- [ ] I've updated the part of the docs that are affected the PR changes
- [ ] I've generated a changeset, if a version bump is required
- [ ] I've updated the jsDoc comments to the public APIs I've modified, or added them when missing