### PR TITLE
Fix return type on deep loaded co.record() when using single keys

### DIFF
--- a/.changeset/tall-pillows-accept.md
+++ b/.changeset/tall-pillows-accept.md
@@ -1,0 +1,5 @@
+---
+"jazz-tools": patch
+---
+
+co.record partial deep loading now resolve correct type

--- a/packages/jazz-tools/src/tools/coValues/deepLoading.ts
+++ b/packages/jazz-tools/src/tools/coValues/deepLoading.ts
@@ -97,6 +97,27 @@ type onErrorNullEnabled<Depth> = Depth extends { $onError: null }
   ? null
   : never;
 
+type CoMapLikeLoaded<
+  V extends object,
+  Depth,
+  DepthLimit extends number,
+  CurrentDepth extends number[],
+> = {
+  -readonly [Key in keyof Depth]-?: Key extends CoKeys<V>
+    ? NonNullable<V[Key]> extends CoValue
+      ?
+          | DeeplyLoaded<
+              NonNullable<V[Key]>,
+              Depth[Key],
+              DepthLimit,
+              [0, ...CurrentDepth]
+            >
+          | (undefined extends V[Key] ? undefined : never)
+          | onErrorNullEnabled<Depth[Key]>
+      : never
+    : never;
+} & V;
+
 export type DeeplyLoaded<
   V,
   Depth,
@@ -126,38 +147,27 @@ export type DeeplyLoaded<
         : V
       : // Basically V extends CoMap | Group | Account - but if we used that we'd introduce circularity into the definition of CoMap itself
         [V] extends [{ _type: "CoMap" | "Group" | "Account" }]
