### PR TITLE
fix: fix UnknownError: Unknown transaction on IndexedDB

### DIFF
--- a/.changeset/bright-pandas-joke.md
+++ b/.changeset/bright-pandas-joke.md
@@ -1,0 +1,5 @@
+---
+"cojson-storage-indexeddb": patch
+---
+
+Fix Unknown transaction error on IndexedDB showing up sometimes when using a readwrite transaction to read values

--- a/packages/cojson-storage-indexeddb/src/CoJsonIDBTransaction.ts
+++ b/packages/cojson-storage-indexeddb/src/CoJsonIDBTransaction.ts
@@ -118,3 +118,23 @@ export class CoJsonIDBTransaction {
     }
   }
 }
+
+export function queryIndexedDbStore<T>(
+  db: IDBDatabase,
+  storeName: StoreName,
+  callback: (store: IDBObjectStore) => IDBRequest<T>,
+) {
+  return new Promise<T>((resolve, reject) => {
+    const tx = db.transaction(storeName, "readonly");
+    const request = callback(tx.objectStore(storeName));
+
+    request.onerror = () => {
+      reject(request.error);
+    };
+
+    request.onsuccess = () => {
+      resolve(request.result as T);
+      tx.commit();
+    };
+  });
+}


### PR DESCRIPTION
While playing around with the Music Player, I've got into "UnknownError: Unknown transaction" on IndexedDB.

Reproduced the issue on two different devices (Chrome on desktop and mobile) so it may be a browser-specific bug.
Fixed by using "readonly" transactions for read operations.

Benchmarked this before, this is slower but the performance difference is minimal when doing load tests but the behavoir should be way more predictable.
