### PR TITLE
fix: fix stuck authentication when using onAnonymousAccountDiscarded with a storage

### DIFF
--- a/.changeset/rude-drinks-deliver.md
+++ b/.changeset/rude-drinks-deliver.md
@@ -1,0 +1,5 @@
+---
+"jazz-tools": patch
+---
+
+Fix stuck authentication when using onAnonymousAccountDiscarded with a storage

--- a/packages/cojson/src/localNode.ts
+++ b/packages/cojson/src/localNode.ts
@@ -82,6 +82,11 @@ export class LocalNode {
     this.storage = storage;
   }
 
+  removeStorage() {
+    this.storage?.close();
+    this.storage = undefined;
+  }
+
   getCoValue(id: RawCoID) {
     let entry = this.coValues.get(id);
 

--- a/packages/jazz-tools/src/tools/implementation/ContextManager.ts
+++ b/packages/jazz-tools/src/tools/implementation/ContextManager.ts
@@ -279,8 +279,13 @@ export class JazzContextManager<
           },
         );
 
-      prevContext.node.syncManager.addPeer(currentAccountAsPeer);
+      // Closing storage on the prevContext to avoid conflicting transactions and getting stuck on waitForAllCoValuesSync
+      // The storage is reachable through currentContext using the connectedPeers
+      prevContext.node.storage?.close();
+      prevContext.node.storage = undefined;
+
       currentContext.node.syncManager.addPeer(prevAccountAsPeer);
+      prevContext.node.syncManager.addPeer(currentAccountAsPeer);
 
       try {
         await this.props.onAnonymousAccountDiscarded?.(prevContext.me);

--- a/packages/jazz-tools/src/tools/implementation/ContextManager.ts
+++ b/packages/jazz-tools/src/tools/implementation/ContextManager.ts
@@ -281,8 +281,7 @@ export class JazzContextManager<
 
       // Closing storage on the prevContext to avoid conflicting transactions and getting stuck on waitForAllCoValuesSync
       // The storage is reachable through currentContext using the connectedPeers
-      prevContext.node.storage?.close();
-      prevContext.node.storage = undefined;
+      prevContext.node.removeStorage();
 
       currentContext.node.syncManager.addPeer(prevAccountAsPeer);
       prevContext.node.syncManager.addPeer(currentAccountAsPeer);

--- a/packages/jazz-tools/src/tools/tests/testStorage.ts
+++ b/packages/jazz-tools/src/tools/tests/testStorage.ts
@@ -1,0 +1,70 @@
+import { randomUUID } from "node:crypto";
+import { unlinkSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { SQLiteDatabaseDriverAsync, getSqliteStorageAsync } from "cojson";
+import Database, { type Database as DatabaseT } from "libsql";
+import { onTestFinished } from "vitest";
+
+class LibSQLSqliteAsyncDriver implements SQLiteDatabaseDriverAsync {
+  private readonly db: DatabaseT;
+
+  constructor(filename: string) {
+    this.db = new Database(filename, {});
+  }
+
+  async initialize() {
+    await this.db.pragma("journal_mode = WAL");
+  }
+
+  async run(sql: string, params: unknown[]) {
+    this.db.prepare(sql).run(params);
+  }
+
+  async query<T>(sql: string, params: unknown[]): Promise<T[]> {
+    return this.db.prepare(sql).all(params) as T[];
+  }
+
+  async get<T>(sql: string, params: unknown[]): Promise<T | undefined> {
+    return this.db.prepare(sql).get(params) as T | undefined;
+  }
+
+  async transaction(callback: () => unknown) {
+    await this.run("BEGIN TRANSACTION", []);
+
+    try {
+      await callback();
+      await this.run("COMMIT", []);
+    } catch (error) {
+      await this.run("ROLLBACK", []);
+    }
+  }
+
+  async closeDb() {
+    this.db.close();
+  }
+}
+
+export async function createAsyncStorage({ filename }: { filename?: string }) {
+  const storage = await getSqliteStorageAsync(
+    new LibSQLSqliteAsyncDriver(getDbPath(filename)),
+  );
+
+  onTestFinished(() => {
+    storage.close();
+  });
+
+  return storage;
+}
+
+export function getDbPath(defaultDbPath?: string) {
+  const dbPath = defaultDbPath ?? join(tmpdir(), `test-${randomUUID()}.db`);
+
+  if (!defaultDbPath) {
+    onTestFinished(() => {
+      unlinkSync(dbPath);
+    });
+  }
+
+  return dbPath;
+}


### PR DESCRIPTION

# Description

Having two storage instances at the same time was causing issues with transactions when a onAnonymousAccountDiscarded was declared, causing authentication to be stuck and the auth storage never be updated on login.

Fixes #2642 

## Manual testing instructions

Follow the repro step mentioned in the issue in the music player preview

## Tests

- [x] Tests have been added and/or updated
- [ ] Tests have not been updated, because: <!-- Insert reason for not updating tests here -->
- [ ] I need help with writing tests


## Checklist

- [x] I've updated the part of the docs that are affected the PR changes
- [x] I've generated a changeset, if a version bump is required
- [x] I've updated the jsDoc comments to the public APIs I've modified, or added them when missing