### PR TITLE
Fix HTTP API link in inbox.mdx. Fixes #2687

### DIFF
--- a/homepage/homepage/content/docs/server-side/inbox.mdx
+++ b/homepage/homepage/content/docs/server-side/inbox.mdx
@@ -7,7 +7,7 @@ import { Alert } from "@garden-co/design-system/src/components/atoms/Alert";
 
 # Inbox API with Server Workers
 
-The Inbox API provides a message-based communication system for Server Workers in Jazz. 
+The Inbox API provides a message-based communication system for Server Workers in Jazz.
 
 It works on top of the Jazz APIs and uses sync to transfer messages between the client and the server.
 
@@ -154,8 +154,8 @@ function EventComponent({ event }: { event: Event }) {
 ```
 </CodeGroup>
 
-The `sendInboxMessage` API returns a Promise that waits for the message to be handled by a Worker. 
-A message is considered to be handled when the Promise returned by `inbox.subscribe` resolves. 
+The `sendInboxMessage` API returns a Promise that waits for the message to be handled by a Worker.
+A message is considered to be handled when the Promise returned by `inbox.subscribe` resolves.
 The value returned will be the id of the CoValue returned in the `inbox.subscribe` resolved promise.
 
 
@@ -163,4 +163,4 @@ The value returned will be the id of the CoValue returned in the `inbox.subscrib
 
 Multi-region deployments are not supported when using the Inbox API.
 
-If you need to split the workload across multiple regions, you can use the [HTTP API](./http-requests.mdx) instead.
+If you need to split the workload across multiple regions, you can use the [HTTP API](./http-requests) instead.


### PR DESCRIPTION
# Description

Quick docs-only fix to correct a link which had `.mdx` at the end. Thanks @nicolasembleton for the report (fixes #2687)!

## Manual testing instructions

Run in dev mode, click the link from the issue. Should navigate without issues to the correct page. 

## Tests

- [ ] Tests have been added and/or updated
- [x] Tests have not been updated, because: Typo fix
- [ ] I need help with writing tests

## Checklist

- [ ] I've updated the part of the docs that are affected the PR changes
- [ ] I've generated a changeset, if a version bump is required
- [ ] I've updated the jsDoc comments to the public APIs I've modified, or added them when missing