### PR TITLE
feat: support updating CoValues using JSON objects

### DIFF
--- a/packages/jazz-tools/src/tools/coValues/CoFieldInit.ts
+++ b/packages/jazz-tools/src/tools/coValues/CoFieldInit.ts
@@ -3,7 +3,6 @@ import { CoList } from "./coList";
 import { CoMap, CoMapInit } from "./coMap";
 import { CoPlainText } from "./coPlainText";
 import { CoRichText } from "./coRichText";
-import { CoValue } from "./interfaces";
 
 /**
  * Returns the type of values that can be used to initialize a field of the provided type.
@@ -11,14 +10,11 @@ import { CoValue } from "./interfaces";
  * For CoValue references, either a CoValue of the same type, or a plain JSON value that can be
  * converted to the CoValue type are allowed.
  */
-export type CoFieldInit<V> =
-  | V
-  | (V extends CoValue
-      ? V extends CoMap
-        ? CoMapInit<V>
-        : V extends CoList<infer T> | CoFeed<infer T>
-          ? ReadonlyArray<CoFieldInit<T>>
-          : V extends CoPlainText | CoRichText
-            ? string
-            : never
-      : never);
+// Note: we don't define this type as V | ... because it prevents TS from inlining the type
+export type CoFieldInit<V> = V extends CoMap
+  ? V | CoMapInit<V>
+  : V extends CoList<infer T> | CoFeed<infer T>
+    ? V | ReadonlyArray<CoFieldInit<T>>
+    : V extends CoPlainText | CoRichText
+      ? V | string
+      : V;

--- a/packages/jazz-tools/src/tools/coValues/CoFieldInit.ts
+++ b/packages/jazz-tools/src/tools/coValues/CoFieldInit.ts
@@ -1,0 +1,24 @@
+import { CoFeed } from "./coFeed";
+import { CoList } from "./coList";
+import { CoMap, CoMapInit } from "./coMap";
+import { CoPlainText } from "./coPlainText";
+import { CoRichText } from "./coRichText";
+import { CoValue } from "./interfaces";
+
+/**
+ * Returns the type of values that can be used to initialize a field of the provided type.
+ *
+ * For CoValue references, either a CoValue of the same type, or a plain JSON value that can be
+ * converted to the CoValue type are allowed.
+ */
+export type CoFieldInit<V> =
+  | V
+  | (V extends CoValue
+      ? V extends CoMap
+        ? CoMapInit<V>
+        : V extends CoList<infer T> | CoFeed<infer T>
+          ? ReadonlyArray<CoFieldInit<T>>
+          : V extends CoPlainText | CoRichText
+            ? string
+            : never
+      : never);

--- a/packages/jazz-tools/src/tools/coValues/account.ts
+++ b/packages/jazz-tools/src/tools/coValues/account.ts
@@ -233,6 +233,9 @@ export class Account extends CoValueBase implements CoValue {
     return activeAccountContext.get() as A;
   }
 
