### PR TITLE
feat: introduce persistent peers

### DIFF
--- a/.changeset/nasty-donkeys-search.md
+++ b/.changeset/nasty-donkeys-search.md
@@ -1,0 +1,6 @@
+---
+"cojson-transport-ws": patch
+"cojson": patch
+---
+
+Introduce the persistent peers. Used to mark the WebSocket connections to the server as persistent, and wait for reconnection before failing load.

--- a/packages/cojson-transport-ws/src/createWebSocketPeer.ts
+++ b/packages/cojson-transport-ws/src/createWebSocketPeer.ts
@@ -165,6 +165,6 @@ export function createWebSocketPeer({
     incoming,
     outgoing,
     role,
-    deletePeerStateOnClose,
+    persistent: !deletePeerStateOnClose,
   };
 }

--- a/packages/cojson/src/PeerState.ts
+++ b/packages/cojson/src/PeerState.ts
@@ -97,6 +97,10 @@ export class PeerState {
     return this.peer.incoming;
   }
 
+  get persistent() {
+    return this.peer.persistent;
+  }
+
   pushOutgoingMessage(msg: SyncMessage) {
     this.peer.outgoing.push(msg);
   }

--- a/packages/cojson/src/coValueCore/coValueCore.ts
+++ b/packages/cojson/src/coValueCore/coValueCore.ts
@@ -1056,37 +1056,29 @@ export class CoValueCore {
       return;
     }
 
