### PR TITLE
fix: handle missing child groups when rotating key

### DIFF
--- a/.changeset/eleven-rules-remain.md
+++ b/.changeset/eleven-rules-remain.md
@@ -1,0 +1,10 @@
+---
+"jazz-tools": patch
+"cojson": patch
+---
+
+Makes the key rotation not fail when child groups are unavailable or their readkey is not accessible.
+
+Also changes the Group.removeMember method to not return a Promise, because:
+- All the locally available child groups are rotated immediately
+- All the remote child groups are rotated in background, but since they are not locally available the user won't need the new key immediately

--- a/examples/music-player/src/4_actions.ts
+++ b/examples/music-player/src/4_actions.ts
@@ -116,7 +116,7 @@ export async function removeTrackFromPlaylist(
 
   if (track._owner._type === "Group" && playlist._owner._type === "Group") {
     const trackGroup = track._owner;
-    await trackGroup.removeMember(playlist._owner);
+    trackGroup.removeMember(playlist._owner);
 
     const index =
       playlist.tracks?.findIndex(

--- a/packages/cojson/src/tests/group.removeMember.test.ts
+++ b/packages/cojson/src/tests/group.removeMember.test.ts
@@ -1,11 +1,14 @@
 import { beforeEach, describe, expect, test } from "vitest";
+import { setCoValueLoadingRetryDelay } from "../config.js";
 import {
   SyncMessagesLog,
-  TEST_NODE_CONFIG,
+  blockMessageTypeOnOutgoingPeer,
   loadCoValueOrFail,
   setupTestAccount,
   setupTestNode,
 } from "./testUtils.js";
+
+setCoValueLoadingRetryDelay(10);
 
 let jazzCloud: ReturnType<typeof setupTestNode>;
 
@@ -352,5 +355,186 @@ describe("Group.removeMember", () => {
     expect(childGroupOnChildAdminNode.roleOf(reader.accountID)).toEqual(
       undefined,
     );
+  });
+
+  test("removing a member should rotate the readKey on available child groups", async () => {
+    const admin = await setupTestAccount({
+      connected: true,
+    });
+
+    const alice = await setupTestAccount({
+      connected: true,
+    });
+
+    const aliceOnAdminNode = await loadCoValueOrFail(
+      admin.node,
+      alice.accountID,
+    );
+
+    const group = admin.node.createGroup();
+    const childGroup = admin.node.createGroup();
+    group.addMember(aliceOnAdminNode, "reader");
+
+    childGroup.extend(group);
+
+    group.removeMember(aliceOnAdminNode);
+
+    const map = childGroup.createMap();
+    map.set("test", "Not readable by alice");
+
+    await map.core.waitForSync();
+
+    const mapOnAliceNode = await loadCoValueOrFail(alice.node, map.id);
+    expect(mapOnAliceNode.get("test")).toBeUndefined();
+  });
+
+  test("removing a member should rotate the readKey on unloaded child groups", async () => {
+    const admin = await setupTestAccount({
+      connected: true,
+    });
+
+    const bob = await setupTestAccount({
+      connected: true,
+    });
+
+    const alice = await setupTestAccount({
+      connected: true,
+    });
+
+    const bobOnAdminNode = await loadCoValueOrFail(admin.node, bob.accountID);
+
+    const aliceOnAdminNode = await loadCoValueOrFail(
+      admin.node,
+      alice.accountID,
+    );
+
+    const group = admin.node.createGroup();
+
+    const childGroup = bob.node.createGroup();
+    group.addMember(bobOnAdminNode, "reader");
+    group.addMember(aliceOnAdminNode, "reader");
+
+    const groupOnBobNode = await loadCoValueOrFail(bob.node, group.id);
+
+    childGroup.extend(groupOnBobNode);
+
+    await childGroup.core.waitForSync();
+
+    group.removeMember(aliceOnAdminNode);
+
+    // Rotating the child group keys is async when the child group is not loaded
+    await admin.node.getCoValue(childGroup.id).waitForAvailableOrUnavailable();
+    await admin.node.syncManager.waitForAllCoValuesSync();
+
+    const map = childGroup.createMap();
+    map.set("test", "Not readable by alice");
+
+    await map.core.waitForSync();
+
+    const mapOnAliceNode = await loadCoValueOrFail(alice.node, map.id);
+    expect(mapOnAliceNode.get("test")).toBeUndefined();
+  });
+
+  test("removing a member should work even if there are partially available child groups", async () => {
+    const admin = await setupTestAccount({
+      connected: true,
+    });
+
+    const bob = await setupTestAccount();
+    const { peer } = bob.connectToSyncServer();
+
+    const alice = await setupTestAccount({
+      connected: true,
+    });
+
+    const bobOnAdminNode = await loadCoValueOrFail(admin.node, bob.accountID);
+
+    const aliceOnAdminNode = await loadCoValueOrFail(
+      admin.node,
+      alice.accountID,
+    );
+
+    const group = admin.node.createGroup();
+    const childGroup = bob.node.createGroup();
+
+    group.addMember(bobOnAdminNode, "reader");
+    group.addMember(aliceOnAdminNode, "reader");
+
+    await group.core.waitForSync();
+
+    blockMessageTypeOnOutgoingPeer(peer, "content", {
+      id: childGroup.id,
+    });
+
+    const groupOnBobNode = await loadCoValueOrFail(bob.node, group.id);
+
+    childGroup.extend(groupOnBobNode);
+
+    await groupOnBobNode.core.waitForSync();
+
+    group.removeMember(aliceOnAdminNode);
+
+    await admin.node.syncManager.waitForAllCoValuesSync();
+
+    const map = group.createMap();
+    map.set("test", "Not readable by alice");
+
+    await map.core.waitForSync();
+
+    const mapOnAliceNode = await loadCoValueOrFail(alice.node, map.id);
+    expect(mapOnAliceNode.get("test")).toBeUndefined();
+  });
+
+  test("removing a member should work even if there are unavailable child groups", async () => {
+    const admin = await setupTestAccount({
+      connected: true,
+    });
+
+    const { peerOnServer } = admin.connectToSyncServer();
+
+    const bob = await setupTestAccount({
+      connected: true,
+    });
+
+    const alice = await setupTestAccount({
+      connected: true,
+    });
+
+    const bobOnAdminNode = await loadCoValueOrFail(admin.node, bob.accountID);
+
+    const aliceOnAdminNode = await loadCoValueOrFail(
+      admin.node,
+      alice.accountID,
+    );
+
+    const group = admin.node.createGroup();
+    const childGroup = bob.node.createGroup();
+
+    blockMessageTypeOnOutgoingPeer(peerOnServer, "content", {
+      id: childGroup.id,
+    });
+
+    group.addMember(bobOnAdminNode, "reader");
+    group.addMember(aliceOnAdminNode, "reader");
+
+    await group.core.waitForSync();
+
+    const groupOnBobNode = await loadCoValueOrFail(bob.node, group.id);
+
+    childGroup.extend(groupOnBobNode);
+
+    await groupOnBobNode.core.waitForSync();
+
+    group.removeMember(aliceOnAdminNode);
+
+    await group.core.waitForSync();
+
+    const map = group.createMap();
+    map.set("test", "Not readable by alice");
+
+    await map.core.waitForSync();
+
+    const mapOnAliceNode = await loadCoValueOrFail(alice.node, map.id);
+    expect(mapOnAliceNode.get("test")).toBeUndefined();
   });
 });

--- a/packages/cojson/src/tests/group.roleOf.test.ts
+++ b/packages/cojson/src/tests/group.roleOf.test.ts
@@ -33,7 +33,7 @@ describe("roleOf", () => {
     const [agent2] = randomAgentAndSessionID();
 
     group.addMember(agent2, "writer");
-    group.removeMemberInternal(agent2);
+    group.removeMember(agent2);
     expect(group.roleOfInternal(agent2.id)).toEqual(undefined);
   });
 
@@ -63,7 +63,7 @@ describe("roleOf", () => {
 
     group.addMemberInternal("everyone", "reader");
     group.addMember(agent2, "writer");
-    group.removeMemberInternal("everyone");
+    group.removeMember("everyone");
     expect(group.roleOfInternal(agent2.id)).toEqual("writer");
     expect(group.roleOfInternal("123" as RawAccountID)).toEqual(undefined);
   });

--- a/packages/cojson/src/tests/sync.load.test.ts
+++ b/packages/cojson/src/tests/sync.load.test.ts
@@ -590,11 +590,14 @@ describe("loading coValues from server", () => {
         "client -> server | LOAD Map sessions: empty",
         "server -> client | CONTENT Group header: true new: After: 0 New: 5",
         "client -> server | KNOWN Group sessions: header/5",
-        "client -> server | LOAD Map sessions: empty",
-        "server -> client | KNOWN Group sessions: header/5",
+        "server -> client | CONTENT Group header: true new: After: 0 New: 5",
+        "client -> server | KNOWN Group sessions: header/5",
         "server -> client | CONTENT Map header: true new: After: 0 New: 1",
-        "client -> server | LOAD Group sessions: header/5",
         "client -> server | KNOWN Map sessions: header/1",
+        "client -> server | LOAD Group sessions: header/5",
+        "server -> client | KNOWN Group sessions: header/5",
+        "client -> server | LOAD Map sessions: header/1",
+        "server -> client | KNOWN Map sessions: header/1",
       ]
     `);
   });

--- a/packages/cojson/src/tests/testUtils.ts
+++ b/packages/cojson/src/tests/testUtils.ts
@@ -657,6 +657,11 @@ export async function setupTestAccount(
     connectToSyncServer,
     addStorage,
     addAsyncStorage,
+    disconnect: () => {
+      ctx.node.syncManager.getPeers().forEach((peer) => {
+        peer.gracefulShutdown();
+      });
+    },
   };
 }
 

--- a/packages/jazz-tools/src/tools/coValues/group.ts
+++ b/packages/jazz-tools/src/tools/coValues/group.ts
@@ -167,15 +167,15 @@ export class Group extends CoValueBase implements CoValue {
     }
   }
 
-  removeMember(member: Everyone | Account): Promise<void>;
+  removeMember(member: Everyone | Account): void;
   /** @category Identity & Permissions
    * Revokes membership from members a parent group.
    * @param member The group that will lose access to this group.
    */
-  removeMember(member: Group): Promise<void>;
+  removeMember(member: Group): void;
   removeMember(member: Group | Everyone | Account) {
     if (member !== "everyone" && member._type === "Group") {
-      return this._raw.revokeExtend(member._raw);
+      this._raw.revokeExtend(member._raw);
     } else {
       return this._raw.removeMember(
         member === "everyone" ? member : member._raw,


### PR DESCRIPTION
# Description

Makes the key rotation not fail when child groups are unavailable or their readkey is not accessible.

Also changes the Group.removeMember method to not return a Promise, because:
- All the locally available child groups are rotated immediately
- All the remote child groups are rotated in background, but since they are not locally available the user won't need the new key immediately

## Tests

- [x] Tests have been added and/or updated
- [ ] Tests have not been updated, because: <!-- Insert reason for not updating tests here -->
- [ ] I need help with writing tests

## Checklist

- [ ] I've updated the part of the docs that are affected the PR changes
- [ ] I've generated a changeset, if a version bump is required
- [ ] I've updated the jsDoc comments to the public APIs I've modified, or added them when missing