### PR TITLE
Revert "feat: add markAsStorageSignatureToFix to make it possible to fix bad signatures caused by the storage bug fixed in 0.15.9"

### DIFF
--- a/.changeset/dirty-cats-sparkle.md
+++ b/.changeset/dirty-cats-sparkle.md
@@ -1,5 +1,0 @@
----
-"cojson": patch
----
-
-Add markAsStorageSignatureToFix to make it possible to fix bad signatures caused by the storage bug fixed in 0.15.9

--- a/packages/cojson/src/coValueCore/coValueCore.ts
+++ b/packages/cojson/src/coValueCore/coValueCore.ts
@@ -526,7 +526,6 @@ export class CoValueCore {
   makeTransaction(
     changes: JsonValue[],
     privacy: "private" | "trusting",
-    forcedSessionID?: SessionID,
   ): boolean {
     if (!this.verified) {
       throw new Error(
@@ -566,23 +565,14 @@ export class CoValueCore {
       };
     }
 
+    // This is an ugly hack to get a unique but stable session ID for editing the current account
     const sessionID =
-      (forcedSessionID ?? this.verified.header.meta?.type === "account")
+      this.verified.header.meta?.type === "account"
         ? (this.node.currentSessionID.replace(
             this.node.getCurrentAgent().id,
             this.node.getCurrentAgent().currentAgentID(),
           ) as SessionID)
         : this.node.currentSessionID;
-
-    return this.commitTransaction(sessionID, transaction);
-  }
-
-  commitTransaction(sessionID: SessionID, transaction: Transaction) {
-    if (!this.verified) {
-      throw new Error(
-        "CoValueCore: commitTransaction called on coValue without verified state",
-      );
-    }
 
     const { expectedNewHash, newStreamingHash } =
       this.verified.expectedNewHashAfter(sessionID, [transaction]);

--- a/packages/cojson/src/localNode.ts
+++ b/packages/cojson/src/localNode.ts
@@ -62,7 +62,6 @@ export class LocalNode {
 
   /** @category 3. Low-level */
   syncManager = new SyncManager(this);
-  fixStorageSignatures = new Set<string>();
 
   crashed: Error | undefined = undefined;
 
@@ -149,10 +148,6 @@ export class LocalNode {
     return expectAccount(
       this.expectCoValueLoaded(accountID).getCurrentContent(),
     );
-  }
-
-  markAsStorageSignatureToFix(id: string) {
-    this.fixStorageSignatures.add(id);
   }
 
   static internalCreateAccount(opts: {

--- a/packages/cojson/src/sync.ts
+++ b/packages/cojson/src/sync.ts
@@ -14,7 +14,6 @@ import {
 } from "./coValueCore/verifiedState.js";
 import { Signature } from "./crypto/crypto.js";
 import { RawCoID, SessionID, isRawCoID } from "./ids.js";
-import { stableStringify } from "./jsonStringify.js";
 import { LocalNode } from "./localNode.js";
 import { logger } from "./logger.js";
 import { CoValuePriority } from "./priority.js";
@@ -616,35 +615,6 @@ export class SyncManager {
       );
 
       if (result.isErr()) {
-        if (
-          from === "storage" &&
-          this.local.fixStorageSignatures.has(msg.id) &&
-          sessionID.startsWith(this.local.getCurrentAccountOrAgentID())
-        ) {
-          coValue.tryAddTransactions(
-            sessionID,
-            newTransactions,
-            undefined,
-            newContentForSession.lastSignature,
-            "immediate",
-            true,
-          );
-          // Push an empty transaction to the session to fix the signature
-          coValue.commitTransaction(sessionID, {
-            privacy: "trusting",
-            madeAt: Date.now(),
-            changes: stableStringify([]),
-          });
-          logger.error(
-            "Pushing an empty transaction to the session to fix the signature",
-            {
-              id: msg.id,
-              sessionID,
-            },
-          );
-          continue;
-        }
-
         if (peer) {
           logger.error("Failed to add transactions", {
             peerId: peer.id,

--- a/packages/cojson/src/tests/sync.storage.test.ts
+++ b/packages/cojson/src/tests/sync.storage.test.ts
@@ -8,7 +8,7 @@ import {
   vi,
 } from "vitest";
 
-import { CoID, RawCoMap, emptyKnownState } from "../exports";
+import { emptyKnownState } from "../exports";
 import {
   SyncMessagesLog,
   TEST_NODE_CONFIG,
@@ -427,68 +427,5 @@ describe("client syncs with a server with storage", () => {
         largeMap.core.knownState(),
       );
     });
-  });
-
-  test("should autofix marked CoValues with invalid signatures", async () => {
-    const client = setupTestNode();
-
-    const coMap = client.node
-      .createCoValue({
-        type: "comap",
-        ruleset: { type: "unsafeAllowAll" },
-        meta: null,
-        ...client.node.crypto.createdNowUnique(),
-      })
-      .getCurrentContent() as RawCoMap;
-    coMap.set("hello", "world", "trusting");
-
-    const content = coMap.core.verified.newContentSince(undefined)?.[0];
-
-    assert(content);
-
-    const sessionChanges = content.new[client.node.currentSessionID];
-
-    assert(sessionChanges);
-
-    // Overwrite the signature with an invalid one to force the fix
-    sessionChanges.lastSignature =
-      "signature_z3tsE7U1JaeNeUmZ4EY3Xq5uQ9jq9jDi6Rkhdt7T7b7z4NCnpMgB4bo8TwLXYVCrRdBm6PoyyPdK8fYFzHJUh5EzA";
-
-    client.restart();
-    const { storage } = client.addStorage();
-
-    storage.store(content, vi.fn());
-    SyncMessagesLog.clear();
-
-    client.node.markAsStorageSignatureToFix(coMap.id);
-
-    const mapWithFixedSignature = await loadCoValueOrFail(
-      client.node,
-      coMap.id as CoID<RawCoMap>,
-    );
-
-    expect(mapWithFixedSignature.get("hello")).toEqual("world");
-
-    expect(
-      SyncMessagesLog.getMessages({
-        Map: coMap.core,
-      }),
-    ).toMatchInlineSnapshot(`
-      [
-        "client -> storage | LOAD Map sessions: empty",
-        "storage -> client | CONTENT Map header: true new: After: 0 New: 1",
-        "client -> storage | CONTENT Map header: false new: After: 1 New: 1",
-      ]
-    `);
-
-    client.restart();
-    client.addStorage({ storage });
-
-    const mapStoredWithTheCorrectSignature = await loadCoValueOrFail(
-      client.node,
-      coMap.id as CoID<RawCoMap>,
-    );
-
-    expect(mapStoredWithTheCorrectSignature.get("hello")).toEqual("world");
   });
 });


### PR DESCRIPTION
Reverts garden-co/jazz#2712