### PR TITLE
feat: make the unmount function detach the CoValue from the localNode

### DIFF
--- a/.changeset/serious-mayflies-search.md
+++ b/.changeset/serious-mayflies-search.md
@@ -1,0 +1,5 @@
+---
+"cojson": patch
+---
+
+Make the CoValueCore.unmount function detach the CoValue from LocalNode

--- a/packages/cojson/src/GarbageCollector.ts
+++ b/packages/cojson/src/GarbageCollector.ts
@@ -33,11 +33,7 @@ export class GarbageCollector {
       const timeSinceLastAccessed = currentTime - verified.lastAccessed;
 
       if (timeSinceLastAccessed > GARBAGE_COLLECTOR_CONFIG.MAX_AGE) {
-        const unmounted = coValue.unmount();
-
-        if (unmounted) {
-          this.coValues.delete(coValue.id);
-        }
+        coValue.unmount();
       }
     }
   }

--- a/packages/cojson/src/coValueCore/coValueCore.ts
+++ b/packages/cojson/src/coValueCore/coValueCore.ts
@@ -219,6 +219,8 @@ export class CoValueCore {
       this.groupInvalidationSubscription = undefined;
     }
 
+    this.node.internalDeleteCoValue(this.id);
+
     return true;
   }
 


### PR DESCRIPTION
This makes possible to mark a CoValue ready for GC with:

```ts
map._raw.core.unmount();
```