### PR TITLE
Add Fallback properties to JazzProvider and ClerkProvider

### DIFF
--- a/examples/clerk/index.html
+++ b/examples/clerk/index.html
@@ -9,7 +9,9 @@
 </head>
 
 <body>
-  <div id="root"></div>
+  <div id="root">
+    <p>Loading...</p>
+  </div>
   <script type="module" src="/src/main.tsx"></script>
 </body>
 

--- a/examples/clerk/src/main.tsx
+++ b/examples/clerk/src/main.tsx
@@ -24,6 +24,7 @@ function JazzProvider({ children }: { children: ReactNode }) {
       sync={{
         peer: `wss://cloud.jazz.tools/?key=${apiKey}`,
       }}
+      fallback={<p>Loading...</p>}
     >
       {children}
     </JazzReactProviderWithClerk>

--- a/packages/jazz-tools/src/react/auth/Clerk.tsx
+++ b/packages/jazz-tools/src/react/auth/Clerk.tsx
@@ -9,7 +9,7 @@ import {
 } from "jazz-tools";
 import { LocalStorageKVStore } from "jazz-tools/browser";
 import { useAuthSecretStorage, useJazzContext } from "jazz-tools/react-core";
-import { useEffect, useMemo, useState } from "react";
+import { ReactNode, useEffect, useMemo, useState } from "react";
 import { JazzProviderProps, JazzReactProvider } from "../provider.js";
 
 function useJazzClerkAuth(clerk: MinimalClerkClient) {
@@ -43,7 +43,10 @@ export const JazzReactProviderWithClerk = <
     | (AccountClass<Account> & CoValueFromRaw<Account>)
     | AnyAccountSchema,
 >(
-  props: { clerk: MinimalClerkClient } & JazzProviderProps<S>,
+  props: {
+    clerk: MinimalClerkClient;
+    fallback?: ReactNode;
+  } & JazzProviderProps<S>,
 ) => {
   const [isLoaded, setIsLoaded] = useState(false);
 
@@ -61,11 +64,15 @@ export const JazzReactProviderWithClerk = <
   }, []);
 
   if (!isLoaded) {
-    return null;
+    return props.fallback ?? null;
   }
 
   return (
-    <JazzReactProvider {...props} logOutReplacement={props.clerk.signOut}>
+    <JazzReactProvider
+      {...props}
+      logOutReplacement={props.clerk.signOut}
+      fallback={props.fallback}
+    >
       <RegisterClerkAuth clerk={props.clerk}>
         {props.children}
       </RegisterClerkAuth>

--- a/packages/jazz-tools/src/react/auth/Clerk.tsx
+++ b/packages/jazz-tools/src/react/auth/Clerk.tsx
@@ -45,7 +45,6 @@ export const JazzReactProviderWithClerk = <
 >(
   props: {
     clerk: MinimalClerkClient;
-    fallback?: ReactNode;
   } & JazzProviderProps<S>,
 ) => {
   const [isLoaded, setIsLoaded] = useState(false);
@@ -68,11 +67,7 @@ export const JazzReactProviderWithClerk = <
   }
 
   return (
-    <JazzReactProvider
-      {...props}
-      logOutReplacement={props.clerk.signOut}
-      fallback={props.fallback}
-    >
+    <JazzReactProvider {...props} logOutReplacement={props.clerk.signOut}>
       <RegisterClerkAuth clerk={props.clerk}>
         {props.children}
       </RegisterClerkAuth>

--- a/packages/jazz-tools/src/react/provider.tsx
+++ b/packages/jazz-tools/src/react/provider.tsx
@@ -20,7 +20,7 @@ export type JazzProviderProps<
 > = {
   children: React.ReactNode;
   enableSSR?: boolean;
-  fallback?: React.ReactNode;
+  fallback?: React.ReactNode | null;
 } & JazzContextManagerProps<S>;
 
 /** @category Context & Hooks */
@@ -39,7 +39,7 @@ export function JazzReactProvider<
   logOutReplacement,
   onAnonymousAccountDiscarded,
   enableSSR,
-  fallback,
+  fallback = null,
 }: JazzProviderProps<S>) {
   const [contextManager] = React.useState(
     () =>
@@ -102,7 +102,7 @@ export function JazzReactProvider<
   return (
     <JazzContext.Provider value={value}>
       <JazzContextManagerContext.Provider value={contextManager}>
-        {!fallback ? value && children : !value ? fallback : children}
+        {value ? children : fallback}
       </JazzContextManagerContext.Provider>
     </JazzContext.Provider>
   );

--- a/packages/jazz-tools/src/react/provider.tsx
+++ b/packages/jazz-tools/src/react/provider.tsx
@@ -20,6 +20,7 @@ export type JazzProviderProps<
 > = {
   children: React.ReactNode;
   enableSSR?: boolean;
+  fallback?: React.ReactNode;
 } & JazzContextManagerProps<S>;
 
 /** @category Context & Hooks */
@@ -38,6 +39,7 @@ export function JazzReactProvider<
   logOutReplacement,
   onAnonymousAccountDiscarded,
   enableSSR,
+  fallback,
 }: JazzProviderProps<S>) {
   const [contextManager] = React.useState(
     () =>
@@ -100,7 +102,7 @@ export function JazzReactProvider<
   return (
     <JazzContext.Provider value={value}>
       <JazzContextManagerContext.Provider value={contextManager}>
-        {value && children}
+        {!fallback ? value && children : !value ? fallback : children}
       </JazzContextManagerContext.Provider>
     </JazzContext.Provider>
   );


### PR DESCRIPTION
# Description

fixes https://github.com/garden-co/jazz/issues/2758

This PR adds a fallback property to both the JazzProvider and the JazzReactProviderWithClerk.
I need this to avoid an empty content flash while my app is loading.

You can add a loading placeholder to the HTML that is returned by the server and use the same placeholder as the fallback.
Then the app will effectively have a consistent Splash-Screen like start.

## Manual testing instructions

I've added a loading fallback to the index.html and JazzReactProviderWithClerk in the clerk example.
I wasn't able to execute them due to vite failing to resolve imports when i try to run the dev server in the example directory?

## Tests

- [ ] Tests have been added and/or updated
- [ ] Tests have not been updated, because: 
- [x] I need help with writing tests

## Checklist

- [ ] I've updated the part of the docs that are affected the PR changes
- [ ] I've generated a changeset, if a version bump is required
- [ ] I've updated the jsDoc comments to the public APIs I've modified, or added them when missing