### PR TITLE
feat: add ingress/egress metering on cojosn-transport-ws

### DIFF
--- a/.changeset/shaggy-vans-retire.md
+++ b/.changeset/shaggy-vans-retire.md
@@ -1,0 +1,6 @@
+---
+"cojson-transport-ws": patch
+"cojson": patch
+---
+
+Add ingress and egress metering

--- a/packages/cojson-transport-ws/package.json
+++ b/packages/cojson-transport-ws/package.json
@@ -6,6 +6,7 @@
   "types": "dist/index.d.ts",
   "license": "MIT",
   "dependencies": {
+    "@opentelemetry/api": "^1.9.0",
     "cojson": "workspace:*"
   },
   "scripts": {
@@ -17,8 +18,9 @@
     "build": "rm -rf ./dist && tsc --sourceMap --outDir dist"
   },
   "devDependencies": {
-    "typescript": "catalog:",
+    "@opentelemetry/sdk-metrics": "^2.0.0",
     "@types/ws": "8.5.10",
+    "typescript": "catalog:",
     "ws": "^8.14.2"
   }
 }

--- a/packages/cojson-transport-ws/src/tests/BatchedOutgoingMessages.test.ts
+++ b/packages/cojson-transport-ws/src/tests/BatchedOutgoingMessages.test.ts
@@ -1,0 +1,83 @@
+import type { SyncMessage } from "cojson";
+import { type Mocked, afterEach, describe, expect, test, vi } from "vitest";
+import { BatchedOutgoingMessages } from "../BatchedOutgoingMessages";
+import type { AnyWebSocket } from "../types";
+import { createTestMetricReader, tearDownTestMetricReader } from "./utils.js";
+
+describe("BatchedOutgoingMessages", () => {
+  describe("telemetry", () => {
+    afterEach(() => {
+      tearDownTestMetricReader();
+    });
+
+    test("should correctly measure egress", async () => {
+      const metricReader = createTestMetricReader();
+
+      const mockWebSocket = {
+        readyState: 1,
+        addEventListener: vi.fn(),
+        removeEventListener: vi.fn(),
+        close: vi.fn(),
+        send: vi.fn(),
+      } as unknown as Mocked<AnyWebSocket>;
+
+      const outgoing = new BatchedOutgoingMessages(
+        mockWebSocket,
+        true,
+        "server",
+        { test: "test" },
+      );
+
+      const encryptedChanges = "Hello, world!";
+      vi.useFakeTimers();
+      outgoing.push({
+        action: "content",
+        new: {
+          someSessionId: {
+            newTransactions: [
+              {
+                privacy: "private",
+                encryptedChanges,
+              },
+            ],
+          },
+        },
+      } as unknown as SyncMessage);
+
+      await vi.runAllTimersAsync();
+      vi.useRealTimers();
+
+      expect(
+        await metricReader.getMetricValue("jazz.usage.egress", {
+          test: "test",
+        }),
+      ).toBe(encryptedChanges.length);
+
+      const trustingChanges = "Jazz is great!";
+      vi.useFakeTimers();
+      outgoing.push({
+        action: "content",
+        new: {
+          someSessionId: {
+            after: 0,
+            newTransactions: [
+              {
+                privacy: "trusting",
+                changes: trustingChanges,
+              },
+            ],
+          },
+        },
+      } as unknown as SyncMessage);
+
+      await vi.runAllTimersAsync();
+      vi.useRealTimers();
+
+      expect(
+        await metricReader.getMetricValue("jazz.usage.egress", {
+          test: "test",
+        }),
+      ).toBe(encryptedChanges.length + trustingChanges.length);
+    });
+  });
+});

--- a/packages/cojson-transport-ws/src/tests/createWebSocketPeer.test.ts
+++ b/packages/cojson-transport-ws/src/tests/createWebSocketPeer.test.ts
@@ -1,6 +1,6 @@
 import type { CojsonInternalTypes, SyncMessage } from "cojson";
 import { cojsonInternals } from "cojson";
