### PR TITLE
feat: create CoValues using plain JSON objects

### DIFF
--- a/.changeset/long-tools-smash.md
+++ b/.changeset/long-tools-smash.md
@@ -1,0 +1,7 @@
+---
+"jazz-tools": patch
+---
+
+Streamlined CoValue creation:
+- CoValues can be created with plain JSON objects. Nested CoValues will be automatically created when necessary.
+- Optional fields can be ommited (i.e. it's no longer necessary to provide an explicit `undefined` value).

--- a/examples/form/src/CreateOrder.tsx
+++ b/examples/form/src/CreateOrder.tsx
@@ -34,7 +34,7 @@ export function CreateOrder() {
 
     // reset the draft
     me.root.draft = DraftBubbleTeaOrder.create({
-      addOns: ListOfBubbleTeaAddOns.create([]),
+      addOns: [],
     });
 
     router.navigate("/");

--- a/examples/form/src/CreateOrder.tsx
+++ b/examples/form/src/CreateOrder.tsx
@@ -9,7 +9,6 @@ import {
   BubbleTeaOrder,
   DraftBubbleTeaOrder,
   JazzAccount,
-  ListOfBubbleTeaAddOns,
   validateDraftOrder,
 } from "./schema.ts";
 

--- a/examples/form/src/schema.ts
+++ b/examples/form/src/schema.ts
@@ -73,15 +73,9 @@ export const JazzAccount = co
   })
   .withMigration((account) => {
     if (!account.root) {
-      const orders = co.list(BubbleTeaOrder).create([], account);
-      const draft = DraftBubbleTeaOrder.create(
-        {
-          addOns: ListOfBubbleTeaAddOns.create([], account),
-          instructions: co.plainText().create("", account),
-        },
+      account.root = AccountRoot.create(
+        { draft: { addOns: [], instructions: "" }, orders: [] },
         account,
       );
-
-      account.root = AccountRoot.create({ draft, orders }, account);
     }
   });

--- a/homepage/homepage/content/docs/groups/inheritance.mdx
+++ b/homepage/homepage/content/docs/groups/inheritance.mdx
@@ -233,15 +233,49 @@ const board = Board.create({
 </CodeGroup>
 
 For each created column and task CoValue, Jazz also creates a new group as its owner and
-adds the referencing CoValue's owner as a member of that group. This allows you to then manage
-permissions for each CoValue independently.
+adds the referencing CoValue's owner as a member of that group. This means permissions for nested CoValues 
+are inherited from the CoValue that references them, but can also be modified independently for each CoValue
+if needed.
+
+<CodeGroup>
+```ts twoslash
+import { co, z, Group, Account } from "jazz-tools";
+
+const alice = {} as unknown as Account;
+const bob = {} as unknown as Account;
+const Task = co.plainText();
+const Column = co.list(Task);
+const Board = co.map({
+  title: z.string(),
+  columns: co.list(Column),
+});
+// ---cut---
+const writeAccess = Group.create();
+writeAccess.addMember(bob, "writer")
+
+// Give Bob write access to the board, columns and tasks
+const board = Board.create({
+  title: "My board",
+  columns: [
+    ["Task 1.1", "Task 1.2"],
+    ["Task 2.1", "Task 2.2"],
+  ],
+}, writeAccess);
+
+// Give Alice read access to one specific task
+const task = board.columns[0][0];
+const taskGroup = task._owner.castAs(Group);
+taskGroup.addMember(alice, "reader");
+```
+</CodeGroup>
 
 If you prefer to manage permissions differently, you can always create CoValues explicitly:
 
 <CodeGroup>
 ```ts twoslash
-import { co, Group, z } from "jazz-tools";
+import { co, Group, z, Account } from "jazz-tools";
 
+const bob = {} as unknown as Account;
 const Task = co.plainText();
 const Column = co.list(Task);
 const Board = co.map({
@@ -250,21 +284,19 @@ const Board = co.map({
 });
 
 // ---cut---
-// Set a single group as the owner of all CoValues
-const group = Group.create();
+const writeAccess = Group.create();
+writeAccess.addMember(bob, "writer");
+const readAccess =  Group.create();
+readAccess.addMember(bob, "reader");
+
+// Give Bob read access to the board and write access to the columns and tasks
 const board = Board.create({
   title: "My board",
   columns: co.list(Column).create([
-    Column.create([
-      Task.create("Task 1.1", group),
-      Task.create("Task 1.2", group),
-    ], group),
-    Column.create([
-      Task.create("Task 2.1", group),
-      Task.create("Task 2.2", group),
-    ], group),
-  ], group),
-}, group);
+    ["Task 1.1", "Task 1.2"],
+    ["Task 2.1", "Task 2.2"],
+  ], writeAccess),
+}, readAccess);
 ```
 </CodeGroup>
 

--- a/homepage/homepage/content/docs/groups/inheritance.mdx
+++ b/homepage/homepage/content/docs/groups/inheritance.mdx
@@ -205,6 +205,69 @@ console.log(containingGroup.getParentGroups()); // [addedGroup]
 ```
 </CodeGroup>
 
+## Group hierarchy on CoValue creation
+
+When creating CoValues that contain other CoValues using plain JSON objects, Jazz not only creates
+the necessary CoValues automatically but it will also manage their group ownership.
+
+<CodeGroup>
+```ts twoslash
+import { co } from "jazz-tools";
+
+// ---cut---
+const Task = co.plainText();
+const Column = co.list(Task);
+const Board = co.map({
+  title: z.string(),
+  columns: co.list(Column),
+});
+
+const board = Board.create({
+  title: "My board",
+  columns: [
+    ["Task 1.1", "Task 1.2"],
+    ["Task 2.1", "Task 2.2"],
+  ],
+});
+```
+</CodeGroup>
+
+For each created column and task CoValue, Jazz also creates a new group as its owner and
+adds the referencing CoValue's owner as a member of that group. This allows you to then manage
+permissions for each CoValue independently.
+
+If you prefer to manage permissions differently, you can always create CoValues explicitly:
+
+<CodeGroup>
+```ts twoslash
+import { co } from "jazz-tools";
+
+const Task = co.plainText();
+const Column = co.list(Task);
+const Board = co.map({
+  title: z.string(),
+  columns: co.list(Column),
+});
+
+// ---cut---
+// Set a single group as the owner of all CoValues
+const group = Group.create();
+const board = Board.create({
+  title: "My board",
+  columns: co.list(Column, group).create([
+    Column.create([
+      Task.create("Task 1.1", group),
+      Task.create("Task 1.2", group),
+    ], group),
+    Column.create([
+      Task.create("Task 2.1", group),
+      Task.create("Task 2.2", group),
+    ], group),
+  ]),
+}, group);
+```
+</CodeGroup>
+
 ## Example: Team Hierarchy
 
 Here's a practical example of using group inheritance for team permissions:

--- a/homepage/homepage/content/docs/groups/inheritance.mdx
+++ b/homepage/homepage/content/docs/groups/inheritance.mdx
@@ -251,7 +251,7 @@ const Board = co.map({
 });
 // ---cut---
 const writeAccess = Group.create();
-writeAccess.addMember(bob, "writer")
+writeAccess.addMember(bob, "writer");
 
 // Give Bob write access to the board, columns and tasks
 const board = Board.create({

--- a/homepage/homepage/content/docs/groups/inheritance.mdx
+++ b/homepage/homepage/content/docs/groups/inheritance.mdx
@@ -212,7 +212,7 @@ the necessary CoValues automatically but it will also manage their group ownersh
 
 <CodeGroup>
 ```ts twoslash
-import { co } from "jazz-tools";
+import { co, z } from "jazz-tools";
 
 // ---cut---
 const Task = co.plainText();
@@ -240,7 +240,7 @@ If you prefer to manage permissions differently, you can always create CoValues 
 
 <CodeGroup>
 ```ts twoslash
-import { co } from "jazz-tools";
+import { co, Group, z } from "jazz-tools";
 
 const Task = co.plainText();
 const Column = co.list(Task);
@@ -254,7 +254,7 @@ const Board = co.map({
 const group = Group.create();
 const board = Board.create({
   title: "My board",
-  columns: co.list(Column, group).create([
+  columns: co.list(Column).create([
     Column.create([
       Task.create("Task 1.1", group),
       Task.create("Task 1.2", group),
@@ -263,7 +263,7 @@ const board = Board.create({
       Task.create("Task 2.1", group),
       Task.create("Task 2.2", group),
     ], group),
-  ]),
+  ], group),
 }, group);
 ```
 </CodeGroup>

--- a/homepage/homepage/content/docs/schemas/covalues.mdx
+++ b/homepage/homepage/content/docs/schemas/covalues.mdx
@@ -102,10 +102,11 @@ export const TodoProject = co.map({
 import { Group } from "jazz-tools";
 import { TodoProject, ListOfTasks } from "./schema";
 
+const group = Group.create().makePublic();
 const project = TodoProject.create({
   title: "New Project",
-  tasks: [],
-});
+  tasks: [], // Permissions are inherited, so the tasks list will also be public
+}, group);
 ```
 </CodeGroup>
 

--- a/homepage/homepage/content/docs/schemas/covalues.mdx
+++ b/homepage/homepage/content/docs/schemas/covalues.mdx
@@ -3,6 +3,7 @@ export const metadata = {
 };
 
 import { CodeGroup, ComingSoon } from "@/components/forMdx";
+import { Alert } from "@garden-co/design-system/src/components/atoms/Alert";
 
 # Defining schemas: CoValues
 

--- a/homepage/homepage/content/docs/schemas/covalues.mdx
+++ b/homepage/homepage/content/docs/schemas/covalues.mdx
@@ -80,6 +80,40 @@ const project = TodoProject.create(
 
 </CodeGroup>
 
+When creating CoValues that contain other CoValues, you can pass in a plain JSON object.
+Jazz will automatically create the CoValues for you.
+
+<CodeGroup>
+```ts twoslash
+// @filename: schema.ts
+import { co, z, CoMap, CoList } from "jazz-tools";
+
+export const ListOfTasks = co.list(z.string());
+
+export const TodoProject = co.map({
+  title: z.string(),
+  tasks: ListOfTasks,
+});
+
+// @filename: app.ts
+// ---cut---
+// app.ts
+import { Group } from "jazz-tools";
+import { TodoProject, ListOfTasks } from "./schema";
+
+const project = TodoProject.create({
+  title: "New Project",
+  tasks: [],
+});
+```
+
+<Alert variant="info" className="flex gap-2 items-center my-4">
+To learn more about how permissions work when creating nested CoValues with plain JSON objects,
+refer to [Group hierarchy on CoValue creation](/docs/groups/inheritance#group-hierarchy-on-covalue-creation).
+</Alert>
+
+</CodeGroup>
+
 ## Types of CoValues
 
 ### `CoMap` (declaration)

--- a/homepage/homepage/content/docs/schemas/covalues.mdx
+++ b/homepage/homepage/content/docs/schemas/covalues.mdx
@@ -107,13 +107,12 @@ const project = TodoProject.create({
   tasks: [],
 });
 ```
+</CodeGroup>
 
 <Alert variant="info" className="flex gap-2 items-center my-4">
 To learn more about how permissions work when creating nested CoValues with plain JSON objects,
 refer to [Group hierarchy on CoValue creation](/docs/groups/inheritance#group-hierarchy-on-covalue-creation).
 </Alert>
-
-</CodeGroup>
 
 ## Types of CoValues
 

--- a/packages/jazz-tools/src/tools/coValues/coFeed.ts
+++ b/packages/jazz-tools/src/tools/coValues/coFeed.ts
@@ -34,6 +34,7 @@ import {
   coField,
   ensureCoValueLoaded,
   inspect,
+  instantiateRefEncodedWithInit,
   isRefEncoded,
   loadCoValueWithoutMe,
   parseCoValueCreateOptions,
@@ -278,7 +279,16 @@ export class CoFeed<out Item = any> extends CoValueBase implements CoValue {
     } else if ("encoded" in itemDescriptor) {
       this._raw.push(itemDescriptor.encoded.encode(item));
     } else if (isRefEncoded(itemDescriptor)) {
-      this._raw.push((item as unknown as CoValue).id);
+      let refId = (item as unknown as CoValue).id;
+      if (!refId) {
+        const coValue = instantiateRefEncodedWithInit(
+          itemDescriptor,
+          item,
+          this._owner,
+        );
+        refId = coValue.id;
+      }
+      this._raw.push(refId);
     }
   }
 
@@ -418,9 +428,7 @@ export class CoFeed<out Item = any> extends CoValueBase implements CoValue {
    *
    * @category Subscription & Loading
    */
-  waitForSync(options?: {
-    timeout?: number;
-  }) {
+  waitForSync(options?: { timeout?: number }) {
     return this._raw.core.waitForSync(options);
   }
 }

--- a/packages/jazz-tools/src/tools/coValues/coList.ts
+++ b/packages/jazz-tools/src/tools/coValues/coList.ts
@@ -29,6 +29,8 @@ import {
   coValuesCache,
   ensureCoValueLoaded,
   inspect,
+  instantiateRefEncodedWithInit,
+  isCoValueClass,
   isRefEncoded,
   loadCoValueWithoutMe,
   makeRefs,
@@ -240,7 +242,7 @@ export class CoList<out Item = any> extends Array<Item> implements CoValue {
     const { owner } = parseCoValueCreateOptions(options);
     const instance = new this({ init: items, owner });
     const raw = owner._raw.createList(
-      toRawItems(items, instance._schema[ItemsSym]),
+      toRawItems(items, instance._schema[ItemsSym], owner),
     );
 
     Object.defineProperties(instance, {
@@ -256,7 +258,7 @@ export class CoList<out Item = any> extends Array<Item> implements CoValue {
 
   push(...items: Item[]): number {
     this._raw.appendItems(
-      toRawItems(items, this._schema[ItemsSym]),
+      toRawItems(items, this._schema[ItemsSym], this._owner),
       undefined,
       "private",
     );
@@ -265,7 +267,11 @@ export class CoList<out Item = any> extends Array<Item> implements CoValue {
   }
 
   unshift(...items: Item[]): number {
-    for (const item of toRawItems(items as Item[], this._schema[ItemsSym])) {
+    for (const item of toRawItems(
+      items as Item[],
+      this._schema[ItemsSym],
+      this._owner,
+    )) {
       this._raw.prepend(item);
     }
 
@@ -306,7 +312,11 @@ export class CoList<out Item = any> extends Array<Item> implements CoValue {
       this._raw.delete(idxToDelete);
     }
 
-    const rawItems = toRawItems(items as Item[], this._schema[ItemsSym]);
+    const rawItems = toRawItems(
+      items as Item[],
+      this._schema[ItemsSym],
+      this._owner,
+    );
 
     // If there are no items to insert, return the deleted items
     if (rawItems.length === 0) {
@@ -551,23 +561,36 @@ export class CoList<out Item = any> extends Array<Item> implements CoValue {
  * Convert an array of items to a raw array of items.
  * @param items - The array of items to convert.
  * @param itemDescriptor - The descriptor of the items.
+ * @param owner - The owner of the CoList.
  * @returns The raw array of items.
  */
-function toRawItems<Item>(items: Item[], itemDescriptor: Schema) {
-  const rawItems =
-    itemDescriptor === "json"
-      ? (items as JsonValue[])
-      : "encoded" in itemDescriptor
-        ? items?.map((e) => itemDescriptor.encoded.encode(e))
-        : isRefEncoded(itemDescriptor)
-          ? items?.map((v) => {
-              if (!v) return null;
-
-              return (v as unknown as CoValue).id;
-            })
-          : (() => {
-              throw new Error("Invalid element descriptor");
-            })();
+function toRawItems<Item>(
+  items: Item[],
+  itemDescriptor: Schema,
+  owner: Account | Group,
+) {
+  let rawItems: JsonValue[] = [];
+  if (itemDescriptor === "json") {
+    rawItems = items as JsonValue[];
+  } else if ("encoded" in itemDescriptor) {
+    rawItems = items?.map((e) => itemDescriptor.encoded.encode(e));
+  } else if (isRefEncoded(itemDescriptor)) {
+    rawItems = items?.map((value) => {
+      if (!value) return null;
+      let refId = (value as unknown as CoValue).id;
+      if (!refId) {
+        const coValue = instantiateRefEncodedWithInit(
+          itemDescriptor,
+          value,
+          owner,
+        );
+        refId = coValue.id;
+      }
+      return refId;
+    });
+  } else {
+    throw new Error("Invalid element descriptor");
+  }
   return rawItems;
 }
 

--- a/packages/jazz-tools/src/tools/coValues/coList.ts
+++ b/packages/jazz-tools/src/tools/coValues/coList.ts
@@ -575,7 +575,7 @@ function toRawItems<Item>(
     rawItems = items?.map((e) => itemDescriptor.encoded.encode(e));
   } else if (isRefEncoded(itemDescriptor)) {
     rawItems = items?.map((value) => {
-      if (!value) return null;
+      if (value == null) return null;
       let refId = (value as unknown as CoValue).id;
       if (!refId) {
         const coValue = instantiateRefEncodedWithInit(

--- a/packages/jazz-tools/src/tools/coValues/coList.ts
+++ b/packages/jazz-tools/src/tools/coValues/coList.ts
@@ -30,7 +30,6 @@ import {
   ensureCoValueLoaded,
   inspect,
   instantiateRefEncodedWithInit,
-  isCoValueClass,
   isRefEncoded,
   loadCoValueWithoutMe,
   makeRefs,

--- a/packages/jazz-tools/src/tools/coValues/coMap.ts
+++ b/packages/jazz-tools/src/tools/coValues/coMap.ts
@@ -37,7 +37,7 @@ import {
   activeAccountContext,
   ensureCoValueLoaded,
   inspect,
-  instantiateRefEncoded,
+  instantiateRefEncodedWithInit,
   isCoValueClass,
   isRefEncoded,
   loadCoValueWithoutMe,
@@ -429,14 +429,11 @@ export class CoMap extends CoValueBase implements CoValue {
           if (initValue) {
             let refId = (initValue as unknown as CoValue).id;
             if (!refId) {
-              if (!isCoValueClass(descriptor.ref)) {
-                // TODO do we need to support (raw: RawCoValue) => CoValueClass<V> refs?
-                throw Error(
-                  "Cannot create a CoMap with a reference to a non-CoValue",
-                );
-              }
-              // @ts-expect-error - create is a static method in all CoValue classes
-              const coValue = descriptor.ref.create(initValue, owner);
+              const coValue = instantiateRefEncodedWithInit(
+                descriptor,
+                initValue,
+                owner,
+              );
               refId = coValue.id;
             }
             rawInit[key] = refId;

--- a/packages/jazz-tools/src/tools/coValues/coMap.ts
+++ b/packages/jazz-tools/src/tools/coValues/coMap.ts
@@ -38,7 +38,6 @@ import {
   ensureCoValueLoaded,
   inspect,
   instantiateRefEncodedWithInit,
-  isCoValueClass,
   isRefEncoded,
   loadCoValueWithoutMe,
   makeRefs,

--- a/packages/jazz-tools/src/tools/coValues/coMap.ts
+++ b/packages/jazz-tools/src/tools/coValues/coMap.ts
@@ -425,7 +425,7 @@ export class CoMap extends CoValueBase implements CoValue {
         if (descriptor === "json") {
           rawInit[key] = initValue as JsonValue;
         } else if (isRefEncoded(descriptor)) {
-          if (initValue) {
+          if (initValue != null) {
             let refId = (initValue as unknown as CoValue).id;
             if (!refId) {
               const coValue = instantiateRefEncodedWithInit(

--- a/packages/jazz-tools/src/tools/coValues/inbox.ts
+++ b/packages/jazz-tools/src/tools/coValues/inbox.ts
@@ -145,7 +145,7 @@ export class Inbox {
 
       for (const [sessionID, items] of Object.entries(stream.items) as [
         SessionID,
-        CoStreamItem<CoID<InboxMessage<InstanceOfSchema<M>, O>>>[],
+        CoStreamItem<CoID<InboxMessage<NonNullable<InstanceOfSchema<M>>, O>>>[],
       ][]) {
         const accountID = getAccountIDfromSessionID(sessionID);
 

--- a/packages/jazz-tools/src/tools/exports.ts
+++ b/packages/jazz-tools/src/tools/exports.ts
@@ -107,7 +107,6 @@ export {
   type CoreAccountSchema as AnyAccountSchema,
   type ResolveQuery,
   type ResolveQueryStrict,
-  type InitFor,
 } from "./internal.js";
 
 export {

--- a/packages/jazz-tools/src/tools/implementation/schema.ts
+++ b/packages/jazz-tools/src/tools/implementation/schema.ts
@@ -157,19 +157,22 @@ export function instantiateRefEncodedFromRaw<V extends CoValue>(
  *
  * @param schema - The schema of the CoValue to create.
  * @param init - The init values to use to create the CoValue.
- * @param owner - The owner of the CoValue.
+ * @param parentOwner - The owner of the referencing CoValue. Will be used
+ * as the parent group of the created CoValue's group
  * @returns The created CoValue.
  */
 export function instantiateRefEncodedWithInit<V extends CoValue>(
   schema: RefEncoded<V>,
   init: any,
-  owner: Account | Group,
+  parentOwner: Account | Group,
 ): V {
   if (!isCoValueClass<V>(schema.ref)) {
     throw Error(
       `Cannot automatically create CoValue from value: ${JSON.stringify(init)}. Use the CoValue schema's create() method instead.`,
     );
   }
+  const owner = Group.create();
+  owner.addMember(parentOwner.castAs(Group));
   // @ts-expect-error - create is a static method in all CoValue classes
   return schema.ref.create(init, owner);
 }

--- a/packages/jazz-tools/src/tools/implementation/schema.ts
+++ b/packages/jazz-tools/src/tools/implementation/schema.ts
@@ -1,9 +1,11 @@
 import type { JsonValue, RawCoValue } from "cojson";
 import { CojsonInternalTypes } from "cojson";
 import {
+  Account,
   type CoValue,
   type CoValueClass,
   CoValueFromRaw,
+  Group,
   ItemsSym,
   JazzToolsSymbol,
   SchemaInit,
@@ -149,6 +151,20 @@ export function instantiateRefEncoded<V extends CoValue>(
     : (schema.ref as (raw: RawCoValue) => CoValueClass<V> & CoValueFromRaw<V>)(
         raw,
       ).fromRaw(raw);
+}
+
+export function instantiateRefEncodedWithInit<V extends CoValue>(
+  schema: RefEncoded<V>,
+  // TODO add a generic type to derive the type of initValues for each type of CoValue
+  initValues: any,
+  owner: Account | Group,
+): V {
+  if (!isCoValueClass<V>(schema.ref)) {
+    // TODO do we need to support (raw: RawCoValue) => CoValueClass<V> refs?
+    throw Error("Cannot create a CoMap with a reference to a non-CoValue");
+  }
+  // @ts-expect-error - create is a static method in all CoValue classes
+  return schema.ref.create(initValues, owner);
 }
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/packages/jazz-tools/src/tools/implementation/schema.ts
+++ b/packages/jazz-tools/src/tools/implementation/schema.ts
@@ -7,7 +7,6 @@ import {
   CoValueFromRaw,
   Group,
   ItemsSym,
-  JazzToolsSymbol,
   SchemaInit,
   isCoValueClass,
 } from "../internal.js";
@@ -142,7 +141,7 @@ export function isRefEncoded<V extends CoValue>(
   );
 }
 
-export function instantiateRefEncoded<V extends CoValue>(
+export function instantiateRefEncodedFromRaw<V extends CoValue>(
   schema: RefEncoded<V>,
   raw: RawCoValue,
 ): V {
@@ -153,18 +152,26 @@ export function instantiateRefEncoded<V extends CoValue>(
       ).fromRaw(raw);
 }
 
+/**
+ * Creates a new CoValue of the given ref type, using the provided init values.
+ *
+ * @param schema - The schema of the CoValue to create.
+ * @param init - The init values to use to create the CoValue.
+ * @param owner - The owner of the CoValue.
+ * @returns The created CoValue.
+ */
 export function instantiateRefEncodedWithInit<V extends CoValue>(
   schema: RefEncoded<V>,
-  // TODO add a generic type to derive the type of initValues for each type of CoValue
-  initValues: any,
+  init: any,
   owner: Account | Group,
 ): V {
   if (!isCoValueClass<V>(schema.ref)) {
-    // TODO do we need to support (raw: RawCoValue) => CoValueClass<V> refs?
-    throw Error("Cannot create a CoMap with a reference to a non-CoValue");
+    throw Error(
+      `Cannot automatically create CoValue from value: ${JSON.stringify(init)}. Use the CoValue schema's create() method instead.`,
+    );
   }
   // @ts-expect-error - create is a static method in all CoValue classes
-  return schema.ref.create(initValues, owner);
+  return schema.ref.create(init, owner);
 }
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/packages/jazz-tools/src/tools/implementation/zodSchema/schemaTypes/CoFeedSchema.ts
+++ b/packages/jazz-tools/src/tools/implementation/zodSchema/schemaTypes/CoFeedSchema.ts
@@ -6,20 +6,15 @@ import {
   RefsToResolve,
   RefsToResolveStrict,
   Resolved,
-  Simplify,
   SubscribeListenerOptions,
   coOptionalDefiner,
 } from "../../../internal.js";
 import { AnonymousJazzAgent } from "../../anonymousJazzAgent.js";
-import { CoFieldInit } from "../typeConverters/CoFieldInit.js";
+import { CoFeedInit } from "../typeConverters/CoFieldInit.js";
 import { InstanceOrPrimitiveOfSchema } from "../typeConverters/InstanceOrPrimitiveOfSchema.js";
 import { InstanceOrPrimitiveOfSchemaCoValuesNullable } from "../typeConverters/InstanceOrPrimitiveOfSchemaCoValuesNullable.js";
 import { CoOptionalSchema } from "./CoOptionalSchema.js";
 import { CoreCoValueSchema } from "./CoValueSchema.js";
-
-type CoFeedInit<T extends AnyZodOrCoValueSchema> = Simplify<
-  Array<CoFieldInit<T>>
->;
 
 export class CoFeedSchema<T extends AnyZodOrCoValueSchema>
   implements CoreCoFeedSchema<T>
@@ -36,7 +31,7 @@ export class CoFeedSchema<T extends AnyZodOrCoValueSchema>
     init: CoFeedInit<T>,
     options?: { owner: Account | Group } | Account | Group,
   ): CoFeedInstance<T> {
-    return this.coValueClass.create(init, options) as CoFeedInstance<T>;
+    return this.coValueClass.create(init as any, options) as CoFeedInstance<T>;
   }
 
   load<const R extends RefsToResolve<CoFeedInstanceCoValuesNullable<T>> = true>(

--- a/packages/jazz-tools/src/tools/implementation/zodSchema/schemaTypes/CoListSchema.ts
+++ b/packages/jazz-tools/src/tools/implementation/zodSchema/schemaTypes/CoListSchema.ts
@@ -5,21 +5,16 @@ import {
   RefsToResolve,
   RefsToResolveStrict,
   Resolved,
-  Simplify,
   SubscribeListenerOptions,
   coOptionalDefiner,
 } from "../../../internal.js";
 import { AnonymousJazzAgent } from "../../anonymousJazzAgent.js";
-import { CoFieldInit } from "../typeConverters/CoFieldInit.js";
+import { CoListInit } from "../typeConverters/CoFieldInit.js";
 import { InstanceOrPrimitiveOfSchema } from "../typeConverters/InstanceOrPrimitiveOfSchema.js";
 import { InstanceOrPrimitiveOfSchemaCoValuesNullable } from "../typeConverters/InstanceOrPrimitiveOfSchemaCoValuesNullable.js";
 import { AnyZodOrCoValueSchema } from "../zodSchema.js";
 import { CoOptionalSchema } from "./CoOptionalSchema.js";
 import { CoreCoValueSchema } from "./CoValueSchema.js";
-
-type CoListInit<T extends AnyZodOrCoValueSchema> = Simplify<
-  Array<CoFieldInit<T>>
->;
 
 export class CoListSchema<T extends AnyZodOrCoValueSchema>
   implements CoreCoListSchema<T>
@@ -36,7 +31,7 @@ export class CoListSchema<T extends AnyZodOrCoValueSchema>
     items: CoListInit<T>,
     options?: { owner: Account | Group } | Account | Group,
   ): CoListInstance<T> {
-    return this.coValueClass.create(items, options) as CoListInstance<T>;
+    return this.coValueClass.create(items as any, options) as CoListInstance<T>;
   }
 
   load<const R extends RefsToResolve<CoListInstanceCoValuesNullable<T>> = true>(

--- a/packages/jazz-tools/src/tools/implementation/zodSchema/schemaTypes/CoMapSchema.ts
+++ b/packages/jazz-tools/src/tools/implementation/zodSchema/schemaTypes/CoMapSchema.ts
@@ -17,7 +17,7 @@ import {
 } from "../../../internal.js";
 import { AnonymousJazzAgent } from "../../anonymousJazzAgent.js";
 import { removeGetters } from "../../schemaUtils.js";
-import { CoFieldInit } from "../typeConverters/CoFieldInit.js";
+import { CoMapSchemaInit } from "../typeConverters/CoFieldInit.js";
 import { InstanceOrPrimitiveOfSchema } from "../typeConverters/InstanceOrPrimitiveOfSchema.js";
 import { InstanceOrPrimitiveOfSchemaCoValuesNullable } from "../typeConverters/InstanceOrPrimitiveOfSchemaCoValuesNullable.js";
 import { z } from "../zodReExport.js";
@@ -30,7 +30,7 @@ export interface CoMapSchema<
   Owner extends Account | Group = Account | Group,
 > extends CoreCoMapSchema<Shape, CatchAll> {
   create: (
-    init: Simplify<CoMapSchemaInit<Shape>>,
+    init: Simplify<PartialOnUndefined<CoMapSchemaInit<Shape>>>,
     options?:
       | {
           owner: Owner;
@@ -226,13 +226,6 @@ export function enrichCoMapSchema<
   }) as unknown as CoMapSchema<Shape, CatchAll>;
   return coValueSchema;
 }
-
-// Due to a TS limitation with types that contain known properties and
-// an index signature, we cannot accept catchall properties on creation
-export type CoMapSchemaInit<Shape extends z.core.$ZodLooseShape> =
-  PartialOnUndefined<{
-    [key in keyof Shape]: CoFieldInit<Shape[key]>;
-  }>;
 
 export interface CoMapSchemaDefinition<
   Shape extends z.core.$ZodLooseShape = z.core.$ZodLooseShape,

--- a/packages/jazz-tools/src/tools/implementation/zodSchema/schemaTypes/CoMapSchema.ts
+++ b/packages/jazz-tools/src/tools/implementation/zodSchema/schemaTypes/CoMapSchema.ts
@@ -5,7 +5,6 @@ import {
   DiscriminableCoValueSchemaDefinition,
   DiscriminableCoreCoValueSchema,
   Group,
-  PartialOnUndefined,
   RefsToResolve,
   RefsToResolveStrict,
   Resolved,
@@ -30,7 +29,7 @@ export interface CoMapSchema<
   Owner extends Account | Group = Account | Group,
 > extends CoreCoMapSchema<Shape, CatchAll> {
   create: (
-    init: Simplify<PartialOnUndefined<CoMapSchemaInit<Shape>>>,
+    init: CoMapSchemaInit<Shape>,
     options?:
       | {
           owner: Owner;

--- a/packages/jazz-tools/src/tools/implementation/zodSchema/typeConverters/CoFieldInit.ts
+++ b/packages/jazz-tools/src/tools/implementation/zodSchema/typeConverters/CoFieldInit.ts
@@ -73,9 +73,9 @@ type InstanceOrPrimitiveOfSchemaInit<
           : S extends CoreCoFeedSchema<infer T>
             ? CoFeed<InstanceOrPrimitiveOfSchemaInit<T>> | null
             : S extends CorePlainTextSchema
-              ? CoPlainText | null
+              ? string | CoPlainText | null
               : S extends CoreRichTextSchema
-                ? CoRichText | null
+                ? string | CoRichText | null
                 : S extends CoreFileStreamSchema
                   ? FileStream | null
                   : S extends CoreCoOptionalSchema<infer T>

--- a/packages/jazz-tools/src/tools/implementation/zodSchema/typeConverters/CoFieldInit.ts
+++ b/packages/jazz-tools/src/tools/implementation/zodSchema/typeConverters/CoFieldInit.ts
@@ -49,23 +49,25 @@ export type CoFieldInit<S extends CoValueClass | AnyZodOrCoValueSchema> =
 
 // Due to a TS limitation with types that contain known properties and
 // an index signature, we cannot accept catchall properties on creation
-export type CoMapSchemaInit<Shape extends z.core.$ZodLooseShape> = {
-  /**
-   * Cannot use {@link PartialOnUndefined} because evaluating CoFieldInit<Shape[Key]>
-   * to know if the value can be undefined does not work with recursive types.
-   */
-  [Key in keyof Shape as Shape[Key] extends
-    | CoreCoOptionalSchema
-    | z.core.$ZodOptional
-    ? never
-    : Key]: CoFieldInit<Shape[Key]>;
-} & {
-  [Key in keyof Shape as Shape[Key] extends
-    | CoreCoOptionalSchema
-    | z.core.$ZodOptional
-    ? Key
-    : never]?: CoFieldInit<Shape[Key]>;
-};
+export type CoMapSchemaInit<Shape extends z.core.$ZodLooseShape> = Simplify<
+  {
+    /**
+     * Cannot use {@link PartialOnUndefined} because evaluating CoFieldInit<Shape[Key]>
+     * to know if the value can be undefined does not work with recursive types.
+     */
+    [Key in keyof Shape as Shape[Key] extends
+      | CoreCoOptionalSchema
+      | z.core.$ZodOptional
+      ? never
+      : Key]: CoFieldInit<Shape[Key]>;
+  } & {
+    [Key in keyof Shape as Shape[Key] extends
+      | CoreCoOptionalSchema
+      | z.core.$ZodOptional
+      ? Key
+      : never]?: CoFieldInit<Shape[Key]>;
+  }
+>;
 
 export type CoListInit<T extends AnyZodOrCoValueSchema> = Simplify<
   ReadonlyArray<CoFieldInit<T>>

--- a/packages/jazz-tools/src/tools/implementation/zodSchema/typeConverters/CoFieldInit.ts
+++ b/packages/jazz-tools/src/tools/implementation/zodSchema/typeConverters/CoFieldInit.ts
@@ -68,9 +68,7 @@ type InstanceOrPrimitiveOfSchemaInit<
                   }
                 : {}))
             | null
-        : // TODO for now we're only allowing JSON inputs for creating CoMaps
-          // TODO continue with the rest of the CoValue types
-          S extends CoreCoListSchema<infer T>
+        : S extends CoreCoListSchema<infer T>
           ? ReadonlyArray<InstanceOrPrimitiveOfSchemaInit<T>> | null
           : S extends CoreCoFeedSchema<infer T>
             ?

--- a/packages/jazz-tools/src/tools/implementation/zodSchema/typeConverters/CoFieldInit.ts
+++ b/packages/jazz-tools/src/tools/implementation/zodSchema/typeConverters/CoFieldInit.ts
@@ -73,7 +73,10 @@ type InstanceOrPrimitiveOfSchemaInit<
           S extends CoreCoListSchema<infer T>
           ? ReadonlyArray<InstanceOrPrimitiveOfSchemaInit<T>> | null
           : S extends CoreCoFeedSchema<infer T>
-            ? CoFeed<InstanceOrPrimitiveOfSchemaInit<T>> | null
+            ?
+                | ReadonlyArray<InstanceOrPrimitiveOfSchemaInit<T>>
+                | CoFeed<InstanceOrPrimitiveOfSchemaInit<T>>
+                | null
             : S extends CorePlainTextSchema
               ? string | CoPlainText | null
               : S extends CoreRichTextSchema

--- a/packages/jazz-tools/src/tools/implementation/zodSchema/typeConverters/CoFieldInit.ts
+++ b/packages/jazz-tools/src/tools/implementation/zodSchema/typeConverters/CoFieldInit.ts
@@ -1,7 +1,29 @@
-import { NotNull } from "../../../internal.js";
+import { JsonValue } from "cojson";
+import {
+  Account,
+  CoDiscriminatedUnionSchema,
+  CoFeed,
+  CoList,
+  CoPlainText,
+  CoRichText,
+  CoValueClass,
+  CoreAccountSchema,
+  CoreCoFeedSchema,
+  CoreCoListSchema,
+  CoreCoMapSchema,
+  CoreCoRecordSchema,
+  CoreFileStreamSchema,
+  CorePlainTextSchema,
+  FileStream,
+  InstanceOrPrimitiveOfSchema,
+  NotNull,
+  Profile,
+} from "../../../internal.js";
+import { CoreCoOptionalSchema } from "../schemaTypes/CoOptionalSchema.js";
+import { CoreCoValueSchema } from "../schemaTypes/CoValueSchema.js";
+import { CoreRichTextSchema } from "../schemaTypes/RichTextSchema.js";
 import { z } from "../zodReExport.js";
 import { AnyZodOrCoValueSchema } from "../zodSchema.js";
-import { InstanceOrPrimitiveOfSchemaCoValuesNullable } from "./InstanceOrPrimitiveOfSchemaCoValuesNullable.js";
 
 /**
  * Returns the type of the value that should be used to initialize a coField
@@ -9,5 +31,115 @@ import { InstanceOrPrimitiveOfSchemaCoValuesNullable } from "./InstanceOrPrimiti
  */
 export type CoFieldInit<T extends AnyZodOrCoValueSchema> =
   T extends z.core.$ZodNullable
-    ? InstanceOrPrimitiveOfSchemaCoValuesNullable<T>
-    : NotNull<InstanceOrPrimitiveOfSchemaCoValuesNullable<T>>;
+    ? InstanceOrPrimitiveOfSchemaInit<T>
+    : NotNull<InstanceOrPrimitiveOfSchemaInit<T>>;
+
+// Makes all of the value's fields nullable by default, to support using
+// partially-loaded CoValues to initialize new CoValues.
+type InstanceOrPrimitiveOfSchemaInit<
+  S extends CoValueClass | AnyZodOrCoValueSchema,
+> = S extends CoreCoValueSchema
+  ? S extends CoreAccountSchema<infer Shape>
+    ?
+        | ({
+            -readonly [key in keyof Shape]: InstanceOrPrimitiveOfSchemaInit<
+              Shape[key]
+            >;
+          } & { profile: Profile | null } & Account)
+        | null
+    : S extends CoreCoRecordSchema<infer K, infer V>
+      ?
+          | {
+              -readonly [key in z.output<K> &
+                string]: InstanceOrPrimitiveOfSchemaInit<V>;
+            }
+          | null
+      : S extends CoreCoMapSchema<infer Shape, infer CatchAll>
+        ?
+            | ({
+                -readonly [key in keyof Shape]: InstanceOrPrimitiveOfSchemaInit<
+                  Shape[key]
+                >;
+              } & (CatchAll extends AnyZodOrCoValueSchema
+                ? {
+                    [key: string]: InstanceOrPrimitiveOfSchemaInit<CatchAll>;
+                  }
+                : {}))
+            | null
+        : // TODO for now we're only allowing JSON inputs for creating CoMaps
+          // TODO continue with the rest of the CoValue types
+          S extends CoreCoListSchema<infer T>
+          ? CoList<InstanceOrPrimitiveOfSchemaInit<T>> | null
+          : S extends CoreCoFeedSchema<infer T>
+            ? CoFeed<InstanceOrPrimitiveOfSchemaInit<T>> | null
+            : S extends CorePlainTextSchema
+              ? CoPlainText | null
+              : S extends CoreRichTextSchema
+                ? CoRichText | null
+                : S extends CoreFileStreamSchema
+                  ? FileStream | null
+                  : S extends CoreCoOptionalSchema<infer T>
+                    ? InstanceOrPrimitiveOfSchemaInit<T> | undefined
+                    : S extends CoDiscriminatedUnionSchema<infer Members>
+                      ? InstanceOrPrimitiveOfSchemaInit<Members[number]>
+                      : never
+  : S extends z.core.$ZodType
+    ? S extends z.core.$ZodOptional<infer Inner extends z.core.$ZodType>
+      ? InstanceOrPrimitiveOfSchemaInit<Inner> | undefined
+      : S extends z.core.$ZodNullable<infer Inner extends z.core.$ZodType>
+        ? InstanceOrPrimitiveOfSchemaInit<Inner> | null
+        : S extends z.ZodJSONSchema
+          ? JsonValue
+          : S extends z.core.$ZodUnion<
+                infer Members extends readonly z.core.$ZodType[]
+              >
+            ? InstanceOrPrimitiveOfSchemaInit<Members[number]>
+            : // primitives below here - we manually traverse to ensure we only allow what we can handle
+              S extends z.core.$ZodObject<infer Shape>
+              ? {
+                  -readonly [key in keyof Shape]: InstanceOrPrimitiveOfSchema<
+                    Shape[key]
+                  >;
+                }
+              : S extends z.core.$ZodArray<infer Item extends z.core.$ZodType>
+                ? InstanceOrPrimitiveOfSchema<Item>[]
+                : S extends z.core.$ZodTuple<
+                      infer Items extends z.core.$ZodType[]
+                    >
+                  ? {
+                      [key in keyof Items]: InstanceOrPrimitiveOfSchema<
+                        Items[key]
+                      >;
+                    }
+                  : S extends z.core.$ZodString
+                    ? string
+                    : S extends z.core.$ZodNumber
+                      ? number
+                      : S extends z.core.$ZodBoolean
+                        ? boolean
+                        : S extends z.core.$ZodLiteral<infer Literal>
+                          ? Literal
+                          : S extends z.core.$ZodDate
+                            ? Date
+                            : S extends z.core.$ZodEnum<infer Enum>
+                              ? Enum[keyof Enum]
+                              : S extends z.core.$ZodTemplateLiteral<
+                                    infer pattern
+                                  >
+                                ? pattern
+                                : S extends z.core.$ZodReadonly<
+                                      infer Inner extends z.core.$ZodType
+                                    >
+                                  ? InstanceOrPrimitiveOfSchema<Inner>
+                                  : S extends z.core.$ZodDefault<
+                                        infer Default extends z.core.$ZodType
+                                      >
+                                    ? InstanceOrPrimitiveOfSchema<Default>
+                                    : S extends z.core.$ZodCatch<
+                                          infer Catch extends z.core.$ZodType
+                                        >
+                                      ? InstanceOrPrimitiveOfSchema<Catch>
+                                      : never
+    : S extends CoValueClass
+      ? InstanceType<S> | null
+      : never;

--- a/packages/jazz-tools/src/tools/implementation/zodSchema/typeConverters/CoFieldInit.ts
+++ b/packages/jazz-tools/src/tools/implementation/zodSchema/typeConverters/CoFieldInit.ts
@@ -1,94 +1,61 @@
-import { JsonValue } from "cojson";
 import {
-  Account,
   CoDiscriminatedUnionSchema,
-  CoFeed,
-  CoList,
-  CoPlainText,
-  CoRichText,
   CoValueClass,
-  CoreAccountSchema,
   CoreCoFeedSchema,
   CoreCoListSchema,
   CoreCoMapSchema,
   CoreCoRecordSchema,
-  CoreFileStreamSchema,
   CorePlainTextSchema,
-  FileStream,
-  InstanceOrPrimitiveOfSchema,
-  NotNull,
-  Profile,
+  Simplify,
 } from "../../../internal.js";
 import { CoreCoOptionalSchema } from "../schemaTypes/CoOptionalSchema.js";
 import { CoreCoValueSchema } from "../schemaTypes/CoValueSchema.js";
 import { CoreRichTextSchema } from "../schemaTypes/RichTextSchema.js";
 import { z } from "../zodReExport.js";
-import { AnyZodOrCoValueSchema } from "../zodSchema.js";
+import { AnyZodOrCoValueSchema, Loaded } from "../zodSchema.js";
 import { TypeOfZodSchema } from "./TypeOfZodSchema.js";
 
 /**
- * Returns the type of the value that should be used to initialize a coField
- * of the given schema.
+ * The type of value that can be used to initialize a CoField of the given schema.
+ *
+ * For CoValue fields, this can be either a shallowly-loaded CoValue instance
+ * or a JSON object that will be used to create the CoValue.
  */
-export type CoFieldInit<T extends AnyZodOrCoValueSchema> =
-  T extends z.core.$ZodNullable
-    ? InstanceOrPrimitiveOfSchemaInit<T>
-    : NotNull<InstanceOrPrimitiveOfSchemaInit<T>>;
-
-// Makes all of the value's fields nullable by default, to support using
-// partially-loaded CoValues to initialize new CoValues.
-// TODO this isn't correct: the input should either be a partially-loaded CoValue
-// or a "complete" JSON object that can be used to create a new CoValue.
-type InstanceOrPrimitiveOfSchemaInit<
-  S extends CoValueClass | AnyZodOrCoValueSchema,
-> = S extends CoreCoValueSchema
-  ? S extends CoreAccountSchema<infer Shape>
+export type CoFieldInit<S extends CoValueClass | AnyZodOrCoValueSchema> =
+  S extends CoreCoValueSchema
     ?
-        | ({
-            -readonly [key in keyof Shape]: InstanceOrPrimitiveOfSchemaInit<
-              Shape[key]
-            >;
-          } & { profile: Profile | null } & Account)
-        | null
-    : S extends CoreCoRecordSchema<infer K, infer V>
-      ?
-          | {
-              -readonly [key in z.output<K> &
-                string]: InstanceOrPrimitiveOfSchemaInit<V>;
-            }
-          | null
-      : S extends CoreCoMapSchema<infer Shape, infer CatchAll>
-        ?
-            | ({
-                -readonly [key in keyof Shape]: InstanceOrPrimitiveOfSchemaInit<
-                  Shape[key]
-                >;
-              } & (CatchAll extends AnyZodOrCoValueSchema
-                ? {
-                    [key: string]: InstanceOrPrimitiveOfSchemaInit<CatchAll>;
-                  }
-                : {}))
-            | null
-        : S extends CoreCoListSchema<infer T>
-          ? ReadonlyArray<InstanceOrPrimitiveOfSchemaInit<T>> | null
-          : S extends CoreCoFeedSchema<infer T>
-            ?
-                | ReadonlyArray<InstanceOrPrimitiveOfSchemaInit<T>>
-                | CoFeed<InstanceOrPrimitiveOfSchemaInit<T>>
-                | null
-            : S extends CorePlainTextSchema
-              ? string | CoPlainText | null
-              : S extends CoreRichTextSchema
-                ? string | CoRichText | null
-                : S extends CoreFileStreamSchema
-                  ? FileStream | null
-                  : S extends CoreCoOptionalSchema<infer T>
-                    ? InstanceOrPrimitiveOfSchemaInit<T> | undefined
-                    : S extends CoDiscriminatedUnionSchema<infer Members>
-                      ? InstanceOrPrimitiveOfSchemaInit<Members[number]>
-                      : never
-  : S extends z.core.$ZodType
-    ? TypeOfZodSchema<S>
-    : S extends CoValueClass
-      ? InstanceType<S> | null
-      : never;
+        | Loaded<S>
+        | (S extends CoreCoRecordSchema<infer K, infer V>
+            ? CoMapSchemaInit<{ [key in z.output<K> & string]: V }>
+            : S extends CoreCoMapSchema<infer Shape>
+              ? CoMapSchemaInit<Shape>
+              : S extends CoreCoListSchema<infer T>
+                ? CoListInit<T>
+                : S extends CoreCoFeedSchema<infer T>
+                  ? CoFeedInit<T>
+                  : S extends CorePlainTextSchema | CoreRichTextSchema
+                    ? string
+                    : S extends CoreCoOptionalSchema<infer T>
+                      ? CoFieldInit<T> | undefined
+                      : S extends CoDiscriminatedUnionSchema<infer Members>
+                        ? CoFieldInit<Members[number]>
+                        : never)
+    : S extends z.core.$ZodType
+      ? TypeOfZodSchema<S>
+      : S extends CoValueClass
+        ? InstanceType<S>
+        : never;
+
+// Due to a TS limitation with types that contain known properties and
+// an index signature, we cannot accept catchall properties on creation
+export type CoMapSchemaInit<Shape extends z.core.$ZodLooseShape> = Simplify<{
+  [key in keyof Shape]: CoFieldInit<Shape[key]>;
+}>;
+
+export type CoListInit<T extends AnyZodOrCoValueSchema> = Simplify<
+  ReadonlyArray<CoFieldInit<T>>
+>;
+
+export type CoFeedInit<T extends AnyZodOrCoValueSchema> = Simplify<
+  ReadonlyArray<CoFieldInit<T>>
+>;

--- a/packages/jazz-tools/src/tools/implementation/zodSchema/typeConverters/CoFieldInit.ts
+++ b/packages/jazz-tools/src/tools/implementation/zodSchema/typeConverters/CoFieldInit.ts
@@ -36,6 +36,8 @@ export type CoFieldInit<T extends AnyZodOrCoValueSchema> =
 
 // Makes all of the value's fields nullable by default, to support using
 // partially-loaded CoValues to initialize new CoValues.
+// TODO this isn't correct: the input should either be a partially-loaded CoValue
+// or a "complete" JSON object that can be used to create a new CoValue.
 type InstanceOrPrimitiveOfSchemaInit<
   S extends CoValueClass | AnyZodOrCoValueSchema,
 > = S extends CoreCoValueSchema
@@ -69,7 +71,7 @@ type InstanceOrPrimitiveOfSchemaInit<
         : // TODO for now we're only allowing JSON inputs for creating CoMaps
           // TODO continue with the rest of the CoValue types
           S extends CoreCoListSchema<infer T>
-          ? CoList<InstanceOrPrimitiveOfSchemaInit<T>> | null
+          ? ReadonlyArray<InstanceOrPrimitiveOfSchemaInit<T>> | null
           : S extends CoreCoFeedSchema<infer T>
             ? CoFeed<InstanceOrPrimitiveOfSchemaInit<T>> | null
             : S extends CorePlainTextSchema

--- a/packages/jazz-tools/src/tools/implementation/zodSchema/typeConverters/CoFieldInit.ts
+++ b/packages/jazz-tools/src/tools/implementation/zodSchema/typeConverters/CoFieldInit.ts
@@ -24,6 +24,7 @@ import { CoreCoValueSchema } from "../schemaTypes/CoValueSchema.js";
 import { CoreRichTextSchema } from "../schemaTypes/RichTextSchema.js";
 import { z } from "../zodReExport.js";
 import { AnyZodOrCoValueSchema } from "../zodSchema.js";
+import { TypeOfZodSchema } from "./TypeOfZodSchema.js";
 
 /**
  * Returns the type of the value that should be used to initialize a coField
@@ -87,62 +88,7 @@ type InstanceOrPrimitiveOfSchemaInit<
                       ? InstanceOrPrimitiveOfSchemaInit<Members[number]>
                       : never
   : S extends z.core.$ZodType
-    ? S extends z.core.$ZodOptional<infer Inner extends z.core.$ZodType>
-      ? InstanceOrPrimitiveOfSchemaInit<Inner> | undefined
-      : S extends z.core.$ZodNullable<infer Inner extends z.core.$ZodType>
-        ? InstanceOrPrimitiveOfSchemaInit<Inner> | null
-        : S extends z.ZodJSONSchema
-          ? JsonValue
-          : S extends z.core.$ZodUnion<
-                infer Members extends readonly z.core.$ZodType[]
-              >
-            ? InstanceOrPrimitiveOfSchemaInit<Members[number]>
-            : // primitives below here - we manually traverse to ensure we only allow what we can handle
-              S extends z.core.$ZodObject<infer Shape>
-              ? {
-                  -readonly [key in keyof Shape]: InstanceOrPrimitiveOfSchema<
-                    Shape[key]
-                  >;
-                }
-              : S extends z.core.$ZodArray<infer Item extends z.core.$ZodType>
-                ? InstanceOrPrimitiveOfSchema<Item>[]
-                : S extends z.core.$ZodTuple<
-                      infer Items extends z.core.$ZodType[]
-                    >
-                  ? {
-                      [key in keyof Items]: InstanceOrPrimitiveOfSchema<
-                        Items[key]
-                      >;
-                    }
-                  : S extends z.core.$ZodString
-                    ? string
-                    : S extends z.core.$ZodNumber
-                      ? number
-                      : S extends z.core.$ZodBoolean
-                        ? boolean
-                        : S extends z.core.$ZodLiteral<infer Literal>
-                          ? Literal
-                          : S extends z.core.$ZodDate
-                            ? Date
-                            : S extends z.core.$ZodEnum<infer Enum>
-                              ? Enum[keyof Enum]
-                              : S extends z.core.$ZodTemplateLiteral<
-                                    infer pattern
-                                  >
-                                ? pattern
-                                : S extends z.core.$ZodReadonly<
-                                      infer Inner extends z.core.$ZodType
-                                    >
-                                  ? InstanceOrPrimitiveOfSchema<Inner>
-                                  : S extends z.core.$ZodDefault<
-                                        infer Default extends z.core.$ZodType
-                                      >
-                                    ? InstanceOrPrimitiveOfSchema<Default>
-                                    : S extends z.core.$ZodCatch<
-                                          infer Catch extends z.core.$ZodType
-                                        >
-                                      ? InstanceOrPrimitiveOfSchema<Catch>
-                                      : never
+    ? TypeOfZodSchema<S>
     : S extends CoValueClass
       ? InstanceType<S> | null
       : never;

--- a/packages/jazz-tools/src/tools/implementation/zodSchema/typeConverters/InstanceOfSchema.ts
+++ b/packages/jazz-tools/src/tools/implementation/zodSchema/typeConverters/InstanceOfSchema.ts
@@ -11,6 +11,7 @@ import {
   CoreAccountSchema,
   CoreCoRecordSchema,
   FileStream,
+  Profile,
 } from "../../../internal.js";
 import { CoreCoFeedSchema } from "../schemaTypes/CoFeedSchema.js";
 import { CoreCoListSchema } from "../schemaTypes/CoListSchema.js";
@@ -27,15 +28,20 @@ export type InstanceOfSchema<S extends CoValueClass | AnyZodOrCoValueSchema> =
   S extends CoreCoValueSchema
     ? S extends CoreAccountSchema<infer Shape>
       ? {
-          [key in keyof Shape]: InstanceOrPrimitiveOfSchema<Shape[key]>;
+          -readonly [key in keyof Shape]: InstanceOrPrimitiveOfSchema<
+            Shape[key]
+          >;
         } & Account
       : S extends CoreCoRecordSchema<infer K, infer V>
         ? {
-            [key in z.output<K> & string]: InstanceOrPrimitiveOfSchema<V>;
+            -readonly [key in z.output<K> &
+              string]: InstanceOrPrimitiveOfSchema<V>;
           } & CoMap
         : S extends CoreCoMapSchema<infer Shape, infer CatchAll>
           ? {
-              [key in keyof Shape]: InstanceOrPrimitiveOfSchema<Shape[key]>;
+              -readonly [key in keyof Shape]: InstanceOrPrimitiveOfSchema<
+                Shape[key]
+              >;
             } & (CatchAll extends AnyZodOrCoValueSchema
               ? {
                   [key: string]: InstanceOrPrimitiveOfSchema<CatchAll>;
@@ -53,7 +59,7 @@ export type InstanceOfSchema<S extends CoValueClass | AnyZodOrCoValueSchema> =
                   : S extends CoreFileStreamSchema
                     ? FileStream
                     : S extends CoreCoOptionalSchema<infer T>
-                      ? InstanceOrPrimitiveOfSchema<T>
+                      ? InstanceOrPrimitiveOfSchema<T> | undefined
                       : S extends CoDiscriminatedUnionSchema<infer Members>
                         ? InstanceOrPrimitiveOfSchema<Members[number]>
                         : never

--- a/packages/jazz-tools/src/tools/implementation/zodSchema/typeConverters/InstanceOfSchema.ts
+++ b/packages/jazz-tools/src/tools/implementation/zodSchema/typeConverters/InstanceOfSchema.ts
@@ -11,7 +11,6 @@ import {
   CoreAccountSchema,
   CoreCoRecordSchema,
   FileStream,
-  Profile,
 } from "../../../internal.js";
 import { CoreCoFeedSchema } from "../schemaTypes/CoFeedSchema.js";
 import { CoreCoListSchema } from "../schemaTypes/CoListSchema.js";

--- a/packages/jazz-tools/src/tools/implementation/zodSchema/typeConverters/InstanceOfSchemaCoValuesNullable.ts
+++ b/packages/jazz-tools/src/tools/implementation/zodSchema/typeConverters/InstanceOfSchemaCoValuesNullable.ts
@@ -29,7 +29,7 @@ export type InstanceOfSchemaCoValuesNullable<
   ? S extends CoreAccountSchema<infer Shape>
     ?
         | ({
-            [key in keyof Shape]: InstanceOrPrimitiveOfSchemaCoValuesNullable<
+            -readonly [key in keyof Shape]: InstanceOrPrimitiveOfSchemaCoValuesNullable<
               Shape[key]
             >;
           } & Account)
@@ -37,14 +37,14 @@ export type InstanceOfSchemaCoValuesNullable<
     : S extends CoreCoRecordSchema<infer K, infer V>
       ?
           | ({
-              [key in z.output<K> &
+              -readonly [key in z.output<K> &
                 string]: InstanceOrPrimitiveOfSchemaCoValuesNullable<V>;
             } & CoMap)
           | null
       : S extends CoreCoMapSchema<infer Shape, infer CatchAll>
         ?
             | ({
-                [key in keyof Shape]: InstanceOrPrimitiveOfSchemaCoValuesNullable<
+                -readonly [key in keyof Shape]: InstanceOrPrimitiveOfSchemaCoValuesNullable<
                   Shape[key]
                 >;
               } & (CatchAll extends AnyZodOrCoValueSchema

--- a/packages/jazz-tools/src/tools/implementation/zodSchema/typeConverters/InstanceOrPrimitiveOfSchema.ts
+++ b/packages/jazz-tools/src/tools/implementation/zodSchema/typeConverters/InstanceOrPrimitiveOfSchema.ts
@@ -1,69 +1,11 @@
 import {
-  Account,
   AnyZodOrCoValueSchema,
-  CoDiscriminatedUnionSchema,
-  CoFeed,
-  CoList,
-  CoMap,
-  CoPlainText,
-  CoRichText,
   CoValueClass,
-  CoreAccountSchema,
-  CoreCoRecordSchema,
-  FileStream,
-  Profile,
+  InstanceOfSchema,
 } from "../../../internal.js";
-import { CoreCoFeedSchema } from "../schemaTypes/CoFeedSchema.js";
-import { CoreCoListSchema } from "../schemaTypes/CoListSchema.js";
-import { CoreCoMapSchema } from "../schemaTypes/CoMapSchema.js";
-import { CoreCoOptionalSchema } from "../schemaTypes/CoOptionalSchema.js";
-import { CoreCoValueSchema } from "../schemaTypes/CoValueSchema.js";
-import { CoreFileStreamSchema } from "../schemaTypes/FileStreamSchema.js";
-import { CorePlainTextSchema } from "../schemaTypes/PlainTextSchema.js";
-import { CoreRichTextSchema } from "../schemaTypes/RichTextSchema.js";
 import { z } from "../zodReExport.js";
 import { TypeOfZodSchema } from "./TypeOfZodSchema.js";
 
 export type InstanceOrPrimitiveOfSchema<
   S extends CoValueClass | AnyZodOrCoValueSchema,
-> = S extends CoreCoValueSchema
-  ? S extends CoreAccountSchema<infer Shape>
-    ? {
-        -readonly [key in keyof Shape]: InstanceOrPrimitiveOfSchema<Shape[key]>;
-      } & { profile: Profile } & Account
-    : S extends CoreCoRecordSchema<infer K, infer V>
-      ? {
-          -readonly [key in z.output<K> &
-            string]: InstanceOrPrimitiveOfSchema<V>;
-        } & CoMap
-      : S extends CoreCoMapSchema<infer Shape, infer CatchAll>
-        ? {
-            -readonly [key in keyof Shape]: InstanceOrPrimitiveOfSchema<
-              Shape[key]
-            >;
-          } & (CatchAll extends AnyZodOrCoValueSchema
-            ? {
-                [key: string]: InstanceOrPrimitiveOfSchema<CatchAll>;
-              }
-            : {}) &
-            CoMap
-        : S extends CoreCoListSchema<infer T>
-          ? CoList<InstanceOrPrimitiveOfSchema<T>>
-          : S extends CoreCoFeedSchema<infer T>
-            ? CoFeed<InstanceOrPrimitiveOfSchema<T>>
-            : S extends CorePlainTextSchema
-              ? CoPlainText
-              : S extends CoreRichTextSchema
-                ? CoRichText
-                : S extends CoreFileStreamSchema
-                  ? FileStream
-                  : S extends CoreCoOptionalSchema<infer T>
-                    ? InstanceOrPrimitiveOfSchema<T> | undefined
-                    : S extends CoDiscriminatedUnionSchema<infer Members>
-                      ? InstanceOrPrimitiveOfSchema<Members[number]>
-                      : never
-  : S extends z.core.$ZodType
-    ? TypeOfZodSchema<S>
-    : S extends CoValueClass
-      ? InstanceType<S>
-      : never;
+> = S extends z.core.$ZodType ? TypeOfZodSchema<S> : InstanceOfSchema<S>;

--- a/packages/jazz-tools/src/tools/implementation/zodSchema/typeConverters/InstanceOrPrimitiveOfSchema.ts
+++ b/packages/jazz-tools/src/tools/implementation/zodSchema/typeConverters/InstanceOrPrimitiveOfSchema.ts
@@ -1,4 +1,3 @@
-import { JsonValue } from "cojson";
 import {
   Account,
   AnyZodOrCoValueSchema,
@@ -23,6 +22,7 @@ import { CoreFileStreamSchema } from "../schemaTypes/FileStreamSchema.js";
 import { CorePlainTextSchema } from "../schemaTypes/PlainTextSchema.js";
 import { CoreRichTextSchema } from "../schemaTypes/RichTextSchema.js";
 import { z } from "../zodReExport.js";
+import { TypeOfZodSchema } from "./TypeOfZodSchema.js";
 
 export type InstanceOrPrimitiveOfSchema<
   S extends CoValueClass | AnyZodOrCoValueSchema,
@@ -63,60 +63,7 @@ export type InstanceOrPrimitiveOfSchema<
                       ? InstanceOrPrimitiveOfSchema<Members[number]>
                       : never
   : S extends z.core.$ZodType
-    ? S extends z.core.$ZodOptional<infer Inner extends z.core.$ZodType>
-      ? InstanceOrPrimitiveOfSchema<Inner> | undefined
-      : S extends z.core.$ZodNullable<infer Inner extends z.core.$ZodType>
-        ? InstanceOrPrimitiveOfSchema<Inner> | null
-        : S extends z.ZodJSONSchema
-          ? JsonValue
-          : S extends z.core.$ZodUnion<infer Members extends z.core.$ZodType[]>
-            ? InstanceOrPrimitiveOfSchema<Members[number]>
-            : // primitives below here - we manually traverse to ensure we only allow what we can handle
-              S extends z.core.$ZodObject<infer Shape>
-              ? {
-                  -readonly [key in keyof Shape]: InstanceOrPrimitiveOfSchema<
-                    Shape[key]
-                  >;
-                }
-              : S extends z.core.$ZodArray<infer Item extends z.core.$ZodType>
-                ? InstanceOrPrimitiveOfSchema<Item>[]
-                : S extends z.core.$ZodTuple<
-                      infer Items extends readonly z.core.$ZodType[]
-                    >
-                  ? {
-                      [key in keyof Items]: InstanceOrPrimitiveOfSchema<
-                        Items[key]
-                      >;
-                    }
-                  : S extends z.core.$ZodString
-                    ? string
-                    : S extends z.core.$ZodNumber
-                      ? number
-                      : S extends z.core.$ZodBoolean
-                        ? boolean
-                        : S extends z.core.$ZodLiteral<infer Literal>
-                          ? Literal
-                          : S extends z.core.$ZodDate
-                            ? Date
-                            : S extends z.core.$ZodEnum<infer Enum>
-                              ? Enum[keyof Enum]
-                              : S extends z.core.$ZodTemplateLiteral<
-                                    infer pattern
-                                  >
-                                ? pattern
-                                : S extends z.core.$ZodReadonly<
-                                      infer Inner extends z.core.$ZodType
-                                    >
-                                  ? InstanceOrPrimitiveOfSchema<Inner>
-                                  : S extends z.core.$ZodDefault<
-                                        infer Default extends z.core.$ZodType
-                                      >
-                                    ? InstanceOrPrimitiveOfSchema<Default>
-                                    : S extends z.core.$ZodCatch<
-                                          infer Catch extends z.core.$ZodType
-                                        >
-                                      ? InstanceOrPrimitiveOfSchema<Catch>
-                                      : never
+    ? TypeOfZodSchema<S>
     : S extends CoValueClass
       ? InstanceType<S>
       : never;

--- a/packages/jazz-tools/src/tools/implementation/zodSchema/typeConverters/InstanceOrPrimitiveOfSchemaCoValuesNullable.ts
+++ b/packages/jazz-tools/src/tools/implementation/zodSchema/typeConverters/InstanceOrPrimitiveOfSchemaCoValuesNullable.ts
@@ -1,81 +1,13 @@
 import {
-  Account,
   AnyZodOrCoValueSchema,
-  CoDiscriminatedUnionSchema,
-  CoFeed,
-  CoList,
-  CoMap,
-  CoPlainText,
-  CoRichText,
   CoValueClass,
-  CoreAccountSchema,
-  CoreCoRecordSchema,
-  FileStream,
-  Profile,
+  InstanceOfSchemaCoValuesNullable,
 } from "../../../internal.js";
-import { CoreCoFeedSchema } from "../schemaTypes/CoFeedSchema.js";
-import { CoreCoListSchema } from "../schemaTypes/CoListSchema.js";
-import { CoreCoMapSchema } from "../schemaTypes/CoMapSchema.js";
-import { CoreCoOptionalSchema } from "../schemaTypes/CoOptionalSchema.js";
-import { CoreCoValueSchema } from "../schemaTypes/CoValueSchema.js";
-import { CoreFileStreamSchema } from "../schemaTypes/FileStreamSchema.js";
-import { CorePlainTextSchema } from "../schemaTypes/PlainTextSchema.js";
-import { CoreRichTextSchema } from "../schemaTypes/RichTextSchema.js";
 import { z } from "../zodReExport.js";
 import { TypeOfZodSchema } from "./TypeOfZodSchema.js";
 
 export type InstanceOrPrimitiveOfSchemaCoValuesNullable<
   S extends CoValueClass | AnyZodOrCoValueSchema,
-> = S extends CoreCoValueSchema
-  ? S extends CoreAccountSchema<infer Shape>
-    ?
-        | ({
-            -readonly [key in keyof Shape]: InstanceOrPrimitiveOfSchemaCoValuesNullable<
-              Shape[key]
-            >;
-          } & { profile: Profile | null } & Account)
-        | null
-    : S extends CoreCoRecordSchema<infer K, infer V>
-      ?
-          | ({
-              -readonly [key in z.output<K> &
-                string]: InstanceOrPrimitiveOfSchemaCoValuesNullable<V>;
-            } & CoMap)
-          | null
-      : S extends CoreCoMapSchema<infer Shape, infer CatchAll>
-        ?
-            | ({
-                -readonly [key in keyof Shape]: InstanceOrPrimitiveOfSchemaCoValuesNullable<
-                  Shape[key]
-                >;
-              } & (CatchAll extends AnyZodOrCoValueSchema
-                ? {
-                    [
-                      key: string
-                    ]: InstanceOrPrimitiveOfSchemaCoValuesNullable<CatchAll>;
-                  }
-                : {}) &
-                CoMap)
-            | null
-        : S extends CoreCoListSchema<infer T>
-          ? CoList<InstanceOrPrimitiveOfSchemaCoValuesNullable<T>> | null
-          : S extends CoreCoFeedSchema<infer T>
-            ? CoFeed<InstanceOrPrimitiveOfSchemaCoValuesNullable<T>> | null
-            : S extends CorePlainTextSchema
-              ? CoPlainText | null
-              : S extends CoreRichTextSchema
-                ? CoRichText | null
-                : S extends CoreFileStreamSchema
-                  ? FileStream | null
-                  : S extends CoreCoOptionalSchema<infer T>
-                    ? InstanceOrPrimitiveOfSchemaCoValuesNullable<T> | undefined
-                    : S extends CoDiscriminatedUnionSchema<infer Members>
-                      ? InstanceOrPrimitiveOfSchemaCoValuesNullable<
-                          Members[number]
-                        >
-                      : never
-  : S extends z.core.$ZodType
-    ? TypeOfZodSchema<S>
-    : S extends CoValueClass
-      ? InstanceType<S> | null
-      : never;
+> = S extends z.core.$ZodType
+  ? TypeOfZodSchema<S>
+  : InstanceOfSchemaCoValuesNullable<S>;

--- a/packages/jazz-tools/src/tools/implementation/zodSchema/typeConverters/InstanceOrPrimitiveOfSchemaCoValuesNullable.ts
+++ b/packages/jazz-tools/src/tools/implementation/zodSchema/typeConverters/InstanceOrPrimitiveOfSchemaCoValuesNullable.ts
@@ -1,4 +1,3 @@
-import { JsonValue } from "cojson";
 import {
   Account,
   AnyZodOrCoValueSchema,
@@ -12,7 +11,6 @@ import {
   CoreAccountSchema,
   CoreCoRecordSchema,
   FileStream,
-  InstanceOrPrimitiveOfSchema,
   Profile,
 } from "../../../internal.js";
 import { CoreCoFeedSchema } from "../schemaTypes/CoFeedSchema.js";
@@ -24,6 +22,7 @@ import { CoreFileStreamSchema } from "../schemaTypes/FileStreamSchema.js";
 import { CorePlainTextSchema } from "../schemaTypes/PlainTextSchema.js";
 import { CoreRichTextSchema } from "../schemaTypes/RichTextSchema.js";
 import { z } from "../zodReExport.js";
+import { TypeOfZodSchema } from "./TypeOfZodSchema.js";
 
 export type InstanceOrPrimitiveOfSchemaCoValuesNullable<
   S extends CoValueClass | AnyZodOrCoValueSchema,
@@ -76,62 +75,7 @@ export type InstanceOrPrimitiveOfSchemaCoValuesNullable<
                         >
                       : never
   : S extends z.core.$ZodType
-    ? S extends z.core.$ZodOptional<infer Inner extends z.core.$ZodType>
-      ? InstanceOrPrimitiveOfSchemaCoValuesNullable<Inner> | undefined
-      : S extends z.core.$ZodNullable<infer Inner extends z.core.$ZodType>
-        ? InstanceOrPrimitiveOfSchemaCoValuesNullable<Inner> | null
-        : S extends z.ZodJSONSchema
-          ? JsonValue
-          : S extends z.core.$ZodUnion<
-                infer Members extends readonly z.core.$ZodType[]
-              >
-            ? InstanceOrPrimitiveOfSchemaCoValuesNullable<Members[number]>
-            : // primitives below here - we manually traverse to ensure we only allow what we can handle
-              S extends z.core.$ZodObject<infer Shape>
-              ? {
-                  -readonly [key in keyof Shape]: InstanceOrPrimitiveOfSchema<
-                    Shape[key]
-                  >;
-                }
-              : S extends z.core.$ZodArray<infer Item extends z.core.$ZodType>
-                ? InstanceOrPrimitiveOfSchema<Item>[]
-                : S extends z.core.$ZodTuple<
-                      infer Items extends z.core.$ZodType[]
-                    >
-                  ? {
-                      [key in keyof Items]: InstanceOrPrimitiveOfSchema<
-                        Items[key]
-                      >;
-                    }
-                  : S extends z.core.$ZodString
-                    ? string
-                    : S extends z.core.$ZodNumber
-                      ? number
-                      : S extends z.core.$ZodBoolean
-                        ? boolean
-                        : S extends z.core.$ZodLiteral<infer Literal>
-                          ? Literal
-                          : S extends z.core.$ZodDate
-                            ? Date
-                            : S extends z.core.$ZodEnum<infer Enum>
-                              ? Enum[keyof Enum]
-                              : S extends z.core.$ZodTemplateLiteral<
-                                    infer pattern
-                                  >
-                                ? pattern
-                                : S extends z.core.$ZodReadonly<
-                                      infer Inner extends z.core.$ZodType
-                                    >
-                                  ? InstanceOrPrimitiveOfSchema<Inner>
-                                  : S extends z.core.$ZodDefault<
-                                        infer Default extends z.core.$ZodType
-                                      >
-                                    ? InstanceOrPrimitiveOfSchema<Default>
-                                    : S extends z.core.$ZodCatch<
-                                          infer Catch extends z.core.$ZodType
-                                        >
-                                      ? InstanceOrPrimitiveOfSchema<Catch>
-                                      : never
+    ? TypeOfZodSchema<S>
     : S extends CoValueClass
       ? InstanceType<S> | null
       : never;

--- a/packages/jazz-tools/src/tools/implementation/zodSchema/typeConverters/TypeOfZodSchema.ts
+++ b/packages/jazz-tools/src/tools/implementation/zodSchema/typeConverters/TypeOfZodSchema.ts
@@ -1,0 +1,58 @@
+import { JsonValue } from "cojson";
+import { z } from "../zodReExport.js";
+
+/**
+ * Get type from Zod schema definition.
+ *
+ * Similar to `z.infer`, but we manually traverse Zod types to ensure we only allow what we can handle
+ */
+export type TypeOfZodSchema<S extends z.core.$ZodType> =
+  S extends z.core.$ZodOptional<infer Inner extends z.core.$ZodType>
+    ? TypeOfZodSchema<Inner> | undefined
+    : S extends z.core.$ZodNullable<infer Inner extends z.core.$ZodType>
+      ? TypeOfZodSchema<Inner> | null
+      : S extends z.ZodJSONSchema
+        ? JsonValue
+        : S extends z.core.$ZodUnion<infer Members extends z.core.$ZodType[]>
+          ? TypeOfZodSchema<Members[number]>
+          : S extends z.core.$ZodObject<infer Shape>
+            ? {
+                -readonly [key in keyof Shape]: TypeOfZodSchema<Shape[key]>;
+              }
+            : S extends z.core.$ZodArray<infer Item extends z.core.$ZodType>
+              ? TypeOfZodSchema<Item>[]
+              : S extends z.core.$ZodTuple<
+                    infer Items extends readonly z.core.$ZodType[]
+                  >
+                ? {
+                    [key in keyof Items]: TypeOfZodSchema<Items[key]>;
+                  }
+                : S extends z.core.$ZodString
+                  ? string
+                  : S extends z.core.$ZodNumber
+                    ? number
+                    : S extends z.core.$ZodBoolean
+                      ? boolean
+                      : S extends z.core.$ZodLiteral<infer Literal>
+                        ? Literal
+                        : S extends z.core.$ZodDate
+                          ? Date
+                          : S extends z.core.$ZodEnum<infer Enum>
+                            ? Enum[keyof Enum]
+                            : S extends z.core.$ZodTemplateLiteral<
+                                  infer pattern
+                                >
+                              ? pattern
+                              : S extends z.core.$ZodReadonly<
+                                    infer Inner extends z.core.$ZodType
+                                  >
+                                ? TypeOfZodSchema<Inner>
+                                : S extends z.core.$ZodDefault<
+                                      infer Default extends z.core.$ZodType
+                                    >
+                                  ? TypeOfZodSchema<Default>
+                                  : S extends z.core.$ZodCatch<
+                                        infer Catch extends z.core.$ZodType
+                                      >
+                                    ? TypeOfZodSchema<Catch>
+                                    : never;

--- a/packages/jazz-tools/src/tools/implementation/zodSchema/typeConverters/TypeOfZodSchema.ts
+++ b/packages/jazz-tools/src/tools/implementation/zodSchema/typeConverters/TypeOfZodSchema.ts
@@ -13,7 +13,9 @@ export type TypeOfZodSchema<S extends z.core.$ZodType> =
       ? TypeOfZodSchema<Inner> | null
       : S extends z.ZodJSONSchema
         ? JsonValue
-        : S extends z.core.$ZodUnion<infer Members extends z.core.$ZodType[]>
+        : S extends z.core.$ZodUnion<
+              infer Members extends readonly z.core.$ZodType[]
+            >
           ? TypeOfZodSchema<Members[number]>
           : S extends z.core.$ZodObject<infer Shape>
             ? {

--- a/packages/jazz-tools/src/tools/implementation/zodSchema/unionUtils.ts
+++ b/packages/jazz-tools/src/tools/implementation/zodSchema/unionUtils.ts
@@ -7,6 +7,7 @@ import {
   CoreCoMapSchema,
   DiscriminableCoValueSchemas,
   DiscriminableCoreCoValueSchema,
+  SchemaUnionDiscriminator,
 } from "../../internal.js";
 import {
   hydrateCoreCoValueSchema,
@@ -56,21 +57,17 @@ export function schemaUnionDiscriminatorFor(
       }
     }
 
-    const determineSchema = (_raw: RawCoMap | RawAccount | RawCoList) => {
-      if (_raw instanceof RawCoList) {
-        throw new Error(
-          "co.discriminatedUnion() of collaborative types is not supported for CoLists",
-        );
-      }
-
+    const determineSchema: SchemaUnionDiscriminator<CoMap> = (
+      discriminable,
+    ) => {
       for (const option of availableOptions) {
         let match = true;
 
         for (const key of Object.keys(discriminatorMap)) {
           const discriminatorDef = (option as CoreCoMapSchema).getDefinition()
-            .shape[key as string];
+            .shape[key];
 
-          const discriminatorValue = (_raw as RawCoMap).get(key as string);
+          const discriminatorValue = discriminable.get(key);
 
           if (discriminatorValue && typeof discriminatorValue === "object") {
             throw new Error("Discriminator must be a primitive value");

--- a/packages/jazz-tools/src/tools/implementation/zodSchema/zodSchema.ts
+++ b/packages/jazz-tools/src/tools/implementation/zodSchema/zodSchema.ts
@@ -84,8 +84,8 @@ export type CoValueSchemaFromCoreSchema<S extends CoreCoValueSchema> =
 export type CoValueClassFromAnySchema<S extends CoValueClassOrSchema> =
   S extends CoValueClass<any>
     ? S
-    : CoValueClass<InstanceOfSchema<S>> &
-        CoValueFromRaw<InstanceOfSchema<S>> &
+    : CoValueClass<NonNullable<InstanceOfSchema<S>>> &
+        CoValueFromRaw<NonNullable<InstanceOfSchema<S>>> &
         (S extends CoreAccountSchema ? AccountClassEssentials : {});
 
 type AccountClassEssentials = {

--- a/packages/jazz-tools/src/tools/implementation/zodSchema/zodSchema.ts
+++ b/packages/jazz-tools/src/tools/implementation/zodSchema/zodSchema.ts
@@ -23,11 +23,7 @@ import {
 } from "./schemaTypes/CoDiscriminatedUnionSchema.js";
 import { CoFeedSchema, CoreCoFeedSchema } from "./schemaTypes/CoFeedSchema.js";
 import { CoListSchema, CoreCoListSchema } from "./schemaTypes/CoListSchema.js";
-import {
-  CoMapSchema,
-  CoMapSchemaInit,
-  CoreCoMapSchema,
-} from "./schemaTypes/CoMapSchema.js";
+import { CoMapSchema, CoreCoMapSchema } from "./schemaTypes/CoMapSchema.js";
 import {
   CoOptionalSchema,
   CoreCoOptionalSchema,
@@ -122,9 +118,3 @@ export type ResolveQueryStrict<
   T extends CoValueClassOrSchema,
   R extends ResolveQuery<T>,
 > = RefsToResolveStrict<NonNullable<InstanceOfSchemaCoValuesNullable<T>>, R>;
-
-export type InitFor<T extends CoValueClassOrSchema> = T extends CoreCoMapSchema<
-  infer Shape
->
-  ? Simplify<CoMapSchemaInit<Shape>>
-  : never;

--- a/packages/jazz-tools/src/tools/internal.ts
+++ b/packages/jazz-tools/src/tools/internal.ts
@@ -45,6 +45,7 @@ export * from "./implementation/zodSchema/typeConverters/InstanceOrPrimitiveOfSc
 export * from "./implementation/zodSchema/typeConverters/InstanceOrPrimitiveOfSchemaCoValuesNullable.js";
 export * from "./implementation/zodSchema/typeConverters/InstanceOfSchema.js";
 export * from "./implementation/zodSchema/typeConverters/InstanceOfSchemaCoValuesNullable.js";
+export * from "./implementation/zodSchema/typeConverters/CoFieldInit.js";
 export * from "./implementation/zodSchema/runtimeConverters/coValueSchemaTransformation.js";
 export * from "./implementation/zodSchema/runtimeConverters/schemaFieldToCoFieldDef.js";
 export * from "./coValues/extensions/imageDef.js";

--- a/packages/jazz-tools/src/tools/subscribe/SubscriptionScope.ts
+++ b/packages/jazz-tools/src/tools/subscribe/SubscriptionScope.ts
@@ -7,7 +7,7 @@ import {
   type ID,
   type RefEncoded,
   type RefsToResolve,
-  instantiateRefEncoded,
+  instantiateRefEncodedFromRaw,
   isRefEncoded,
 } from "../internal.js";
 import { applyCoValueMigrations } from "../lib/migration.js";
@@ -75,7 +75,9 @@ export class SubscriptionScope<D extends CoValue> {
           }
 
           this.migrating = true;
-          applyCoValueMigrations(instantiateRefEncoded(this.schema, value));
+          applyCoValueMigrations(
+            instantiateRefEncodedFromRaw(this.schema, value),
+          );
           this.migrated = true;
           this.handleUpdate(lastUpdate);
           return;

--- a/packages/jazz-tools/src/tools/subscribe/utils.ts
+++ b/packages/jazz-tools/src/tools/subscribe/utils.ts
@@ -4,7 +4,7 @@ import {
   CoValue,
   RefEncoded,
   coValueClassFromCoValueClassOrSchema,
-  instantiateRefEncoded,
+  instantiateRefEncodedFromRaw,
 } from "../internal.js";
 import { coValuesCache } from "../lib/cache.js";
 import { SubscriptionScope } from "./SubscriptionScope.js";
@@ -26,7 +26,7 @@ export function createCoValue<D extends CoValue>(
   raw: RawCoValue,
   subscriptionScope: SubscriptionScope<D>,
 ) {
-  const freshValueInstance = instantiateRefEncoded(ref, raw);
+  const freshValueInstance = instantiateRefEncodedFromRaw(ref, raw);
 
   Object.defineProperty(freshValueInstance, "_subscriptionScope", {
     value: subscriptionScope,

--- a/packages/jazz-tools/src/tools/tests/coFeed.test.ts
+++ b/packages/jazz-tools/src/tools/tests/coFeed.test.ts
@@ -73,14 +73,22 @@ describe("Simple CoFeed operations", async () => {
       expect(coValue?.toString()).toEqual("milk");
     });
 
-    test("using JSON", () => {
-      const Text = co.plainText();
-      const TextStream = co.feed(Text);
+    describe("using JSON", () => {
+      test("automatically creates CoValues for nested objects", () => {
+        const Text = co.plainText();
+        const TextStream = co.feed(Text);
 
-      const stream = TextStream.create(["milk"], { owner: me });
+        const stream = TextStream.create(["milk"], { owner: me });
 
-      const coValue = stream.perAccount[me.id]?.value;
-      expect(coValue?.toString()).toEqual("milk");
+        const coValue = stream.perAccount[me.id]?.value;
+        expect(coValue?.toString()).toEqual("milk");
+      });
+
+      test("can create a coPlainText from an empty string", () => {
+        const Schema = co.feed(co.plainText());
+        const feed = Schema.create([""]);
+        expect(feed.perAccount[me.id]?.value?.toString()).toBe("");
+      });
     });
   });
 

--- a/packages/jazz-tools/src/tools/tests/coFeed.test.ts
+++ b/packages/jazz-tools/src/tools/tests/coFeed.test.ts
@@ -52,6 +52,38 @@ describe("Simple CoFeed operations", async () => {
     expect(stream.perSession[me.sessionID]?.value).toEqual("milk");
   });
 
+  describe("Create CoFeed with a reference", () => {
+    let me: Account;
+
+    beforeEach(async () => {
+      await setupJazzTestSync();
+      me = await createJazzTestAccount({
+        isCurrentActiveAccount: true,
+        creationProps: { name: "Hermes Puggington" },
+      });
+    });
+
+    test("using a CoValue", () => {
+      const Text = co.plainText();
+      const TextStream = co.feed(Text);
+
+      const stream = TextStream.create([Text.create("milk")], { owner: me });
+
+      const coValue = stream.perAccount[me.id]?.value;
+      expect(coValue?.toString()).toEqual("milk");
+    });
+
+    test("using JSON", () => {
+      const Text = co.plainText();
+      const TextStream = co.feed(Text);
+
+      const stream = TextStream.create(["milk"], { owner: me });
+
+      const coValue = stream.perAccount[me.id]?.value;
+      expect(coValue?.toString()).toEqual("milk");
+    });
+  });
+
   test("Construction with nullable values", () => {
     const NullableTestStream = co.feed(z.string().nullable());
     const stream = NullableTestStream.create(["milk", null], { owner: me });

--- a/packages/jazz-tools/src/tools/tests/coList.test.ts
+++ b/packages/jazz-tools/src/tools/tests/coList.test.ts
@@ -52,6 +52,40 @@ describe("Simple CoList operations", async () => {
     expect(list[2]).toBe("c");
   });
 
+  test("create CoList with reference using CoValue", () => {
+    const Dog = co.map({
+      name: z.string(),
+    });
+    const Person = co.map({
+      pets: co.list(Dog),
+    });
+
+    const person = Person.create({
+      pets: [Dog.create({ name: "Rex" }), Dog.create({ name: "Fido" })],
+    });
+
+    expect(person.pets.length).toEqual(2);
+    expect(person.pets[0]?.name).toEqual("Rex");
+    expect(person.pets[1]?.name).toEqual("Fido");
+  });
+
+  test("create CoList with reference using JSON", () => {
+    const Dog = co.map({
+      name: z.string(),
+    });
+    const Person = co.map({
+      pets: co.list(Dog),
+    });
+
+    const person = Person.create({
+      pets: [{ name: "Rex" }, { name: "Fido" }],
+    });
+
+    expect(person.pets.length).toEqual(2);
+    expect(person.pets[0]?.name).toEqual("Rex");
+    expect(person.pets[1]?.name).toEqual("Fido");
+  });
+
   test("list with nullable content", () => {
     const List = co.list(z.string().nullable());
     const list = List.create(["a", "b", "c", null]);

--- a/packages/jazz-tools/src/tools/tests/coList.test.ts
+++ b/packages/jazz-tools/src/tools/tests/coList.test.ts
@@ -69,21 +69,29 @@ describe("Simple CoList operations", async () => {
     expect(person.pets[1]?.name).toEqual("Fido");
   });
 
-  test("create CoList with reference using JSON", () => {
-    const Dog = co.map({
-      name: z.string(),
-    });
-    const Person = co.map({
-      pets: co.list(Dog),
+  describe("create CoList with reference using JSON", () => {
+    test("automatically creates CoValues for nested objects", () => {
+      const Dog = co.map({
+        name: z.string(),
+      });
+      const Person = co.map({
+        pets: co.list(Dog),
+      });
+
+      const person = Person.create({
+        pets: [{ name: "Rex" }, { name: "Fido" }],
+      });
+
+      expect(person.pets.length).toEqual(2);
+      expect(person.pets[0]?.name).toEqual("Rex");
+      expect(person.pets[1]?.name).toEqual("Fido");
     });
 
-    const person = Person.create({
-      pets: [{ name: "Rex" }, { name: "Fido" }],
+    test("can create a coPlainText from an empty string", () => {
+      const Schema = co.list(co.plainText());
+      const list = Schema.create([""]);
+      expect(list[0]?.toString()).toBe("");
     });
-
-    expect(person.pets.length).toEqual(2);
-    expect(person.pets[0]?.name).toEqual("Rex");
-    expect(person.pets[1]?.name).toEqual("Fido");
   });
 
   test("list with nullable content", () => {

--- a/packages/jazz-tools/src/tools/tests/coMap.test-d.ts
+++ b/packages/jazz-tools/src/tools/tests/coMap.test-d.ts
@@ -109,8 +109,6 @@ describe("CoMap", async () => {
             breed: "Labrador",
           },
           dog2: { name: "Fido", breed: "Labrador" },
-          // TODO make undefined fields optional (!!!)
-          friend: undefined,
         },
       });
 

--- a/packages/jazz-tools/src/tools/tests/coMap.test.ts
+++ b/packages/jazz-tools/src/tools/tests/coMap.test.ts
@@ -139,24 +139,26 @@ describe("CoMap", async () => {
       expect(person.dog?.breed).toEqual("Labrador");
     });
 
-    test("create CoMap with reference using JSON", () => {
+    test("create CoMap with references using JSON", () => {
       const Dog = co.map({
         name: z.string(),
         breed: z.string(),
       });
 
       const Person = co.map({
-        name: z.string(),
-        age: z.number(),
+        name: co.plainText(),
+        bio: co.richText(),
         dog: Dog,
       });
 
       const person = Person.create({
         name: "John",
-        age: 20,
+        bio: "I am a software engineer",
         dog: { name: "Rex", breed: "Labrador" },
       });
 
+      expect(person.name.toString()).toEqual("John");
+      expect(person.bio.toString()).toEqual("I am a software engineer");
       expect(person.dog?.name).toEqual("Rex");
       expect(person.dog?.breed).toEqual("Labrador");
     });

--- a/packages/jazz-tools/src/tools/tests/coMap.test.ts
+++ b/packages/jazz-tools/src/tools/tests/coMap.test.ts
@@ -260,7 +260,7 @@ describe("CoMap", async () => {
       const Person = co.map({
         name: z.string(),
         age: z.number(),
-        get friend(): co.Optional<typeof Person> {
+        get friend() {
           return co.optional(Person);
         },
       });

--- a/packages/jazz-tools/src/tools/tests/coMap.test.ts
+++ b/packages/jazz-tools/src/tools/tests/coMap.test.ts
@@ -208,6 +208,12 @@ describe("CoMap", async () => {
           ).toContain(friend._owner.id);
         }
       });
+
+      it("can create a coPlainText from an empty string", () => {
+        const Schema = co.map({ text: co.plainText() });
+        const map = Schema.create({ text: "" });
+        expect(map.text.toString()).toBe("");
+      });
     });
 
     test("CoMap with self reference", () => {

--- a/packages/jazz-tools/src/tools/tests/coMap.test.ts
+++ b/packages/jazz-tools/src/tools/tests/coMap.test.ts
@@ -139,6 +139,11 @@ describe("CoMap", async () => {
 
     test("create CoMap with references using JSON", () => {
       const Dog = co.map({
+        type: z.literal("dog"),
+        name: z.string(),
+      });
+      const Cat = co.map({
+        type: z.literal("cat"),
         name: z.string(),
       });
 
@@ -150,22 +155,25 @@ describe("CoMap", async () => {
           return co.list(Person);
         },
         reactions: co.feed(co.plainText()),
+        pet: co.discriminatedUnion("type", [Dog, Cat]),
       });
 
       const person = Person.create({
         name: "John",
         bio: "I am a software engineer",
-        dog: { name: "Rex" },
+        dog: { type: "dog", name: "Rex" },
         friends: [
           {
             name: "Jane",
             bio: "I am a mechanical engineer",
-            dog: { name: "Fido" },
+            dog: { type: "dog", name: "Fido" },
             friends: [],
             reactions: [],
+            pet: { type: "dog", name: "Fido" },
           },
         ],
         reactions: ["👎", "👍"],
+        pet: { type: "cat", name: "Whiskers" },
       });
 
       expect(person.name.toString()).toEqual("John");
@@ -179,6 +187,7 @@ describe("CoMap", async () => {
       expect(person.friends[0]?.dog.name).toEqual("Fido");
       expect(person.friends[0]?.friends.length).toEqual(0);
       expect(person.reactions.byMe?.value?.toString()).toEqual("👍");
+      expect(person.pet.name).toEqual("Whiskers");
     });
 
     test("CoMap with self reference", () => {

--- a/packages/jazz-tools/src/tools/tests/coMap.test.ts
+++ b/packages/jazz-tools/src/tools/tests/coMap.test.ts
@@ -120,7 +120,6 @@ describe("CoMap", async () => {
     test("create CoMap with reference using CoValue", () => {
       const Dog = co.map({
         name: z.string(),
-        breed: z.string(),
       });
 
       const Person = co.map({
@@ -132,35 +131,50 @@ describe("CoMap", async () => {
       const person = Person.create({
         name: "John",
         age: 20,
-        dog: Dog.create({ name: "Rex", breed: "Labrador" }),
+        dog: Dog.create({ name: "Rex" }),
       });
 
       expect(person.dog?.name).toEqual("Rex");
-      expect(person.dog?.breed).toEqual("Labrador");
     });
 
     test("create CoMap with references using JSON", () => {
       const Dog = co.map({
         name: z.string(),
-        breed: z.string(),
       });
 
       const Person = co.map({
         name: co.plainText(),
         bio: co.richText(),
         dog: Dog,
+        get friends() {
+          return co.list(Person);
+        },
       });
 
       const person = Person.create({
         name: "John",
         bio: "I am a software engineer",
-        dog: { name: "Rex", breed: "Labrador" },
+        dog: { name: "Rex" },
+        friends: [
+          {
+            name: "Jane",
+            bio: "I am a mechanical engineer",
+            dog: { name: "Fido" },
+            friends: [],
+          },
+        ],
       });
 
       expect(person.name.toString()).toEqual("John");
       expect(person.bio.toString()).toEqual("I am a software engineer");
       expect(person.dog?.name).toEqual("Rex");
-      expect(person.dog?.breed).toEqual("Labrador");
+      expect(person.friends.length).toEqual(1);
+      expect(person.friends[0]?.name.toString()).toEqual("Jane");
+      expect(person.friends[0]?.bio.toString()).toEqual(
+        "I am a mechanical engineer",
+      );
+      expect(person.friends[0]?.dog.name).toEqual("Fido");
+      expect(person.friends[0]?.friends.length).toEqual(0);
     });
 
     test("CoMap with self reference", () => {

--- a/packages/jazz-tools/src/tools/tests/coMap.test.ts
+++ b/packages/jazz-tools/src/tools/tests/coMap.test.ts
@@ -117,7 +117,7 @@ describe("CoMap", async () => {
       expect(emptyMap.color).toEqual(undefined);
     });
 
-    test("CoMap with reference", () => {
+    test("create CoMap with reference using CoValue", () => {
       const Dog = co.map({
         name: z.string(),
         breed: z.string(),
@@ -133,6 +133,28 @@ describe("CoMap", async () => {
         name: "John",
         age: 20,
         dog: Dog.create({ name: "Rex", breed: "Labrador" }),
+      });
+
+      expect(person.dog?.name).toEqual("Rex");
+      expect(person.dog?.breed).toEqual("Labrador");
+    });
+
+    test("create CoMap with reference using JSON", () => {
+      const Dog = co.map({
+        name: z.string(),
+        breed: z.string(),
+      });
+
+      const Person = co.map({
+        name: z.string(),
+        age: z.number(),
+        dog: Dog,
+      });
+
+      const person = Person.create({
+        name: "John",
+        age: 20,
+        dog: { name: "Rex", breed: "Labrador" },
       });
 
       expect(person.dog?.name).toEqual("Rex");

--- a/packages/jazz-tools/src/tools/tests/coMap.test.ts
+++ b/packages/jazz-tools/src/tools/tests/coMap.test.ts
@@ -149,6 +149,7 @@ describe("CoMap", async () => {
         get friends() {
           return co.list(Person);
         },
+        reactions: co.feed(co.plainText()),
       });
 
       const person = Person.create({
@@ -161,8 +162,10 @@ describe("CoMap", async () => {
             bio: "I am a mechanical engineer",
             dog: { name: "Fido" },
             friends: [],
+            reactions: [],
           },
         ],
+        reactions: ["👎", "👍"],
       });
 
       expect(person.name.toString()).toEqual("John");
@@ -175,6 +178,7 @@ describe("CoMap", async () => {
       );
       expect(person.friends[0]?.dog.name).toEqual("Fido");
       expect(person.friends[0]?.friends.length).toEqual(0);
+      expect(person.reactions.byMe?.value?.toString()).toEqual("👍");
     });
 
     test("CoMap with self reference", () => {

--- a/packages/jazz-tools/src/tools/tests/zod.test.ts
+++ b/packages/jazz-tools/src/tools/tests/zod.test.ts
@@ -98,6 +98,22 @@ describe("co.map and Zod schema compatibility", () => {
       expect(map.updatedAt).toEqual("Test");
     });
 
+    it("should handle nested optional fields", async () => {
+      const RecursiveZodSchema = z.object({
+        get optionalField() {
+          return RecursiveZodSchema.optional();
+        },
+      });
+      const CoMapSchema = co.map({ field: RecursiveZodSchema });
+
+      const map = CoMapSchema.create({
+        field: { optionalField: { optionalField: {} } },
+      });
+      expect(
+        map.field.optionalField!.optionalField!.optionalField,
+      ).toBeUndefined();
+    });
+
     it("should handle literal fields", async () => {
       const schema = co.map({
         status: z.literal("active"),


### PR DESCRIPTION
# Description

Allows creating CoValues using plain JSON objects.

For example:
```typescript
const Track = co.plainText();
const ListOfTracks = co.list(Track);
const Playlist = co.map({
  title: z.string(),
  tracks: ListOfTracks,
});

// Instead of
const playlist = Playlist.create({
  title: "My playlist",
  tracks: ListOfTracks.create([Track.create("Track 1")]),
});

// People can now do
const playlist = Playlist.create({ title: "My playlist", tracks: ["Track 1"] });
```

This PR also makes fields that can be `undefined` optional for create methods' inputs, instead of requiring an explicit `undefined` value.

I also took the opportunity to reduce duplication across generic types used to derive instance types from CoValue schemas.

## Tests

- [x] Tests have been added and/or updated

## Checklist

- [x] I've updated the part of the docs that are affected the PR changes
- [x] I've generated a changeset, if a version bump is required
- [ ] I've updated the jsDoc comments to the public APIs I've modified, or added them when missing