### PR TITLE
feat: Add support for nullable non-collaborative fields

### DIFF
--- a/.changeset/tough-spies-float.md
+++ b/.changeset/tough-spies-float.md
@@ -1,0 +1,5 @@
+---
+"jazz-tools": patch
+---
+
+Add support for nullable non-collaborative fields

--- a/packages/jazz-tools/src/tools/coValues/coMap.ts
+++ b/packages/jazz-tools/src/tools/coValues/coMap.ts
@@ -14,6 +14,7 @@ import type {
   CoValueClass,
   Group,
   ID,
+  OptionalizeUndefinedKeys,
   RefEncoded,
   RefIfCoValue,
   RefsToResolve,
@@ -778,13 +779,9 @@ type ForceRequiredRef<V> = V extends InstanceType<CoValueClass> | null
     ? V | null
     : V;
 
-export type CoMapInit<Map extends object> = {
-  [Key in CoKeys<Map> as undefined extends Map[Key]
-    ? never
-    : Key]: ForceRequiredRef<Map[Key]>;
-} & {
-  [Key in CoKeys<Map>]?: ForceRequiredRef<Map[Key]>;
-};
+export type CoMapInit<Map extends object> = OptionalizeUndefinedKeys<{
+  [Key in CoKeys<Map>]: ForceRequiredRef<Map[Key]>;
+}>;
 
 // TODO: cache handlers per descriptor for performance?
 const CoMapProxyHandler: ProxyHandler<CoMap> = {

--- a/packages/jazz-tools/src/tools/coValues/coMap.ts
+++ b/packages/jazz-tools/src/tools/coValues/coMap.ts
@@ -14,7 +14,7 @@ import type {
   CoValueClass,
   Group,
   ID,
-  OptionalizeUndefinedKeys,
+  PartialOnUndefined,
   RefEncoded,
   RefIfCoValue,
   RefsToResolve,
@@ -779,7 +779,7 @@ type ForceRequiredRef<V> = V extends InstanceType<CoValueClass> | null
     ? V | null
     : V;
 
-export type CoMapInit<Map extends object> = OptionalizeUndefinedKeys<{
+export type CoMapInit<Map extends object> = PartialOnUndefined<{
   [Key in CoKeys<Map>]: ForceRequiredRef<Map[Key]>;
 }>;
 

--- a/packages/jazz-tools/src/tools/coValues/request.ts
+++ b/packages/jazz-tools/src/tools/coValues/request.ts
@@ -10,8 +10,8 @@ import z from "zod/v4";
 import {
   AnyZodOrCoValueSchema,
   CoMap,
-  CoMapInitZod,
   CoMapSchema,
+  CoMapSchemaInit,
   CoValueClass,
   CoreCoMapSchema,
   Group,
@@ -93,7 +93,7 @@ type AsNullablePayload<T extends MessageShape> = T extends Record<string, never>
   ? undefined
   : never;
 type MessageValuePayload<T extends MessageShape> =
-  | Simplify<CoMapInitZod<T>>
+  | Simplify<CoMapSchemaInit<T>>
   | AsNullablePayload<T>;
 
 function createMessageEnvelope<S extends MessageShape>(

--- a/packages/jazz-tools/src/tools/implementation/zodSchema/runtimeConverters/schemaFieldToCoFieldDef.ts
+++ b/packages/jazz-tools/src/tools/implementation/zodSchema/runtimeConverters/schemaFieldToCoFieldDef.ts
@@ -22,6 +22,7 @@ export type SchemaField =
   | CoValueClass
   | ZodPrimitiveSchema
   | z.core.$ZodOptional<z.core.$ZodType>
+  | z.core.$ZodNullable<z.core.$ZodType>
   | z.core.$ZodUnion<z.core.$ZodType[]>
   | z.core.$ZodDiscriminatedUnion<z.core.$ZodType[]>
   | z.core.$ZodObject<z.core.$ZodLooseShape>
@@ -49,9 +50,22 @@ export function schemaFieldToCoFieldDef(schema: SchemaField) {
   } else {
     if ("_zod" in schema) {
       const zodSchemaDef = schema._zod.def;
-      if (zodSchemaDef.type === "optional") {
+      if (
+        zodSchemaDef.type === "optional" ||
+        zodSchemaDef.type === "nullable"
+      ) {
         const inner = zodSchemaDef.innerType as ZodPrimitiveSchema;
-        return schemaFieldToCoFieldDef(inner);
+        const coFieldDef: any = schemaFieldToCoFieldDef(inner);
+        if (
+          zodSchemaDef.type === "nullable" &&
+          coFieldDef === coField.optional.Date
+        ) {
+          throw new Error("Nullable z.date() is not supported");
+        }
+        // Primitive coField types support null and undefined as values,
+        // so we can just return the inner type here and rely on support
+        // for null/undefined at the type level
+        return coFieldDef;
       } else if (zodSchemaDef.type === "string") {
         return coField.string;
       } else if (zodSchemaDef.type === "number") {

--- a/packages/jazz-tools/src/tools/implementation/zodSchema/runtimeConverters/schemaFieldToCoFieldDef.ts
+++ b/packages/jazz-tools/src/tools/implementation/zodSchema/runtimeConverters/schemaFieldToCoFieldDef.ts
@@ -60,6 +60,8 @@ export function schemaFieldToCoFieldDef(schema: SchemaField) {
           zodSchemaDef.type === "nullable" &&
           coFieldDef === coField.optional.Date
         ) {
+          // We do not currently have a way to encode null Date coFields.
+          // We only support encoding optional (i.e. Date | undefined) coFields.
           throw new Error("Nullable z.date() is not supported");
         }
         // Primitive coField types support null and undefined as values,

--- a/packages/jazz-tools/src/tools/implementation/zodSchema/schemaTypes/CoFeedSchema.ts
+++ b/packages/jazz-tools/src/tools/implementation/zodSchema/schemaTypes/CoFeedSchema.ts
@@ -3,7 +3,6 @@ import {
   AnyZodOrCoValueSchema,
   CoFeed,
   Group,
-  NotNull,
   RefsToResolve,
   RefsToResolveStrict,
   Resolved,
@@ -12,13 +11,14 @@ import {
   coOptionalDefiner,
 } from "../../../internal.js";
 import { AnonymousJazzAgent } from "../../anonymousJazzAgent.js";
+import { CoFieldInit } from "../typeConverters/CoFieldInit.js";
 import { InstanceOrPrimitiveOfSchema } from "../typeConverters/InstanceOrPrimitiveOfSchema.js";
 import { InstanceOrPrimitiveOfSchemaCoValuesNullable } from "../typeConverters/InstanceOrPrimitiveOfSchemaCoValuesNullable.js";
 import { CoOptionalSchema } from "./CoOptionalSchema.js";
 import { CoreCoValueSchema } from "./CoValueSchema.js";
 
 type CoFeedInit<T extends AnyZodOrCoValueSchema> = Simplify<
-  Array<NotNull<InstanceOrPrimitiveOfSchemaCoValuesNullable<T>>>
+  Array<CoFieldInit<T>>
 >;
 
 export class CoFeedSchema<T extends AnyZodOrCoValueSchema>

--- a/packages/jazz-tools/src/tools/implementation/zodSchema/schemaTypes/CoListSchema.ts
+++ b/packages/jazz-tools/src/tools/implementation/zodSchema/schemaTypes/CoListSchema.ts
@@ -2,7 +2,6 @@ import {
   Account,
   CoList,
   Group,
-  NotNull,
   RefsToResolve,
   RefsToResolveStrict,
   Resolved,
@@ -11,6 +10,7 @@ import {
   coOptionalDefiner,
 } from "../../../internal.js";
 import { AnonymousJazzAgent } from "../../anonymousJazzAgent.js";
+import { CoFieldInit } from "../typeConverters/CoFieldInit.js";
 import { InstanceOrPrimitiveOfSchema } from "../typeConverters/InstanceOrPrimitiveOfSchema.js";
 import { InstanceOrPrimitiveOfSchemaCoValuesNullable } from "../typeConverters/InstanceOrPrimitiveOfSchemaCoValuesNullable.js";
 import { AnyZodOrCoValueSchema } from "../zodSchema.js";
@@ -18,7 +18,7 @@ import { CoOptionalSchema } from "./CoOptionalSchema.js";
 import { CoreCoValueSchema } from "./CoValueSchema.js";
 
 type CoListInit<T extends AnyZodOrCoValueSchema> = Simplify<
-  Array<NotNull<InstanceOrPrimitiveOfSchemaCoValuesNullable<T>>>
+  Array<CoFieldInit<T>>
 >;
 
 export class CoListSchema<T extends AnyZodOrCoValueSchema>

--- a/packages/jazz-tools/src/tools/implementation/zodSchema/schemaTypes/CoMapSchema.ts
+++ b/packages/jazz-tools/src/tools/implementation/zodSchema/schemaTypes/CoMapSchema.ts
@@ -39,12 +39,11 @@ export interface CoMapSchema<
       | Owner,
   ) => {
     -readonly [key in keyof Shape]: InstanceOrPrimitiveOfSchema<Shape[key]>;
-  } & (unknown extends CatchAll
-    ? {}
-    : {
-        // @ts-expect-error
+  } & (CatchAll extends AnyZodOrCoValueSchema
+    ? {
         [key: string]: InstanceOrPrimitiveOfSchema<CatchAll>;
-      }) &
+      }
+    : {}) &
     CoMap;
 
   load<

--- a/packages/jazz-tools/src/tools/implementation/zodSchema/schemaTypes/CoMapSchema.ts
+++ b/packages/jazz-tools/src/tools/implementation/zodSchema/schemaTypes/CoMapSchema.ts
@@ -37,17 +37,14 @@ export interface CoMapSchema<
           unique?: CoValueUniqueness["uniqueness"];
         }
       | Owner,
-  ) => (Shape extends Record<string, never>
+  ) => {
+    -readonly [key in keyof Shape]: InstanceOrPrimitiveOfSchema<Shape[key]>;
+  } & (unknown extends CatchAll
     ? {}
     : {
-        -readonly [key in keyof Shape]: InstanceOrPrimitiveOfSchema<Shape[key]>;
+        // @ts-expect-error
+        [key: string]: InstanceOrPrimitiveOfSchema<CatchAll>;
       }) &
-    (unknown extends CatchAll
-      ? {}
-      : {
-          // @ts-expect-error
-          [key: string]: InstanceOrPrimitiveOfSchema<CatchAll>;
-        }) &
     CoMap;
 
   load<

--- a/packages/jazz-tools/src/tools/implementation/zodSchema/schemaTypes/CoMapSchema.ts
+++ b/packages/jazz-tools/src/tools/implementation/zodSchema/schemaTypes/CoMapSchema.ts
@@ -37,14 +37,7 @@ export interface CoMapSchema<
           unique?: CoValueUniqueness["uniqueness"];
         }
       | Owner,
-  ) => {
-    -readonly [key in keyof Shape]: InstanceOrPrimitiveOfSchema<Shape[key]>;
-  } & (CatchAll extends AnyZodOrCoValueSchema
-    ? {
-        [key: string]: InstanceOrPrimitiveOfSchema<CatchAll>;
-      }
-    : {}) &
-    CoMap;
+  ) => CoMapInstanceShape<Shape, CatchAll> & CoMap;
 
   load<
     const R extends RefsToResolve<
@@ -260,9 +253,16 @@ export interface CoreCoMapSchema<
   getDefinition: () => CoMapSchemaDefinition;
 }
 
-export type CoMapInstance<Shape extends z.core.$ZodLooseShape> = {
+export type CoMapInstanceShape<
+  Shape extends z.core.$ZodLooseShape,
+  CatchAll extends AnyZodOrCoValueSchema | unknown = unknown,
+> = {
   -readonly [key in keyof Shape]: InstanceOrPrimitiveOfSchema<Shape[key]>;
-} & CoMap;
+} & (CatchAll extends AnyZodOrCoValueSchema
+  ? {
+      [key: string]: InstanceOrPrimitiveOfSchema<CatchAll>;
+    }
+  : {});
 
 export type CoMapInstanceCoValuesNullable<Shape extends z.core.$ZodLooseShape> =
   {

--- a/packages/jazz-tools/src/tools/implementation/zodSchema/schemaTypes/CoMapSchema.ts
+++ b/packages/jazz-tools/src/tools/implementation/zodSchema/schemaTypes/CoMapSchema.ts
@@ -6,7 +6,7 @@ import {
   DiscriminableCoreCoValueSchema,
   Group,
   NotNull,
-  OptionalizeUndefinedKeys,
+  PartialOnUndefined,
   RefsToResolve,
   RefsToResolveStrict,
   Resolved,
@@ -230,7 +230,7 @@ export function enrichCoMapSchema<
 // Due to a TS limitation with types that contain known properties and
 // an index signature, we cannot accept catchall properties on creation
 export type CoMapSchemaInit<Shape extends z.core.$ZodLooseShape> =
-  OptionalizeUndefinedKeys<{
+  PartialOnUndefined<{
     [key in keyof Shape]: NotNull<
       InstanceOrPrimitiveOfSchemaCoValuesNullable<Shape[key]>
     >;

--- a/packages/jazz-tools/src/tools/implementation/zodSchema/schemaTypes/CoMapSchema.ts
+++ b/packages/jazz-tools/src/tools/implementation/zodSchema/schemaTypes/CoMapSchema.ts
@@ -30,7 +30,7 @@ export interface CoMapSchema<
   Owner extends Account | Group = Account | Group,
 > extends CoreCoMapSchema<Shape, CatchAll> {
   create: (
-    init: Simplify<CoMapInitZod<Shape>>,
+    init: Simplify<CoMapSchemaInit<Shape>>,
     options?:
       | {
           owner: Owner;
@@ -89,7 +89,7 @@ export interface CoMapSchema<
       Simplify<CoMapInstanceCoValuesNullable<Shape>> & CoMap
     > = true,
   >(options: {
-    value: Simplify<CoMapInitZod<Shape>>;
+    value: Simplify<CoMapSchemaInit<Shape>>;
     unique: CoValueUniqueness["uniqueness"];
     owner: Owner;
     resolve?: RefsToResolveStrict<
@@ -227,7 +227,9 @@ export function enrichCoMapSchema<
   return coValueSchema;
 }
 
-export type CoMapInitZod<Shape extends z.core.$ZodLooseShape> =
+// Due to a TS limitation with types that contain known properties and
+// an index signature, we cannot accept catchall properties on creation
+export type CoMapSchemaInit<Shape extends z.core.$ZodLooseShape> =
   OptionalizeUndefinedKeys<{
     [key in keyof Shape]: NotNull<
       InstanceOrPrimitiveOfSchemaCoValuesNullable<Shape[key]>

--- a/packages/jazz-tools/src/tools/implementation/zodSchema/schemaTypes/CoMapSchema.ts
+++ b/packages/jazz-tools/src/tools/implementation/zodSchema/schemaTypes/CoMapSchema.ts
@@ -5,6 +5,8 @@ import {
   DiscriminableCoValueSchemaDefinition,
   DiscriminableCoreCoValueSchema,
   Group,
+  NotNull,
+  OptionalizeUndefinedKeys,
   RefsToResolve,
   RefsToResolveStrict,
   Resolved,
@@ -20,7 +22,7 @@ import { InstanceOrPrimitiveOfSchema } from "../typeConverters/InstanceOrPrimiti
 import { InstanceOrPrimitiveOfSchemaCoValuesNullable } from "../typeConverters/InstanceOrPrimitiveOfSchemaCoValuesNullable.js";
 import { z } from "../zodReExport.js";
 import { AnyZodOrCoValueSchema } from "../zodSchema.js";
-import { CoOptionalSchema, CoreCoOptionalSchema } from "./CoOptionalSchema.js";
+import { CoOptionalSchema } from "./CoOptionalSchema.js";
 
 export interface CoMapSchema<
   Shape extends z.core.$ZodLooseShape,
@@ -236,31 +238,12 @@ export function enrichCoMapSchema<
   return coValueSchema;
 }
 
-export type optionalKeys<Shape extends z.core.$ZodLooseShape> = {
-  [key in keyof Shape]: Shape[key] extends
-    | z.core.$ZodOptional<any>
-    | CoreCoOptionalSchema<any>
-    ? key
-    : never;
-}[keyof Shape];
-
-export type requiredKeys<Shape extends z.core.$ZodLooseShape> = {
-  [key in keyof Shape]: Shape[key] extends
-    | z.core.$ZodOptional<any>
-    | CoreCoOptionalSchema<any>
-    ? never
-    : key;
-}[keyof Shape];
-
-export type CoMapInitZod<Shape extends z.core.$ZodLooseShape> = {
-  [key in optionalKeys<Shape>]?: NonNullable<
-    InstanceOrPrimitiveOfSchemaCoValuesNullable<Shape[key]>
-  >;
-} & {
-  [key in requiredKeys<Shape>]: NonNullable<
-    InstanceOrPrimitiveOfSchemaCoValuesNullable<Shape[key]>
-  >;
-} & { [key in keyof Shape]?: unknown };
+export type CoMapInitZod<Shape extends z.core.$ZodLooseShape> =
+  OptionalizeUndefinedKeys<{
+    [key in keyof Shape]: NotNull<
+      InstanceOrPrimitiveOfSchemaCoValuesNullable<Shape[key]>
+    >;
+  }>;
 
 export interface CoMapSchemaDefinition<
   Shape extends z.core.$ZodLooseShape = z.core.$ZodLooseShape,

--- a/packages/jazz-tools/src/tools/implementation/zodSchema/schemaTypes/CoMapSchema.ts
+++ b/packages/jazz-tools/src/tools/implementation/zodSchema/schemaTypes/CoMapSchema.ts
@@ -5,7 +5,6 @@ import {
   DiscriminableCoValueSchemaDefinition,
   DiscriminableCoreCoValueSchema,
   Group,
-  NotNull,
   PartialOnUndefined,
   RefsToResolve,
   RefsToResolveStrict,
@@ -18,6 +17,7 @@ import {
 } from "../../../internal.js";
 import { AnonymousJazzAgent } from "../../anonymousJazzAgent.js";
 import { removeGetters } from "../../schemaUtils.js";
+import { CoFieldInit } from "../typeConverters/CoFieldInit.js";
 import { InstanceOrPrimitiveOfSchema } from "../typeConverters/InstanceOrPrimitiveOfSchema.js";
 import { InstanceOrPrimitiveOfSchemaCoValuesNullable } from "../typeConverters/InstanceOrPrimitiveOfSchemaCoValuesNullable.js";
 import { z } from "../zodReExport.js";
@@ -231,9 +231,7 @@ export function enrichCoMapSchema<
 // an index signature, we cannot accept catchall properties on creation
 export type CoMapSchemaInit<Shape extends z.core.$ZodLooseShape> =
   PartialOnUndefined<{
-    [key in keyof Shape]: NotNull<
-      InstanceOrPrimitiveOfSchemaCoValuesNullable<Shape[key]>
-    >;
+    [key in keyof Shape]: CoFieldInit<Shape[key]>;
   }>;
 
 export interface CoMapSchemaDefinition<

--- a/packages/jazz-tools/src/tools/implementation/zodSchema/schemaTypes/CoRecordSchema.ts
+++ b/packages/jazz-tools/src/tools/implementation/zodSchema/schemaTypes/CoRecordSchema.ts
@@ -5,7 +5,6 @@ import {
   CoMapSchemaDefinition,
   Group,
   ID,
-  NotNull,
   RefsToResolve,
   RefsToResolveStrict,
   Resolved,
@@ -13,6 +12,7 @@ import {
   SubscribeListenerOptions,
 } from "../../../internal.js";
 import { AnonymousJazzAgent } from "../../anonymousJazzAgent.js";
+import { CoFieldInit } from "../typeConverters/CoFieldInit.js";
 import { InstanceOrPrimitiveOfSchema } from "../typeConverters/InstanceOrPrimitiveOfSchema.js";
 import { InstanceOrPrimitiveOfSchemaCoValuesNullable } from "../typeConverters/InstanceOrPrimitiveOfSchemaCoValuesNullable.js";
 import { z } from "../zodReExport.js";
@@ -24,7 +24,7 @@ type CoRecordInit<
   K extends z.core.$ZodString<string>,
   V extends AnyZodOrCoValueSchema,
 > = {
-  [key in z.output<K>]: NotNull<InstanceOrPrimitiveOfSchemaCoValuesNullable<V>>;
+  [key in z.output<K>]: CoFieldInit<V>;
 };
 
 export interface CoRecordSchema<

--- a/packages/jazz-tools/src/tools/implementation/zodSchema/typeConverters/CoFieldInit.ts
+++ b/packages/jazz-tools/src/tools/implementation/zodSchema/typeConverters/CoFieldInit.ts
@@ -1,0 +1,13 @@
+import { NotNull } from "../../../internal.js";
+import { z } from "../zodReExport.js";
+import { AnyZodOrCoValueSchema } from "../zodSchema.js";
+import { InstanceOrPrimitiveOfSchemaCoValuesNullable } from "./InstanceOrPrimitiveOfSchemaCoValuesNullable.js";
+
+/**
+ * Returns the type of the value that should be used to initialize a coField
+ * of the given schema.
+ */
+export type CoFieldInit<T extends AnyZodOrCoValueSchema> =
+  T extends z.core.$ZodNullable
+    ? InstanceOrPrimitiveOfSchemaCoValuesNullable<T>
+    : NotNull<InstanceOrPrimitiveOfSchemaCoValuesNullable<T>>;

--- a/packages/jazz-tools/src/tools/implementation/zodSchema/typeConverters/InstanceOfSchema.ts
+++ b/packages/jazz-tools/src/tools/implementation/zodSchema/typeConverters/InstanceOfSchema.ts
@@ -36,12 +36,11 @@ export type InstanceOfSchema<S extends CoValueClass | AnyZodOrCoValueSchema> =
         : S extends CoreCoMapSchema<infer Shape, infer CatchAll>
           ? {
               [key in keyof Shape]: InstanceOrPrimitiveOfSchema<Shape[key]>;
-            } & (unknown extends CatchAll
-              ? {}
-              : {
-                  // @ts-expect-error
+            } & (CatchAll extends AnyZodOrCoValueSchema
+              ? {
                   [key: string]: InstanceOrPrimitiveOfSchema<CatchAll>;
-                }) &
+                }
+              : {}) &
               CoMap
           : S extends CoreCoListSchema<infer T>
             ? CoList<InstanceOrPrimitiveOfSchema<T>>

--- a/packages/jazz-tools/src/tools/implementation/zodSchema/typeConverters/InstanceOfSchemaCoValuesNullable.ts
+++ b/packages/jazz-tools/src/tools/implementation/zodSchema/typeConverters/InstanceOfSchemaCoValuesNullable.ts
@@ -47,13 +47,13 @@ export type InstanceOfSchemaCoValuesNullable<
                 [key in keyof Shape]: InstanceOrPrimitiveOfSchemaCoValuesNullable<
                   Shape[key]
                 >;
-              } & (unknown extends CatchAll
-                ? {}
-                : {
+              } & (CatchAll extends AnyZodOrCoValueSchema
+                ? {
                     [
-                      key: string // @ts-expect-error
+                      key: string
                     ]: InstanceOrPrimitiveOfSchemaCoValuesNullable<CatchAll>;
-                  }) &
+                  }
+                : {}) &
                 CoMap)
             | null
         : S extends CoreCoListSchema<infer T>

--- a/packages/jazz-tools/src/tools/implementation/zodSchema/typeConverters/InstanceOrPrimitiveOfSchema.ts
+++ b/packages/jazz-tools/src/tools/implementation/zodSchema/typeConverters/InstanceOrPrimitiveOfSchema.ts
@@ -65,56 +65,58 @@ export type InstanceOrPrimitiveOfSchema<
   : S extends z.core.$ZodType
     ? S extends z.core.$ZodOptional<infer Inner extends z.core.$ZodType>
       ? InstanceOrPrimitiveOfSchema<Inner> | undefined
-      : S extends z.ZodJSONSchema
-        ? JsonValue
-        : S extends z.core.$ZodUnion<infer Members extends z.core.$ZodType[]>
-          ? InstanceOrPrimitiveOfSchema<Members[number]>
-          : // primitives below here - we manually traverse to ensure we only allow what we can handle
-            S extends z.core.$ZodObject<infer Shape>
-            ? {
-                -readonly [key in keyof Shape]: InstanceOrPrimitiveOfSchema<
-                  Shape[key]
-                >;
-              }
-            : S extends z.core.$ZodArray<infer Item extends z.core.$ZodType>
-              ? InstanceOrPrimitiveOfSchema<Item>[]
-              : S extends z.core.$ZodTuple<
-                    infer Items extends readonly z.core.$ZodType[]
-                  >
-                ? {
-                    [key in keyof Items]: InstanceOrPrimitiveOfSchema<
-                      Items[key]
-                    >;
-                  }
-                : S extends z.core.$ZodString
-                  ? string
-                  : S extends z.core.$ZodNumber
-                    ? number
-                    : S extends z.core.$ZodBoolean
-                      ? boolean
-                      : S extends z.core.$ZodLiteral<infer Literal>
-                        ? Literal
-                        : S extends z.core.$ZodDate
-                          ? Date
-                          : S extends z.core.$ZodEnum<infer Enum>
-                            ? Enum[keyof Enum]
-                            : S extends z.core.$ZodTemplateLiteral<
-                                  infer pattern
-                                >
-                              ? pattern
-                              : S extends z.core.$ZodReadonly<
-                                    infer Inner extends z.core.$ZodType
+      : S extends z.core.$ZodNullable<infer Inner extends z.core.$ZodType>
+        ? InstanceOrPrimitiveOfSchema<Inner> | null
+        : S extends z.ZodJSONSchema
+          ? JsonValue
+          : S extends z.core.$ZodUnion<infer Members extends z.core.$ZodType[]>
+            ? InstanceOrPrimitiveOfSchema<Members[number]>
+            : // primitives below here - we manually traverse to ensure we only allow what we can handle
+              S extends z.core.$ZodObject<infer Shape>
+              ? {
+                  -readonly [key in keyof Shape]: InstanceOrPrimitiveOfSchema<
+                    Shape[key]
+                  >;
+                }
+              : S extends z.core.$ZodArray<infer Item extends z.core.$ZodType>
+                ? InstanceOrPrimitiveOfSchema<Item>[]
+                : S extends z.core.$ZodTuple<
+                      infer Items extends readonly z.core.$ZodType[]
+                    >
+                  ? {
+                      [key in keyof Items]: InstanceOrPrimitiveOfSchema<
+                        Items[key]
+                      >;
+                    }
+                  : S extends z.core.$ZodString
+                    ? string
+                    : S extends z.core.$ZodNumber
+                      ? number
+                      : S extends z.core.$ZodBoolean
+                        ? boolean
+                        : S extends z.core.$ZodLiteral<infer Literal>
+                          ? Literal
+                          : S extends z.core.$ZodDate
+                            ? Date
+                            : S extends z.core.$ZodEnum<infer Enum>
+                              ? Enum[keyof Enum]
+                              : S extends z.core.$ZodTemplateLiteral<
+                                    infer pattern
                                   >
-                                ? InstanceOrPrimitiveOfSchema<Inner>
-                                : S extends z.core.$ZodDefault<
-                                      infer Default extends z.core.$ZodType
+                                ? pattern
+                                : S extends z.core.$ZodReadonly<
+                                      infer Inner extends z.core.$ZodType
                                     >
-                                  ? InstanceOrPrimitiveOfSchema<Default>
-                                  : S extends z.core.$ZodCatch<
-                                        infer Catch extends z.core.$ZodType
+                                  ? InstanceOrPrimitiveOfSchema<Inner>
+                                  : S extends z.core.$ZodDefault<
+                                        infer Default extends z.core.$ZodType
                                       >
-                                    ? InstanceOrPrimitiveOfSchema<Catch>
-                                    : never
+                                    ? InstanceOrPrimitiveOfSchema<Default>
+                                    : S extends z.core.$ZodCatch<
+                                          infer Catch extends z.core.$ZodType
+                                        >
+                                      ? InstanceOrPrimitiveOfSchema<Catch>
+                                      : never
     : S extends CoValueClass
       ? InstanceType<S>
       : never;

--- a/packages/jazz-tools/src/tools/implementation/zodSchema/typeConverters/InstanceOrPrimitiveOfSchema.ts
+++ b/packages/jazz-tools/src/tools/implementation/zodSchema/typeConverters/InstanceOrPrimitiveOfSchema.ts
@@ -41,12 +41,11 @@ export type InstanceOrPrimitiveOfSchema<
             -readonly [key in keyof Shape]: InstanceOrPrimitiveOfSchema<
               Shape[key]
             >;
-          } & (unknown extends CatchAll
-            ? {}
-            : {
-                // @ts-expect-error
+          } & (CatchAll extends AnyZodOrCoValueSchema
+            ? {
                 [key: string]: InstanceOrPrimitiveOfSchema<CatchAll>;
-              }) &
+              }
+            : {}) &
             CoMap
         : S extends CoreCoListSchema<infer T>
           ? CoList<InstanceOrPrimitiveOfSchema<T>>

--- a/packages/jazz-tools/src/tools/implementation/zodSchema/typeConverters/InstanceOrPrimitiveOfSchemaCoValuesNullable.ts
+++ b/packages/jazz-tools/src/tools/implementation/zodSchema/typeConverters/InstanceOrPrimitiveOfSchemaCoValuesNullable.ts
@@ -49,13 +49,13 @@ export type InstanceOrPrimitiveOfSchemaCoValuesNullable<
                 -readonly [key in keyof Shape]: InstanceOrPrimitiveOfSchemaCoValuesNullable<
                   Shape[key]
                 >;
-              } & (unknown extends CatchAll
-                ? {}
-                : {
+              } & (CatchAll extends AnyZodOrCoValueSchema
+                ? {
                     [
-                      key: string // @ts-expect-error
+                      key: string
                     ]: InstanceOrPrimitiveOfSchemaCoValuesNullable<CatchAll>;
-                  }) &
+                  }
+                : {}) &
                 CoMap)
             | null
         : S extends CoreCoListSchema<infer T>

--- a/packages/jazz-tools/src/tools/implementation/zodSchema/typeConverters/InstanceOrPrimitiveOfSchemaCoValuesNullable.ts
+++ b/packages/jazz-tools/src/tools/implementation/zodSchema/typeConverters/InstanceOrPrimitiveOfSchemaCoValuesNullable.ts
@@ -78,58 +78,60 @@ export type InstanceOrPrimitiveOfSchemaCoValuesNullable<
   : S extends z.core.$ZodType
     ? S extends z.core.$ZodOptional<infer Inner extends z.core.$ZodType>
       ? InstanceOrPrimitiveOfSchemaCoValuesNullable<Inner> | undefined
-      : S extends z.ZodJSONSchema
-        ? JsonValue
-        : S extends z.core.$ZodUnion<
-              infer Members extends readonly z.core.$ZodType[]
-            >
-          ? InstanceOrPrimitiveOfSchemaCoValuesNullable<Members[number]>
-          : // primitives below here - we manually traverse to ensure we only allow what we can handle
-            S extends z.core.$ZodObject<infer Shape>
-            ? {
-                -readonly [key in keyof Shape]: InstanceOrPrimitiveOfSchema<
-                  Shape[key]
-                >;
-              }
-            : S extends z.core.$ZodArray<infer Item extends z.core.$ZodType>
-              ? InstanceOrPrimitiveOfSchema<Item>[]
-              : S extends z.core.$ZodTuple<
-                    infer Items extends z.core.$ZodType[]
-                  >
-                ? {
-                    [key in keyof Items]: InstanceOrPrimitiveOfSchema<
-                      Items[key]
-                    >;
-                  }
-                : S extends z.core.$ZodString
-                  ? string
-                  : S extends z.core.$ZodNumber
-                    ? number
-                    : S extends z.core.$ZodBoolean
-                      ? boolean
-                      : S extends z.core.$ZodLiteral<infer Literal>
-                        ? Literal
-                        : S extends z.core.$ZodDate
-                          ? Date
-                          : S extends z.core.$ZodEnum<infer Enum>
-                            ? Enum[keyof Enum]
-                            : S extends z.core.$ZodTemplateLiteral<
-                                  infer pattern
-                                >
-                              ? pattern
-                              : S extends z.core.$ZodReadonly<
-                                    infer Inner extends z.core.$ZodType
+      : S extends z.core.$ZodNullable<infer Inner extends z.core.$ZodType>
+        ? InstanceOrPrimitiveOfSchemaCoValuesNullable<Inner> | null
+        : S extends z.ZodJSONSchema
+          ? JsonValue
+          : S extends z.core.$ZodUnion<
+                infer Members extends readonly z.core.$ZodType[]
+              >
+            ? InstanceOrPrimitiveOfSchemaCoValuesNullable<Members[number]>
+            : // primitives below here - we manually traverse to ensure we only allow what we can handle
+              S extends z.core.$ZodObject<infer Shape>
+              ? {
+                  -readonly [key in keyof Shape]: InstanceOrPrimitiveOfSchema<
+                    Shape[key]
+                  >;
+                }
+              : S extends z.core.$ZodArray<infer Item extends z.core.$ZodType>
+                ? InstanceOrPrimitiveOfSchema<Item>[]
+                : S extends z.core.$ZodTuple<
+                      infer Items extends z.core.$ZodType[]
+                    >
+                  ? {
+                      [key in keyof Items]: InstanceOrPrimitiveOfSchema<
+                        Items[key]
+                      >;
+                    }
+                  : S extends z.core.$ZodString
+                    ? string
+                    : S extends z.core.$ZodNumber
+                      ? number
+                      : S extends z.core.$ZodBoolean
+                        ? boolean
+                        : S extends z.core.$ZodLiteral<infer Literal>
+                          ? Literal
+                          : S extends z.core.$ZodDate
+                            ? Date
+                            : S extends z.core.$ZodEnum<infer Enum>
+                              ? Enum[keyof Enum]
+                              : S extends z.core.$ZodTemplateLiteral<
+                                    infer pattern
                                   >
-                                ? InstanceOrPrimitiveOfSchema<Inner>
-                                : S extends z.core.$ZodDefault<
-                                      infer Default extends z.core.$ZodType
+                                ? pattern
+                                : S extends z.core.$ZodReadonly<
+                                      infer Inner extends z.core.$ZodType
                                     >
-                                  ? InstanceOrPrimitiveOfSchema<Default>
-                                  : S extends z.core.$ZodCatch<
-                                        infer Catch extends z.core.$ZodType
+                                  ? InstanceOrPrimitiveOfSchema<Inner>
+                                  : S extends z.core.$ZodDefault<
+                                        infer Default extends z.core.$ZodType
                                       >
-                                    ? InstanceOrPrimitiveOfSchema<Catch>
-                                    : never
+                                    ? InstanceOrPrimitiveOfSchema<Default>
+                                    : S extends z.core.$ZodCatch<
+                                          infer Catch extends z.core.$ZodType
+                                        >
+                                      ? InstanceOrPrimitiveOfSchema<Catch>
+                                      : never
     : S extends CoValueClass
       ? InstanceType<S> | null
       : never;

--- a/packages/jazz-tools/src/tools/implementation/zodSchema/zodCo.ts
+++ b/packages/jazz-tools/src/tools/implementation/zodSchema/zodCo.ts
@@ -108,7 +108,7 @@ export const coListDefiner = <T extends AnyZodOrCoValueSchema>(
   element: T,
 ): CoListSchema<T> => {
   const coreSchema = createCoreCoListSchema(element);
-  return hydrateCoreCoValueSchema(coreSchema) as unknown as CoListSchema<T>;
+  return hydrateCoreCoValueSchema(coreSchema);
 };
 
 export const coProfileDefiner = <
@@ -121,7 +121,7 @@ export const coProfileDefiner = <
     inbox: z.optional(z.string()),
     inboxInvite: z.optional(z.string()),
   });
-  return coMapDefiner(ehnancedShape) as CoProfileSchema<Shape>;
+  return coMapDefiner(ehnancedShape) as unknown as CoProfileSchema<Shape>;
 };
 
 export const coFeedDefiner = <T extends AnyZodOrCoValueSchema>(

--- a/packages/jazz-tools/src/tools/implementation/zodSchema/zodSchema.ts
+++ b/packages/jazz-tools/src/tools/implementation/zodSchema/zodSchema.ts
@@ -24,8 +24,8 @@ import {
 import { CoFeedSchema, CoreCoFeedSchema } from "./schemaTypes/CoFeedSchema.js";
 import { CoListSchema, CoreCoListSchema } from "./schemaTypes/CoListSchema.js";
 import {
-  CoMapInitZod,
   CoMapSchema,
+  CoMapSchemaInit,
   CoreCoMapSchema,
 } from "./schemaTypes/CoMapSchema.js";
 import {
@@ -126,5 +126,5 @@ export type ResolveQueryStrict<
 export type InitFor<T extends CoValueClassOrSchema> = T extends CoreCoMapSchema<
   infer Shape
 >
-  ? Simplify<CoMapInitZod<Shape>>
+  ? Simplify<CoMapSchemaInit<Shape>>
   : never;

--- a/packages/jazz-tools/src/tools/lib/utilityTypes.ts
+++ b/packages/jazz-tools/src/tools/lib/utilityTypes.ts
@@ -1,7 +1,7 @@
 /**
  * Make any property optional if its type includes `undefined`, preserving the type as-is
  */
-export type OptionalizeUndefinedKeys<T> = {
+export type PartialOnUndefined<T> = {
   [K in keyof T as undefined extends T[K] ? never : K]: T[K];
 } & {
   [K in keyof T as undefined extends T[K] ? K : never]?: T[K];

--- a/packages/jazz-tools/src/tools/lib/utilityTypes.ts
+++ b/packages/jazz-tools/src/tools/lib/utilityTypes.ts
@@ -1,4 +1,13 @@
 /**
+ * Make any property optional if its type includes `undefined`, preserving the type as-is
+ */
+export type OptionalizeUndefinedKeys<T> = {
+  [K in keyof T as undefined extends T[K] ? never : K]: T[K];
+} & {
+  [K in keyof T as undefined extends T[K] ? K : never]?: T[K];
+};
+
+/**
  * Useful to flatten the type output to improve type hints shown in editors.
  * And also to transform an interface into a type to aide with assignability.
  *

--- a/packages/jazz-tools/src/tools/tests/coFeed.test.ts
+++ b/packages/jazz-tools/src/tools/tests/coFeed.test.ts
@@ -13,15 +13,9 @@ import {
   FileStream,
   Group,
   co,
-  cojsonInternals,
   isControlledAccount,
   z,
 } from "../index.js";
-import {
-  Loaded,
-  createJazzContextFromExistingCredentials,
-  randomSessionProvider,
-} from "../internal.js";
 import { createJazzTestAccount, setupJazzTestSync } from "../testing.js";
 import { setupTwoNodes } from "./utils.js";
 
@@ -56,6 +50,14 @@ describe("Simple CoFeed operations", async () => {
   test("Construction", () => {
     expect(stream.perAccount[me.id]?.value).toEqual("milk");
     expect(stream.perSession[me.sessionID]?.value).toEqual("milk");
+  });
+
+  test("Construction with nullable values", () => {
+    const NullableTestStream = co.feed(z.string().nullable());
+    const stream = NullableTestStream.create(["milk", null], { owner: me });
+
+    expect(stream.perAccount[me.id]?.value).toEqual(null);
+    expect(stream.perSession[me.sessionID]?.value).toEqual(null);
   });
 
   test("Construction with an Account", () => {

--- a/packages/jazz-tools/src/tools/tests/coList.test.ts
+++ b/packages/jazz-tools/src/tools/tests/coList.test.ts
@@ -52,6 +52,16 @@ describe("Simple CoList operations", async () => {
     expect(list[2]).toBe("c");
   });
 
+  test("list with nullable content", () => {
+    const List = co.list(z.string().nullable());
+    const list = List.create(["a", "b", "c", null]);
+    expect(list.length).toBe(4);
+    expect(list[0]).toBe("a");
+    expect(list[1]).toBe("b");
+    expect(list[2]).toBe("c");
+    expect(list[3]).toBeNull();
+  });
+
   test("Construction with an Account", () => {
     const list = TestList.create(["milk"], me);
 

--- a/packages/jazz-tools/src/tools/tests/coMap.record.test.ts
+++ b/packages/jazz-tools/src/tools/tests/coMap.record.test.ts
@@ -52,6 +52,15 @@ describe("CoMap.Record", async () => {
       expect(Object.keys(person)).toEqual(["age"]);
     });
 
+    test("create a Record with nullable values", () => {
+      const Person = co.record(z.string(), z.string().nullable());
+      const person = Person.create({ name: "John", age: null });
+      person.bio = null;
+      expect(person.name).toEqual("John");
+      expect(person.age).toEqual(null);
+      expect(person.bio).toEqual(null);
+    });
+
     test("property existence", () => {
       const Person = co.record(z.string(), z.string());
 
@@ -159,7 +168,7 @@ describe("CoMap.Record", async () => {
 
       person.name = "Jane";
 
-      const edits = person._edits.name?.all;
+      const edits = person.$jazz.getEdits().name?.all;
       expect(edits).toEqual([
         expect.objectContaining({
           value: "John",

--- a/packages/jazz-tools/src/tools/tests/coMap.record.test.ts
+++ b/packages/jazz-tools/src/tools/tests/coMap.record.test.ts
@@ -168,7 +168,7 @@ describe("CoMap.Record", async () => {
 
       person.name = "Jane";
 
-      const edits = person.$jazz.getEdits().name?.all;
+      const edits = person._edits.name?.all;
       expect(edits).toEqual([
         expect.objectContaining({
           value: "John",

--- a/packages/jazz-tools/src/tools/tests/coMap.test-d.ts
+++ b/packages/jazz-tools/src/tools/tests/coMap.test-d.ts
@@ -1,7 +1,7 @@
 import { assert, describe, expectTypeOf, test } from "vitest";
 import { Group, co, z } from "../exports.js";
 import { Account } from "../index.js";
-import { Loaded } from "../internal.js";
+import { CoMap, Loaded } from "../internal.js";
 
 describe("CoMap", async () => {
   describe("init", () => {
@@ -406,6 +406,34 @@ describe("CoMap resolution", async () => {
           $onError: never; // TODO: Clean the $onError from the type
         })
       | null
+    >();
+  });
+
+  test("loading a map with a nullable field", async () => {
+    const Dog = co.map({
+      name: z.string(),
+      breed: z.string(),
+    });
+    const Person = co.map({
+      name: z.string(),
+      age: z.number().nullable(),
+      dog: Dog,
+    });
+
+    const person = Person.create({
+      name: "John",
+      age: 20,
+      dog: Dog.create({ name: "Rex", breed: "Labrador" }),
+    });
+
+    const loadedPerson = await Person.load(person.id);
+
+    expectTypeOf(loadedPerson!).toEqualTypeOf<
+      {
+        name: string;
+        age: number | null;
+        dog: Loaded<typeof Dog> | null;
+      } & CoMap
     >();
   });
 });

--- a/packages/jazz-tools/src/tools/tests/coMap.test.ts
+++ b/packages/jazz-tools/src/tools/tests/coMap.test.ts
@@ -143,8 +143,7 @@ describe("CoMap", async () => {
       const Person = co.map({
         name: z.string(),
         age: z.number(),
-        // TODO: would be nice if this didn't need a type annotation
-        get friend(): co.Optional<typeof Person> {
+        get friend() {
           return co.optional(Person);
         },
       });
@@ -312,6 +311,52 @@ describe("CoMap", async () => {
       expect(person.name).toEqual("Jane");
       expect(person.age).toEqual(28);
       expect(person.extra).toEqual("extra");
+    });
+
+    test("CoMap with reference can be created with a shallowly resolved reference", async () => {
+      const Dog = co.map({
+        name: z.string(),
+        breed: z.string(),
+      });
+      const Person = co.map({
+        name: z.string(),
+        age: z.number(),
+        pet: Dog,
+        get friend() {
+          return Person.optional();
+        },
+      });
+
+      const group = Group.create();
+      group.addMember("everyone", "writer");
+
+      const pet = Dog.create({ name: "Rex", breed: "Labrador" }, group);
+      const personA = Person.create(
+        {
+          name: "John",
+          age: 20,
+          pet,
+        },
+        { owner: group },
+      );
+
+      const userB = await createJazzTestAccount();
+      const loadedPersonA = await Person.load(personA.id, {
+        resolve: true,
+        loadAs: userB,
+      });
+
+      expect(loadedPersonA).not.toBeNull();
+      assert(loadedPersonA);
+
+      const personB = Person.create({
+        name: "Jane",
+        age: 28,
+        pet,
+        friend: loadedPersonA,
+      });
+
+      expect(personB.friend?.pet.name).toEqual("Rex");
     });
   });
 

--- a/packages/jazz-tools/src/tools/tests/coMap.test.ts
+++ b/packages/jazz-tools/src/tools/tests/coMap.test.ts
@@ -291,6 +291,28 @@ describe("CoMap", async () => {
         age: 30,
       });
     });
+
+    it("should allow extra properties when catchall is provided", () => {
+      const Person = co
+        .map({
+          name: z.string(),
+          age: z.number(),
+        })
+        .catchall(z.string());
+
+      const person = Person.create({ name: "John", age: 20 });
+      expect(person.name).toEqual("John");
+      expect(person.age).toEqual(20);
+      expect(person.extra).toBeUndefined();
+
+      person.name = "Jane";
+      person.age = 28;
+      person.extra = "extra";
+
+      expect(person.name).toEqual("Jane");
+      expect(person.age).toEqual(28);
+      expect(person.extra).toEqual("extra");
+    });
   });
 
   describe("Mutation", () => {

--- a/packages/jazz-tools/src/tools/tests/zod.test.ts
+++ b/packages/jazz-tools/src/tools/tests/zod.test.ts
@@ -60,6 +60,44 @@ describe("co.map and Zod schema compatibility", () => {
       expect(map.createdAt).toEqual(undefined);
     });
 
+    it("should not handle nullable date fields", () => {
+      const schema = co.map({
+        updatedAt: z.date().nullable(),
+      });
+      expect(() => schema.create({ updatedAt: null })).toThrow(
+        "Nullable z.date() is not supported",
+      );
+    });
+
+    it("should handle nullable fields", () => {
+      const schema = co.map({
+        updatedAt: z.string().nullable(),
+      });
+
+      const map = schema.create({
+        updatedAt: null,
+      });
+      expect(map.updatedAt).toBeNull();
+
+      map.updatedAt = "Test";
+      expect(map.updatedAt).toEqual("Test");
+    });
+
+    it("should handle nullish fields", () => {
+      const schema = co.map({
+        updatedAt: z.string().nullish(),
+      });
+
+      const map = schema.create({});
+      expect(map.updatedAt).toBeUndefined();
+
+      map.updatedAt = null;
+      expect(map.updatedAt).toBeNull();
+
+      map.updatedAt = "Test";
+      expect(map.updatedAt).toEqual("Test");
+    });
+
     it("should handle literal fields", async () => {
       const schema = co.map({
         status: z.literal("active"),


### PR DESCRIPTION
# Description

Add support for nullable non-collaborative fields. I also took the opportunity to simplify `CoMapSchema.create`'s input and return types.

Motivation: an adopter was asking about it: https://discord.com/channels/1139617727565271160/1139621689882321009/1399159852416372826, and I think it's an useful feature to have. Plus, it's easy to implement now that we distinguish between collaborative and non-collaborative fields.

## Tests

- [x] Tests have been added and/or updated

## Checklist

- [ ] I've updated the part of the docs that are affected the PR changes
- [x] I've generated a changeset, if a version bump is required
- [ ] I've updated the jsDoc comments to the public APIs I've modified, or added them when missing