### PR TITLE
fix: make it possible for an admin to self-downgrade to writeOnly

### DIFF
--- a/.changeset/popular-mangos-run.md
+++ b/.changeset/popular-mangos-run.md
@@ -1,0 +1,8 @@
+---
+"cojson": patch
+---
+
+Fix admin permission downgrade to writeOnly
+- Allow admin to self-downgrade to writeOnly
+- Prevent admin from downgrading other admins to writeOnly
+

--- a/packages/cojson/src/coValues/group.ts
+++ b/packages/cojson/src/coValues/group.ts
@@ -370,16 +370,15 @@ export class RawGroup<
     if (role === "writeOnly" || role === "writeOnlyInvite") {
       const previousRole = this.get(memberKey);
 
-      this.set(memberKey, role, "trusting");
-
       if (
         previousRole === "reader" ||
         previousRole === "writer" ||
         previousRole === "admin"
       ) {
-        this.rotateReadKey();
+        this.rotateReadKey(memberKey);
       }
 
+      this.set(memberKey, role, "trusting");
       this.internalCreateWriteOnlyKeyForMember(memberKey, agent);
     } else {
       const currentReadKey = this.getCurrentReadKey();

--- a/packages/cojson/src/coValues/group.ts
+++ b/packages/cojson/src/coValues/group.ts
@@ -371,6 +371,15 @@ export class RawGroup<
       const previousRole = this.get(memberKey);
 
       if (
+        previousRole === "admin" &&
+        memberKey !== this.core.node.getCurrentAgent().id
+      ) {
+        throw new Error(
+          "Administrators cannot demote other administrators in a group",
+        );
+      }
+
+      if (
         previousRole === "reader" ||
         previousRole === "writer" ||
         previousRole === "admin"

--- a/packages/cojson/src/permissions.ts
+++ b/packages/cojson/src/permissions.ts
@@ -31,7 +31,23 @@ export type PermissionsDef =
   | { type: "ownedByGroup"; group: RawCoID }
   | { type: "unsafeAllowAll" };
 
-export type AccountRole = "reader" | "writer" | "admin" | "writeOnly";
+export type AccountRole =
+  /**
+   * Can read the group's CoValues
+   */
+  | "reader"
+  /**
+   * Can read and write to the group's CoValues
+   */
+  | "writer"
+  /**
+   * Can read and write to the group, and change group member roles
+   */
+  | "admin"
+  /**
+   * Can only write to the group's CoValues and read their own changes
+   */
+  | "writeOnly";
 
 export type Role =
   | AccountRole


### PR DESCRIPTION
# Description

- Allow admin to self-downgrade to `writeOnly`
- Prevent admin from downgrading other admins to `writeOnly`

## Tests

- [x] Tests have been added and/or updated

## Checklist

- [ ] I've updated the part of the docs that are affected the PR changes
- [x] I've generated a changeset, if a version bump is required
- [x] I've updated the jsDoc comments to the public APIs I've modified, or added them when missing