### PR TITLE
POC: Caching queries

### DIFF
--- a/packages/jazz-tools/src/react-core/hooks.ts
+++ b/packages/jazz-tools/src/react-core/hooks.ts
@@ -110,6 +110,9 @@ function useCoValueSubscription<
         ref: coValueClassFromCoValueClassOrSchema(Schema),
         optional: true,
       },
+      false,
+      false,
+      true,
     );
 
     return {
@@ -286,10 +289,18 @@ function useAccountSubscription<
     const resolve: any = options?.resolve ?? true;
 
     const node = contextManager.getCurrentValue()!.node;
-    const subscription = new SubscriptionScope<any>(node, resolve, agent.id, {
-      ref: coValueClassFromCoValueClassOrSchema(Schema),
-      optional: true,
-    });
+    const subscription = new SubscriptionScope<any>(
+      node,
+      resolve,
+      agent.id,
+      {
+        ref: coValueClassFromCoValueClassOrSchema(Schema),
+        optional: true,
+      },
+      false,
+      false,
+      true,
+    );
 
     return {
       subscription,

--- a/packages/jazz-tools/src/tools/implementation/ContextManager.ts
+++ b/packages/jazz-tools/src/tools/implementation/ContextManager.ts
@@ -137,6 +137,21 @@ export class JazzContextManager<
       logOut: this.logOut,
     };
 
+    const keys = JSON.parse(localStorage.getItem("$keys") ?? "[]");
+
+    const promises = [];
+    for (const key of keys) {
+      if (key.startsWith("$preload-")) {
+        const ids = JSON.parse(localStorage.getItem(key) || "[]");
+
+        for (const id of ids) {
+          promises.push(context.node.loadCoValueCore(id));
+        }
+      }
+    }
+
+    await Promise.all(promises);
+
     if (authProps?.credentials) {
       this.authSecretStorage.emitUpdate(authProps.credentials);
     } else {

--- a/packages/jazz-tools/src/tools/implementation/ContextManager.ts
+++ b/packages/jazz-tools/src/tools/implementation/ContextManager.ts
@@ -4,6 +4,7 @@ import { AuthSecretStorage } from "../auth/AuthSecretStorage.js";
 import { InMemoryKVStore } from "../auth/InMemoryKVStore.js";
 import { KvStore, KvStoreContext } from "../auth/KvStoreContext.js";
 import { Account } from "../coValues/account.js";
+import { preloadFromCache } from "../internal.js";
 import { AuthCredentials } from "../types.js";
 import { JazzContextType } from "../types.js";
 import { AnonymousJazzAgent } from "./anonymousJazzAgent.js";
@@ -139,18 +140,11 @@ export class JazzContextManager<
 
     const keys = JSON.parse(localStorage.getItem("$keys") ?? "[]");
 
-    const promises = [];
     for (const key of keys) {
-      if (key.startsWith("$preload-")) {
-        const ids = JSON.parse(localStorage.getItem(key) || "[]");
-
-        for (const id of ids) {
-          promises.push(context.node.loadCoValueCore(id));
-        }
+      if (key.startsWith("$content-")) {
+        preloadFromCache(key, context.node);
       }
     }
-
-    await Promise.all(promises);
 
     if (authProps?.credentials) {
       this.authSecretStorage.emitUpdate(authProps.credentials);

--- a/tests/stress-test/src/ProjectScreen.tsx
+++ b/tests/stress-test/src/ProjectScreen.tsx
@@ -7,7 +7,11 @@ export function ProjectScreen() {
   const { projectId } = useParams();
   const project = useCoState(TodoProject, projectId, {
     resolve: {
-      tasks: true,
+      tasks: {
+        $each: {
+          text: true,
+        },
+      },
     },
   });
   const { me } = useAccount(TodoAccount, {


### PR DESCRIPTION
Experiments with precaching the queries content or ids.

Caching ids helps with making the load of lightweight apps instant.
Caching content helps with making medium-weight apps loading.

Loading 1k tasks

Before

https://github.com/user-attachments/assets/15bad8af-24ed-4968-8bd3-bf46b86b5b53

After

https://github.com/user-attachments/assets/2e1f8c61-a200-4189-925b-287cdccf0c1a

