### PR TITLE
fix: add missing export

### DIFF
--- a/.changeset/young-sloths-brake.md
+++ b/.changeset/young-sloths-brake.md
@@ -1,0 +1,5 @@
+---
+"jazz-tools": patch
+---
+
+Add missing BaseProfileShape export

--- a/packages/jazz-tools/src/tools/exports.ts
+++ b/packages/jazz-tools/src/tools/exports.ts
@@ -35,6 +35,7 @@ export type {
   TextPos,
   AccountClass,
   AccountCreationProps,
+  BaseProfileShape,
 } from "./internal.js";
 
 export {


### PR DESCRIPTION
Adds a missing `BaseProfileShape` export in jazz-tools