### PR TITLE
Expose current Account id in unauthorized error message

### DIFF
--- a/.changeset/green-jobs-smash.md
+++ b/.changeset/green-jobs-smash.md
@@ -1,0 +1,5 @@
+---
+"jazz-tools": patch
+---
+
+Exposed the current Account's ID in unauthorized error message

--- a/packages/jazz-tools/src/tools/subscribe/SubscriptionScope.ts
+++ b/packages/jazz-tools/src/tools/subscribe/SubscriptionScope.ts
@@ -126,8 +126,7 @@ export class SubscriptionScope<D extends CoValue> {
           new JazzError(this.id, "unauthorized", [
             {
               code: "unauthorized",
-              message:
-                "The current user is not authorized to access this value",
+              message: `The current user (${this.node.getCurrentAgent().id}) is not authorized to access this value`,
               params: {
                 id: this.id,
               },

--- a/packages/jazz-tools/src/tools/tests/deepLoading.test.ts
+++ b/packages/jazz-tools/src/tools/tests/deepLoading.test.ts
@@ -409,7 +409,7 @@ describe("Deep loading with unauthorized account", async () => {
     expect(mapOnAlice).toBe(null);
 
     expect(errorSpy).toHaveBeenCalledWith(
-      `The current user is not authorized to access this value from ${map.id}`,
+      `The current user (${alice.id}) is not authorized to access this value from ${map.id}`,
     );
 
     errorSpy.mockReset();
@@ -431,7 +431,7 @@ describe("Deep loading with unauthorized account", async () => {
     expect(mapWithListOnAlice).toBe(null);
 
     expect(errorSpy).toHaveBeenCalledWith(
-      `The current user is not authorized to access this value from ${map.id} on path list`,
+      `The current user (${alice.id}) is not authorized to access this value from ${map.id} on path list`,
     );
 
     errorSpy.mockReset();
@@ -465,7 +465,7 @@ describe("Deep loading with unauthorized account", async () => {
     expect(mapOnAlice).toBe(null);
 
     expect(errorSpy).toHaveBeenCalledWith(
-      `The current user is not authorized to access this value from ${map.id} on path list.0`,
+      `The current user (${alice.id}) is not authorized to access this value from ${map.id} on path list.0`,
     );
 
     errorSpy.mockReset();
@@ -492,7 +492,7 @@ describe("Deep loading with unauthorized account", async () => {
     expect(mapOnAlice?.optionalRef?.value).toBe(undefined);
 
     expect(errorSpy).toHaveBeenCalledWith(
-      `The current user is not authorized to access this value from ${map.id} on path optionalRef`,
+      `The current user (${alice.id}) is not authorized to access this value from ${map.id} on path optionalRef`,
     );
 
     errorSpy.mockReset();
@@ -551,7 +551,7 @@ describe("Deep loading with unauthorized account", async () => {
     expect(mapOnAlice).toBe(null);
 
     expect(errorSpy).toHaveBeenCalledWith(
-      `The current user is not authorized to access this value from ${map.id} on path list.0.stream`,
+      `The current user (${alice.id}) is not authorized to access this value from ${map.id} on path list.0.stream`,
     );
 
     errorSpy.mockReset();
@@ -587,7 +587,7 @@ describe("Deep loading with unauthorized account", async () => {
     expect(mapOnAlice).toBe(null);
 
     expect(errorSpy).toHaveBeenCalledWith(
-      `The current user is not authorized to access this value from ${map.id} on path list.0.stream.${value.id}`,
+      `The current user (${alice.id}) is not authorized to access this value from ${map.id} on path list.0.stream.${value.id}`,
     );
 
     errorSpy.mockReset();


### PR DESCRIPTION
# Description
Previously, when an Account requested a CoValue they couldn't access, the error message displayed was: `The current user is not authorized to access this value from co_valueId on path xyz`.

To help with debugging, especially with server workers, the Account id is shown in the error message like:
`The current user (co_accountId) is not authorized to access this value from co_valueId on path xyz`

## Tests

- [x] Tests have been added and/or updated
- [ ] Tests have not been updated, because: <!-- Insert reason for not updating tests here -->
- [ ] I need help with writing tests


## Checklist

- [ ] I've updated the part of the docs that are affected the PR changes
- [x] I've generated a changeset, if a version bump is required
- [ ] I've updated the jsDoc comments to the public APIs I've modified, or added them when missing