+  /**
+   * @deprecated Use `co.account(...).createAs` instead.
+   */
   static async createAs<A extends Account>(
     this: CoValueClass<A> & typeof Account,
     as: Account,
@@ -311,7 +314,11 @@ export class Account extends CoValueBase implements CoValue {
     creationProps; // To avoid unused parameter warning
   }
 
-  /** @category Subscription & Loading */
+  /**
+   * Load an `Account`
+   * @category Subscription & Loading
+   * @deprecated Use `co.account(...).load` instead.
+   */
   static load<A extends Account, const R extends RefsToResolve<A> = true>(
     this: CoValueClass<A>,
     id: ID<A>,
@@ -323,7 +330,11 @@ export class Account extends CoValueBase implements CoValue {
     return loadCoValueWithoutMe(this, id, options);
   }
 
-  /** @category Subscription & Loading */
+  /**
+   * Subscribe to an `Account`, when you have an ID but don't have an `Account` instance yet
+   * @category Subscription & Loading
+   * @deprecated Use `co.account(...).subscribe` instead.
+   */
   static subscribe<A extends Account, const R extends RefsToResolve<A> = true>(
     this: CoValueClass<A>,
     id: ID<A>,

--- a/packages/jazz-tools/src/tools/coValues/account.ts
+++ b/packages/jazz-tools/src/tools/coValues/account.ts
@@ -1,7 +1,7 @@
 import {
   AgentSecret,
   CoID,
-  ControlledAccount,
+  ControlledAccount as RawControlledAccount,
   CryptoProvider,
   Everyone,
   InviteSecret,
@@ -493,7 +493,7 @@ class AccountJazzApi<A extends Account> extends CoValueJazzApi<A> {
 
     const agent = this.localNode.getCurrentAgent();
 
-    if (agent instanceof ControlledAccount) {
+    if (agent instanceof RawControlledAccount) {
       return coValuesCache.get(agent.account, () =>
         Account.fromRaw(agent.account),
       );
@@ -565,14 +565,18 @@ export const AccountAndGroupProxyHandler: ProxyHandler<Account | Group> = {
   },
 };
 
-/** @category Identity & Permissions */
-export function isControlledAccount(account: Account): account is Account & {
+export type ControlledAccount = Account & {
   $jazz: {
     raw: RawAccount;
     isLocalNodeOwner: true;
     sessionID: SessionID;
   };
-} {
+};
+
+/** @category Identity & Permissions */
+export function isControlledAccount(
+  account: Account,
+): account is ControlledAccount {
   return account.$jazz.isLocalNodeOwner;
 }
 

--- a/packages/jazz-tools/src/tools/coValues/coFeed.ts
+++ b/packages/jazz-tools/src/tools/coValues/coFeed.ts
@@ -12,6 +12,7 @@ import type {
 import { cojsonInternals } from "cojson";
 import {
   AnonymousJazzAgent,
+  CoFieldInit,
   CoValue,
   CoValueClass,
   Group,
@@ -361,13 +362,13 @@ export class CoFeedJazzApi<F extends CoFeed> extends CoValueJazzApi<F> {
    *
    * @category Content
    */
-  push(...items: CoFeedItem<F>[]): void {
+  push(...items: CoFieldInit<CoFeedItem<F>>[]): void {
     for (const item of items) {
       this.pushItem(item);
     }
   }
 
-  private pushItem(item: CoFeedItem<F>) {
+  private pushItem(item: CoFieldInit<CoFeedItem<F>>) {
     const itemDescriptor = this.schema[ItemsSym] as Schema;
 
     if (itemDescriptor === "json") {

--- a/packages/jazz-tools/src/tools/coValues/coFeed.ts
+++ b/packages/jazz-tools/src/tools/coValues/coFeed.ts
@@ -210,6 +210,7 @@ export class CoFeed<out Item = any> extends CoValueBase implements CoValue {
   /**
    * Create a new `CoFeed`
    * @category Creation
+   * @deprecated Use `co.feed(...).create` instead.
    */
   static create<S extends CoFeed>(
     this: CoValueClass<S>,
@@ -286,6 +287,7 @@ export class CoFeed<out Item = any> extends CoValueBase implements CoValue {
   /**
    * Load a `CoFeed`
    * @category Subscription & Loading
+   * @deprecated Use `co.feed(...).load` instead.
    */
   static load<F extends CoFeed, const R extends RefsToResolve<F> = true>(
     this: CoValueClass<F>,
@@ -301,6 +303,7 @@ export class CoFeed<out Item = any> extends CoValueBase implements CoValue {
   /**
    * Subscribe to a `CoFeed`, when you have an ID but don't have a `CoFeed` instance yet
    * @category Subscription & Loading
+   * @deprecated Use `co.feed(...).subscribe` instead.
    */
   static subscribe<F extends CoFeed, const R extends RefsToResolve<F> = true>(
     this: CoValueClass<F>,
@@ -723,6 +726,7 @@ export class FileStream extends CoValueBase implements CoValue {
    * For uploading an existing file or blob, use {@link FileStream.createFromBlob} instead.
    *
    * @category Creation
+   * @deprecated Use `co.fileStream(...).create` instead.
    */
   static create<S extends FileStream>(
     this: CoValueClass<S>,
@@ -776,6 +780,7 @@ export class FileStream extends CoValueBase implements CoValue {
    * Load a `FileStream` as a `Blob`
    *
    * @category Content
+   * @deprecated Use `co.fileStream(...).loadAsBlob` instead.
    */
   static async loadAsBlob(
     id: ID<FileStream>,
@@ -839,6 +844,7 @@ export class FileStream extends CoValueBase implements CoValue {
    * const fileStream = await FileStream.createFromBlob(file, {owner: group})
    * ```
    * @category Content
+   * @deprecated Use `co.fileStream(...).createFromBlob` instead.
    */
   static async createFromBlob(
     blob: Blob | File,
@@ -869,6 +875,7 @@ export class FileStream extends CoValueBase implements CoValue {
    * const fileStream = await FileStream.createFromBlob(file, {owner: group})
    * ```
    * @category Content
+   * @deprecated Use `co.fileStream(...).createFromArrayBuffer` instead.
    */
   static async createFromArrayBuffer(
     arrayBuffer: ArrayBuffer,
@@ -947,6 +954,7 @@ export class FileStream extends CoValueBase implements CoValue {
   /**
    * Load a `FileStream`
    * @category Subscription & Loading
+   * @deprecated Use `co.fileStream(...).load` instead.
    */
   static async load<C extends FileStream>(
     this: CoValueClass<C>,
@@ -984,6 +992,7 @@ export class FileStream extends CoValueBase implements CoValue {
   /**
    * Subscribe to a `FileStream`, when you have an ID but don't have a `FileStream` instance yet
    * @category Subscription & Loading
+   * @deprecated Use `co.fileStream(...).subscribe` instead.
    */
   static subscribe<F extends FileStream, const R extends RefsToResolve<F>>(
     this: CoValueClass<F>,

--- a/packages/jazz-tools/src/tools/coValues/coList.ts
+++ b/packages/jazz-tools/src/tools/coValues/coList.ts
@@ -588,14 +588,15 @@ export class CoListJazzApi<L extends CoList>
    *
    * @category Content
    */
-  applyDiff(result: CoListItem<L>[]): L {
+  applyDiff(result: CoFieldInit<CoListItem<L>>[]): L {
     const current = this.raw.asArray() as CoListItem<L>[];
     const comparator = isRefEncoded(this.schema[ItemsSym])
       ? (aIdx: number, bIdx: number) => {
-          return (
-            (current[aIdx] as CoValue)?.$jazz?.id ===
-            (result[bIdx] as CoValue)?.$jazz?.id
-          );
+          const oldCoValueId = (current[aIdx] as CoValue)?.$jazz?.id;
+          const newCoValueId = (result[bIdx] as CoValue)?.$jazz?.id;
+          const isSame =
+            !!oldCoValueId && !!newCoValueId && oldCoValueId === newCoValueId;
+          return isSame;
         }
       : undefined;
 

--- a/packages/jazz-tools/src/tools/coValues/coList.ts
+++ b/packages/jazz-tools/src/tools/coValues/coList.ts
@@ -150,6 +150,7 @@ export class CoList<out Item = any>
    * ```
    *
    * @category Creation
+   * @deprecated Use `co.list(...).create` instead.
    **/
   static create<L extends CoList>(
     this: CoValueClass<L>,
@@ -239,6 +240,7 @@ export class CoList<out Item = any>
    * ```
    *
    * @category Subscription & Loading
+   * @deprecated Use `co.list(...).load` instead.
    */
   static load<L extends CoList, const R extends RefsToResolve<L> = true>(
     this: CoValueClass<L>,
@@ -278,6 +280,7 @@ export class CoList<out Item = any>
    * ```
    *
    * @category Subscription & Loading
+   * @deprecated Use `co.list(...).subscribe` instead.
    */
   static subscribe<L extends CoList, const R extends RefsToResolve<L> = true>(
     this: CoValueClass<L>,

--- a/packages/jazz-tools/src/tools/coValues/coList.ts
+++ b/packages/jazz-tools/src/tools/coValues/coList.ts
@@ -457,7 +457,7 @@ export class CoListJazzApi<L extends CoList>
    *
    * @category Content
    */
-  push(...items: CoListItem<L>[]): number {
+  push(...items: CoFieldInit<CoListItem<L>>[]): number {
     this.raw.appendItems(
       toRawItems(items, this.schema[ItemsSym], this.owner),
       undefined,
@@ -473,7 +473,7 @@ export class CoListJazzApi<L extends CoList>
    *
    * @category Content
    */
-  unshift(...items: CoListItem<L>[]): number {
+  unshift(...items: CoFieldInit<CoListItem<L>>[]): number {
     for (const item of toRawItems(
       items as CoListItem<L>[],
       this.schema[ItemsSym],
@@ -525,7 +525,7 @@ export class CoListJazzApi<L extends CoList>
   splice(
     start: number,
     deleteCount: number,
-    ...items: CoListItem<L>[]
+    ...items: CoFieldInit<CoListItem<L>>[]
   ): CoListItem<L>[] {
     const deleted = this.coList.slice(start, start + deleteCount);
 

--- a/packages/jazz-tools/src/tools/coValues/coList.ts
+++ b/packages/jazz-tools/src/tools/coValues/coList.ts
@@ -592,7 +592,7 @@ export class CoListJazzApi<L extends CoList>
    * @category Content
    */
   applyDiff(result: CoFieldInit<CoListItem<L>>[]): L {
-    const current = this.raw.asArray() as CoListItem<L>[];
+    const current = this.raw.asArray() as CoFieldInit<CoListItem<L>>[];
     const comparator = isRefEncoded(this.schema[ItemsSym])
       ? (aIdx: number, bIdx: number) => {
           const oldCoValueId = (current[aIdx] as CoValue)?.$jazz?.id;

--- a/packages/jazz-tools/src/tools/coValues/coList.ts
+++ b/packages/jazz-tools/src/tools/coValues/coList.ts
@@ -586,7 +586,9 @@ export class CoListJazzApi<L extends CoList>
   /**
    * Modify the `CoList` to match another list, where the changes are managed internally.
    *
-   * @param result - The resolved list of items.
+   * Changes are detected using `Object.is` for non-collaborative values and `$jazz.id` for collaborative values.
+   *
+   * @param result - The resolved list of items. For collaborative values, both CoValues and JSON values are supported.
    * @returns The modified CoList.
    *
    * @category Content

--- a/packages/jazz-tools/src/tools/coValues/coList.ts
+++ b/packages/jazz-tools/src/tools/coValues/coList.ts
@@ -3,6 +3,7 @@ import { ControlledAccount, RawAccount } from "cojson";
 import { calcPatch } from "fast-myers-diff";
 import {
   Account,
+  CoFieldInit,
   CoValue,
   CoValueClass,
   CoValueFromRaw,
@@ -441,7 +442,7 @@ export class CoListJazzApi<L extends CoList>
     return cl.fromRaw(this.raw) as InstanceType<Cl>;
   }
 
-  set(index: number, value: CoListItem<L>): void {
+  set(index: number, value: CoFieldInit<CoListItem<L>>): void {
     const itemDescriptor = this.schema[ItemsSym];
     const rawValue = toRawItems([value], itemDescriptor, this.owner)[0]!;
     if (rawValue === null && !itemDescriptor.optional) {

--- a/packages/jazz-tools/src/tools/coValues/coMap.ts
+++ b/packages/jazz-tools/src/tools/coValues/coMap.ts
@@ -639,13 +639,13 @@ class CoMapJazzApi<M extends CoMap> extends CoValueJazzApi<M> {
 
         if (descriptor === "json" || "encoded" in descriptor) {
           if (currentValue !== newValue) {
-            this.set(tKey as any, newValue);
+            this.set(tKey as any, newValue as CoFieldInit<M[keyof M]>);
           }
         } else if (isRefEncoded(descriptor)) {
           const currentId = (currentValue as CoValue | undefined)?.$jazz.id;
           let newId = (newValue as CoValue | undefined)?.$jazz?.id;
           if (currentId !== newId) {
-            this.set(tKey as any, newValue);
+            this.set(tKey as any, newValue as CoFieldInit<M[keyof M]>);
           }
         }
       }

--- a/packages/jazz-tools/src/tools/coValues/coMap.ts
+++ b/packages/jazz-tools/src/tools/coValues/coMap.ts
@@ -621,7 +621,11 @@ class CoMapJazzApi<M extends CoMap> extends CoValueJazzApi<M> {
   /**
    * Modify the `CoMap` to match another map.
    *
-   * @param newValues - The new values to apply to the CoMap.
+   * The new values are assigned to the CoMap, overwriting existing values
+   * when the property already exists.
+   *
+   * @param newValues - The new values to apply to the CoMap. For collaborative values,
+   * both CoValues and JSON values are supported.
    * @returns The modified CoMap.
    *
    * @category Content

--- a/packages/jazz-tools/src/tools/coValues/coMap.ts
+++ b/packages/jazz-tools/src/tools/coValues/coMap.ts
@@ -505,7 +505,7 @@ export class CoMap extends CoValueBase implements CoValue {
       }) as Resolved<M, R>;
     } else {
       (map as M).$jazz.applyDiff(
-        options.value as Partial<CoMapInit_DEPRECATED<M>>,
+        options.value as unknown as Partial<CoMapInit<M>>,
       );
     }
 
@@ -625,7 +625,7 @@ class CoMapJazzApi<M extends CoMap> extends CoValueJazzApi<M> {
    *
    * @category Content
    */
-  applyDiff<N extends Partial<CoMapInit_DEPRECATED<M>>>(newValues: N): M {
+  applyDiff<N extends Partial<CoMapInit<M>>>(newValues: N): M {
     for (const key in newValues) {
       if (Object.prototype.hasOwnProperty.call(newValues, key)) {
         const tKey = key as keyof typeof newValues & keyof this;
@@ -642,7 +642,7 @@ class CoMapJazzApi<M extends CoMap> extends CoValueJazzApi<M> {
           }
         } else if (isRefEncoded(descriptor)) {
           const currentId = (currentValue as CoValue | undefined)?.$jazz.id;
-          const newId = (newValue as CoValue | undefined)?.$jazz.id;
+          let newId = (newValue as CoValue | undefined)?.$jazz?.id;
           if (currentId !== newId) {
             this.set(tKey as any, newValue);
           }

--- a/packages/jazz-tools/src/tools/coValues/coMap.ts
+++ b/packages/jazz-tools/src/tools/coValues/coMap.ts
@@ -11,6 +11,7 @@ import {
 import {
   AnonymousJazzAgent,
   CoFeed,
+  CoFieldInit,
   CoList,
   CoPlainText,
   CoRichText,
@@ -883,19 +884,6 @@ type ForceRequiredRef<V> = V extends InstanceType<CoValueClass> | null
 export type CoMapInit_DEPRECATED<Map extends object> = PartialOnUndefined<{
   [Key in CoKeys<Map>]: ForceRequiredRef<Map[Key]>;
 }>;
-
-// TODO simplify on $jazz.set hover
-export type CoFieldInit<V> =
-  | V
-  | (V extends CoValue
-      ? V extends CoMap
-        ? CoMapInit<V>
-        : V extends CoList<infer T> | CoFeed<infer T>
-          ? ReadonlyArray<CoFieldInit<T>>
-          : V extends CoPlainText | CoRichText
-            ? string
-            : never
-      : never);
 
 export type CoMapInit<Map extends object> = {
   [K in RequiredCoKeys<Map>]: CoFieldInit<Map[K]>;

--- a/packages/jazz-tools/src/tools/coValues/coMap.ts
+++ b/packages/jazz-tools/src/tools/coValues/coMap.ts
@@ -160,10 +160,12 @@ export class CoMap extends CoValueBase implements CoValue {
    * ```
    *
    * @category Creation
+   *
+   * @deprecated Use `co.map(...).create`.
    **/
   static create<M extends CoMap>(
     this: CoValueClass<M>,
-    init: Simplify<CoMapInit<M>>,
+    init: Simplify<CoMapInit_DEPRECATED<M>>,
     options?:
       | {
           owner: Account | Group;
@@ -234,7 +236,7 @@ export class CoMap extends CoValueBase implements CoValue {
    */
   static _createCoMap<M extends CoMap>(
     instance: M,
-    init: Simplify<CoMapInit<M>>,
+    init: Simplify<CoMapInit_DEPRECATED<M>>,
     options?:
       | {
           owner: Account | Group;
@@ -261,7 +263,7 @@ export class CoMap extends CoValueBase implements CoValue {
    */
   static rawFromInit<M extends CoMap, Fields extends object>(
     instance: M,
-    init: Simplify<CoMapInit<Fields>> | undefined,
+    init: Simplify<CoMapInit_DEPRECATED<Fields>> | undefined,
     owner: Account | Group,
     uniqueness?: CoValueUniqueness,
   ) {
@@ -355,6 +357,8 @@ export class CoMap extends CoValueBase implements CoValue {
    * ```
    *
    * @category Subscription & Loading
+   *
+   * @deprecated Use `co.map(...).load` instead.
    */
   static load<M extends CoMap, const R extends RefsToResolve<M> = true>(
     this: CoValueClass<M>,
@@ -394,6 +398,8 @@ export class CoMap extends CoValueBase implements CoValue {
    * ```
    *
    * @category Subscription & Loading
+   *
+   * @deprecated Use `co.map(...).subscribe` instead.
    */
   static subscribe<M extends CoMap, const R extends RefsToResolve<M> = true>(
     this: CoValueClass<M>,
@@ -470,6 +476,8 @@ export class CoMap extends CoValueBase implements CoValue {
    * @param options The options for creating or loading the CoMap. This includes the intended state of the CoMap, its unique identifier, its owner, and the references to resolve.
    * @returns Either an existing & modified CoMap, or a new initialised CoMap if none exists.
    * @category Subscription & Loading
+   *
+   * @deprecated Use `co.map(...).upsertUnique` instead.
    */
   static async upsertUnique<
     M extends CoMap,
@@ -477,7 +485,7 @@ export class CoMap extends CoValueBase implements CoValue {
   >(
     this: CoValueClass<M>,
     options: {
-      value: Simplify<CoMapInit<M>>;
+      value: Simplify<CoMapInit_DEPRECATED<M>>;
       unique: CoValueUniqueness["uniqueness"];
       owner: Account | Group;
       resolve?: RefsToResolveStrict<M, R>;
@@ -496,7 +504,9 @@ export class CoMap extends CoValueBase implements CoValue {
         unique: options.unique,
       }) as Resolved<M, R>;
     } else {
-      (map as M).$jazz.applyDiff(options.value as Partial<CoMapInit<M>>);
+      (map as M).$jazz.applyDiff(
+        options.value as Partial<CoMapInit_DEPRECATED<M>>,
+      );
     }
 
     return await loadCoValueWithoutMe(this, mapId, {
@@ -512,6 +522,8 @@ export class CoMap extends CoValueBase implements CoValue {
    * @param ownerID The ID of the owner of the CoMap.
    * @param options Additional options for loading the CoMap.
    * @returns The loaded CoMap, or null if unavailable.
+   *
+   * @deprecated Use `co.map(...).loadUnique` instead.
    */
   static loadUnique<M extends CoMap, const R extends RefsToResolve<M> = true>(
     this: CoValueClass<M>,
@@ -613,7 +625,7 @@ class CoMapJazzApi<M extends CoMap> extends CoValueJazzApi<M> {
    *
    * @category Content
    */
-  applyDiff<N extends Partial<CoMapInit<M>>>(newValues: N): M {
+  applyDiff<N extends Partial<CoMapInit_DEPRECATED<M>>>(newValues: N): M {
     for (const key in newValues) {
       if (Object.prototype.hasOwnProperty.call(newValues, key)) {
         const tKey = key as keyof typeof newValues & keyof this;
@@ -868,7 +880,7 @@ type ForceRequiredRef<V> = V extends InstanceType<CoValueClass> | null
     ? V | null
     : V;
 
-export type CoMapInit<Map extends object> = PartialOnUndefined<{
+export type CoMapInit_DEPRECATED<Map extends object> = PartialOnUndefined<{
   [Key in CoKeys<Map>]: ForceRequiredRef<Map[Key]>;
 }>;
 
@@ -877,7 +889,7 @@ export type CoFieldInit<V> =
   | V
   | (V extends CoValue
       ? V extends CoMap
-        ? CoMapInit2<V>
+        ? CoMapInit<V>
         : V extends CoList<infer T> | CoFeed<infer T>
           ? ReadonlyArray<CoFieldInit<T>>
           : V extends CoPlainText | CoRichText
@@ -885,7 +897,7 @@ export type CoFieldInit<V> =
             : never
       : never);
 
-export type CoMapInit2<Map extends object> = {
+export type CoMapInit<Map extends object> = {
   [K in RequiredCoKeys<Map>]: CoFieldInit<Map[K]>;
 } & {
   [K in OptionalCoKeys<Map>]?: CoFieldInit<Map[K]> | undefined;

--- a/packages/jazz-tools/src/tools/coValues/coPlainText.ts
+++ b/packages/jazz-tools/src/tools/coValues/coPlainText.ts
@@ -83,6 +83,7 @@ export class CoPlainText extends String implements CoValue {
    * ```
    *
    * @category Creation
+   * @deprecated Use `co.plainText(...).create` instead.
    */
   static create<T extends CoPlainText>(
     this: CoValueClass<T>,
@@ -141,6 +142,7 @@ export class CoPlainText extends String implements CoValue {
     return this.$jazz.raw.mapping.idxAfterOpID[stringifyOpID(pos)];
   }
 
+  /** @category Internals */
   static fromRaw<V extends CoPlainText>(
     this: CoValueClass<V> & typeof CoPlainText,
     raw: RawCoPlainText,
@@ -152,6 +154,7 @@ export class CoPlainText extends String implements CoValue {
    * Load a `CoPlainText` with a given ID, as a given account.
    *
    * @category Subscription & Loading
+   * @deprecated Use `co.plainText(...).load` instead.
    */
   static load<T extends CoPlainText>(
     this: CoValueClass<T>,
@@ -173,6 +176,7 @@ export class CoPlainText extends String implements CoValue {
    * Also see the `useCoState` hook to reactively subscribe to a CoValue in a React component.
    *
    * @category Subscription & Loading
+   * @deprecated Use `co.plainText(...).subscribe` instead.
    */
   static subscribe<T extends CoPlainText>(
     this: CoValueClass<T>,

--- a/packages/jazz-tools/src/tools/coValues/profile.ts
+++ b/packages/jazz-tools/src/tools/coValues/profile.ts
@@ -21,6 +21,7 @@ export class Profile extends CoMap {
    * The owner (a Group) determines access rights to the Profile.
    *
    * @category Creation
+   * @deprecated Use `co.profile(...).create` instead.
    */
   static override create<M extends CoMap>(
     this: CoValueClass<M>,

--- a/packages/jazz-tools/src/tools/coValues/profile.ts
+++ b/packages/jazz-tools/src/tools/coValues/profile.ts
@@ -1,7 +1,7 @@
 import {
   Account,
   CoMap,
-  CoMapInit,
+  CoMapInit_DEPRECATED,
   CoValueClass,
   Group,
   Simplify,
@@ -24,7 +24,7 @@ export class Profile extends CoMap {
    */
   static override create<M extends CoMap>(
     this: CoValueClass<M>,
-    init: Simplify<CoMapInit<M>>,
+    init: Simplify<CoMapInit_DEPRECATED<M>>,
     options?:
       | {
           owner: Group;

--- a/packages/jazz-tools/src/tools/coValues/schemaUnion.ts
+++ b/packages/jazz-tools/src/tools/coValues/schemaUnion.ts
@@ -2,7 +2,7 @@ import { JsonValue, RawCoMap } from "cojson";
 import {
   Account,
   AnonymousJazzAgent,
-  CoMapInit,
+  CoMapInit_DEPRECATED,
   CoValue,
   CoValueBase,
   CoValueClass,
@@ -105,7 +105,7 @@ export abstract class SchemaUnion extends CoValueBase implements CoValue {
 
       static override create<V extends CoValue>(
         this: CoValueClass<V>,
-        init: Simplify<CoMapInit<V>>,
+        init: Simplify<CoMapInit_DEPRECATED<V>>,
         owner: Account | Group,
       ): V {
         const ResolvedClass = discriminator(new Map(Object.entries(init)));
@@ -127,7 +127,7 @@ export abstract class SchemaUnion extends CoValueBase implements CoValue {
 
   static create<V extends CoValue>(
     this: CoValueClass<V>,
-    init: Simplify<CoMapInit<V>>,
+    init: Simplify<CoMapInit_DEPRECATED<V>>,
     owner: Account | Group,
   ): V {
     throw new Error("Not implemented");

--- a/packages/jazz-tools/src/tools/exports.ts
+++ b/packages/jazz-tools/src/tools/exports.ts
@@ -30,7 +30,7 @@ export type {
   Resolved,
   RefsToResolve,
   RefsToResolveStrict,
-  CoMapInit,
+  CoMapInit_DEPRECATED as CoMapInit,
   CoFeedEntry,
   TextPos,
   AccountClass,

--- a/packages/jazz-tools/src/tools/implementation/zodSchema/schemaTypes/CoFeedSchema.ts
+++ b/packages/jazz-tools/src/tools/implementation/zodSchema/schemaTypes/CoFeedSchema.ts
@@ -10,7 +10,7 @@ import {
   coOptionalDefiner,
 } from "../../../internal.js";
 import { AnonymousJazzAgent } from "../../anonymousJazzAgent.js";
-import { CoFeedInit } from "../typeConverters/CoFieldInit.js";
+import { CoFeedSchemaInit } from "../typeConverters/CoFieldSchemaInit.js";
 import { InstanceOrPrimitiveOfSchema } from "../typeConverters/InstanceOrPrimitiveOfSchema.js";
 import { InstanceOrPrimitiveOfSchemaCoValuesNullable } from "../typeConverters/InstanceOrPrimitiveOfSchemaCoValuesNullable.js";
 import { CoOptionalSchema } from "./CoOptionalSchema.js";
@@ -28,7 +28,7 @@ export class CoFeedSchema<T extends AnyZodOrCoValueSchema>
   ) {}
 
   create(
-    init: CoFeedInit<T>,
+    init: CoFeedSchemaInit<T>,
     options?: { owner: Account | Group } | Account | Group,
   ): CoFeedInstance<T> {
     return this.coValueClass.create(init as any, options) as CoFeedInstance<T>;

--- a/packages/jazz-tools/src/tools/implementation/zodSchema/schemaTypes/CoListSchema.ts
+++ b/packages/jazz-tools/src/tools/implementation/zodSchema/schemaTypes/CoListSchema.ts
@@ -9,7 +9,7 @@ import {
   coOptionalDefiner,
 } from "../../../internal.js";
 import { AnonymousJazzAgent } from "../../anonymousJazzAgent.js";
-import { CoListInit } from "../typeConverters/CoFieldInit.js";
+import { CoListSchemaInit } from "../typeConverters/CoFieldSchemaInit.js";
 import { InstanceOrPrimitiveOfSchema } from "../typeConverters/InstanceOrPrimitiveOfSchema.js";
 import { InstanceOrPrimitiveOfSchemaCoValuesNullable } from "../typeConverters/InstanceOrPrimitiveOfSchemaCoValuesNullable.js";
 import { AnyZodOrCoValueSchema } from "../zodSchema.js";
@@ -28,7 +28,7 @@ export class CoListSchema<T extends AnyZodOrCoValueSchema>
   ) {}
 
   create(
-    items: CoListInit<T>,
+    items: CoListSchemaInit<T>,
     options?: { owner: Account | Group } | Account | Group,
   ): CoListInstance<T> {
     return this.coValueClass.create(items as any, options) as CoListInstance<T>;

--- a/packages/jazz-tools/src/tools/implementation/zodSchema/schemaTypes/CoMapSchema.ts
+++ b/packages/jazz-tools/src/tools/implementation/zodSchema/schemaTypes/CoMapSchema.ts
@@ -17,7 +17,7 @@ import {
 } from "../../../internal.js";
 import { AnonymousJazzAgent } from "../../anonymousJazzAgent.js";
 import { removeGetters } from "../../schemaUtils.js";
-import { CoMapSchemaInit } from "../typeConverters/CoFieldInit.js";
+import { CoMapSchemaInit } from "../typeConverters/CoFieldSchemaInit.js";
 import { InstanceOrPrimitiveOfSchema } from "../typeConverters/InstanceOrPrimitiveOfSchema.js";
 import { InstanceOrPrimitiveOfSchemaCoValuesNullable } from "../typeConverters/InstanceOrPrimitiveOfSchemaCoValuesNullable.js";
 import { z } from "../zodReExport.js";

--- a/packages/jazz-tools/src/tools/implementation/zodSchema/schemaTypes/CoRecordSchema.ts
+++ b/packages/jazz-tools/src/tools/implementation/zodSchema/schemaTypes/CoRecordSchema.ts
@@ -12,7 +12,7 @@ import {
   SubscribeListenerOptions,
 } from "../../../internal.js";
 import { AnonymousJazzAgent } from "../../anonymousJazzAgent.js";
-import { CoFieldInit } from "../typeConverters/CoFieldInit.js";
+import { CoFieldSchemaInit } from "../typeConverters/CoFieldSchemaInit.js";
 import { InstanceOrPrimitiveOfSchema } from "../typeConverters/InstanceOrPrimitiveOfSchema.js";
 import { InstanceOrPrimitiveOfSchemaCoValuesNullable } from "../typeConverters/InstanceOrPrimitiveOfSchemaCoValuesNullable.js";
 import { z } from "../zodReExport.js";
@@ -24,7 +24,7 @@ type CoRecordInit<
   K extends z.core.$ZodString<string>,
   V extends AnyZodOrCoValueSchema,
 > = {
-  [key in z.output<K>]: CoFieldInit<V>;
+  [key in z.output<K>]: CoFieldSchemaInit<V>;
 };
 
 export interface CoRecordSchema<

--- a/packages/jazz-tools/src/tools/implementation/zodSchema/typeConverters/CoFieldSchemaInit.ts
+++ b/packages/jazz-tools/src/tools/implementation/zodSchema/typeConverters/CoFieldSchemaInit.ts
@@ -22,7 +22,7 @@ import { TypeOfZodSchema } from "./TypeOfZodSchema.js";
  * For CoValue fields, this can be either a shallowly-loaded CoValue instance
  * or a JSON object that will be used to create the CoValue.
  */
-export type CoFieldInit<S extends CoValueClass | AnyZodOrCoValueSchema> =
+export type CoFieldSchemaInit<S extends CoValueClass | AnyZodOrCoValueSchema> =
   S extends CoreCoValueSchema
     ?
         | Loaded<S>
@@ -31,15 +31,15 @@ export type CoFieldInit<S extends CoValueClass | AnyZodOrCoValueSchema> =
             : S extends CoreCoMapSchema<infer Shape>
               ? CoMapSchemaInit<Shape>
               : S extends CoreCoListSchema<infer T>
-                ? CoListInit<T>
+                ? CoListSchemaInit<T>
                 : S extends CoreCoFeedSchema<infer T>
-                  ? CoFeedInit<T>
+                  ? CoFeedSchemaInit<T>
                   : S extends CorePlainTextSchema | CoreRichTextSchema
                     ? string
                     : S extends CoreCoOptionalSchema<infer T>
-                      ? CoFieldInit<T> | undefined
+                      ? CoFieldSchemaInit<T> | undefined
                       : S extends CoDiscriminatedUnionSchema<infer Members>
-                        ? CoFieldInit<Members[number]>
+                        ? CoFieldSchemaInit<Members[number]>
                         : never)
     : S extends z.core.$ZodType
       ? TypeOfZodSchema<S>
@@ -59,20 +59,20 @@ export type CoMapSchemaInit<Shape extends z.core.$ZodLooseShape> = Simplify<
       | CoreCoOptionalSchema
       | z.core.$ZodOptional
       ? never
-      : Key]: CoFieldInit<Shape[Key]>;
+      : Key]: CoFieldSchemaInit<Shape[Key]>;
   } & {
     [Key in keyof Shape as Shape[Key] extends
       | CoreCoOptionalSchema
       | z.core.$ZodOptional
       ? Key
-      : never]?: CoFieldInit<Shape[Key]>;
+      : never]?: CoFieldSchemaInit<Shape[Key]>;
   }
 >;
 
-export type CoListInit<T extends AnyZodOrCoValueSchema> = Simplify<
-  ReadonlyArray<CoFieldInit<T>>
+export type CoListSchemaInit<T extends AnyZodOrCoValueSchema> = Simplify<
+  ReadonlyArray<CoFieldSchemaInit<T>>
 >;
 
-export type CoFeedInit<T extends AnyZodOrCoValueSchema> = Simplify<
-  ReadonlyArray<CoFieldInit<T>>
+export type CoFeedSchemaInit<T extends AnyZodOrCoValueSchema> = Simplify<
+  ReadonlyArray<CoFieldSchemaInit<T>>
 >;

--- a/packages/jazz-tools/src/tools/internal.ts
+++ b/packages/jazz-tools/src/tools/internal.ts
@@ -45,7 +45,7 @@ export * from "./implementation/zodSchema/typeConverters/InstanceOrPrimitiveOfSc
 export * from "./implementation/zodSchema/typeConverters/InstanceOrPrimitiveOfSchemaCoValuesNullable.js";
 export * from "./implementation/zodSchema/typeConverters/InstanceOfSchema.js";
 export * from "./implementation/zodSchema/typeConverters/InstanceOfSchemaCoValuesNullable.js";
-export * from "./implementation/zodSchema/typeConverters/CoFieldInit.js";
+export * from "./implementation/zodSchema/typeConverters/CoFieldSchemaInit.js";
 export * from "./implementation/zodSchema/runtimeConverters/coValueSchemaTransformation.js";
 export * from "./implementation/zodSchema/runtimeConverters/schemaFieldToCoFieldDef.js";
 export * from "./coValues/extensions/imageDef.js";

--- a/packages/jazz-tools/src/tools/internal.ts
+++ b/packages/jazz-tools/src/tools/internal.ts
@@ -1,5 +1,6 @@
 export * from "./coValues/interfaces.js";
 export * from "./coValues/CoValueBase.js";
+export * from "./coValues/CoFieldInit.js";
 export * from "./implementation/inspect.js";
 export * from "./implementation/symbols.js";
 

--- a/packages/jazz-tools/src/tools/tests/coList.test.ts
+++ b/packages/jazz-tools/src/tools/tests/coList.test.ts
@@ -206,32 +206,64 @@ describe("Simple CoList operations", async () => {
       expect(recipe[1]?.name).toBe("margarine");
     });
 
-    test("push", () => {
-      const list = TestList.create(["bread", "butter", "onion"], {
-        owner: me,
+    describe("push", () => {
+      test("push into CoList of non-collaborative values", () => {
+        const list = TestList.create(["bread", "butter", "onion"], {
+          owner: me,
+        });
+        list.$jazz.push("cheese");
+        expect(list[3]).toBe("cheese");
+        expect(list.$jazz.raw.asArray()).toEqual([
+          "bread",
+          "butter",
+          "onion",
+          "cheese",
+        ]);
       });
-      list.$jazz.push("cheese");
-      expect(list[3]).toBe("cheese");
-      expect(list.$jazz.raw.asArray()).toEqual([
-        "bread",
-        "butter",
-        "onion",
-        "cheese",
-      ]);
+
+      test("push CoValue into list of CoValues", () => {
+        const Schema = co.list(co.plainText());
+        const list = Schema.create(["bread", "butter", "onion"]);
+        list.$jazz.push(Schema.element.create("cheese"));
+        expect(list[3]?.toString()).toBe("cheese");
+      });
+
+      test("push JSON into list of CoValues", () => {
+        const Schema = co.list(co.plainText());
+        const list = Schema.create(["bread", "butter", "onion"]);
+        list.$jazz.push("cheese");
+        expect(list[3]?.toString()).toBe("cheese");
+      });
     });
 
-    test("unshift", () => {
-      const list = TestList.create(["bread", "butter", "onion"], {
-        owner: me,
+    describe("unshift", () => {
+      test("add non-collaborative element at the beginning of the list", () => {
+        const list = TestList.create(["bread", "butter", "onion"], {
+          owner: me,
+        });
+        list.$jazz.unshift("lettuce");
+        expect(list[0]).toBe("lettuce");
+        expect(list.$jazz.raw.asArray()).toEqual([
+          "lettuce",
+          "bread",
+          "butter",
+          "onion",
+        ]);
       });
-      list.$jazz.unshift("lettuce");
-      expect(list[0]).toBe("lettuce");
-      expect(list.$jazz.raw.asArray()).toEqual([
-        "lettuce",
-        "bread",
-        "butter",
-        "onion",
-      ]);
+
+      test("add CoValue at the beginning of a CoValue CoList", () => {
+        const Schema = co.list(co.plainText());
+        const list = Schema.create(["bread", "butter", "onion"]);
+        list.$jazz.unshift(Schema.element.create("lettuce"));
+        expect(list[0]?.toString()).toBe("lettuce");
+      });
+
+      test("add JSON at the beginning of a CoValue CoList", () => {
+        const Schema = co.list(co.plainText());
+        const list = Schema.create(["bread", "butter", "onion"]);
+        list.$jazz.unshift("lettuce");
+        expect(list[0]?.toString()).toBe("lettuce");
+      });
     });
 
     test("pop", () => {
@@ -310,6 +342,20 @@ describe("Simple CoList operations", async () => {
           "pepper",
           "onion",
         ]);
+      });
+
+      test("insert CoValue into a CoValue CoList", () => {
+        const Schema = co.list(co.plainText());
+        const list = Schema.create(["bread", "butter", "onion"]);
+        list.$jazz.splice(1, 0, Schema.element.create("lettuce"));
+        expect(list[1]?.toString()).toBe("lettuce");
+      });
+
+      test("insert JSON into a CoValue CoList", () => {
+        const Schema = co.list(co.plainText());
+        const list = Schema.create(["bread", "butter", "onion"]);
+        list.$jazz.splice(1, 0, "lettuce");
+        expect(list[1]?.toString()).toBe("lettuce");
       });
     });
 

--- a/packages/jazz-tools/src/tools/tests/coList.test.ts
+++ b/packages/jazz-tools/src/tools/tests/coList.test.ts
@@ -142,9 +142,11 @@ describe("Simple CoList operations", async () => {
         ],
         { owner: me },
       );
+      const originalIngredient = recipe[1];
 
       recipe.$jazz.set(1, Ingredient.create({ name: "margarine" }, me));
       expect(recipe[1]?.name).toBe("margarine");
+      expect(recipe[1]?.$jazz.id).not.toBe(originalIngredient?.$jazz.id);
     });
 
     test("assign undefined on a required ref", () => {
@@ -201,9 +203,11 @@ describe("Simple CoList operations", async () => {
         [{ name: "bread" }, { name: "butter" }, { name: "onion" }],
         { owner: me },
       );
+      const originalIngredient = recipe[1];
 
       recipe.$jazz.set(1, { name: "margarine" });
       expect(recipe[1]?.name).toBe("margarine");
+      expect(recipe[1]?.$jazz.id).not.toBe(originalIngredient?.$jazz.id);
     });
 
     describe("push", () => {
@@ -442,12 +446,15 @@ describe("CoList applyDiff operations", async () => {
     list.$jazz.applyDiff([item1, item3]);
     expect(list.length).toBe(2);
     expect(list[0]?.[0]).toBe("item1");
+    expect(list[0]?.$jazz.id).toBe(item1?.$jazz.id);
     expect(list[1]?.[0]).toBe("item3");
+    expect(list[1]?.$jazz.id).not.toBe(item2?.$jazz.id);
 
     // Test replacing reference items
     list.$jazz.applyDiff([item4]);
     expect(list.length).toBe(1);
     expect(list[0]?.[0]).toBe("item4");
+    expect(list[0]?.$jazz.id).not.toBe(item1?.$jazz.id);
 
     // Test empty list
     list.$jazz.applyDiff([]);
@@ -464,6 +471,8 @@ describe("CoList applyDiff operations", async () => {
     const item4 = ["item4"];
 
     const list = RefList.create([item1, item2], { owner: me });
+    const originalItem1 = list[0];
+    const originalItem2 = list[1];
 
     // Test adding reference items
     list.$jazz.applyDiff([item1, item2, item3]);
@@ -474,12 +483,15 @@ describe("CoList applyDiff operations", async () => {
     list.$jazz.applyDiff([item1, item3]);
     expect(list.length).toBe(2);
     expect(list[0]?.[0]).toBe("item1");
+    expect(list[0]?.$jazz.id).not.toBe(originalItem1?.$jazz.id);
     expect(list[1]?.[0]).toBe("item3");
+    expect(list[1]?.$jazz.id).not.toBe(originalItem2?.$jazz.id);
 
     // Test replacing reference items
     list.$jazz.applyDiff([item4]);
     expect(list.length).toBe(1);
     expect(list[0]?.[0]).toBe("item4");
+    expect(list[0]?.$jazz.id).not.toBe(originalItem1?.$jazz.id);
 
     // Test empty list
     list.$jazz.applyDiff([]);

--- a/packages/jazz-tools/src/tools/tests/coList.test.ts
+++ b/packages/jazz-tools/src/tools/tests/coList.test.ts
@@ -427,34 +427,37 @@ describe("CoList applyDiff operations", async () => {
   });
 
   test("applyDiff with reference values using CoValues", () => {
-    const NestedItem = co.list(z.string());
-    const RefList = co.list(NestedItem);
+    const TicTacToeRow = co.list(z.string());
+    const TicTacToeBoard = co.list(TicTacToeRow);
 
-    const item1 = NestedItem.create(["item1"], { owner: me });
-    const item2 = NestedItem.create(["item2"], { owner: me });
-    const item3 = NestedItem.create(["item3"], { owner: me });
-    const item4 = NestedItem.create(["item4"], { owner: me });
+    const row1 = TicTacToeRow.create(["X", "O", ""], { owner: me });
+    const row2 = TicTacToeRow.create(["", "X", "O"], { owner: me });
+    const row3 = TicTacToeRow.create(["O", "O", ""], { owner: me });
+    const winningRow = TicTacToeRow.create(["O", "O", "X"], { owner: me });
 
-    const list = RefList.create([item1, item2], { owner: me });
+    const list = TicTacToeBoard.create([row1, row2], { owner: me });
 
     // Test adding reference items
-    list.$jazz.applyDiff([item1, item2, item3]);
+    list.$jazz.applyDiff([row1, row2, row3]);
     expect(list.length).toBe(3);
-    expect(list[2]?.[0]).toBe("item3");
-
-    // Test removing reference items
-    list.$jazz.applyDiff([item1, item3]);
-    expect(list.length).toBe(2);
-    expect(list[0]?.[0]).toBe("item1");
-    expect(list[0]?.$jazz.id).toBe(item1?.$jazz.id);
-    expect(list[1]?.[0]).toBe("item3");
-    expect(list[1]?.$jazz.id).not.toBe(item2?.$jazz.id);
+    expect(list[2]?.toJSON()).toEqual(["O", "O", ""]);
 
     // Test replacing reference items
-    list.$jazz.applyDiff([item4]);
-    expect(list.length).toBe(1);
-    expect(list[0]?.[0]).toBe("item4");
-    expect(list[0]?.$jazz.id).not.toBe(item1?.$jazz.id);
+    list.$jazz.applyDiff([row1, row2, winningRow]);
+    expect(list.length).toBe(3);
+    expect(list[2]?.toJSON()).toEqual(["O", "O", "X"]);
+    // Only elements with different $jazz.id are replaced
+    expect(list[0]?.$jazz.id).toBe(row1?.$jazz.id);
+    expect(list[1]?.$jazz.id).toBe(row2?.$jazz.id);
+    expect(list[2]?.$jazz.id).not.toBe(row3?.$jazz.id);
+
+    // Test removing reference items
+    list.$jazz.applyDiff([row1, row3]);
+    expect(list.length).toBe(2);
+    expect(list[0]?.toJSON()).toEqual(["X", "O", ""]);
+    expect(list[0]?.$jazz.id).toBe(row1?.$jazz.id);
+    expect(list[1]?.toJSON()).toEqual(["O", "O", ""]);
+    expect(list[1]?.$jazz.id).not.toBe(row2?.$jazz.id);
 
     // Test empty list
     list.$jazz.applyDiff([]);
@@ -462,36 +465,40 @@ describe("CoList applyDiff operations", async () => {
   });
 
   test("applyDiff with reference values using JSON", () => {
-    const NestedItem = co.list(z.string());
-    const RefList = co.list(NestedItem);
+    const TicTacToeRow = co.list(z.string());
+    const TicTacToeBoard = co.list(TicTacToeRow);
 
-    const item1 = ["item1"];
-    const item2 = ["item2"];
-    const item3 = ["item3"];
-    const item4 = ["item4"];
+    const row1 = ["X", "O", ""];
+    const row2 = ["", "X", "O"];
+    const row3 = ["O", "O", ""];
+    const winningRow = ["O", "O", "X"];
 
-    const list = RefList.create([item1, item2], { owner: me });
-    const originalItem1 = list[0];
-    const originalItem2 = list[1];
+    const list = TicTacToeBoard.create([row1, row2], { owner: me });
+    const originalRow1 = list[0];
+    const originalRow2 = list[1];
+    const originalRow3 = list[2];
 
     // Test adding reference items
-    list.$jazz.applyDiff([item1, item2, item3]);
+    list.$jazz.applyDiff([row1, row2, row3]);
     expect(list.length).toBe(3);
-    expect(list[2]?.[0]).toBe("item3");
-
-    // Test removing reference items
-    list.$jazz.applyDiff([item1, item3]);
-    expect(list.length).toBe(2);
-    expect(list[0]?.[0]).toBe("item1");
-    expect(list[0]?.$jazz.id).not.toBe(originalItem1?.$jazz.id);
-    expect(list[1]?.[0]).toBe("item3");
-    expect(list[1]?.$jazz.id).not.toBe(originalItem2?.$jazz.id);
+    expect(list[2]?.toJSON()).toEqual(["O", "O", ""]);
 
     // Test replacing reference items
-    list.$jazz.applyDiff([item4]);
-    expect(list.length).toBe(1);
-    expect(list[0]?.[0]).toBe("item4");
-    expect(list[0]?.$jazz.id).not.toBe(originalItem1?.$jazz.id);
+    list.$jazz.applyDiff([row1, row2, winningRow]);
+    expect(list.length).toBe(3);
+    expect(list[2]?.toJSON()).toEqual(["O", "O", "X"]);
+    // All elements are replaced because new JSON values are set
+    expect(list[0]?.$jazz.id).not.toBe(originalRow1?.$jazz.id);
+    expect(list[1]?.$jazz.id).not.toBe(originalRow2?.$jazz.id);
+    expect(list[2]?.$jazz.id).not.toBe(originalRow3?.$jazz.id);
+
+    // Test removing reference items
+    list.$jazz.applyDiff([row1, row3]);
+    expect(list.length).toBe(2);
+    expect(list[0]?.toJSON()).toEqual(["X", "O", ""]);
+    expect(list[0]?.$jazz.id).not.toBe(originalRow1?.$jazz.id);
+    expect(list[1]?.toJSON()).toEqual(["O", "O", ""]);
+    expect(list[1]?.$jazz.id).not.toBe(originalRow2?.$jazz.id);
 
     // Test empty list
     list.$jazz.applyDiff([]);

--- a/packages/jazz-tools/src/tools/tests/coList.test.ts
+++ b/packages/jazz-tools/src/tools/tests/coList.test.ts
@@ -359,26 +359,6 @@ describe("Simple CoList operations", async () => {
       });
     });
 
-    test("applyDiff", () => {
-      const list = TestList.create(["bread", "butter", "onion"], {
-        owner: me,
-      });
-      // replace
-      list.$jazz.applyDiff(["bread", "margarine", "onion"]);
-      expect(list.$jazz.raw.asArray()).toEqual(["bread", "margarine", "onion"]);
-      // delete
-      list.$jazz.applyDiff(["bread", "onion"]);
-      expect(list.$jazz.raw.asArray()).toEqual(["bread", "onion"]);
-      // insert multiple
-      list.$jazz.applyDiff(["bread", "margarine", "onion", "cheese"]);
-      expect(list.$jazz.raw.asArray()).toEqual([
-        "bread",
-        "margarine",
-        "onion",
-        "cheese",
-      ]);
-    });
-
     test("filter + assign to coMap", () => {
       const TestMap = co.map({
         list: TestList,
@@ -442,7 +422,7 @@ describe("CoList applyDiff operations", async () => {
     expect(list.$jazz.raw.asArray()).toEqual([]);
   });
 
-  test("applyDiff with reference values", () => {
+  test("applyDiff with reference values using CoValues", () => {
     const NestedItem = co.list(z.string());
     const RefList = co.list(NestedItem);
 
@@ -450,6 +430,38 @@ describe("CoList applyDiff operations", async () => {
     const item2 = NestedItem.create(["item2"], { owner: me });
     const item3 = NestedItem.create(["item3"], { owner: me });
     const item4 = NestedItem.create(["item4"], { owner: me });
+
+    const list = RefList.create([item1, item2], { owner: me });
+
+    // Test adding reference items
+    list.$jazz.applyDiff([item1, item2, item3]);
+    expect(list.length).toBe(3);
+    expect(list[2]?.[0]).toBe("item3");
+
+    // Test removing reference items
+    list.$jazz.applyDiff([item1, item3]);
+    expect(list.length).toBe(2);
+    expect(list[0]?.[0]).toBe("item1");
+    expect(list[1]?.[0]).toBe("item3");
+
+    // Test replacing reference items
+    list.$jazz.applyDiff([item4]);
+    expect(list.length).toBe(1);
+    expect(list[0]?.[0]).toBe("item4");
+
+    // Test empty list
+    list.$jazz.applyDiff([]);
+    expect(list.$jazz.raw.asArray()).toEqual([]);
+  });
+
+  test("applyDiff with reference values using JSON", () => {
+    const NestedItem = co.list(z.string());
+    const RefList = co.list(NestedItem);
+
+    const item1 = ["item1"];
+    const item2 = ["item2"];
+    const item3 = ["item3"];
+    const item4 = ["item4"];
 
     const list = RefList.create([item1, item2], { owner: me });
 

--- a/packages/jazz-tools/src/tools/tests/coList.test.ts
+++ b/packages/jazz-tools/src/tools/tests/coList.test.ts
@@ -331,19 +331,12 @@ describe("Simple CoList operations", async () => {
         { owner: me },
       );
 
-      expect(() => {
-        map.$jazz.set(
-          "list",
-          // @ts-expect-error
-          map.list?.filter((item) => item !== "butter"),
-        );
-      }).toThrow("Cannot set reference list to a non-CoValue. Got bread,onion");
+      map.$jazz.set(
+        "list",
+        map.list?.filter((item) => item !== "butter"),
+      );
 
-      expect(map.list?.$jazz.raw.asArray()).toEqual([
-        "bread",
-        "butter",
-        "onion",
-      ]);
+      expect(map.list?.$jazz.raw.asArray()).toEqual(["bread", "onion"]);
     });
 
     test("filter + assign to CoList", () => {

--- a/packages/jazz-tools/src/tools/tests/coList.test.ts
+++ b/packages/jazz-tools/src/tools/tests/coList.test.ts
@@ -127,7 +127,7 @@ describe("Simple CoList operations", async () => {
       expect(list[1]).toBe("margarine");
     });
 
-    test("assignment with ref", () => {
+    test("assignment with ref using CoValue", () => {
       const Ingredient = co.map({
         name: z.string(),
       });
@@ -188,6 +188,22 @@ describe("Simple CoList operations", async () => {
 
       recipe.$jazz.set(1, undefined);
       expect(recipe[1]).toBe(undefined);
+    });
+
+    test("assignment with ref using JSON", () => {
+      const Ingredient = co.map({
+        name: z.string(),
+      });
+
+      const Recipe = co.list(Ingredient);
+
+      const recipe = Recipe.create(
+        [{ name: "bread" }, { name: "butter" }, { name: "onion" }],
+        { owner: me },
+      );
+
+      recipe.$jazz.set(1, { name: "margarine" });
+      expect(recipe[1]?.name).toBe("margarine");
     });
 
     test("push", () => {
@@ -351,11 +367,7 @@ describe("Simple CoList operations", async () => {
         { owner: me },
       );
 
-      list.$jazz.set(
-        0,
-        // @ts-expect-error
-        list[0]?.filter((item) => item !== "butter"),
-      );
+      list.$jazz.set(0, list[0]?.filter((item) => item !== "butter") ?? []);
 
       expect(list[0]?.$jazz.raw.asArray()).toEqual(["bread", "onion"]);
     });

--- a/packages/jazz-tools/src/tools/tests/coMap.test.ts
+++ b/packages/jazz-tools/src/tools/tests/coMap.test.ts
@@ -1487,6 +1487,24 @@ describe("CoMap applyDiff", async () => {
       "Cannot set required reference nested to undefined",
     );
   });
+
+  test("applyDiff from JSON", () => {
+    const map = TestMap.create({
+      name: "Alice",
+      age: 30,
+      isActive: true,
+      birthday: new Date("1990-01-01"),
+      nested: NestedMap.create({ value: "original" }),
+    });
+
+    const newValues = {
+      nested: { value: "updated" },
+    };
+
+    map.$jazz.applyDiff(newValues);
+
+    expect(map.nested?.value).toEqual("updated");
+  });
 });
 
 describe("CoMap Typescript validation", async () => {

--- a/packages/jazz-tools/src/tools/tests/coMap.test.ts
+++ b/packages/jazz-tools/src/tools/tests/coMap.test.ts
@@ -1348,13 +1348,17 @@ describe("CoMap applyDiff", async () => {
   });
 
   test("applyDiff with nested changes", () => {
+    const originalNestedMap = NestedMap.create(
+      { value: "original" },
+      { owner: me },
+    );
     const map = TestMap.create(
       {
         name: "Charlie",
         age: 25,
         isActive: true,
         birthday: new Date("1995-01-01"),
-        nested: NestedMap.create({ value: "original" }, { owner: me }),
+        nested: originalNestedMap,
       },
       { owner: me },
     );
@@ -1369,6 +1373,8 @@ describe("CoMap applyDiff", async () => {
     expect(map.name).toEqual("David");
     expect(map.age).toEqual(25);
     expect(map.nested?.value).toEqual("updated");
+    // A new nested CoMap is created
+    expect(map.nested.$jazz.id).not.toBe(originalNestedMap.$jazz.id);
   });
 
   test("applyDiff with encoded fields", () => {
@@ -1510,6 +1516,7 @@ describe("CoMap applyDiff", async () => {
       birthday: new Date("1990-01-01"),
       nested: NestedMap.create({ value: "original" }),
     });
+    const originalNestedMap = map.nested;
 
     const newValues = {
       nested: { value: "updated" },
@@ -1518,6 +1525,8 @@ describe("CoMap applyDiff", async () => {
     map.$jazz.applyDiff(newValues);
 
     expect(map.nested?.value).toEqual("updated");
+    // A new nested CoMap is created
+    expect(map.nested.$jazz.id).not.toBe(originalNestedMap.$jazz.id);
   });
 });
 

--- a/packages/jazz-tools/src/tools/tests/coMap.test.ts
+++ b/packages/jazz-tools/src/tools/tests/coMap.test.ts
@@ -602,10 +602,22 @@ describe("CoMap", async () => {
         });
       });
 
-      test("automatically creates CoValues for each CoValue reference", () => {
+      test("automatically creates CoValues for plain text reference", () => {
         person.$jazz.set("name", "Jack");
+        expect(person.name.toString()).toEqual("Jack");
+      });
+
+      test("automatically creates CoValues for rich text reference", () => {
         person.$jazz.set("bio", "I am a lawyer");
+        expect(person.bio!.toString()).toEqual("I am a lawyer");
+      });
+
+      test("automatically creates CoValues for CoMap reference", () => {
         person.$jazz.set("dog", { type: "dog", name: "Fido" });
+        expect(person.dog.name).toEqual("Fido");
+      });
+
+      test("automatically creates CoValues for CoList reference", () => {
         person.$jazz.set("friends", [
           {
             name: "Jane",
@@ -616,16 +628,18 @@ describe("CoMap", async () => {
             pet: { type: "cat", name: "Nala" },
           },
         ]);
-        person.$jazz.set("reactions", ["🧑‍🔬"]);
-        person.$jazz.set("pet", { type: "cat", name: "Salem" });
-
-        expect(person.name.toString()).toEqual("Jack");
-        expect(person.bio!.toString()).toEqual("I am a lawyer");
-        expect(person.dog.name).toEqual("Fido");
         expect(person.friends[0]!.name.toString()).toEqual("Jane");
         expect(person.friends[0]!.dog.name).toEqual("Firulais");
         expect(person.friends[0]!.pet.name).toEqual("Nala");
+      });
+
+      test("automatically creates CoValues for CoFeed reference", () => {
+        person.$jazz.set("reactions", ["🧑‍🔬"]);
         expect(person.reactions.byMe?.value?.toString()).toEqual("🧑‍🔬");
+      });
+
+      test("automatically creates CoValues for discriminated union reference", () => {
+        person.$jazz.set("pet", { type: "cat", name: "Salem" });
         expect(person.pet.name).toEqual("Salem");
       });
 


### PR DESCRIPTION
# Description

Follow-up to https://github.com/garden-co/jazz/pull/2683. CoValues can now be updated using JSON objects.

For example:
```typescript
const Todo = co.plainText();
const TodoList = co.list(Todo);
const todos = TodoList.create([]);

// Instead of
todos.$jazz.push(Todo.create("Buy groceries"));
todos.$jazz.push(Todo.create("Walk the dog"));

// People can now use
todos.$jazz.push("Buy groceries");
todos.$jazz.push("Walk the dog");
```

CoValues are created automatically, and permissions are handled in the same way than when creating CoValues from JSON (see [docs](https://jazz.tools/docs/react/groups/inheritance#group-hierarchy-on-covalue-creation)).

The update methods that support JSON inputs are:
- `CoMap.$jazz.set`
- `CoMap.$jazz.applyDiff`
- `CoList.$jazz.set`
- `CoList.$jazz.push`
- `CoList.$jazz.unshift`
- `CoList.$jazz.splice`
- `CoList.$jazz.applyDiff`
- `CoFeed.$jazz.push`

## Tests

- [x] Tests have been added and/or updated

## Checklist

- [ ] I've updated the part of the docs that are affected the PR changes
- [ ] I've generated a changeset, if a version bump is required
- [ ] I've updated the jsDoc comments to the public APIs I've modified, or added them when missing