### PR TITLE
fix: load failures when loading a missing ref declared with z.optional and Schema.optional

### DIFF
--- a/.changeset/polite-planets-smoke.md
+++ b/.changeset/polite-planets-smoke.md
@@ -1,0 +1,5 @@
+---
+"jazz-tools": patch
+---
+
+Fix load failures when loading a missing ref declared with z.optional and Schema.optional

--- a/packages/jazz-tools/src/tools/tests/load.test.ts
+++ b/packages/jazz-tools/src/tools/tests/load.test.ts
@@ -42,6 +42,120 @@ test("return null if id is invalid", async () => {
   expect(john).toBeNull();
 });
 
+test("load a missing optional value (co.optional)", async () => {
+  const Dog = co.map({
+    name: z.string(),
+  });
+
+  const Person = co.map({
+    name: z.string(),
+    dog: co.optional(Dog),
+  });
+
+  const group = Group.create();
+  const map = Person.create({ name: "John" }, group);
+  group.addMember("everyone", "reader");
+
+  const alice = await createJazzTestAccount();
+
+  const john = await Person.load(map.id, {
+    loadAs: alice,
+    resolve: { dog: true },
+  });
+
+  assert(john);
+
+  expect(john.name).toBe("John");
+  expect(john.dog).toBeUndefined();
+});
+
+test("load a missing optional value (z.optional)", async () => {
+  const Dog = co.map({
+    name: z.string(),
+  });
+
+  const Person = co.map({
+    name: z.string(),
+    dog: z.optional(Dog),
+  });
+
+  const group = Group.create();
+  const map = Person.create({ name: "John" }, group);
+  group.addMember("everyone", "reader");
+
+  const alice = await createJazzTestAccount();
+
+  const john = await Person.load(map.id, {
+    loadAs: alice,
+    resolve: { dog: true },
+  });
+
+  assert(john);
+
+  expect(john.name).toBe("John");
+  expect(john.dog).toBeUndefined();
+});
+
+test("load a missing optional value (Schema.optional)", async () => {
+  const Dog = co.map({
+    name: z.string(),
+  });
+
+  const Person = co.map({
+    name: z.string(),
+    dog: Dog.optional(),
+  });
+
+  const group = Group.create();
+  const map = Person.create({ name: "John" }, group);
+  group.addMember("everyone", "reader");
+
+  const alice = await createJazzTestAccount();
+
+  const john = await Person.load(map.id, {
+    loadAs: alice,
+    resolve: { dog: true },
+  });
+
+  assert(john);
+
+  expect(john.name).toBe("John");
+  expect(john.dog).toBeUndefined();
+});
+
+test("load a missing optional value (optional discrminatedUnion)", async () => {
+  const Dog = co.map({
+    type: z.literal("dog"),
+    name: z.string(),
+  });
+
+  const Cat = co.map({
+    type: z.literal("cat"),
+    name: z.string(),
+  });
+
+  const Person = co.map({
+    name: z.string(),
+    pet: co.discriminatedUnion("type", [Dog, Cat]).optional(),
+  });
+
+  const group = Group.create();
+  const map = Person.create({ name: "John" }, group);
+  group.addMember("everyone", "reader");
+
+  const alice = await createJazzTestAccount();
+
+  const john = await Person.load(map.id, {
+    loadAs: alice,
+    resolve: { pet: true },
+  });
+
+  assert(john);
+
+  expect(john.name).toBe("John");
+  expect(john.pet).toBeUndefined();
+});
+
 test("retry an unavailable value", async () => {
   const Person = co.map({
     name: z.string(),


### PR DESCRIPTION
# Description

This PR fixes the loading of missing optional refs declared with z.optional and Schema.optional

## Tests

- [x] Tests have been added and/or updated
- [ ] Tests have not been updated, because: <!-- Insert reason for not updating tests here -->
- [ ] I need help with writing tests


## Checklist

- [x] I've updated the part of the docs that are affected the PR changes
- [x] I've generated a changeset, if a version bump is required
- [x] I've updated the jsDoc comments to the public APIs I've modified, or added them when missing