-    const peersToActuallyLoadFrom = [] as PeerState[];
-
     for (const peer of peers) {
-      const currentState = this.peers.get(peer.id)?.type;
+      const currentState = this.peers.get(peer.id)?.type ?? "unknown";
 
-      if (
-        !currentState ||
-        currentState === "unknown" ||
-        currentState === "unavailable"
-      ) {
-        peersToActuallyLoadFrom.push(peer);
+      if (currentState === "unknown" || currentState === "unavailable") {
         this.markPending(peer.id);
+        this.internalLoadFromPeer(peer);
       }
-    }
-
-    for (const peer of peersToActuallyLoadFrom) {
-      this.internalLoadFromPeer(peer);
     }
   }
 
   internalLoadFromPeer(peer: PeerState) {
-    if (peer.closed) {
+    if (peer.closed && !peer.persistent) {
       this.markNotFoundInPeer(peer.id);
       return;
     }
 
-    peer.pushOutgoingMessage({
-      action: "load",
-      ...this.knownState(),
-    });
-    peer.trackLoadRequestSent(this.id);
+    if (!peer.closed) {
+      peer.pushOutgoingMessage({
+        action: "load",
+        ...this.knownState(),
+      });
+      peer.trackLoadRequestSent(this.id);
+    }
 
     return new Promise<void>((resolve) => {
       const markNotFound = () => {
@@ -1100,7 +1092,9 @@ export class CoValueCore {
       };
 
       const timeout = setTimeout(markNotFound, CO_VALUE_LOADING_CONFIG.TIMEOUT);
-      const removeCloseListener = peer.addCloseListener(markNotFound);
+      const removeCloseListener = peer.persistent
+        ? undefined
+        : peer.addCloseListener(markNotFound);
 
       const listener = (state: CoValueCore) => {
         const peerState = state.peers.get(peer.id);
@@ -1111,7 +1105,7 @@ export class CoValueCore {
           peerState?.type === "unavailable"
         ) {
           this.listeners.delete(listener);
-          removeCloseListener();
+          removeCloseListener?.();
           clearTimeout(timeout);
           resolve();
         }

--- a/packages/cojson/src/coValueCore/coValueCore.ts
+++ b/packages/cojson/src/coValueCore/coValueCore.ts
@@ -1072,6 +1072,10 @@ export class CoValueCore {
       return;
     }
 
+    /**
+     * On reconnection persistent peers will automatically fire the load request
+     * as part of the reconnection process.
+     */
     if (!peer.closed) {
       peer.pushOutgoingMessage({
         action: "load",

--- a/packages/cojson/src/config.ts
+++ b/packages/cojson/src/config.ts
@@ -13,6 +13,14 @@ export const CO_VALUE_LOADING_CONFIG = {
   RETRY_DELAY: 3000,
 };
 
+export function setCoValueLoadingMaxRetries(maxRetries: number) {
+  CO_VALUE_LOADING_CONFIG.MAX_RETRIES = maxRetries;
+}
+
+export function setCoValueLoadingTimeout(timeout: number) {
+  CO_VALUE_LOADING_CONFIG.TIMEOUT = timeout;
+}
+
 export function setCoValueLoadingRetryDelay(delay: number) {
   CO_VALUE_LOADING_CONFIG.RETRY_DELAY = delay;
 }

--- a/packages/cojson/src/streamUtils.ts
+++ b/packages/cojson/src/streamUtils.ts
@@ -13,9 +13,11 @@ export function connectedPeers(
   {
     peer1role = "client",
     peer2role = "client",
+    persistent = false,
   }: {
     peer1role?: Peer["role"];
     peer2role?: Peer["role"];
+    persistent?: boolean;
   } = {},
 ): [Peer, Peer] {
   const from1to2 = new ConnectedPeerChannel();
@@ -26,6 +28,7 @@ export function connectedPeers(
     incoming: from2to1,
     outgoing: from1to2,
     role: peer2role,
+    persistent,
   };
 
   const peer1AsPeer: Peer = {
@@ -33,6 +36,7 @@ export function connectedPeers(
     incoming: from1to2,
     outgoing: from2to1,
     role: peer1role,
+    persistent,
   };
 
   return [peer1AsPeer, peer2AsPeer];

--- a/packages/cojson/src/sync.ts
+++ b/packages/cojson/src/sync.ts
@@ -88,7 +88,7 @@ export interface Peer {
   outgoing: OutgoingPeerChannel;
   role: "server" | "client";
   priority?: number;
-  deletePeerStateOnClose?: boolean;
+  persistent?: boolean;
 }
 
 export function combinedKnownStates(
@@ -157,8 +157,7 @@ export class SyncManager {
 
   getServerPeers(excludePeerId?: PeerID): PeerState[] {
     return this.getPeers().filter(
-      (peer) =>
-        peer.role === "server" && peer.id !== excludePeerId && !peer.closed,
+      (peer) => peer.role === "server" && peer.id !== excludePeerId,
     );
   }
 
@@ -353,7 +352,7 @@ export class SyncManager {
       unsubscribeFromKnownStatesUpdates();
       this.peersCounter.add(-1, { role: peer.role });
 
-      if (peer.deletePeerStateOnClose && this.peers[peer.id] === peerState) {
+      if (!peer.persistent && this.peers[peer.id] === peerState) {
         delete this.peers[peer.id];
       }
     });
@@ -794,8 +793,8 @@ export class SyncManager {
 
     const peerState = this.peers[peerId];
 
-    // The peer has been closed, so it isn't possible to sync
-    if (!peerState || peerState.closed) {
+    // The peer has been closed and is not persistent, so it isn't possible to sync
+    if (!peerState) {
       return;
     }
 
@@ -830,7 +829,7 @@ export class SyncManager {
     return this.local.storage?.waitForSync(id, this.local.getCoValue(id));
   }
 
-  waitForSync(id: RawCoID, timeout = 30_000) {
+  waitForSync(id: RawCoID, timeout = 60_000) {
     const peers = this.getPeers();
 
     return Promise.all(

--- a/packages/cojson/src/tests/sync.mesh.test.ts
+++ b/packages/cojson/src/tests/sync.mesh.test.ts
@@ -26,6 +26,7 @@ function setupMesh() {
     ourName: "edge-italy",
     syncServerName: "core",
     syncServer: coreServer.node,
+    persistent: true,
   });
   edgeItaly.addStorage({
     ourName: "edge-italy",
@@ -36,6 +37,7 @@ function setupMesh() {
     ourName: "edge-france",
     syncServerName: "core",
     syncServer: coreServer.node,
+    persistent: true,
   });
   edgeFrance.addStorage({
     ourName: "edge-france",

--- a/packages/cojson/src/tests/sync.test.ts
+++ b/packages/cojson/src/tests/sync.test.ts
@@ -111,10 +111,12 @@ test("Can sync a coValue with private transactions through a server to another c
   expect(mapOnClient2.get("hello")).toEqual("world");
 });
 
-test("should keep the peer state when the peer closes", async () => {
+test("should keep the peer state when the peer closes if persistent is true", async () => {
   const client = setupTestNode();
 
-  const { peer, peerState, peerOnServer } = client.connectToSyncServer();
+  const { peer, peerState, peerOnServer } = client.connectToSyncServer({
+    persistent: true,
+  });
 
   const group = jazzCloud.node.createGroup();
   const map = group.createMap();
@@ -133,12 +135,12 @@ test("should keep the peer state when the peer closes", async () => {
   expect(syncManager.peers[peer.id]).not.toBeUndefined();
 });
 
-test("should delete the peer state when the peer closes if deletePeerStateOnClose is true", async () => {
+test("should delete the peer state when the peer closes if persistent is false", async () => {
   const client = setupTestNode();
 
-  const { peer, peerState, peerOnServer } = client.connectToSyncServer();
-
-  peer.deletePeerStateOnClose = true;
+  const { peer, peerState, peerOnServer } = client.connectToSyncServer({
+    persistent: false,
+  });
 
   const group = jazzCloud.node.createGroup();
   const map = group.createMap();

--- a/packages/cojson/src/tests/testUtils.ts
+++ b/packages/cojson/src/tests/testUtils.ts
@@ -429,6 +429,7 @@ export function getSyncServerConnectedPeer(opts: {
   ourName?: string;
   syncServer?: LocalNode;
   peerId: string;
+  persistent?: boolean;
 }) {
   const currentSyncServer = opts?.syncServer ?? syncServer.current;
 
@@ -451,6 +452,7 @@ export function getSyncServerConnectedPeer(opts: {
       role: "client",
       name: opts.ourName,
     },
+    persistent: opts?.persistent,
   });
 
   currentSyncServer.syncManager.addPeer(peer2);
@@ -483,6 +485,7 @@ export function setupTestNode(
     syncServerName?: string;
     ourName?: string;
     syncServer?: LocalNode;
+    persistent?: boolean;
   }) {
     const { peer, peerStateOnServer, peerOnServer } =
       getSyncServerConnectedPeer({
@@ -490,6 +493,7 @@ export function setupTestNode(
         syncServerName: opts?.syncServerName,
         ourName: opts?.ourName,
         syncServer: opts?.syncServer,
+        persistent: opts?.persistent,
       });
 
     node.syncManager.addPeer(peer);
@@ -646,11 +650,29 @@ export type SyncTestMessage = {
 export function connectedPeersWithMessagesTracking(opts: {
   peer1: { id: string; role: Peer["role"]; name?: string };
   peer2: { id: string; role: Peer["role"]; name?: string };
+  persistent?: boolean;
 }) {
   const [peer1, peer2] = connectedPeers(opts.peer1.id, opts.peer2.id, {
     peer1role: opts.peer1.role,
     peer2role: opts.peer2.role,
+    persistent: opts.persistent,
   });
+
+  // If the persistent option is not provided, we default to true for the server and false for the client
+  // Trying to mimic the real world behavior of the sync server
+  if (opts.persistent === undefined) {
+    if (opts.peer1.role === "server") {
+      peer1.persistent = true;
+    } else {
+      peer1.persistent = false;
+    }
+
+    if (opts.peer2.role === "server") {
+      peer2.persistent = true;
+    } else {
+      peer2.persistent = false;
+    }
+  }
 
   const peer1Push = peer1.outgoing.push;
   peer1.outgoing.push = (msg) => {

--- a/packages/cojson/src/tests/testUtils.ts
+++ b/packages/cojson/src/tests/testUtils.ts
@@ -661,17 +661,9 @@ export function connectedPeersWithMessagesTracking(opts: {
   // If the persistent option is not provided, we default to true for the server and false for the client
   // Trying to mimic the real world behavior of the sync server
   if (opts.persistent === undefined) {
-    if (opts.peer1.role === "server") {
-      peer1.persistent = true;
-    } else {
-      peer1.persistent = false;
-    }
+    peer1.persistent = opts.peer1.role === "server";
 
-    if (opts.peer2.role === "server") {
-      peer2.persistent = true;
-    } else {
-      peer2.persistent = false;
-    }
+    peer2.persistent = opts.peer2.role === "server";
   }
 
   const peer1Push = peer1.outgoing.push;

--- a/packages/jazz-run/src/tests/startWorker.test.ts
+++ b/packages/jazz-run/src/tests/startWorker.test.ts
@@ -230,8 +230,7 @@ describe("startWorker integration", () => {
     await worker2.done();
   });
 
-  // Flaky test, fails randomly on CI
-  test.skip("worker reconnects when sync server is closed and reopened", async () => {
+  test("worker reconnects when sync server is closed and reopened", async () => {
     const worker1 = await setup();
     const worker2 = await setupWorker(worker1.syncServer);
 
@@ -266,10 +265,6 @@ describe("startWorker integration", () => {
       inMemory: true,
       db: "",
     });
-
-    // Wait for reconnection
-    await worker1.waitForConnection();
-    await worker2.waitForConnection();
 
     await worker1.worker.waitForAllCoValuesSync();
 

--- a/tests/browser-integration/src/browserSync.test.ts
+++ b/tests/browser-integration/src/browserSync.test.ts
@@ -201,10 +201,10 @@ describe("Browser sync", () => {
 
     await map.waitForSync();
 
-    await syncServer.setOffline(true);
+    await syncServer.setOnline(true);
 
     onTestFinished(async () => {
-      await syncServer.setOffline(false);
+      await syncServer.setOnline(false);
     });
 
     // Clearing the credentials storage so the next auth will be a new account

--- a/tests/browser-integration/src/commands.ts
+++ b/tests/browser-integration/src/commands.ts
@@ -36,9 +36,11 @@ const disconnectAllClientsCommand: BrowserCommand<[url: string]> = async (
   syncServer.disconnectAllClients();
 };
 
-const setOfflineCommand: BrowserCommand<
-  [url: string, active: boolean]
-> = async (ctx, url, active) => {
+const setOnlineCommand: BrowserCommand<[url: string, active: boolean]> = async (
+  ctx,
+  url,
+  active,
+) => {
   const syncServer = syncServers.get(url);
 
   if (!syncServer) {
@@ -77,7 +79,7 @@ declare module "@vitest/browser/context" {
       port: number;
     }>;
     disconnectAllClients: (url: string) => Promise<void>;
-    setOffline: (url: string, active: boolean) => Promise<void>;
+    setOnline: (url: string, active: boolean) => Promise<void>;
     closeSyncServer: (url: string) => Promise<void>;
     cleanup: () => Promise<void>;
   }
@@ -86,7 +88,7 @@ declare module "@vitest/browser/context" {
 export const customCommands = {
   startSyncServer: startSyncServerCommand,
   disconnectAllClients: disconnectAllClientsCommand,
-  setOffline: setOfflineCommand,
+  setOnline: setOnlineCommand,
   closeSyncServer: closeSyncServerCommand,
   cleanup: cleanupCommand,
 };

--- a/tests/browser-integration/src/testUtils.ts
+++ b/tests/browser-integration/src/testUtils.ts
@@ -88,7 +88,7 @@ export async function startSyncServer(port?: number, dbName?: string) {
     url,
     port: syncServerPort,
     disconnectAllClients: () => commands.disconnectAllClients(url),
-    setOffline: (active: boolean) => commands.setOffline(url, active),
+    setOnline: (active: boolean) => commands.setOnline(url, active),
     close,
   };
 }

--- a/tests/browser-integration/src/unstableConnection.test.ts
+++ b/tests/browser-integration/src/unstableConnection.test.ts
@@ -1,28 +1,22 @@
 import { commands } from "@vitest/browser/context";
-import {
-  Account,
-  AuthSecretStorage,
-  CoMap,
-  FileStream,
-  Group,
-  coField,
-} from "jazz-tools";
-import { afterAll, afterEach, describe, expect, test } from "vitest";
+import { AuthSecretStorage, FileStream, Group, co, z } from "jazz-tools";
+import { assert, afterAll, afterEach, describe, expect, test } from "vitest";
 import { createAccountContext, startSyncServer } from "./testUtils";
 
-class TestMap extends CoMap {
-  value = coField.string;
-}
+const TestMAP = co.map({
+  value: z.string(),
+});
 
-class CustomAccount extends Account {
-  root = coField.ref(TestMap);
-
-  migrate() {
-    if (!this.root) {
-      this.root = TestMap.create({ value: "initial" }, { owner: this });
+const CustomAccount = co
+  .account({
+    root: TestMAP,
+    profile: co.profile(),
+  })
+  .withMigration((me) => {
+    if (me.root === undefined) {
+      me.root = TestMAP.create({ value: "initial" }, { owner: me });
     }
-  }
-}
+  });
 
 afterAll(async () => {
   await commands.cleanup();
@@ -43,13 +37,13 @@ describe("Browser sync on unstable connection", () => {
       AccountSchema: CustomAccount,
     });
 
-    const bytes10MB = 1e7;
+    const bytes1MB = 1e6;
 
     const group = Group.create();
     group.addMember("everyone", "reader");
 
     const promise = FileStream.createFromBlob(
-      new Blob(["1".repeat(bytes10MB)], { type: "image/png" }),
+      new Blob(["1".repeat(bytes1MB)], { type: "image/png" }),
       group,
     );
 
@@ -78,7 +72,63 @@ describe("Browser sync on unstable connection", () => {
 
     const fileOnSecondAccount = await promise2;
 
-    expect(fileOnSecondAccount?.size).toBe(bytes10MB);
+    expect(fileOnSecondAccount?.size).toBe(bytes1MB);
+  });
+
+  test("wait for online when creating data when offline and calling waitForSync", async () => {
+    const syncServer = await startSyncServer();
+    const { contextManager } = await createAccountContext({
+      sync: {
+        peer: syncServer.url,
+      },
+      storage: "indexedDB",
+      AccountSchema: CustomAccount,
+    });
+
+    const group = Group.create();
+    group.addMember("everyone", "reader");
+
+    await syncServer.setOnline(false);
+
+    const map = TestMAP.create({ value: "initial" }, { owner: group });
+
+    await new Promise((resolve) => setTimeout(resolve, 10));
+
+    await syncServer.setOnline(true);
+
+    await map.waitForSync();
+
+    contextManager.done();
+
+    await new AuthSecretStorage().clear();
+
+    await new Promise((resolve) => {
+      const req = indexedDB.deleteDatabase("jazz-storage");
+      req.onsuccess = function () {
+        resolve(undefined);
+      };
+    });
+
+    await createAccountContext({
+      sync: {
+        peer: syncServer.url,
+      },
+      storage: "indexedDB",
+      AccountSchema: CustomAccount,
+    });
+
+    await syncServer.setOnline(false);
+
+    const promise = TestMAP.load(map.id);
+
+    await new Promise((resolve) => setTimeout(resolve, 10));
+    await syncServer.setOnline(true);
+
+    const mapOnSecondAccount = await promise;
+
+    assert(mapOnSecondAccount);
+
+    expect(mapOnSecondAccount.value).toBe("initial");
   });
 
   test("load files from storage correctly when pointing to different sync servers", async () => {


### PR DESCRIPTION
# Description

Introduce the persistent peers. Used to mark the WebSocket connections to the server as persistent, and wait for reconnection before failing load.

This improves how Jazz behaves on unstable connections:

* when calling `waitForSync` while the WebSocket is down, it now waits for reconnection instead of resolving immediately
* loading a coValue while offline now doesn't return immediately as unavailable but waits for reconnection

This is a core improvement required for HTTP requests. [https://github.com/garden-co/jazz/pull/2626](https://github.com/garden-co/jazz/pull/2626)
Workers are going to be deployed in serverless environments where the WebSocket connection might be frozen.

This means that when the request is fired, the worker might be disconnected.
With these changes, they will wait for reconnection for 30s + 3s + 30s (one timeout + one retry) instead of failing any load immediately.

fixes #2450

## Manual testing instructions

To test the change from a UX standpoint, I've opened a Jazz app where I have data and nuked the IndexedDB.

After that, by navigating the app and using the DevTools to toggle the offline state, it's possible to observe what happens on a flaky connection.

**Before:**
The "unavailable" state was shown after 3s, but the content was still correctly loaded when going online (thanks to the peer reconciliation process).

**After:**
It takes more time to show the "unavailable" state.

While the difference isn't that big on client apps, this new behavior makes it much easier to work with Workers in serverless environments.

## Tests

* [x] Tests have been added and/or updated
* [ ] Tests have not been updated, because: <!-- Insert reason for not updating tests here -->
* [ ] I need help with writing tests

## Checklist

* [x] I've updated the part of the docs that are affected by the PR changes
* [x] I've generated a changeset, if a version bump is required
* [x] I've updated the jsDoc comments for the public APIs I've modified, or added them when missing
