### PR TITLE
fix: replaces dead link to nodejs workers in homepage

### DIFF
--- a/homepage/homepage/components/home/SupportedEnvironmentsSection.tsx
+++ b/homepage/homepage/components/home/SupportedEnvironmentsSection.tsx
@@ -43,7 +43,7 @@ const serverWorkers = [
   {
     name: "Node.js",
     icon: NodejsLogo,
-    href: "/docs/react/server-workers",
+    href: "/docs/react/server-side/setup",
   },
   {
     name: "Bun",


### PR DESCRIPTION
the  link in the homepage was dead, replacing it with a working one