### PR TITLE
fix: jazz-run package.json exports

### DIFF
--- a/.changeset/smooth-pears-grin.md
+++ b/.changeset/smooth-pears-grin.md
@@ -1,0 +1,5 @@
+---
+"jazz-run": patch
+---
+
+Fix jazz-run package.json exports

--- a/packages/jazz-run/package.json
+++ b/packages/jazz-run/package.json
@@ -6,12 +6,12 @@
   "version": "0.16.0",
   "exports": {
     "./startSyncServer": {
-      "import": "./dist/startSyncServer.js",
-      "types": "./dist/startSyncServer.d.ts"
+      "types": "./dist/startSyncServer.d.ts",
+      "default": "./dist/startSyncServer.js"
     },
     "./createWorkerAccount": {
-      "import": "./dist/createWorkerAccount.js",
-      "types": "./dist/createWorkerAccount.d.ts"
+      "types": "./dist/createWorkerAccount.d.ts",
+      "default": "./dist/createWorkerAccount.js"
     }
   },
   "scripts": {


### PR DESCRIPTION
# Description
Fixes the order of the export conditions and replaces `import` condition with `default`

## Manual testing instructions

<!-- Add any actions required to manually test the changes -->

## Tests

- [ ] Tests have been added and/or updated
- [ ] Tests have not been updated, because: <!-- Insert reason for not updating tests here -->
- [ ] I need help with writing tests


## Checklist

- [ ] I've updated the part of the docs that are affected the PR changes
- [x] I've generated a changeset, if a version bump is required
- [ ] I've updated the jsDoc comments to the public APIs I've modified, or added them when missing