### PR TITLE
fix: Export `WithHelpers` type

### DIFF
--- a/.changeset/tame-ducks-jump.md
+++ b/.changeset/tame-ducks-jump.md
@@ -1,0 +1,5 @@
+---
+"jazz-tools": patch
+---
+
+Export `WithHelpers` type used in CoValue schemas

--- a/packages/jazz-tools/src/tools/exports.ts
+++ b/packages/jazz-tools/src/tools/exports.ts
@@ -35,6 +35,7 @@ export type {
   TextPos,
   AccountClass,
   AccountCreationProps,
+  WithHelpers,
 } from "./internal.js";
 
 export {


### PR DESCRIPTION
# Description

Projects using `jazz-tools` cannot type schemas that use `withHelpers`, because the `WithHelpers` type is not exposed outside of the package, which causes the following error:

<img width="848" height="173" alt="inferred-internal-type" src="https://github.com/user-attachments/assets/0f302e72-be36-48ab-a663-fa0b5930e3d0" />

This should be fixed by exporting the `WithHelpers` type.

## Manual testing instructions

I've only been able to reproduce this issue with Invoice Radar, so it may only occur with some TS toolchains. I validated the fix by manually modifying `/node_modules/jazz-tools/dist/tools/exports.d.ts` in that project to export `WithHelpers`, and confirmed that fixes the type error.

## Tests

- [x] Tests have not been updated, because: we're just exporting a type

## Checklist

- [ ] I've updated the part of the docs that are affected the PR changes
- [x] I've generated a changeset, if a version bump is required
- [ ] I've updated the jsDoc comments to the public APIs I've modified, or added them when missing