### PR TITLE
chore: remove unused params from tryAddTransactions

### DIFF
--- a/packages/cojson/src/coValueCore/coValueCore.ts
+++ b/packages/cojson/src/coValueCore/coValueCore.ts
@@ -431,11 +431,8 @@ export class CoValueCore {
   tryAddTransactions(
     sessionID: SessionID,
     newTransactions: Transaction[],
-    givenExpectedNewHash: Hash | undefined,
     newSignature: Signature,
-    notifyMode: "immediate" | "deferred",
     skipVerify: boolean = false,
-    givenNewStreamingHash?: StreamingHash,
   ): Result<true, TryAddTransactionsError> {
     return this.node
       .resolveAccountAgent(
@@ -456,14 +453,12 @@ export class CoValueCore {
           sessionID,
           signerID,
           newTransactions,
-          givenExpectedNewHash,
           newSignature,
           skipVerify,
-          givenNewStreamingHash,
         );
 
         if (result.isOk()) {
-          this.updateContentAndNotifyUpdate(notifyMode);
+          this.updateContentAndNotifyUpdate("immediate");
         }
 
         return result;

--- a/packages/cojson/src/coValueCore/verifiedState.ts
+++ b/packages/cojson/src/coValueCore/verifiedState.ts
@@ -91,10 +91,8 @@ export class VerifiedState {
     sessionID: SessionID,
     signerID: SignerID,
     newTransactions: Transaction[],
-    givenExpectedNewHash: Hash | undefined,
     newSignature: Signature,
     skipVerify: boolean = false,
-    givenNewStreamingHash?: StreamingHash,
   ): Result<true, TryAddTransactionsError> {
     const result = this.sessions.addTransaction(
       sessionID,

--- a/packages/cojson/src/sync.ts
+++ b/packages/cojson/src/sync.ts
@@ -643,9 +643,7 @@ export class SyncManager {
       const result = coValue.tryAddTransactions(
         sessionID,
         newTransactions,
-        undefined,
         newContentForSession.lastSignature,
-        "immediate",
         this.skipVerify,
       );
 

--- a/packages/cojson/src/tests/PureJSCrypto.test.ts
+++ b/packages/cojson/src/tests/PureJSCrypto.test.ts
@@ -113,9 +113,7 @@ describe("PureJSCrypto", () => {
           madeAt: Date.now(),
         },
       ],
-      "hash_z12345678",
       "signature_z12345678",
-      "immediate",
       true,
     );
 

--- a/packages/cojson/src/tests/WasmCrypto.test.ts
+++ b/packages/cojson/src/tests/WasmCrypto.test.ts
@@ -113,9 +113,7 @@ describe("WasmCrypto", () => {
           madeAt: Date.now(),
         },
       ],
-      "hash_z12345678",
       "signature_z12345678",
-      "immediate",
       true,
     );
 

--- a/packages/cojson/src/tests/coValueCore.test.ts
+++ b/packages/cojson/src/tests/coValueCore.test.ts
@@ -76,9 +76,7 @@ test("transactions with wrong signature are rejected", () => {
   const result = newEntry.tryAddTransactions(
     node.currentSessionID,
     [transaction],
-    undefined,
     signature,
-    "immediate",
   );
 
   expect(result.isErr()).toBe(true);
@@ -301,9 +299,7 @@ test("getValidTransactions should skip private transactions with invalid JSON", 
     .tryAddTransactions(
       fixtures.session,
       [fixtures.transaction],
-      undefined,
       fixtures.signature,
-      "immediate",
     )
     ._unsafeUnwrap();
 

--- a/packages/cojson/src/tests/sync.test.ts
+++ b/packages/cojson/src/tests/sync.test.ts
@@ -180,9 +180,7 @@ test("should not verify transactions when SyncManager has verification disabled"
         madeAt: Date.now(),
       },
     ],
-    undefined,
     Crypto.sign(agent.currentSignerSecret(), "hash_z12345678"),
-    "immediate",
     true,
   );
 


### PR DESCRIPTION
Simplifying tryAddTransactions by pruning the unused params