### PR TITLE
fix: skip rotateKey when everyone has read access

### DIFF
--- a/.changeset/lemon-glasses-scream.md
+++ b/.changeset/lemon-glasses-scream.md
@@ -1,0 +1,5 @@
+---
+"cojson": patch
+---
+
+Groups: fix the readkey not being revealed to everyone when doing a key rotation

--- a/packages/cojson/src/coValue.ts
+++ b/packages/cojson/src/coValue.ts
@@ -1,7 +1,4 @@
-import {
-  AvailableCoValueCore,
-  CoValueCore,
-} from "./coValueCore/coValueCore.js";
+import { AvailableCoValueCore } from "./coValueCore/coValueCore.js";
 import { RawProfile as Profile, RawAccount } from "./coValues/account.js";
 import { RawCoList } from "./coValues/coList.js";
 import { RawCoMap } from "./coValues/coMap.js";

--- a/packages/cojson/src/coValueCore/coValueCore.ts
+++ b/packages/cojson/src/coValueCore/coValueCore.ts
@@ -756,20 +756,7 @@ export class CoValueCore {
     }
 
     if (this.verified.header.ruleset.type === "group") {
-      const content = expectGroup(this.getCurrentContent());
-
-      const currentKeyId = content.getCurrentReadKeyId();
-
-      if (!currentKeyId) {
-        throw new Error("No readKey set");
-      }
-
-      const secret = content.getReadKey(currentKeyId);
-
-      return {
-        secret: secret,
-        id: currentKeyId,
-      };
+      return expectGroup(this.getCurrentContent()).getCurrentReadKey();
     } else if (this.verified.header.ruleset.type === "ownedByGroup") {
       return this.node
         .expectCoValueLoaded(this.verified.header.ruleset.group)

--- a/packages/cojson/src/coValueCore/coValueCore.ts
+++ b/packages/cojson/src/coValueCore/coValueCore.ts
@@ -1,9 +1,9 @@
 import { UpDownCounter, ValueType, metrics } from "@opentelemetry/api";
 import { Result, err } from "neverthrow";
-import { PeerState } from "../PeerState.js";
-import { RawCoValue } from "../coValue.js";
-import { ControlledAccountOrAgent } from "../coValues/account.js";
-import { RawGroup } from "../coValues/group.js";
+import type { PeerState } from "../PeerState.js";
+import type { RawCoValue } from "../coValue.js";
+import type { ControlledAccountOrAgent } from "../coValues/account.js";
+import type { RawGroup } from "../coValues/group.js";
 import { CO_VALUE_LOADING_CONFIG } from "../config.js";
 import { coreToCoValue } from "../coreToCoValue.js";
 import {

--- a/packages/cojson/src/coValues/group.ts
+++ b/packages/cojson/src/coValues/group.ts
@@ -4,8 +4,8 @@ import type {
   AvailableCoValueCore,
   CoValueCore,
 } from "../coValueCore/coValueCore.js";
-import { CoValueUniqueness } from "../coValueCore/verifiedState.js";
-import {
+import type { CoValueUniqueness } from "../coValueCore/verifiedState.js";
+import type {
   CryptoProvider,
   Encrypted,
   KeyID,
@@ -70,6 +70,7 @@ function healMissingKeyForEveryone(group: RawGroup) {
   if (
     readKeyId &&
     canRead(group, EVERYONE) &&
+    canRead(group, group.core.node.getCurrentAgent().id) && // The current account is an explicit member of this group
     !group.get(`${readKeyId}_for_${EVERYONE}`)
   ) {
     const secret = group.getReadKey(readKeyId);

--- a/packages/cojson/src/ids.ts
+++ b/packages/cojson/src/ids.ts
@@ -1,8 +1,8 @@
 import { base58 } from "@scure/base";
-import { CoID } from "./coValue.js";
-import { RawAccountID } from "./coValues/account.js";
+import type { CoID } from "./coValue.js";
+import type { RawAccountID } from "./coValues/account.js";
+import type { RawGroup } from "./coValues/group.js";
 import { shortHashLength } from "./crypto/crypto.js";
-import { RawGroup } from "./exports.js";
 
 export type RawCoID = `co_z${string}`;
 export type ParentGroupReference = `parent_${CoID<RawGroup>}`;

--- a/packages/cojson/src/localNode.ts
+++ b/packages/cojson/src/localNode.ts
@@ -1,14 +1,14 @@
 import { Result, err, ok } from "neverthrow";
-import { CoID } from "./coValue.js";
-import { RawCoValue } from "./coValue.js";
+import type { CoID } from "./coValue.js";
+import type { RawCoValue } from "./coValue.js";
 import {
-  AvailableCoValueCore,
+  type AvailableCoValueCore,
   CoValueCore,
   idforHeader,
 } from "./coValueCore/coValueCore.js";
 import {
-  CoValueHeader,
-  CoValueUniqueness,
+  type CoValueHeader,
+  type CoValueUniqueness,
   VerifiedState,
 } from "./coValueCore/verifiedState.js";
 import {
@@ -26,8 +26,8 @@ import {
   expectAccount,
 } from "./coValues/account.js";
 import {
-  InviteSecret,
-  RawGroup,
+  type InviteSecret,
+  type RawGroup,
   secretSeedFromInviteSecret,
 } from "./coValues/group.js";
 import { CO_VALUE_LOADING_CONFIG } from "./config.js";

--- a/packages/cojson/src/tests/group.test.ts
+++ b/packages/cojson/src/tests/group.test.ts
@@ -5,12 +5,15 @@ import { RawCoStream } from "../coValues/coStream.js";
 import { RawBinaryCoStream } from "../coValues/coStream.js";
 import { WasmCrypto } from "../crypto/WasmCrypto.js";
 import { RawAccountID } from "../exports.js";
+import { NewContentMessage } from "../sync.js";
+import { expectGroup } from "../typeUtils/expectGroup.js";
 import {
   createThreeConnectedNodes,
   createTwoConnectedNodes,
   loadCoValueOrFail,
   nodeWithRandomAgentAndSessionID,
   randomAgentAndSessionID,
+  setupTestNode,
   waitFor,
 } from "./testUtils.js";
 
@@ -305,6 +308,99 @@ test("Invites should have access to the new keys", async () => {
 
   const mapOnNode2 = await loadCoValueOrFail(node2.node, map.id);
   expect(mapOnNode2.get("test")).toEqual("Written from node1");
+});
+
+test.only("Should heal the missing key_for_everyone", async () => {
+  const client = setupTestNode({
+    secret:
+      "sealerSecret_zBTPp7U58Fzq9o7EvJpu4KEziepi8QVf2Xaxuy5xmmXFx/signerSecret_z62DuviZdXCjz4EZWofvr9vaLYFXDeTaC9KWhoQiQjzKk",
+  });
+
+  const brokenGroupContent = {
+    action: "content",
+    id: "co_zW7F36Nnop9A7Er4gUzBcUXnZCK",
+    header: {
+      type: "comap",
+      ruleset: {
+        type: "group",
+        initialAdmin:
+          "sealer_z12QDazYB3ygPZtBV7sMm7iYKMRnNZ6Aaj1dfLXR7LSBm/signer_z2AskZQbc82qxo7iA3oiXoNExHLsAEXC2pHbwJzRnATWv",
+      },
+      meta: null,
+      createdAt: "2025-08-06T10:14:39.617Z",
+      uniqueness: "z3LJjnuPiPJaf5Qb9A",
+    },
+    priority: 0,
+    new: {
+      "sealer_z12QDazYB3ygPZtBV7sMm7iYKMRnNZ6Aaj1dfLXR7LSBm/signer_z2AskZQbc82qxo7iA3oiXoNExHLsAEXC2pHbwJzRnATWv_session_zYLsz2CiW9pW":
+        {
+          after: 0,
+          newTransactions: [
+            {
+              privacy: "trusting",
+              madeAt: 1754475279619,
+              changes:
+                '[{"key":"sealer_z12QDazYB3ygPZtBV7sMm7iYKMRnNZ6Aaj1dfLXR7LSBm/signer_z2AskZQbc82qxo7iA3oiXoNExHLsAEXC2pHbwJzRnATWv","op":"set","value":"admin"}]',
+            },
+            {
+              privacy: "trusting",
+              madeAt: 1754475279621,
+              changes:
+                '[{"key":"key_z5CVahfMkEWPj1B3zH_for_sealer_z12QDazYB3ygPZtBV7sMm7iYKMRnNZ6Aaj1dfLXR7LSBm/signer_z2AskZQbc82qxo7iA3oiXoNExHLsAEXC2pHbwJzRnATWv","op":"set","value":"sealed_UCg4UkytXF-W8PaIvaDffO3pZ3d9hdXUuNkQQEikPTAuOD9us92Pqb5Vgu7lx1Fpb0X8V5BJ2yxz6_D5WOzK3qjWBSsc7J1xDJA=="}]',
+            },
+            {
+              privacy: "trusting",
+              madeAt: 1754475279621,
+              changes:
+                '[{"key":"readKey","op":"set","value":"key_z5CVahfMkEWPj1B3zH"}]',
+            },
+            {
+              privacy: "trusting",
+              madeAt: 1754475279622,
+              changes: '[{"key":"everyone","op":"set","value":"reader"}]',
+            },
+            {
+              privacy: "trusting",
+              madeAt: 1754475279623,
+              changes:
+                '[{"key":"key_z5CVahfMkEWPj1B3zH_for_everyone","op":"set","value":"keySecret_z9U9gzkahQXCxDoSw7isiUnbobXwuLdcSkL9Ci6ZEEkaL"}]',
+            },
+            {
+              privacy: "trusting",
+              madeAt: 1754475279623,
+              changes:
+                '[{"key":"key_z4Fi7hZNBx7XoVAKkP_for_sealer_z12QDazYB3ygPZtBV7sMm7iYKMRnNZ6Aaj1dfLXR7LSBm/signer_z2AskZQbc82qxo7iA3oiXoNExHLsAEXC2pHbwJzRnATWv","op":"set","value":"sealed_UuCBBfZkTnRTrGraqWWlzm9JE-VFduhsfu7WaZjpCbJYOTXpPhSNOnzGeS8qVuIsG6dORbME22lc5ltLxPjRqofQdDCNGQehCeQ=="}]',
+            },
+            {
+              privacy: "trusting",
+              madeAt: 1754475279624,
+              changes:
+                '[{"key":"key_z5CVahfMkEWPj1B3zH_for_key_z4Fi7hZNBx7XoVAKkP","op":"set","value":"encrypted_USTrBuobwTCORwy5yHxy4sFZ7swfrafP6k5ZwcTf76f0MBu9Ie-JmsX3mNXad4mluI47gvGXzi8I_"}]',
+            },
+            {
+              privacy: "trusting",
+              madeAt: 1754475279624,
+              changes:
+                '[{"key":"readKey","op":"set","value":"key_z4Fi7hZNBx7XoVAKkP"}]',
+            },
+          ],
+          lastSignature:
+            "signature_z3tsE7U1JaeNeUmZ4EY3Xq5uQ9jq9jDi6Rkhdt7T7b7z4NCnpMgB4bo8TwLXYVCrRdBm6PoyyPdK8fYFzHJUh5EzA",
+        },
+    },
+  } as unknown as NewContentMessage;
+
+  client.node.syncManager.handleNewContent(brokenGroupContent, "import");
+
+  const group = expectGroup(
+    client.node.getCoValue(brokenGroupContent.id).getCurrentContent(),
+  );
+
+  await waitFor(() => {
+    expect(group.get(`${group.get("readKey")!}_for_everyone`)).toBe(
+      group.core.getCurrentReadKey()?.secret,
+    );
+  });
 });
 
 describe("writeOnly", () => {

--- a/packages/cojson/src/typeUtils/accountOrAgentIDfromSessionID.ts
+++ b/packages/cojson/src/typeUtils/accountOrAgentIDfromSessionID.ts
@@ -1,5 +1,5 @@
-import { RawAccountID } from "../coValues/account.js";
-import { AgentID, SessionID } from "../ids.js";
+import type { RawAccountID } from "../coValues/account.js";
+import type { AgentID, SessionID } from "../ids.js";
 
 export function accountOrAgentIDfromSessionID(
   sessionID: SessionID,

--- a/packages/cojson/src/typeUtils/expectGroup.ts
+++ b/packages/cojson/src/typeUtils/expectGroup.ts
@@ -1,15 +1,18 @@
-import { type RawCoValue, expectMap } from "../coValue.js";
+import { type RawCoValue } from "../coValue.js";
 import { RawGroup } from "../coValues/group.js";
 
 export function expectGroup(content: RawCoValue): RawGroup {
-  const map = expectMap(content);
-  if (map.core.verified.header.ruleset.type !== "group") {
-    throw new Error("Expected group ruleset in group");
-  }
-
-  if (!(map instanceof RawGroup)) {
+  if (content.type !== "comap") {
     throw new Error("Expected group");
   }
 
-  return map;
+  if (content.core.verified.header.ruleset.type !== "group") {
+    throw new Error("Expected group ruleset in group");
+  }
+
+  if (!(content instanceof RawGroup)) {
+    throw new Error("Expected group");
+  }
+
+  return content;
 }


### PR DESCRIPTION
# Description

A user reported that was getting `Error: Can't extend group without parent read key secret` when extending a group

Digging into the issue I've found that in the key rotation we weren't revealing the read key to everyone/reader 

This would lead the Group to be in an inconsistent state, where everyone has a reader role but lack access to the read key.

Fixed by making rotateKey a no-op when everyone has reader access.

## Tests

- [x] Tests have been added and/or updated
- [ ] Tests have not been updated, because: <!-- Insert reason for not updating tests here -->
- [ ] I need help with writing tests
