### PR TITLE
fix: circular constraint type check error with `Simplify`

### DIFF
--- a/packages/jazz-tools/src/tools/coValues/coMap.ts
+++ b/packages/jazz-tools/src/tools/coValues/coMap.ts
@@ -20,6 +20,7 @@ import type {
   RefsToResolveStrict,
   Resolved,
   Schema,
+  Simplify,
   SubscribeListenerOptions,
   SubscribeRestArgs,
 } from "../internal.js";
@@ -53,12 +54,6 @@ type CoMapEdit<V> = {
 };
 
 type LastAndAllCoMapEdits<V> = CoMapEdit<V> & { all: CoMapEdit<V>[] };
-
-export type Simplify<A> = {
-  [K in keyof A]: A[K];
-} extends infer B
-  ? B
-  : never;
 
 /**
  * CoMaps are collaborative versions of plain objects, mapping string-like keys to values.

--- a/packages/jazz-tools/src/tools/internal.ts
+++ b/packages/jazz-tools/src/tools/internal.ts
@@ -26,6 +26,7 @@ export * from "./subscribe/SubscriptionScope.js";
 export * from "./subscribe/types.js";
 export * from "./subscribe/index.js";
 export * from "./lib/cache.js";
+export * from "./lib/utilityTypes.js";
 export * from "./implementation/createContext.js";
 
 export * from "./types.js";

--- a/packages/jazz-tools/src/tools/lib/utilityTypes.ts
+++ b/packages/jazz-tools/src/tools/lib/utilityTypes.ts
@@ -1,0 +1,7 @@
+/**
+ * Useful to flatten the type output to improve type hints shown in editors.
+ * And also to transform an interface into a type to aide with assignability.
+ *
+ * Taken from https://github.com/sindresorhus/type-fest/blob/main/source/simplify.d.ts
+ */
+export type Simplify<T> = { [KeyType in keyof T]: T[KeyType] } & {};


### PR DESCRIPTION
# Description

Both @gdorsi and I started runninng into issues with the `Simplify` utility type that came up both in the IDE and when running jazz-tools tests:
```
⎯⎯⎯⎯⎯ Unhandled Errors ⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯
Vitest caught 1 unhandled error during the test run.
This might cause false positive tests. Resolve unhandled errors to make sure your tests are not affected.
⎯⎯⎯⎯⎯ Unhandled Source Error ⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯
TypeCheckError: Type parameter 'K' has a circular constraint.
 ❯ packages/jazz-tools/src/tools/coValues/coMap.ts:59:9

```

The error did not appear consistently, but after extracting the `Simplify` utility type into its own file and simplifying (🦆) its implementation to match https://github.com/sindresorhus/type-fest 's, I wasn't able to reproduce the error again.

## Manual testing instructions

Confirmed types continue to be simplified:
<img width="689" height="269" alt="Screenshot 2025-07-24 at 4 17 34 PM" src="https://github.com/user-attachments/assets/50425c1b-cf43-4500-9759-1b6cf9bcecb8" />

## Tests

- [ ] Tests have not been updated, but wished we could write type tests for this