### PR TITLE
 Explicit loadAs in CoList.upsertUnique to use it without loaded context

### DIFF
--- a/.changeset/lucky-wasps-rhyme.md
+++ b/.changeset/lucky-wasps-rhyme.md
@@ -1,0 +1,5 @@
+---
+"jazz-tools": patch
+---
+
+Explicit loadAs in CoList.upsertUnique to use it without loaded context

--- a/packages/jazz-tools/src/tools/coValues/coList.ts
+++ b/packages/jazz-tools/src/tools/coValues/coList.ts
@@ -621,7 +621,11 @@ export class CoList<out Item = any> extends Array<Item> implements CoValue {
       resolve?: RefsToResolveStrict<L, R>;
     },
   ): Promise<Resolved<L, R> | null> {
-    let listId = CoList._findUnique(options.unique, options.owner.id);
+    const listId = CoList._findUnique(
+      options.unique,
+      options.owner.id,
+      options.owner._loadedAs,
+    );
     let list: Resolved<L, R> | null = await loadCoValueWithoutMe(this, listId, {
       ...options,
       loadAs: options.owner._loadedAs,

--- a/packages/jazz-tools/src/tools/testing.ts
+++ b/packages/jazz-tools/src/tools/testing.ts
@@ -159,6 +159,8 @@ export function setActiveAccount(account: Account) {
  *
  * Takes care of restoring the active account after the callback is run.
  *
+ * If the callback returns a promise, waits for it before restoring the active account.
+ *
  * @param callback - The callback to run.
  * @returns The result of the callback.
  */
@@ -168,6 +170,14 @@ export function runWithoutActiveAccount<Result>(
   const me = Account.getMe();
   activeAccountContext.set(null);
   const result = callback();
+
+  if (result instanceof Promise) {
+    return result.finally(() => {
+      activeAccountContext.set(me);
+      return result;
+    }) as Result;
+  }
+
   activeAccountContext.set(me);
   return result;
 }

--- a/packages/jazz-tools/src/tools/tests/coList.test.ts
+++ b/packages/jazz-tools/src/tools/tests/coList.test.ts
@@ -3,6 +3,7 @@ import { assert, beforeEach, describe, expect, test, vi } from "vitest";
 import { Account, Group, subscribeToCoValue, z } from "../index.js";
 import {
   Loaded,
+  activeAccountContext,
   co,
   coValueClassFromCoValueClassOrSchema,
 } from "../internal.js";
@@ -904,6 +905,29 @@ describe("CoList unique methods", () => {
     expect(result?.[0]).toBe("item1");
     expect(result?.[1]).toBe("item2");
     expect(result?.[2]).toBe("item3");
+  });
+
+  test("upsertUnique without an active account", async () => {
+    const account = activeAccountContext.get();
+    activeAccountContext.set(null);
+
+    const ItemList = co.list(z.string());
+
+    const sourceData = ["item1", "item2", "item3"];
+
+    const result = await ItemList.upsertUnique({
+      value: sourceData,
+      unique: "new-list",
+      owner: account,
+    });
+
+    expect(result).not.toBeNull();
+    expect(result?.length).toBe(3);
+    expect(result?.[0]).toBe("item1");
+    expect(result?.[1]).toBe("item2");
+    expect(result?.[2]).toBe("item3");
+
+    expect(result?._owner).toEqual(account);
   });
 
   test("upsertUnique updates existing list", async () => {

--- a/packages/jazz-tools/src/tools/tests/coList.test.ts
+++ b/packages/jazz-tools/src/tools/tests/coList.test.ts
@@ -7,7 +7,11 @@ import {
   co,
   coValueClassFromCoValueClassOrSchema,
 } from "../internal.js";
-import { createJazzTestAccount, setupJazzTestSync } from "../testing.js";
+import {
+  createJazzTestAccount,
+  runWithoutActiveAccount,
+  setupJazzTestSync,
+} from "../testing.js";
 import { waitFor } from "./utils.js";
 
 const Crypto = await WasmCrypto.create();
@@ -909,16 +913,16 @@ describe("CoList unique methods", () => {
 
   test("upsertUnique without an active account", async () => {
     const account = activeAccountContext.get();
-    activeAccountContext.set(null);
-
     const ItemList = co.list(z.string());
 
     const sourceData = ["item1", "item2", "item3"];
 
-    const result = await ItemList.upsertUnique({
-      value: sourceData,
-      unique: "new-list",
-      owner: account,
+    const result = await runWithoutActiveAccount(() => {
+      return ItemList.upsertUnique({
+        value: sourceData,
+        unique: "new-list",
+        owner: account,
+      });
     });
 
     expect(result).not.toBeNull();

--- a/packages/jazz-tools/src/tools/tests/coMap.test.ts
+++ b/packages/jazz-tools/src/tools/tests/coMap.test.ts
@@ -1548,6 +1548,47 @@ describe("Creating and finding unique CoMaps", async () => {
     });
   });
 
+  test("upserting without an active account", async () => {
+    const account = activeAccountContext.get();
+
+    activeAccountContext.set(null);
+
+    // Schema
+    const Event = co.map({
+      title: z.string(),
+      identifier: z.string(),
+      external_id: z.string(),
+    });
+
+    // Data
+    const sourceData = {
+      title: "Test Event Title",
+      identifier: "test-event-identifier",
+      _id: "test-event-external-id",
+    };
+
+    // Upserting
+    const activeEvent = await Event.upsertUnique({
+      value: {
+        title: sourceData.title,
+        identifier: sourceData.identifier,
+        external_id: sourceData._id,
+      },
+      unique: sourceData.identifier,
+      owner: account,
+    });
+
+    expect(activeEvent).toEqual({
+      title: sourceData.title,
+      identifier: sourceData.identifier,
+      external_id: sourceData._id,
+    });
+
+    assert(activeEvent);
+
+    expect(activeEvent._owner).toEqual(account);
+  });
+
   test("upserting an existing value", async () => {
     // Schema
     const Event = co.map({

--- a/packages/jazz-tools/src/tools/tests/coMap.test.ts
+++ b/packages/jazz-tools/src/tools/tests/coMap.test.ts
@@ -1551,8 +1551,6 @@ describe("Creating and finding unique CoMaps", async () => {
   test("upserting without an active account", async () => {
     const account = activeAccountContext.get();
 
-    activeAccountContext.set(null);
-
     // Schema
     const Event = co.map({
       title: z.string(),
@@ -1567,15 +1565,16 @@ describe("Creating and finding unique CoMaps", async () => {
       _id: "test-event-external-id",
     };
 
-    // Upserting
-    const activeEvent = await Event.upsertUnique({
-      value: {
-        title: sourceData.title,
-        identifier: sourceData.identifier,
-        external_id: sourceData._id,
-      },
-      unique: sourceData.identifier,
-      owner: account,
+    const activeEvent = await runWithoutActiveAccount(() => {
+      return Event.upsertUnique({
+        value: {
+          title: sourceData.title,
+          identifier: sourceData.identifier,
+          external_id: sourceData._id,
+        },
+        unique: sourceData.identifier,
+        owner: account,
+      });
     });
 
     expect(activeEvent).toEqual({


### PR DESCRIPTION
# Description
As a follow-up to #2777, I found the same behaviour in CoList.upsertUnique.


## Tests
- [x] Tests have been added and/or updated


## Checklist
- [ ] I've updated the part of the docs that are affected the PR changes
- [x] I've generated a changeset, if a version bump is required
- [ ] I've updated the jsDoc comments to the public APIs I've modified, or added them when missing