-import { type Mocked, describe, expect, test, vi } from "vitest";
+import { type Mocked, afterEach, describe, expect, test, vi } from "vitest";
 import { MAX_OUTGOING_MESSAGES_CHUNK_BYTES } from "../BatchedOutgoingMessages.js";
 import {
   type CreateWebSocketPeerOpts,
@@ -8,6 +8,7 @@ import {
 } from "../createWebSocketPeer.js";
 import type { AnyWebSocket } from "../types.js";
 import { BUFFER_LIMIT, BUFFER_LIMIT_POLLING_INTERVAL } from "../utils.js";
+import { createTestMetricReader, tearDownTestMetricReader } from "./utils.js";
 
 const { CO_VALUE_PRIORITY } = cojsonInternals;
 
@@ -518,6 +519,89 @@ describe("createWebSocketPeer", () => {
         2,
         JSON.stringify(message2),
       );
+    });
+  });
+
+  describe("telemetry", () => {
+    afterEach(() => {
+      tearDownTestMetricReader();
+    });
+
+    test("should initialize to 0 when creating a websocket peer", async () => {
+      const metricReader = createTestMetricReader();
+      setup({
+        meta: { test: "test" },
+      });
+
+      const measuredIngress = await metricReader.getMetricValue(
+        "jazz.usage.ingress",
+        {
+          test: "test",
+        },
+      );
+      expect(measuredIngress).toBe(0);
+    });
+
+    test("should correctly measure incoming ingress", async () => {
+      const metricReader = createTestMetricReader();
+      const { listeners } = setup({
+        meta: { label: "value" },
+      });
+
+      const messageHandler = listeners.get("message");
+
+      const encryptedChanges = "Hello, world!";
+      messageHandler?.(
+        new MessageEvent("message", {
+          data: JSON.stringify({
+            action: "content",
+            new: {
+              someSessionId: {
+                after: 0,
+                newTransactions: [
+                  {
+                    privacy: "private" as const,
+                    madeAt: 0,
+                    keyUsed: "key_zkey" as const,
+                    encryptedChanges,
+                  },
+                ],
+              },
+            },
+          }),
+        }),
+      );
+
+      expect(
+        await metricReader.getMetricValue("jazz.usage.ingress", {
+          label: "value",
+        }),
+      ).toBe(encryptedChanges.length);
+
+      const trustingChanges = "Jazz is great!";
+      messageHandler?.(
+        new MessageEvent("message", {
+          data: JSON.stringify({
+            action: "content",
+            new: {
+              someSessionId: {
+                newTransactions: [
+                  {
+                    privacy: "trusting",
+                    changes: trustingChanges,
+                  },
+                ],
+              },
+            },
+          }),
+        }),
+      );
+
+      expect(
+        await metricReader.getMetricValue("jazz.usage.ingress", {
+          label: "value",
+        }),
+      ).toBe(encryptedChanges.length + trustingChanges.length);
     });
   });
 });

--- a/packages/cojson-transport-ws/src/tests/utils.ts
+++ b/packages/cojson-transport-ws/src/tests/utils.ts
@@ -1,3 +1,12 @@
+import { metrics } from "@opentelemetry/api";
+import {
+  AggregationTemporality,
+  InMemoryMetricExporter,
+  MeterProvider,
+  MetricReader,
+} from "@opentelemetry/sdk-metrics";
+import { expect } from "vitest";
+
 // biome-ignore lint/suspicious/noConfusingVoidType: Test helper
 export function waitFor(callback: () => boolean | void) {
   return new Promise<void>((resolve, reject) => {
@@ -25,4 +34,72 @@ export function waitFor(callback: () => boolean | void) {
       }
     }, 100);
   });
+}
+
+/**
+ * This is a test metric reader that uses an in-memory metric exporter and exposes a method to get the value of a metric given its name and attributes.
+ *
+ * This is useful for testing the values of metrics that are collected by the SDK.
+ *
+ * TODO: We may want to rethink how we access metrics (see `getMetricValue` method) to make it more flexible.
+ */
+class TestMetricReader extends MetricReader {
+  private _exporter = new InMemoryMetricExporter(
+    AggregationTemporality.CUMULATIVE,
+  );
+
+  protected onShutdown(): Promise<void> {
+    throw new Error("Method not implemented.");
+  }
+  protected onForceFlush(): Promise<void> {
+    throw new Error("Method not implemented.");
+  }
+
+  async getMetricValue(
+    name: string,
+    attributes: { [key: string]: string | number } = {},
+  ) {
+    await this.collectAndExport();
+    const metric = this._exporter
+      .getMetrics()[0]
+      ?.scopeMetrics[0]?.metrics.find((m) => m.descriptor.name === name);
+
+    const dp = metric?.dataPoints.find(
+      (dp) => JSON.stringify(dp.attributes) === JSON.stringify(attributes),
+    );
+
+    this._exporter.reset();
+
+    return dp?.value;
+  }
+
+  async collectAndExport(): Promise<void> {
+    const result = await this.collect();
+    await new Promise<void>((resolve, reject) => {
+      this._exporter.export(result.resourceMetrics, (result) => {
+        if (result.error != null) {
+          reject(result.error);
+        } else {
+          resolve();
+        }
+      });
+    });
+  }
+}
+
+export function createTestMetricReader() {
+  const metricReader = new TestMetricReader();
+  const success = metrics.setGlobalMeterProvider(
+    new MeterProvider({
+      readers: [metricReader],
+    }),
+  );
+
+  expect(success).toBe(true);
+
+  return metricReader;
+}
+
+export function tearDownTestMetricReader() {
+  metrics.disable();
 }

