### PR TITLE
fix(cojson/sync): restore SyncManager.trackDirtyCoValues feature

### DIFF
--- a/.changeset/ten-squids-sip.md
+++ b/.changeset/ten-squids-sip.md
@@ -1,0 +1,5 @@
+---
+"cojson": patch
+---
+
+Correctly wait for updated CoValues when handling HTTP requests on server workers before sending the response

--- a/packages/cojson/src/sync.ts
+++ b/packages/cojson/src/sync.ts
@@ -804,26 +804,12 @@ export class SyncManager {
     return this.sendNewContentIncludingDependencies(msg.id, peer);
   }
 
-  dirtyCoValuesTrackingSets: Set<Set<RawCoID>> = new Set();
-  trackDirtyCoValues() {
-    const trackingSet = new Set<RawCoID>();
-
-    this.dirtyCoValuesTrackingSets.add(trackingSet);
-
-    return {
-      done: () => {
-        this.dirtyCoValuesTrackingSets.delete(trackingSet);
-
-        return trackingSet;
-      },
-    };
-  }
-
   private syncQueue = new LocalTransactionsSyncQueue((content) =>
     this.syncContent(content),
   );
   syncHeader = this.syncQueue.syncHeader;
   syncLocalTransaction = this.syncQueue.syncTransaction;
+  trackDirtyCoValues = this.syncQueue.trackDirtyCoValues;
 
   syncContent(content: NewContentMessage) {
     const coValue = this.local.getCoValue(content.id);

--- a/packages/cojson/src/tests/sync.test.ts
+++ b/packages/cojson/src/tests/sync.test.ts
@@ -1115,3 +1115,46 @@ describe("SyncManager.handleSyncMessage", () => {
     expect(peerState.knownStates.has(group.id)).toBe(true);
   });
 });
+
+describe("SyncManager.trackDirtyCoValues", () => {
+  test("should track the dirty coValues", async () => {
+    const node = createTestNode();
+
+    const tracking = node.syncManager.trackDirtyCoValues();
+
+    const group = node.createGroup();
+    const map = group.createMap();
+    map.set("key1", "value1", "trusting");
+
+    const trackedValues = tracking.done();
+    expect(trackedValues.size).toBe(2);
+    expect(trackedValues.has(map.id)).toBe(true);
+    expect(trackedValues.has(group.id)).toBe(true);
+  });
+
+  test("should track the dirty coValues only when active", async () => {
+    const node = createTestNode();
+
+    const group = node.createGroup();
+
+    const tracking1 = node.syncManager.trackDirtyCoValues();
+
+    const map1 = group.createMap();
+    map1.set("key1", "value1", "trusting");
+
+    const tracking2 = node.syncManager.trackDirtyCoValues();
+
+    const map2 = group.createMap();
+    map2.set("key2", "value2", "trusting");
+
+    const tracked1 = tracking1.done();
+
+    const map3 = group.createMap();
+    map3.set("key3", "value3", "trusting");
+
+    const tracked2 = tracking2.done();
+
+    expect(Array.from(tracked1)).toEqual([map1.id, map2.id]);
+    expect(Array.from(tracked2)).toEqual([map2.id, map3.id]);
+  });
+});


### PR DESCRIPTION
# Description
In some refactoring, the `SyncManager.trackDirtyCoValues` got broken. This PR restores the feature for tracking CoValues changed between the two invocations.


## Manual testing instructions

<!-- Add any actions required to manually test the changes -->

## Tests
- [x] Tests have been added and/or updated


## Checklist

- [x] I've updated the jsDoc comments to the public APIs I've modified, or added them when missing