### PR TITLE
Closes #GCO-642 - Clarify docs for adding group members by id

### DIFF
--- a/homepage/homepage/content/docs/groups/intro.mdx
+++ b/homepage/homepage/content/docs/groups/intro.mdx
@@ -49,18 +49,22 @@ if (bob) {
 ```
 </CodeGroup>
 
-**Note:** if the account ID is of type `string`, because it comes from a URL parameter or something similar, you need to cast it to `ID<Account>` first:
+**Note:** 
+- Both `Account.load(id)` and `co.account().load(id)` do the same thing — they load an account from its ID.
+
+- If your account ID is a string (e.g., from a URL parameter), you need to cast it to `ID<Account>` before loading:
 
 <CodeGroup>
 ```tsx twoslash
 const bobsID = "co_z123";
-
+import { Group } from "jazz-tools";
 const group = Group.create();
 
 // ---cut---
-import { co, Group } from "jazz-tools";
+import { ID, Account, co } from "jazz-tools";
 
-const bob = await co.account().load(bobsID);
+const bob = await Account.load(bobsID as ID<Account>);
+// Or: const bob = await co.account().load(bobsID as ID<Account>);
 
 if (bob) {
   group.addMember(bob, "writer");

--- a/homepage/homepage/content/docs/groups/intro.mdx
+++ b/homepage/homepage/content/docs/groups/intro.mdx
@@ -52,8 +52,6 @@ if (bob) {
 **Note:** 
 - Both `Account.load(id)` and `co.account().load(id)` do the same thing — they load an account from its ID.
 
-- If your account ID is a string (e.g., from a URL parameter), you need to cast it to `ID<Account>` before loading:
-
 <CodeGroup>
 ```tsx twoslash
 const bobsID = "co_z123";
@@ -63,8 +61,8 @@ const group = Group.create();
 // ---cut---
 import { ID, Account, co } from "jazz-tools";
 
-const bob = await Account.load(bobsID as ID<Account>);
-// Or: const bob = await co.account().load(bobsID as ID<Account>);
+const bob = await Account.load(bobsID);
+// Or: const bob = await co.account().load(bobsID);
 
 if (bob) {
   group.addMember(bob, "writer");


### PR DESCRIPTION
# Description
Updates docs for `adding-group-members-by-id` to confirm the equivalence between co.account().load(...) and Account.load(...)

## Manual testing instructions
Run locally or test deployed version, navigate to `http://localhost:3000/docs/react/groups/intro#adding-group-members-by-id`

## Tests

- [x] Tests have been added and/or updated
- [ ] Tests have not been updated, because: <!-- Insert reason for not updating tests here -->
- [ ] I need help with writing tests


## Checklist

- [x] I've updated the part of the docs that are affected the PR changes
- [ ] I've generated a changeset, if a version bump is required
- [ ] I've updated the jsDoc comments to the public APIs I've modified, or added them when missing