### PR TITLE
chore: removed nested projects in vitest.config

### DIFF
--- a/packages/jazz-tools/vitest.config.ts
+++ b/packages/jazz-tools/vitest.config.ts
@@ -3,30 +3,10 @@ import { defineProject } from "vitest/config";
 export default defineProject({
   test: {
     name: "jazz-tools",
+    include: ["src/**/*.test.{js,ts,svelte}"],
     typecheck: {
       enabled: true,
       checker: "tsc",
     },
-    projects: [
-      {
-        test: {
-          include: ["src/**/*.test.browser.ts"],
-          browser: {
-            enabled: true,
-            provider: "playwright",
-            headless: true,
-            screenshotFailures: false,
-            instances: [{ browser: "chromium" }],
-          },
-          name: "browser",
-        },
-      },
-      {
-        test: {
-          include: ["src/**/*.test.{js,ts,svelte}"],
-          name: "unit",
-        },
-      },
-    ],
   },
 });

--- a/tests/browser-integration/src/createImage.test.ts
+++ b/tests/browser-integration/src/createImage.test.ts
@@ -1,8 +1,8 @@
 // @vitest-environment happy-dom
 
+import { createImage } from "jazz-tools/browser-media-images";
 import { createJazzTestAccount } from "jazz-tools/testing";
 import { describe, expect, it } from "vitest";
-import { createImage } from "./index.js";
 
 describe("createImage", () => {
   it("should create an image with a single size if width/height < 256", async () => {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -4,7 +4,7 @@ import { defineConfig } from "vitest/config";
 export default defineConfig({
   root: "./",
   test: {
-    workspace: [
+    projects: [
       "packages/*",
       "tests/browser-integration",
       "tests/cloudflare-workers",


### PR DESCRIPTION
# Description
Even if there are no type errors and no mentions in Vitest's documentation, the project property inside `defineProject` is ignored. It works running vitest inside the folder, but running from the root with `--project jazz-tools` ignores the browser testing and other configurations.

That's why https://github.com/garden-co/jazz/pull/2654 happened.

Plain configuration restored, and browser testing moved to the common directory.