### PR TITLE
fix: fix nested discriminated unions

### DIFF
--- a/.changeset/nice-days-laugh.md
+++ b/.changeset/nice-days-laugh.md
@@ -1,0 +1,5 @@
+---
+"jazz-tools": patch
+---
+
+Fix error when using nested discriminatedUnion

--- a/packages/jazz-tools/src/tools/implementation/zodSchema/unionUtils.ts
+++ b/packages/jazz-tools/src/tools/implementation/zodSchema/unionUtils.ts
@@ -81,8 +81,7 @@ export function schemaUnionDiscriminatorFor(
               continue;
             }
           }
-
-          if (discriminatorDef._zod.def.type !== "literal") {
+          if (discriminatorDef._zod?.def.type !== "literal") {
             break;
           }
 
@@ -140,4 +139,10 @@ export function isUnionOfPrimitivesDeeply(schema: AnyZodOrCoValueSchema) {
   } else {
     return !isAnyCoValueSchema(schema);
   }
+}
+
+function isCoDiscriminatedUnion(
+  def: any,
+): def is CoreCoDiscriminatedUnionSchema<any> {
+  return def.builtin === "CoDiscriminatedUnion";
 }

--- a/packages/jazz-tools/src/tools/tests/coDiscriminatedUnion.test.ts
+++ b/packages/jazz-tools/src/tools/tests/coDiscriminatedUnion.test.ts
@@ -308,4 +308,54 @@ describe("co.discriminatedUnion", () => {
 
     expect(updates[0]?.name).toEqual("Rex");
   });
+
+  test("should work when one of the options has a dicriminated union field", async () => {
+    const Collie = co.map({
+      type: z.literal("collie"),
+    });
+    const BorderCollie = co.map({
+      type: z.literal("border-collie"),
+    });
+    const Breed = co.discriminatedUnion("type", [Collie, BorderCollie]);
+
+    const Dog = co.map({
+      type: z.literal("dog"),
+      breed: Breed,
+    });
+
+    const Animal = co.discriminatedUnion("type", [Dog]);
+
+    const animal = Dog.create({
+      type: "dog",
+      breed: {
+        type: "collie",
+      },
+    });
+
+    const loadedAnimal = await Animal.load(animal.id);
+
+    expect(loadedAnimal?.breed?.type).toEqual("collie");
+  });
+
+  test("should work with a nested co.discriminatedUnion", async () => {
+    const Collie = co.map({
+      type: z.literal("collie"),
+    });
+    const BorderCollie = co.map({
+      type: z.literal("border-collie"),
+    });
+    const Breed = co.discriminatedUnion("type", [Collie, BorderCollie]);
+
+    const Dog = co.discriminatedUnion("type", [Breed]);
+
+    const Animal = co.discriminatedUnion("type", [Dog]);
+
+    const animal = Collie.create({
+      type: "collie",
+    });
+
+    const loadedAnimal = await Animal.load(animal.id);
+
+    expect(loadedAnimal?.type).toEqual("collie");
+  });
 });


### PR DESCRIPTION
Fixes the following test case:

```ts
  test("should work when one of the options has a dicriminated union field", async () => {
    const Collie = co.map({
      type: z.literal("collie"),
    });
    const BorderCollie = co.map({
      type: z.literal("border-collie"),
    });
    const Breed = co.discriminatedUnion("type", [Collie, BorderCollie]);

    const Dog = co.map({
      type: z.literal("dog"),
      breed: Breed,
    });

    const Animal = co.discriminatedUnion("type", [Dog]);

    const animal = Dog.create({
      type: "dog",
      breed: {
        type: "collie",
      },
    });

    const loadedAnimal = await Animal.load(animal.id);

    expect(loadedAnimal?.breed?.type).toEqual("collie");
  });

```