--- a/packages/cojson/src/coValueContentMessage.ts
+++ b/packages/cojson/src/coValueContentMessage.ts
@@ -71,3 +71,14 @@ export function knownStateFromContent(content: NewContentMessage) {
 
   return knownState;
 }
+
+export function getContentMessageSize(msg: NewContentMessage) {
+  return Object.values(msg.new).reduce((acc, sessionNewContent) => {
+    return (
+      acc +
+      sessionNewContent.newTransactions.reduce((acc, tx) => {
+        return acc + getTransactionSize(tx);
+      }, 0)
+    );
+  }, 0);
+}

--- a/packages/cojson/src/coValueCore/utils.ts
+++ b/packages/cojson/src/coValueCore/utils.ts
@@ -2,6 +2,7 @@ import { getGroupDependentKey } from "../ids.js";
 import { RawCoID, SessionID } from "../ids.js";
 import { Stringified, parseJSON } from "../jsonStringify.js";
 import { JsonValue } from "../jsonValue.js";
+import { NewContentMessage } from "../sync.js";
 import { accountOrAgentIDfromSessionID } from "../typeUtils/accountOrAgentIDfromSessionID.js";
 import { isAccountID } from "../typeUtils/isAccountID.js";
 import { CoValueHeader, Transaction } from "./verifiedState.js";

--- a/packages/cojson/src/exports.ts
+++ b/packages/cojson/src/exports.ts
@@ -61,9 +61,10 @@ import { disablePermissionErrors } from "./permissions.js";
 import type { Peer, SyncMessage } from "./sync.js";
 import { DisconnectedError, SyncManager, emptyKnownState } from "./sync.js";
 
-type Value = JsonValue | AnyRawCoValue;
-
-export { PriorityBasedMessageQueue } from "./queue/PriorityBasedMessageQueue.js";
+import {
+  getContentMessageSize,
+  getTransactionSize,
+} from "./coValueContentMessage.js";
 import { getDependedOnCoValuesFromRawData } from "./coValueCore/utils.js";
 import {
   CO_VALUE_LOADING_CONFIG,
@@ -75,6 +76,9 @@ import { LogLevel, logger } from "./logger.js";
 import { CO_VALUE_PRIORITY, getPriorityFromHeader } from "./priority.js";
 import { getDependedOnCoValues } from "./storage/syncUtils.js";
 
+type Value = JsonValue | AnyRawCoValue;
+
+export { PriorityBasedMessageQueue } from "./queue/PriorityBasedMessageQueue.js";
 /** @hidden */
 export const cojsonInternals = {
   connectedPeers,
@@ -106,6 +110,8 @@ export const cojsonInternals = {
   ConnectedPeerChannel,
   textEncoder,
   textDecoder,
+  getTransactionSize,
+  getContentMessageSize,
 };
 
 export {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1683,10 +1683,16 @@ importers:
 
   packages/cojson-transport-ws:
     dependencies:
+      '@opentelemetry/api':
+        specifier: ^1.9.0
+        version: 1.9.0
       cojson:
         specifier: workspace:*
         version: link:../cojson
     devDependencies:
+      '@opentelemetry/sdk-metrics':
+        specifier: ^2.0.0
+        version: 2.0.0(@opentelemetry/api@1.9.0)
       '@types/ws':
         specifier: 8.5.10
         version: 8.5.10


### PR DESCRIPTION
Reverts #2709, which reverted  https://github.com/garden-co/jazz/pull/2682

# Description

Adds ingress/egress meters. `createWebSocketPeer` and `BatchedOutgoingMessages` takes an additional parameter that will hold KV pairs of attributes to attach to the metrics.

Fixes GCO-692, GCO-693 and GCO-694

Also fixes https://linear.app/garden-co/issue/GCO-661/introduce-a-centralised-util-to-calculate-tx-size by adding an utility to calculate transactions size

## Manual testing instructions

<!-- Add any actions required to manually test the changes -->

## Tests

- [x] Tests have been added and/or updated


## Checklist

- [x] I've generated a changeset, if a version bump is required
- [x] I've updated the jsDoc comments to the public APIs I've modified, or added them when missing