-        ? ItemsSym extends keyof V
-          ? Depth extends { $each: infer ItemDepth }
-            ? // Deeply loaded Record-like CoMap
-              {
-                [key: string]:
-                  | DeeplyLoaded<
-                      NonNullable<V[ItemsSym]>,
-                      ItemDepth,
-                      DepthLimit,
-                      [0, ...CurrentDepth]
-                    >
-                  | onErrorNullEnabled<Depth["$each"]>;
-              } & V // same reason as in CoList
-            : never
-          : keyof Depth extends never // Depth = {}
-            ? V
-            : // Deeply loaded CoMap
-              {
-                -readonly [Key in keyof Depth]-?: Key extends CoKeys<V>
-                  ? NonNullable<V[Key]> extends CoValue
-                    ?
-                        | DeeplyLoaded<
-                            NonNullable<V[Key]>,
-                            Depth[Key],
-                            DepthLimit,
-                            [0, ...CurrentDepth]
-                          >
-                        | (undefined extends V[Key] ? undefined : never)
-                        | onErrorNullEnabled<Depth[Key]>
-                    : never
-                  : never;
-              } & V // same reason as in CoList
+        ? // If Depth = {} return V in any case
+          keyof Depth extends never
+          ? V
+          : // 1. Record-like CoMap
+            ItemsSym extends keyof V
+            ? // 1.1. Deeply loaded Record-like CoMap with { $each: true | {$onError: null} }
+              Depth extends { $each: infer ItemDepth }
+              ? {
+                  [key: string]:
+                    | DeeplyLoaded<
+                        NonNullable<V[ItemsSym]>,
+                        ItemDepth,
+                        DepthLimit,
+                        [0, ...CurrentDepth]
+                      >
+                    | onErrorNullEnabled<Depth["$each"]>;
+                } & V // same reason as in CoList
+              : // 1.2 Deeply loaded Record-like CoMap with single keys
+                CoMapLikeLoaded<V, Depth, DepthLimit, CurrentDepth>
+            : // 2. Deeply loaded CoMap
+              CoMapLikeLoaded<V, Depth, DepthLimit, CurrentDepth>
         : [V] extends [
               {
                 _type: "CoStream";

--- a/packages/jazz-tools/src/tools/coValues/deepLoading.ts
+++ b/packages/jazz-tools/src/tools/coValues/deepLoading.ts
@@ -164,8 +164,20 @@ export type DeeplyLoaded<
                       >
                     | onErrorNullEnabled<Depth["$each"]>;
                 } & V // same reason as in CoList
-              : // 1.2 Deeply loaded Record-like CoMap with single keys
-                CoMapLikeLoaded<V, Depth, DepthLimit, CurrentDepth>
+              : // 1.2. Deeply loaded Record-like CoMap with { [key: string]: true | {$onError: null} }
+                string extends keyof Depth
+                ? {
+                    [key in keyof Depth]:
+                      | DeeplyLoaded<
+                          V[ItemsSym],
+                          Depth[key],
+                          DepthLimit,
+                          [0, ...CurrentDepth]
+                        >
+                      | onErrorNullEnabled<Depth[key]>;
+                  } & V // same reason as in CoList
+                : // 1.2 Deeply loaded Record-like CoMap with single keys
+                  CoMapLikeLoaded<V, Depth, DepthLimit, CurrentDepth>
             : // 2. Deeply loaded CoMap
               CoMapLikeLoaded<V, Depth, DepthLimit, CurrentDepth>
         : [V] extends [

--- a/packages/jazz-tools/src/tools/coValues/deepLoading.ts
+++ b/packages/jazz-tools/src/tools/coValues/deepLoading.ts
@@ -164,19 +164,11 @@ export type DeeplyLoaded<
                       >
                     | onErrorNullEnabled<Depth["$each"]>;
                 } & V // same reason as in CoList
-              : // 1.2. Deeply loaded Record-like CoMap with { [key: string]: true | {$onError: null} }
+              : // 1.2. Deeply loaded Record-like CoMap with { [key: string]: true }
                 string extends keyof Depth
-                ? {
-                    [key in keyof Depth]:
-                      | DeeplyLoaded<
-                          V[ItemsSym],
-                          Depth[key],
-                          DepthLimit,
-                          [0, ...CurrentDepth]
-                        >
-                      | onErrorNullEnabled<Depth[key]>;
-                  } & V // same reason as in CoList
-                : // 1.2 Deeply loaded Record-like CoMap with single keys
+                ? // if at least one key is `string`, then we treat the resolve as it was empty
+                  DeeplyLoaded<V, {}, DepthLimit, [0, ...CurrentDepth]> & V
+                : // 1.3 Deeply loaded Record-like CoMap with single keys
                   CoMapLikeLoaded<V, Depth, DepthLimit, CurrentDepth>
             : // 2. Deeply loaded CoMap
               CoMapLikeLoaded<V, Depth, DepthLimit, CurrentDepth>

--- a/packages/jazz-tools/src/tools/tests/coList.test.ts
+++ b/packages/jazz-tools/src/tools/tests/coList.test.ts
@@ -1,5 +1,5 @@
 import { WasmCrypto } from "cojson/crypto/WasmCrypto";
-import { beforeEach, describe, expect, test, vi } from "vitest";
+import { assert, beforeEach, describe, expect, test, vi } from "vitest";
 import { Account, Group, subscribeToCoValue, z } from "../index.js";
 import {
   Loaded,

--- a/packages/jazz-tools/src/tools/tests/coMap.record.test-d.ts
+++ b/packages/jazz-tools/src/tools/tests/coMap.record.test-d.ts
@@ -206,6 +206,41 @@ describe("CoMap.Record", () => {
       >();
     });
 
+    test("loading a record with generic string resolve", async () => {
+      const Dog = co.map({
+        name: z.string(),
+        breed: z.string(),
+      });
+
+      const Person = co.record(z.string(), Dog);
+
+      const person = Person.create({
+        pet1: Dog.create({ name: "Rex", breed: "Labrador" }),
+        pet2: Dog.create({ name: "Fido", breed: "Poodle" }),
+      });
+
+      const userId: string = "pet1";
+
+      const loadedPerson = await Person.load(person.id, {
+        resolve: {
+          [userId]: true,
+        },
+      });
+
+      type Expect = NonNullable<typeof loadedPerson> extends never
+        ? "error: is never"
+        : "ok";
+
+      expectTypeOf("ok" as const).toEqualTypeOf<Expect>();
+
+      expectTypeOf(loadedPerson?.pet1).toEqualTypeOf<
+        Loaded<typeof Dog> | undefined
+      >();
+      expectTypeOf(loadedPerson?.pet3).toEqualTypeOf<
+        Loaded<typeof Dog> | undefined
+      >();
+    });
+
     test("loading a record with empty resolve", async () => {
       const Dog = co.map({
         name: z.string(),

--- a/packages/jazz-tools/src/tools/tests/coMap.record.test-d.ts
+++ b/packages/jazz-tools/src/tools/tests/coMap.record.test-d.ts
@@ -173,6 +173,68 @@ describe("CoMap.Record", () => {
       matches(loadedPerson);
     });
 
+    test("loading a record with property resolve", async () => {
+      const Dog = co.map({
+        name: z.string(),
+        breed: z.string(),
+      });
+
+      const Person = co.record(z.string(), Dog);
+
+      const person = Person.create({
+        pet1: Dog.create({ name: "Rex", breed: "Labrador" }),
+        pet2: Dog.create({ name: "Fido", breed: "Poodle" }),
+      });
+
+      const loadedPerson = await Person.load(person.id, {
+        resolve: {
+          pet1: true,
+        },
+      });
+
+      type Expect = NonNullable<typeof loadedPerson> extends never
+        ? "error: is never"
+        : "ok";
+
+      expectTypeOf("ok" as const).toEqualTypeOf<Expect>();
+
+      expectTypeOf(loadedPerson?.pet1).toEqualTypeOf<
+        Loaded<typeof Dog> | undefined
+      >();
+      expectTypeOf(loadedPerson?.pet3).toEqualTypeOf<
+        Loaded<typeof Dog> | undefined | null
+      >();
+    });
+
+    test("loading a record with empty resolve", async () => {
+      const Dog = co.map({
+        name: z.string(),
+        breed: z.string(),
+      });
+
+      const Person = co.record(z.string(), Dog);
+
+      const person = Person.create({
+        pet1: Dog.create({ name: "Rex", breed: "Labrador" }),
+        pet2: Dog.create({ name: "Fido", breed: "Poodle" }),
+      });
+
+      const loadedPerson = await Person.load(person.id);
+
+      type Expect = NonNullable<typeof loadedPerson> extends never
+        ? "error: is never"
+        : "ok";
+
+      expectTypeOf("ok" as const).toEqualTypeOf<Expect>();
+
+      expectTypeOf(loadedPerson?.pet1).toEqualTypeOf<
+        Loaded<typeof Dog> | undefined | null
+      >();
+      expectTypeOf(loadedPerson?.pet3).toEqualTypeOf<
+        Loaded<typeof Dog> | undefined | null
+      >();
+    });
+
     test("loading a record with $onError", async () => {
       const Dog = co.map({
         name: z.string(),

--- a/packages/jazz-tools/src/tools/tests/coMap.record.test-d.ts
+++ b/packages/jazz-tools/src/tools/tests/coMap.record.test-d.ts
@@ -220,10 +220,15 @@ describe("CoMap.Record", () => {
       });
 
       const userId: string = "pet1";
+      const userId2: string = "pet3";
 
       const loadedPerson = await Person.load(person.id, {
         resolve: {
           [userId]: true,
+          pet2: true,
+          [userId2]: {
+            $onError: null,
+          },
         },
       });
 
@@ -234,10 +239,13 @@ describe("CoMap.Record", () => {
       expectTypeOf("ok" as const).toEqualTypeOf<Expect>();
 
       expectTypeOf(loadedPerson?.pet1).toEqualTypeOf<
-        Loaded<typeof Dog> | undefined
+        Loaded<typeof Dog> | undefined | null
+      >();
+      expectTypeOf(loadedPerson?.pet2).toEqualTypeOf<
+        Loaded<typeof Dog> | undefined | null
       >();
       expectTypeOf(loadedPerson?.pet3).toEqualTypeOf<
-        Loaded<typeof Dog> | undefined
+        Loaded<typeof Dog> | undefined | null
       >();
     });
 

--- a/packages/jazz-tools/src/tools/tests/coMap.record.test.ts
+++ b/packages/jazz-tools/src/tools/tests/coMap.record.test.ts
@@ -236,6 +236,28 @@ describe("CoMap.Record", async () => {
       expect(loadedPerson.pet1?.name).toEqual("Rex");
     });
 
+    test("loading a locally available record with unavailable single resolve", async () => {
+      const Dog = co.map({
+        name: z.string(),
+        breed: z.string(),
+      });
+
+      const Person = co.record(z.string(), Dog);
+
+      const person = Person.create({
+        pet1: Dog.create({ name: "Rex", breed: "Labrador" }),
+        pet2: Dog.create({ name: "Fido", breed: "Poodle" }),
+      });
+
+      const loadedPerson = await Person.load(person.id, {
+        resolve: {
+          pet3: true,
+        },
+      });
+
+      expect(loadedPerson).toEqual(null);
+    });
+
     test("loading a locally available record using autoload for the refs", async () => {
       const Dog = co.map({
         name: z.string(),

--- a/packages/jazz-tools/src/tools/tests/coMap.record.test.ts
+++ b/packages/jazz-tools/src/tools/tests/coMap.record.test.ts
@@ -213,6 +213,29 @@ describe("CoMap.Record", async () => {
       expect(loadedPerson.pet2?.name).toEqual("Fido");
     });
 
+    test("loading a locally available record with single resolve", async () => {
+      const Dog = co.map({
+        name: z.string(),
+        breed: z.string(),
+      });
+
+      const Person = co.record(z.string(), Dog);
+
+      const person = Person.create({
+        pet1: Dog.create({ name: "Rex", breed: "Labrador" }),
+        pet2: Dog.create({ name: "Fido", breed: "Poodle" }),
+      });
+
+      const loadedPerson = await Person.load(person.id, {
+        resolve: {
+          pet1: true,
+        },
+      });
+
+      assert(loadedPerson);
+      expect(loadedPerson.pet1?.name).toEqual("Rex");
+    });
+
     test("loading a locally available record using autoload for the refs", async () => {
       const Dog = co.map({
         name: z.string(),

--- a/packages/jazz-tools/src/tools/tests/coMap.test-d.ts
+++ b/packages/jazz-tools/src/tools/tests/coMap.test-d.ts
@@ -542,6 +542,56 @@ describe("CoMap resolution", async () => {
     > | null>();
   });
 
+  test("partial loading a map with string resolve", async () => {
+    const Dog = co.map({
+      name: z.string(),
+      breed: z.string(),
+    });
+
+    const Person = co.map({
+      name: z.string(),
+      age: z.number(),
+      dog1: Dog,
+      dog2: Dog,
+    });
+
+    const person = Person.create({
+      name: "John",
+      age: 20,
+      dog1: Dog.create({ name: "Rex", breed: "Labrador" }),
+      dog2: Dog.create({ name: "Fido", breed: "Poodle" }),
+    });
+
+    const userId: string = "dog1";
+
+    const loadedPerson = await Person.load(person.id, {
+      resolve: {
+        [userId]: true,
+      },
+    });
+
+    type ExpectedType = {
+      name: string;
+      age: number;
+      dog1: Loaded<typeof Dog> | null;
+      dog2: Loaded<typeof Dog> | null;
+    } | null;
+
+    function matches(value: ExpectedType) {
+      return value;
+    }
+
+    matches(loadedPerson);
+
+    assert(loadedPerson);
+    expectTypeOf<typeof loadedPerson.dog1>().toEqualTypeOf<Loaded<
+      typeof Dog
+    > | null>();
+    expectTypeOf<typeof loadedPerson.dog2>().toEqualTypeOf<Loaded<
+      typeof Dog
+    > | null>();
+  });
+
   test("loading a map with deep resolve and $onError", async () => {
     const Dog = co.map({
       name: z.string(),


### PR DESCRIPTION
# Description
Deep loading on the co record using single keys returned `never` even if the data is returned properly.
This PR fix that never.

```ts
const Dog = co.map({
  name: z.string(),
  breed: z.string(),
});

const Person = co.record(z.string(), Dog);

Person.create({
  pet1: Dog.create({ name: "Rex", breed: "Labrador" }),
  pet2: Dog.create({ name: "Fido", breed: "Poodle" }),
});


// BEFORE
const p = await Person.load("id", {
  resolve: {
    pet1: true
  }
});

p.pet1 // <- never


// NOW
const p = await Person.load("id", {
  resolve: {
    pet1: true
  }
});

p.pet1 // <- {name: string; breed: string;} & CoMap

```

## Tests

- [x] Tests have been added and/or updated


## Checklist

- [ ] I've updated the part of the docs that are affected the PR changes
- [x] I've generated a changeset, if a version bump is required
- [ ] I've updated the jsDoc comments to the public APIs I've modified, or added them when missing