### PR TITLE
Explicit loadAs in upsertUnique to use it without loaded context

### DIFF
--- a/.changeset/five-donkeys-boil.md
+++ b/.changeset/five-donkeys-boil.md
@@ -1,0 +1,5 @@
+---
+"jazz-tools": patch
+---
+
+Explicit loadAs in upsertUnique to use it without loaded context

--- a/packages/jazz-tools/src/tools/coValues/coMap.ts
+++ b/packages/jazz-tools/src/tools/coValues/coMap.ts
@@ -628,7 +628,11 @@ export class CoMap extends CoValueBase implements CoValue {
       resolve?: RefsToResolveStrict<M, R>;
     },
   ): Promise<Resolved<M, R> | null> {
-    let mapId = CoMap._findUnique(options.unique, options.owner.id);
+    const mapId = CoMap._findUnique(
+      options.unique,
+      options.owner.id,
+      options.owner._loadedAs,
+    );
     let map: Resolved<M, R> | null = await loadCoValueWithoutMe(this, mapId, {
       ...options,
       loadAs: options.owner._loadedAs,


### PR DESCRIPTION
# Description
Using `upsertUnique()` throws `Error: No active account` if no global active user is set.

Like in `loadCoValueWithoutMe()`, we force the loadAs using `owner._loadedAs`.