### PR TITLE
fix: catch errors from CoValue loading and treat it as "unavailable"

### DIFF
--- a/.changeset/tender-pears-march.md
+++ b/.changeset/tender-pears-march.md
@@ -1,0 +1,5 @@
+---
+"jazz-tools": patch
+---
+
+fix unhandled rejection on CoValue.load

--- a/packages/cojson/src/localNode.ts
+++ b/packages/cojson/src/localNode.ts
@@ -348,12 +348,10 @@ export class LocalNode {
     skipLoadingFromPeer?: PeerID,
     skipRetry?: boolean,
   ): Promise<CoValueCore> {
-    if (!id) {
-      throw new Error("Trying to load CoValue with undefined id");
-    }
-
-    if (!id.startsWith("co_z")) {
-      throw new Error(`Trying to load CoValue with invalid id ${id}`);
+    if (typeof id !== "string" || !id.startsWith("co_z")) {
+      throw new TypeError(
+        `Trying to load CoValue with invalid id ${Array.isArray(id) ? JSON.stringify(id) : id}`,
+      );
     }
 
     if (this.crashed) {

--- a/packages/cojson/src/tests/sync.load.test.ts
+++ b/packages/cojson/src/tests/sync.load.test.ts
@@ -54,6 +54,38 @@ describe("loading coValues from server", () => {
     `);
   });
 
+  test("coValue load throws on invalid id", async () => {
+    const { node } = setupTestNode({
+      connected: true,
+    });
+
+    expect(async () => await node.load("test" as any)).rejects.toThrow(
+      "Trying to load CoValue with invalid id test",
+    );
+    expect(async () => await node.load(null as any)).rejects.toThrow(
+      "Trying to load CoValue with invalid id null",
+    );
+    expect(async () => await node.load(undefined as any)).rejects.toThrow(
+      "Trying to load CoValue with invalid id undefined",
+    );
+    expect(async () => await node.load(1 as any)).rejects.toThrow(
+      "Trying to load CoValue with invalid id 1",
+    );
+    expect(async () => await node.load({} as any)).rejects.toThrow(
+      "Trying to load CoValue with invalid id [object Object]",
+    );
+    expect(async () => await node.load([] as any)).rejects.toThrow(
+      "Trying to load CoValue with invalid id []",
+    );
+    expect(async () => await node.load(["test"] as any)).rejects.toThrow(
+      'Trying to load CoValue with invalid id ["test"]',
+    );
+    expect(async () => await node.load((() => {}) as any)).rejects.toThrow(
+      "Trying to load CoValue with invalid id () => {\n    }",
+    );
+    expect(async () => await node.load(new Date() as any)).rejects.toThrow();
+  });
+
   test("unavailable coValue retry with skipRetry set to true", async () => {
     const client = setupTestNode();
     const client2 = setupTestNode();

--- a/packages/cojson/src/tests/sync.test.ts
+++ b/packages/cojson/src/tests/sync.test.ts
@@ -991,7 +991,7 @@ describe("LocalNode.load", () => {
 
     // @ts-expect-error Testing with undefined ID
     await expect(client.node.load(undefined)).rejects.toThrow(
-      "Trying to load CoValue with undefined id",
+      "Trying to load CoValue with invalid id undefined",
     );
   });
 

--- a/packages/jazz-tools/src/react-core/tests/useCoState.test.ts
+++ b/packages/jazz-tools/src/react-core/tests/useCoState.test.ts
@@ -47,6 +47,26 @@ describe("useCoState", () => {
     expect(result.current?.value).toBe("123");
   });
 
+  it("should return null on invalid id", async () => {
+    const TestMap = co.map({
+      value: z.string(),
+    });
+
+    const account = await createJazzTestAccount({
+      isCurrentActiveAccount: true,
+    });
+
+    const { result } = renderHook(() => useCoState(TestMap, "test", {}), {
+      account,
+    });
+
+    expect(result.current).toBeUndefined();
+
+    await waitFor(() => {
+      expect(result.current).toBeNull();
+    });
+  });
+
   it("should update the value when the coValue changes", async () => {
     const TestMap = co.map({
       value: z.string(),

--- a/packages/jazz-tools/src/tools/subscribe/CoValueCoreSubscription.ts
+++ b/packages/jazz-tools/src/tools/subscribe/CoValueCoreSubscription.ts
@@ -28,6 +28,10 @@ export class CoValueCoreSubscription {
             this.subscribeToState();
             this.listener("unavailable");
           }
+        })
+        .catch((error) => {
+          console.error("Unexpected error loading CoValue: ", error);
+          this.listener("unavailable");
         });
     }
   }

--- a/packages/jazz-tools/src/tools/tests/load.test.ts
+++ b/packages/jazz-tools/src/tools/tests/load.test.ts
@@ -33,6 +33,15 @@ test("load a value", async () => {
   expect(john?.name).toBe("John");
 });
 
+test("return null if id is invalid", async () => {
+  const Person = co.map({
+    name: z.string(),
+  });
+
+  const john = await Person.load("test");
+  expect(john).toBeNull();
+});
+
 test("retry an unavailable value", async () => {
   const Person = co.map({
     name: z.string(),


### PR DESCRIPTION
# Description
The `CoValue.load` method throws an error if the ID is invalid. The rejected promise was not acknowledged by `CoValueCoreSubscription`, resulting in the load promise never being settled, and an uncaught rejection was logged.

Now subscription listens to node loading rejection, and it treats it as "unavailable". Any high-level covalue loadings now return null if the ID looked for is invalid.

## Manual testing instructions
```ts
await Account.load("test") // should return null + console.error

const account = useCoState(Account, "test"); // should return null + console.error
```

## Tests

- [x] Tests have been added and/or updated
- [ ] Tests have not been updated, because: <!-- Insert reason for not updating tests here -->
- [ ] I need help with writing tests


## Checklist

- [ ] I've updated the part of the docs that are affected the PR changes
- [x] I've generated a changeset, if a version bump is required
- [ ] I've updated the jsDoc comments to the public APIs I've modified, or added them when missing