### PR TITLE
fix: property update when assigning an optional reference on CoMap

### DIFF
--- a/.changeset/thick-adults-attack.md
+++ b/.changeset/thick-adults-attack.md
@@ -1,0 +1,5 @@
+---
+"jazz-tools": patch
+---
+
+Fix property update when assigning an optional reference on CoMap

--- a/packages/jazz-tools/src/tools/subscribe/SubscriptionScope.ts
+++ b/packages/jazz-tools/src/tools/subscribe/SubscriptionScope.ts
@@ -341,16 +341,14 @@ export class SubscriptionScope<D extends CoValue> {
       this.resolve = {};
     }
 
-    if (this.resolve.$each || key in this.resolve) {
-      return;
+    if (!this.resolve.$each && !(key in this.resolve)) {
+      const resolve = this.resolve as Record<string, any>;
+
+      // Adding the key to the resolve object to resolve the key when calling loadChildren
+      resolve[key] = true;
+      // Track the keys that are autoloaded to flag any id on that key as autoloaded
+      this.autoloadedKeys.add(key);
     }
-
-    const resolve = this.resolve as Record<string, any>;
-
-    // Adding the key to the resolve object to resolve the key when calling loadChildren
-    resolve[key] = true;
-    // Track the keys that are autoloaded to flag any id on that key as autoloaded
-    this.autoloadedKeys.add(key);
 
     if (this.value.type !== "loaded") {
       return;

--- a/packages/jazz-tools/src/tools/tests/coMap.test.ts
+++ b/packages/jazz-tools/src/tools/tests/coMap.test.ts
@@ -2103,3 +2103,144 @@ describe("CoMap migration", () => {
     });
   });
 });
+
+describe("Updating a nested reference", () => {
+  test("should assign a resolved optional reference and expect value is not null", async () => {
+    // Define the schema similar to the server-worker-http example
+    const PlaySelection = co.map({
+      value: z.literal(["rock", "paper", "scissors"]),
+      group: Group,
+    });
+
+    const Player = co.map({
+      account: co.account(),
+      playSelection: PlaySelection.optional(),
+    });
+
+    const Game = co.map({
+      player1: Player,
+      player2: Player,
+      outcome: z.literal(["player1", "player2", "draw"]).optional(),
+      player1Score: z.number(),
+      player2Score: z.number(),
+    });
+
+    // Create accounts for the players
+    const player1Account = await createJazzTestAccount({
+      creationProps: { name: "Player 1" },
+    });
+    const player2Account = await createJazzTestAccount({
+      creationProps: { name: "Player 2" },
+    });
+
+    // Create a game
+    const game = Game.create({
+      player1: Player.create({
+        account: player1Account,
+      }),
+      player2: Player.create({
+        account: player2Account,
+      }),
+      player1Score: 0,
+      player2Score: 0,
+    });
+
+    // Create a group for the play selection (similar to the route logic)
+    const group = Group.create({ owner: Account.getMe() });
+    group.addMember(player1Account, "reader");
+
+    // Load the game to verify the assignment worked
+    const loadedGame = await Game.load(game.id, {
+      resolve: {
+        player1: {
+          account: true,
+          playSelection: true,
+        },
+        player2: {
+          account: true,
+          playSelection: true,
+        },
+      },
+    });
+
+    assert(loadedGame);
+
+    // Create a play selection
+    const playSelection = PlaySelection.create({ value: "rock", group }, group);
+
+    // Assign the play selection to player1 (similar to the route logic)
+    loadedGame.player1.playSelection = playSelection;
+
+    // Verify that the playSelection is not null and has the expected value
+    expect(loadedGame.player1.playSelection).not.toBeNull();
+    expect(loadedGame.player1.playSelection).toBeDefined();
+  });
+
+  test("should assign a resolved reference and expect value to update", async () => {
+    // Define the schema similar to the server-worker-http example
+    const PlaySelection = co.map({
+      value: z.literal(["rock", "paper", "scissors"]),
+    });
+
+    const Player = co.map({
+      account: co.account(),
+      playSelection: PlaySelection,
+    });
+
+    const Game = co.map({
+      player1: Player,
+      player2: Player,
+      outcome: z.literal(["player1", "player2", "draw"]).optional(),
+      player1Score: z.number(),
+      player2Score: z.number(),
+    });
+
+    // Create accounts for the players
+    const player1Account = await createJazzTestAccount({
+      creationProps: { name: "Player 1" },
+    });
+    const player2Account = await createJazzTestAccount({
+      creationProps: { name: "Player 2" },
+    });
+
+    // Create a game
+    const game = Game.create({
+      player1: Player.create({
+        account: player1Account,
+        playSelection: PlaySelection.create({ value: "rock" }),
+      }),
+      player2: Player.create({
+        account: player2Account,
+        playSelection: PlaySelection.create({ value: "paper" }),
+      }),
+      player1Score: 0,
+      player2Score: 0,
+    });
+
+    // Load the game to verify the assignment worked
+    const loadedGame = await Game.load(game.id, {
+      resolve: {
+        player1: {
+          account: true,
+          playSelection: true,
+        },
+        player2: {
+          account: true,
+          playSelection: true,
+        },
+      },
+    });
+
+    assert(loadedGame);
+
+    // Create a play selection
+    const playSelection = PlaySelection.create({ value: "scissors" });
+
+    // Assign the play selection to player1 (similar to the route logic)
+    loadedGame.player1.playSelection = playSelection;
+
+    // Verify that the playSelection is not null and has the expected value
+    expect(loadedGame.player1.playSelection.id).toBe(playSelection.id);
+    expect(loadedGame.player1.playSelection.value).toEqual("scissors");
+  });
+});


### PR DESCRIPTION
# Description

While working on the Rock/Paper/Scissors I found a bug on the reference updates.

When a resolved optional undefined reference is updated, accessing the value was returining `null` instead of the updated value.

This PR fixes the bug.

## Tests

- [x] Tests have been added and/or updated
- [ ] Tests have not been updated, because: <!-- Insert reason for not updating tests here -->
- [ ] I need help with writing tests


## Checklist

- [x] I've updated the part of the docs that are affected the PR changes
- [x] I've generated a changeset, if a version bump is required
- [x] I've updated the jsDoc comments to the public APIs I've modified, or added them when missing