### PR TITLE
feat: add load & subscribe to Discriminated union schemas

### DIFF
--- a/packages/jazz-tools/src/tools/coValues/schemaUnion.ts
+++ b/packages/jazz-tools/src/tools/coValues/schemaUnion.ts
@@ -11,9 +11,9 @@ import {
   Resolved,
   SubscribeListenerOptions,
   SubscribeRestArgs,
-  subscribeToCoValueWithoutMe,
   loadCoValueWithoutMe,
   parseSubscribeRestArgs,
+  subscribeToCoValueWithoutMe,
 } from "../internal.js";
 
 /**

--- a/packages/jazz-tools/src/tools/coValues/schemaUnion.ts
+++ b/packages/jazz-tools/src/tools/coValues/schemaUnion.ts
@@ -114,17 +114,18 @@ export abstract class SchemaUnion extends CoValueBase implements CoValue {
   /**
    * Load a `SchemaUnion` with a given ID, as a given account.
    *
+   * Note: The `resolve` option is not supported for `SchemaUnion`s due to https://github.com/garden-co/jazz/issues/2639
+   *
    * @category Subscription & Loading
    */
-  static load<M extends SchemaUnion, const R extends RefsToResolve<M> = true>(
+  static load<M extends SchemaUnion>(
     this: CoValueClass<M>,
     id: ID<M>,
     options?: {
-      resolve?: RefsToResolveStrict<M, R>;
       loadAs?: Account | AnonymousJazzAgent;
       skipRetry?: boolean;
     },
-  ): Promise<Resolved<M, R> | null> {
+  ): Promise<Resolved<M, true> | null> {
     return loadCoValueWithoutMe(this, id, options);
   }
 
@@ -137,31 +138,27 @@ export abstract class SchemaUnion extends CoValueBase implements CoValue {
    *
    * Also see the `useCoState` hook to reactively subscribe to a CoValue in a React component.
    *
+   * Note: The `resolve` option is not supported for `SchemaUnion`s due to https://github.com/garden-co/jazz/issues/2639
+   *
    * @category Subscription & Loading
    */
-  static subscribe<
-    M extends SchemaUnion,
-    const R extends RefsToResolve<M> = true,
-  >(
+  static subscribe<M extends SchemaUnion>(
     this: CoValueClass<M>,
     id: ID<M>,
-    listener: (value: Resolved<M, R>, unsubscribe: () => void) => void,
+    listener: (value: Resolved<M, true>, unsubscribe: () => void) => void,
   ): () => void;
-  static subscribe<
-    M extends SchemaUnion,
-    const R extends RefsToResolve<M> = true,
-  >(
+  static subscribe<M extends SchemaUnion>(
     this: CoValueClass<M>,
     id: ID<M>,
-    options: SubscribeListenerOptions<M, R>,
-    listener: (value: Resolved<M, R>, unsubscribe: () => void) => void,
+    options: SubscribeListenerOptions<M, true>,
+    listener: (value: Resolved<M, true>, unsubscribe: () => void) => void,
   ): () => void;
-  static subscribe<M extends SchemaUnion, const R extends RefsToResolve<M>>(
+  static subscribe<M extends SchemaUnion>(
     this: CoValueClass<M>,
     id: ID<M>,
-    ...args: SubscribeRestArgs<M, R>
+    ...args: SubscribeRestArgs<M, true>
   ): () => void {
     const { options, listener } = parseSubscribeRestArgs(args);
-    return subscribeToCoValueWithoutMe<M, R>(this, id, options, listener);
+    return subscribeToCoValueWithoutMe<M, true>(this, id, options, listener);
   }
 }

--- a/packages/jazz-tools/src/tools/coValues/schemaUnion.ts
+++ b/packages/jazz-tools/src/tools/coValues/schemaUnion.ts
@@ -9,7 +9,11 @@ import {
   RefsToResolve,
   RefsToResolveStrict,
   Resolved,
+  SubscribeListenerOptions,
+  SubscribeRestArgs,
+  subscribeToCoValueWithoutMe,
   loadCoValueWithoutMe,
+  parseSubscribeRestArgs,
 } from "../internal.js";
 
 /**
@@ -122,5 +126,42 @@ export abstract class SchemaUnion extends CoValueBase implements CoValue {
     },
   ): Promise<Resolved<M, R> | null> {
     return loadCoValueWithoutMe(this, id, options);
+  }
+
+  /**
+   * Load and subscribe to a `CoMap` with a given ID, as a given account.
+   *
+   * Automatically also subscribes to updates to all referenced/nested CoValues as soon as they are accessed in the listener.
+   *
+   * Returns an unsubscribe function that you should call when you no longer need updates.
+   *
+   * Also see the `useCoState` hook to reactively subscribe to a CoValue in a React component.
+   *
+   * @category Subscription & Loading
+   */
+  static subscribe<
+    M extends SchemaUnion,
+    const R extends RefsToResolve<M> = true,
+  >(
+    this: CoValueClass<M>,
+    id: ID<M>,
+    listener: (value: Resolved<M, R>, unsubscribe: () => void) => void,
+  ): () => void;
+  static subscribe<
+    M extends SchemaUnion,
+    const R extends RefsToResolve<M> = true,
+  >(
+    this: CoValueClass<M>,
+    id: ID<M>,
+    options: SubscribeListenerOptions<M, R>,
+    listener: (value: Resolved<M, R>, unsubscribe: () => void) => void,
+  ): () => void;
+  static subscribe<M extends SchemaUnion, const R extends RefsToResolve<M>>(
+    this: CoValueClass<M>,
+    id: ID<M>,
+    ...args: SubscribeRestArgs<M, R>
+  ): () => void {
+    const { options, listener } = parseSubscribeRestArgs(args);
+    return subscribeToCoValueWithoutMe<M, R>(this, id, options, listener);
   }
 }

--- a/packages/jazz-tools/src/tools/coValues/schemaUnion.ts
+++ b/packages/jazz-tools/src/tools/coValues/schemaUnion.ts
@@ -1,8 +1,15 @@
 import {
+  Account,
+  AnonymousJazzAgent,
   CoValue,
   CoValueBase,
   CoValueClass,
   CoValueFromRaw,
+  ID,
+  RefsToResolve,
+  RefsToResolveStrict,
+  Resolved,
+  loadCoValueWithoutMe,
 } from "../internal.js";
 
 /**
@@ -98,5 +105,22 @@ export abstract class SchemaUnion extends CoValueBase implements CoValue {
   // @ts-ignore
   static fromRaw<V extends CoValue>(this: CoValueClass<V>, raw: V["_raw"]): V {
     throw new Error("Not implemented");
+  }
+
+  /**
+   * Load a `SchemaUnion` with a given ID, as a given account.
+   *
+   * @category Subscription & Loading
+   */
+  static load<M extends SchemaUnion, const R extends RefsToResolve<M> = true>(
+    this: CoValueClass<M>,
+    id: ID<M>,
+    options?: {
+      resolve?: RefsToResolveStrict<M, R>;
+      loadAs?: Account | AnonymousJazzAgent;
+      skipRetry?: boolean;
+    },
+  ): Promise<Resolved<M, R> | null> {
+    return loadCoValueWithoutMe(this, id, options);
   }
 }

--- a/packages/jazz-tools/src/tools/implementation/zodSchema/schemaTypes/CoDiscriminatedUnionSchema.ts
+++ b/packages/jazz-tools/src/tools/implementation/zodSchema/schemaTypes/CoDiscriminatedUnionSchema.ts
@@ -7,6 +7,7 @@ import {
   RefsToResolveStrict,
   Resolved,
   SchemaUnion,
+  SubscribeListenerOptions,
 } from "../../../internal.js";
 import { z } from "../zodReExport.js";
 
@@ -30,22 +31,42 @@ export type CoDiscriminatedUnionSchema<
 > = AnyCoDiscriminatedUnionSchema<Types> & {
   load<
     const R extends RefsToResolve<
-      CoDiscriminatedUnionInstanceCoValuesNullable<Types>
+      CoDiscriminatedUnionInstanceCoValuesNullable<Types> & SchemaUnion
     > = true,
   >(
     id: string,
     options?: {
       resolve?: RefsToResolveStrict<
-        CoDiscriminatedUnionInstanceCoValuesNullable<Types>,
+        CoDiscriminatedUnionInstanceCoValuesNullable<Types> & SchemaUnion,
         R
       >;
       loadAs?: Account | AnonymousJazzAgent;
       skipRetry?: boolean;
     },
   ): Promise<Resolved<
-    CoDiscriminatedUnionInstanceCoValuesNullable<Types>,
+    CoDiscriminatedUnionInstanceCoValuesNullable<Types> & SchemaUnion,
     R
   > | null>;
+
+  subscribe<
+    const R extends RefsToResolve<
+      CoDiscriminatedUnionInstanceCoValuesNullable<Types> & SchemaUnion
+    > = true,
+  >(
+    id: string,
+    options: SubscribeListenerOptions<
+      CoDiscriminatedUnionInstanceCoValuesNullable<Types> & SchemaUnion,
+      R
+    >,
+    listener: (
+      value: Resolved<
+        CoDiscriminatedUnionInstanceCoValuesNullable<Types> & SchemaUnion,
+        R
+      >,
+      unsubscribe: () => void,
+    ) => void,
+  ): () => void;
+
   getCoValueClass: () => typeof SchemaUnion;
 };
 
@@ -60,8 +81,12 @@ export function enrichCoDiscriminatedUnionSchema<
 ): CoDiscriminatedUnionSchema<Types> {
   return Object.assign(schema, {
     load: (...args: [any, ...any]) => {
-      // @ts-expect-error TODO check
+      // @ts-expect-error
       return coValueClass.load(...args);
+    },
+    subscribe: (...args: [any, ...any[]]) => {
+      // @ts-expect-error
+      return coValueClass.subscribe(...args);
     },
     getCoValueClass: () => {
       return coValueClass;

--- a/packages/jazz-tools/src/tools/implementation/zodSchema/schemaTypes/CoDiscriminatedUnionSchema.ts
+++ b/packages/jazz-tools/src/tools/implementation/zodSchema/schemaTypes/CoDiscriminatedUnionSchema.ts
@@ -29,39 +29,27 @@ export type CoDiscriminatedUnionSchema<
     ...AnyDiscriminableCoSchema[],
   ],
 > = AnyCoDiscriminatedUnionSchema<Types> & {
-  load<
-    const R extends RefsToResolve<
-      CoDiscriminatedUnionInstanceCoValuesNullable<Types> & SchemaUnion
-    > = true,
-  >(
+  load(
     id: string,
     options?: {
-      resolve?: RefsToResolveStrict<
-        CoDiscriminatedUnionInstanceCoValuesNullable<Types> & SchemaUnion,
-        R
-      >;
       loadAs?: Account | AnonymousJazzAgent;
       skipRetry?: boolean;
     },
   ): Promise<Resolved<
     CoDiscriminatedUnionInstanceCoValuesNullable<Types> & SchemaUnion,
-    R
+    true
   > | null>;
 
-  subscribe<
-    const R extends RefsToResolve<
-      CoDiscriminatedUnionInstanceCoValuesNullable<Types> & SchemaUnion
-    > = true,
-  >(
+  subscribe(
     id: string,
     options: SubscribeListenerOptions<
       CoDiscriminatedUnionInstanceCoValuesNullable<Types> & SchemaUnion,
-      R
+      true
     >,
     listener: (
       value: Resolved<
         CoDiscriminatedUnionInstanceCoValuesNullable<Types> & SchemaUnion,
-        R
+        true
       >,
       unsubscribe: () => void,
     ) => void,

--- a/packages/jazz-tools/src/tools/implementation/zodSchema/schemaTypes/CoDiscriminatedUnionSchema.ts
+++ b/packages/jazz-tools/src/tools/implementation/zodSchema/schemaTypes/CoDiscriminatedUnionSchema.ts
@@ -1,6 +1,7 @@
 import {
   Account,
   AnonymousJazzAgent,
+  AnyCoSchema,
   InstanceOrPrimitiveOfSchemaCoValuesNullable,
   RefsToResolve,
   RefsToResolveStrict,
@@ -9,10 +10,13 @@ import {
 } from "../../../internal.js";
 import { z } from "../zodReExport.js";
 
+export type AnyDiscriminableCoSchema = AnyCoSchema &
+  z.core.$ZodTypeDiscriminable;
+
 export type AnyCoDiscriminatedUnionSchema<
   Types extends readonly [
-    z.core.$ZodTypeDiscriminable,
-    ...z.core.$ZodTypeDiscriminable[],
+    AnyDiscriminableCoSchema,
+    ...AnyDiscriminableCoSchema[],
   ],
 > = z.ZodDiscriminatedUnion<Types> & {
   collaborative: true;
@@ -20,8 +24,8 @@ export type AnyCoDiscriminatedUnionSchema<
 
 export type CoDiscriminatedUnionSchema<
   Types extends readonly [
-    z.core.$ZodTypeDiscriminable,
-    ...z.core.$ZodTypeDiscriminable[],
+    AnyDiscriminableCoSchema,
+    ...AnyDiscriminableCoSchema[],
   ],
 > = AnyCoDiscriminatedUnionSchema<Types> & {
   load<
@@ -47,8 +51,8 @@ export type CoDiscriminatedUnionSchema<
 
 export function enrichCoDiscriminatedUnionSchema<
   Types extends readonly [
-    z.core.$ZodTypeDiscriminable,
-    ...z.core.$ZodTypeDiscriminable[],
+    AnyDiscriminableCoSchema,
+    ...AnyDiscriminableCoSchema[],
   ],
 >(
   schema: z.ZodDiscriminatedUnion<Types>,
@@ -67,7 +71,7 @@ export function enrichCoDiscriminatedUnionSchema<
 
 type CoDiscriminatedUnionInstanceCoValuesNullable<
   Types extends readonly [
-    z.core.$ZodTypeDiscriminable,
-    ...z.core.$ZodTypeDiscriminable[],
+    AnyDiscriminableCoSchema,
+    ...AnyDiscriminableCoSchema[],
   ],
 > = NonNullable<InstanceOrPrimitiveOfSchemaCoValuesNullable<Types[number]>>;

--- a/packages/jazz-tools/src/tools/implementation/zodSchema/schemaTypes/CoDiscriminatedUnionSchema.ts
+++ b/packages/jazz-tools/src/tools/implementation/zodSchema/schemaTypes/CoDiscriminatedUnionSchema.ts
@@ -1,4 +1,12 @@
-import { SchemaUnion } from "../../../internal.js";
+import {
+  Account,
+  AnonymousJazzAgent,
+  InstanceOrPrimitiveOfSchemaCoValuesNullable,
+  RefsToResolve,
+  RefsToResolveStrict,
+  Resolved,
+  SchemaUnion,
+} from "../../../internal.js";
 import { z } from "../zodReExport.js";
 
 export type AnyCoDiscriminatedUnionSchema<
@@ -16,6 +24,24 @@ export type CoDiscriminatedUnionSchema<
     ...z.core.$ZodTypeDiscriminable[],
   ],
 > = AnyCoDiscriminatedUnionSchema<Types> & {
+  load<
+    const R extends RefsToResolve<
+      CoDiscriminatedUnionInstanceCoValuesNullable<Types>
+    > = true,
+  >(
+    id: string,
+    options?: {
+      resolve?: RefsToResolveStrict<
+        CoDiscriminatedUnionInstanceCoValuesNullable<Types>,
+        R
+      >;
+      loadAs?: Account | AnonymousJazzAgent;
+      skipRetry?: boolean;
+    },
+  ): Promise<Resolved<
+    CoDiscriminatedUnionInstanceCoValuesNullable<Types>,
+    R
+  > | null>;
   getCoValueClass: () => typeof SchemaUnion;
 };
 
@@ -29,8 +55,19 @@ export function enrichCoDiscriminatedUnionSchema<
   coValueClass: typeof SchemaUnion,
 ): CoDiscriminatedUnionSchema<Types> {
   return Object.assign(schema, {
+    load: (...args: [any, ...any]) => {
+      // @ts-expect-error TODO check
+      return coValueClass.load(...args);
+    },
     getCoValueClass: () => {
       return coValueClass;
     },
   }) as unknown as CoDiscriminatedUnionSchema<Types>;
 }
+
+type CoDiscriminatedUnionInstanceCoValuesNullable<
+  Types extends readonly [
+    z.core.$ZodTypeDiscriminable,
+    ...z.core.$ZodTypeDiscriminable[],
+  ],
+> = NonNullable<InstanceOrPrimitiveOfSchemaCoValuesNullable<Types[number]>>;

--- a/packages/jazz-tools/src/tools/implementation/zodSchema/zodCo.ts
+++ b/packages/jazz-tools/src/tools/implementation/zodSchema/zodCo.ts
@@ -23,7 +23,10 @@ import {
   type Simplify,
   zodSchemaToCoSchema,
 } from "../../internal.js";
-import { CoDiscriminatedUnionSchema } from "./schemaTypes/CoDiscriminatedUnionSchema.js";
+import {
+  AnyDiscriminableCoSchema,
+  CoDiscriminatedUnionSchema,
+} from "./schemaTypes/CoDiscriminatedUnionSchema.js";
 import {
   CoOptionalSchema,
   createCoOptionalSchema,
@@ -192,8 +195,8 @@ export const coOptionalDefiner = <T extends AnyCoSchema>(
 
 export const coDiscriminatedUnionDefiner = <
   T extends readonly [
-    AnyCoSchema & z.core.$ZodTypeDiscriminable,
-    ...(AnyCoSchema & z.core.$ZodTypeDiscriminable)[],
+    AnyDiscriminableCoSchema,
+    ...AnyDiscriminableCoSchema[],
   ],
 >(
   discriminator: string,

--- a/packages/jazz-tools/src/tools/implementation/zodSchema/zodCo.ts
+++ b/packages/jazz-tools/src/tools/implementation/zodSchema/zodCo.ts
@@ -128,7 +128,7 @@ export const coListDefiner = <T extends z.core.$ZodType>(
   const enrichedSchema = Object.assign(schema, {
     collaborative: true,
   }) as AnyCoListSchema<T>;
-  return zodSchemaToCoSchema(enrichedSchema);
+  return zodSchemaToCoSchema(enrichedSchema) as unknown as CoListSchema<T>;
 };
 
 export const coProfileDefiner = <

--- a/packages/jazz-tools/src/tools/implementation/zodSchema/zodCo.ts
+++ b/packages/jazz-tools/src/tools/implementation/zodSchema/zodCo.ts
@@ -194,10 +194,7 @@ export const coOptionalDefiner = <T extends AnyCoSchema>(
 };
 
 export const coDiscriminatedUnionDefiner = <
-  T extends readonly [
-    AnyDiscriminableCoSchema,
-    ...AnyDiscriminableCoSchema[],
-  ],
+  T extends readonly [AnyDiscriminableCoSchema, ...AnyDiscriminableCoSchema[]],
 >(
   discriminator: string,
   schemas: T,

--- a/packages/jazz-tools/src/tools/implementation/zodSchema/zodSchema.ts
+++ b/packages/jazz-tools/src/tools/implementation/zodSchema/zodSchema.ts
@@ -15,7 +15,10 @@ import {
   AnyAccountSchema,
   BaseAccountShape,
 } from "./schemaTypes/AccountSchema.js";
-import { CoDiscriminatedUnionSchema } from "./schemaTypes/CoDiscriminatedUnionSchema.js";
+import {
+  AnyDiscriminableCoSchema,
+  CoDiscriminatedUnionSchema,
+} from "./schemaTypes/CoDiscriminatedUnionSchema.js";
 import { AnyCoFeedSchema, CoFeedSchema } from "./schemaTypes/CoFeedSchema.js";
 import { AnyCoListSchema, CoListSchema } from "./schemaTypes/CoListSchema.js";
 import {
@@ -114,8 +117,8 @@ export type CoValueSchemaFromZodSchema<S extends z.core.$ZodType> =
                       ? CoValueSchemaFromZodSchema<Inner>
                       : S extends z.core.$ZodUnion<
                             infer Members extends readonly [
-                              z.core.$ZodTypeDiscriminable,
-                              ...z.core.$ZodTypeDiscriminable[],
+                              AnyDiscriminableCoSchema,
+                              ...AnyDiscriminableCoSchema[],
                             ]
                           >
                         ? CoDiscriminatedUnionSchema<Members>

--- a/packages/jazz-tools/src/tools/tests/coDiscriminatedUnion.test.ts
+++ b/packages/jazz-tools/src/tools/tests/coDiscriminatedUnion.test.ts
@@ -1,0 +1,83 @@
+import { beforeEach, describe, expect, test } from "vitest";
+import { Loaded, co, z } from "../exports.js";
+import { createJazzTestAccount, setupJazzTestSync } from "../testing.js";
+
+describe("co.discriminatedUnion", () => {
+  beforeEach(async () => {
+    await setupJazzTestSync();
+
+    await createJazzTestAccount({
+      isCurrentActiveAccount: true,
+      creationProps: { name: "Hermes Puggington" },
+    });
+  });
+
+  test("use co.discriminatedUnion with CoValue schemas as values", () => {
+    const Dog = co.map({
+      type: z.literal("dog"),
+    });
+    const Cat = co.map({
+      type: z.literal("cat"),
+    });
+    const Person = co.map({
+      pet: co.discriminatedUnion("type", [Dog, Cat]),
+    });
+
+    const person = Person.create({
+      pet: Dog.create({
+        type: "dog",
+      }),
+    });
+
+    expect(person.pet.type).toEqual("dog");
+
+    person.pet = Cat.create({
+      type: "cat",
+    });
+
+    expect(person.pet.type).toEqual("cat");
+  });
+
+  test("load CoValue instances using the DiscriminatedUnion schema without resolve", async () => {
+    const Dog = co.map({
+      type: z.literal("dog"),
+    });
+    const Cat = co.map({
+      type: z.literal("cat"),
+    });
+    const Pet = co.discriminatedUnion("type", [Dog, Cat]);
+
+    const dog = Dog.create({ type: "dog" });
+    const loadedPet = await Pet.load(dog.id);
+    expect(loadedPet?.type).toEqual("dog");
+  });
+
+  test("load CoValue instances using the DiscriminatedUnion schema with deep resolve", async () => {
+    const Person = co.map({
+      name: z.string(),
+    });
+    const Dog = co.map({
+      type: z.literal("dog"),
+      owner: Person,
+    });
+    const Cat = co.map({
+      type: z.literal("cat"),
+      owner: Person,
+    });
+    const Pet = co.discriminatedUnion("type", [Dog, Cat]);
+
+    const dog = Dog.create({
+      type: "dog",
+      owner: Person.create({
+        name: "John Doe",
+      }),
+    });
+
+    const loadedPet = await Pet.load(dog.id, {
+      resolve: {
+        owner: true,
+      },
+    });
+    expect(loadedPet?.owner.name).toEqual("John Doe");
+  });
+});

--- a/packages/jazz-tools/src/tools/tests/coDiscriminatedUnion.test.ts
+++ b/packages/jazz-tools/src/tools/tests/coDiscriminatedUnion.test.ts
@@ -1,6 +1,7 @@
-import { beforeEach, describe, expect, test } from "vitest";
+import { beforeEach, describe, expect, test, vi } from "vitest";
 import { Loaded, co, z } from "../exports.js";
 import { createJazzTestAccount, setupJazzTestSync } from "../testing.js";
+import { waitFor } from "./utils.js";
 
 describe("co.discriminatedUnion", () => {
   beforeEach(async () => {
@@ -79,5 +80,69 @@ describe("co.discriminatedUnion", () => {
       },
     });
     expect(loadedPet?.owner.name).toEqual("John Doe");
+  });
+
+  test("subscribe to CoValue instances using the DiscriminatedUnion schema without resolve", async () => {
+    const Dog = co.map({
+      type: z.literal("dog"),
+      name: z.string(),
+    });
+    const Cat = co.map({
+      type: z.literal("cat"),
+      name: z.string(),
+    });
+    const Pet = co.discriminatedUnion("type", [Dog, Cat]);
+
+    const dog = Dog.create({ type: "dog", name: "Rex" });
+
+    const updates: Loaded<typeof Pet>[] = [];
+    const spy = vi.fn((pet) => updates.push(pet));
+
+    Pet.subscribe(dog.id, {}, (pet) => {
+      expect(pet.type).toEqual("dog");
+      spy(pet);
+    });
+
+    expect(spy).not.toHaveBeenCalled();
+
+    await waitFor(() => expect(spy).toHaveBeenCalled());
+
+    expect(spy).toHaveBeenCalledTimes(1);
+
+    expect(updates[0]?.name).toEqual("Rex");
+  });
+
+  test("subscribe to CoValue instances using the DiscriminatedUnion schema with deep resolve", async () => {
+    const Person = co.map({
+      name: z.string(),
+    });
+    const Dog = co.map({
+      type: z.literal("dog"),
+      owner: Person,
+    });
+    const Cat = co.map({
+      type: z.literal("cat"),
+      owner: Person,
+    });
+    const Pet = co.discriminatedUnion("type", [Dog, Cat]);
+
+    const dog = Dog.create({
+      type: "dog",
+      owner: Person.create({
+        name: "John Doe",
+      }),
+    });
+
+    const spy = vi.fn();
+    Pet.subscribe(dog.id, { resolve: { owner: true } }, (pet) => {
+      expect(pet.owner.name).toEqual("John Doe");
+      spy(pet);
+    });
+
+    expect(spy).not.toHaveBeenCalled();
+
+    await waitFor(() => expect(spy).toHaveBeenCalled());
+
+    expect(spy).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/jazz-tools/src/tools/tests/schemaUnion.test.ts
+++ b/packages/jazz-tools/src/tools/tests/schemaUnion.test.ts
@@ -6,7 +6,6 @@ import {
   Loaded,
   anySchemaToCoSchema,
   co,
-  loadCoValue,
   subscribeToCoValue,
   z,
 } from "../exports.js";
@@ -72,25 +71,15 @@ describe("SchemaUnion", () => {
       { owner: me },
     );
 
-    const loadedButtonWidget = await loadCoValue(
-      anySchemaToCoSchema(WidgetUnion),
-      buttonWidget.id,
-      {
-        loadAs: me,
-      },
-    );
-    const loadedSliderWidget = await loadCoValue(
-      anySchemaToCoSchema(WidgetUnion),
-      sliderWidget.id,
-      {
-        loadAs: me,
-      },
-    );
-    const loadedCheckboxWidget = await loadCoValue(
-      anySchemaToCoSchema(WidgetUnion),
-      checkboxWidget.id,
-      { loadAs: me },
-    );
+    const loadedButtonWidget = await WidgetUnion.load(buttonWidget.id, {
+      loadAs: me,
+    });
+    const loadedSliderWidget = await WidgetUnion.load(sliderWidget.id, {
+      loadAs: me,
+    });
+    const loadedCheckboxWidget = await WidgetUnion.load(checkboxWidget.id, {
+      loadAs: me,
+    });
 
     expect(loadedButtonWidget?.type).toBe("button");
     expect(loadedSliderWidget?.type).toBe("slider");


### PR DESCRIPTION
# Description

You can now use load & subscribe in schemas generated with `co.discriminatedUnion`.

Added these methods to the `SchemaUnion` coValue class as well.

## Tests

- [x] Tests have been added and/or updated

## Checklist

- [ ] I've updated the part of the docs that are affected the PR changes
- [ ] I've generated a changeset, if a version bump is required
- [ ] I've updated the jsDoc comments to the public APIs I've modified, or added them when missing