### PR TITLE
fix(jazz-tools/svelte): Make Image reactive to imageId change

### DIFF
--- a/packages/jazz-tools/src/svelte/media/image.svelte
+++ b/packages/jazz-tools/src/svelte/media/image.svelte
@@ -13,7 +13,7 @@ interface ImageProps extends Omit<HTMLImgAttributes, "width" | "height"> {
 
 const { imageId, width, height, ...rest }: ImageProps = $props();
 
-const imageState = new CoState(ImageDefinition, imageId);
+const imageState = new CoState(ImageDefinition, () => imageId);
 let lastBestImage: [string, string] | null = null;
 
 /**

--- a/tests/jazz-svelte/src/routes/+page.svelte
+++ b/tests/jazz-svelte/src/routes/+page.svelte
@@ -1,2 +1,3 @@
 <a href="/costate">CoState</a>
+<a href="/media">Media</a>
 <a href="/virtual-list">Virtual List</a>

--- a/tests/jazz-svelte/src/routes/media/+layout.svelte
+++ b/tests/jazz-svelte/src/routes/media/+layout.svelte
@@ -1,0 +1,22 @@
+<script lang="ts">
+    import { JazzSvelteProvider } from 'jazz-tools/svelte';
+    import "jazz-tools/inspector/register-custom-element"
+    import { TestAccount } from './schema.js';
+
+    if (typeof window !== 'undefined') {
+        localStorage.clear(); // Want to start always from a fresh account
+    }
+  
+    let { children } = $props();
+  </script>
+  
+  <JazzSvelteProvider
+    AccountSchema={TestAccount}
+    sync={{
+      when: "never"
+    }}
+  >
+    <jazz-inspector></jazz-inspector>
+    {@render children()}
+  </JazzSvelteProvider>
+  

--- a/tests/jazz-svelte/src/routes/media/+page.svelte
+++ b/tests/jazz-svelte/src/routes/media/+page.svelte
@@ -1,0 +1,63 @@
+<script lang="ts">
+  import type { ChangeEventHandler } from 'svelte/elements';
+  import { AccountCoState, Image } from 'jazz-tools/svelte';
+  import { createImage } from 'jazz-tools/media';
+  import { TestAccount } from './schema.js';
+
+  const me = new AccountCoState(TestAccount, {
+    resolve: {
+      profile: {
+        image: true
+      }
+    }
+  });
+
+  let input = $state<HTMLInputElement>();
+
+  const onUploadClick = () => {
+    input?.click();
+  };
+
+  const onImageChange: ChangeEventHandler<HTMLInputElement> = (event) => {
+    const file = event.currentTarget.files?.[0];
+		if (!file || !me.current?.profile) return;
+		createImage(file, {
+			owner: me.current?.profile._owner,
+			maxSize: 400
+		}).then((image) => {
+			if (!me.current?.profile) return;
+			me.current.profile.image = image;
+		});
+  }
+</script>
+
+<button onclick={onUploadClick}>
+  {me.current?.profile?.image ? 'Change image' : 'Send image'}
+</button>
+
+{#if me.current?.profile?.image}
+  <Image imageId={me.current.profile.image.id} width={200} height="original" />
+{/if}
+
+<label>
+  <input
+    bind:this={input}
+    type="file"
+    accept="image/png, image/jpeg, image/gif"
+    onchange={onImageChange}
+  />
+</label>
+
+<style>
+  label {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    white-space: nowrap;
+    border-width: 0;
+  }
+</style>

--- a/tests/jazz-svelte/src/routes/media/schema.ts
+++ b/tests/jazz-svelte/src/routes/media/schema.ts
@@ -1,0 +1,10 @@
+import { co } from "jazz-tools";
+
+export const Profile = co.profile({
+  image: co.optional(co.image()),
+});
+
+export const TestAccount = co.account({
+  profile: Profile,
+  root: co.map({}),
+});


### PR DESCRIPTION
Currently Svelte's Image component does not react to imageId change. This PR fixes this.

I also added a simple test for media upload to jazz-svelte folder.