### PR TITLE
fix(jazz-tools/media): ensure file downloaded in loadImageBySize

### DIFF
--- a/.changeset/tidy-eagles-sparkle.md
+++ b/.changeset/tidy-eagles-sparkle.md
@@ -1,0 +1,5 @@
+---
+"jazz-tools": patch
+---
+
+fix: ensure file downloaded in loadImageBySize

--- a/packages/jazz-tools/src/media/utils.ts
+++ b/packages/jazz-tools/src/media/utils.ts
@@ -149,7 +149,7 @@ export async function loadImageBySize(
   wantedWidth: number,
   wantedHeight: number,
 ): Promise<{ width: number; height: number; image: FileStream } | null> {
-  const image =
+  const image: ImageDefinition | null =
     typeof imageOrId === "string"
       ? await ImageDefinition.load(imageOrId)
       : imageOrId;
@@ -184,7 +184,7 @@ export async function loadImageBySize(
   const bestTarget =
     sortedSizes.find((el) => el.match > 0.95) || sortedSizes.at(-1)!;
 
-  const deepLoaded = await ImageDefinition.load(image.id, {
+  const deepLoaded = await image.ensureLoaded({
     resolve: {
       [bestTarget.size[2]]: true,
     },

--- a/packages/jazz-tools/src/media/utils.ts
+++ b/packages/jazz-tools/src/media/utils.ts
@@ -126,13 +126,14 @@ export async function loadImage(
     };
   }
 
-  await imageOrId.ensureLoaded({
-    resolve: {
-      original: true,
-    },
-  });
-
   if (!imageOrId.original) {
+    console.warn("Unable to find the original image");
+    return null;
+  }
+
+  const loadedOriginal = await FileStream.load(imageOrId.original.id);
+
+  if (!loadedOriginal) {
     console.warn("Unable to find the original image");
     return null;
   }
@@ -140,7 +141,7 @@ export async function loadImage(
   return {
     width: imageOrId.originalSize[0],
     height: imageOrId.originalSize[1],
-    image: imageOrId.original,
+    image: loadedOriginal,
   };
 }
 
@@ -184,19 +185,21 @@ export async function loadImageBySize(
   const bestTarget =
     sortedSizes.find((el) => el.match > 0.95) || sortedSizes.at(-1)!;
 
-  const deepLoaded = await image.ensureLoaded({
-    resolve: {
-      [bestTarget.size[2]]: true,
-    },
-  });
+  const file = image[bestTarget.size[2]];
 
-  if (deepLoaded === null || deepLoaded[bestTarget.size[2]] === undefined) {
+  if (!file) {
+    return null;
+  }
+
+  const loadedFile = await FileStream.load(file.id);
+
+  if (!loadedFile) {
     return null;
   }
 
   return {
     width: bestTarget.size[0],
     height: bestTarget.size[1],
-    image: deepLoaded[bestTarget.size[2]]!,
+    image: loadedFile,
   };
 }


### PR DESCRIPTION
# Description
As reported on [Discord](https://discord.com/channels/1139617727565271160/1388086544107044955/1404524777531637943), the new `loadImageBySize` doesn't wait for the file to load.

## Manual testing instructions
1. Upload an image from a peer
2. Use the `loadImageBySize` starting from an empty in-memory storage.

## Tests

- [x] Tests have been added and/or updated

## Checklist
- [x] I've generated a changeset, if a version bump is required