### PR TITLE
docs: reorder sections in the docs' left-hand sidebar

### DIFF
--- a/homepage/homepage/content/docs/docNavigationItems.js
+++ b/homepage/homepage/content/docs/docNavigationItems.js
@@ -66,7 +66,7 @@ export const docNavigationItems = [
   },
   {
     name: "Upgrade guides",
-    // collapse: true,
+    collapse: true,
     prefix: "/docs/upgrade",
     items: [
       {

--- a/homepage/homepage/content/docs/docNavigationItems.js
+++ b/homepage/homepage/content/docs/docNavigationItems.js
@@ -65,51 +65,6 @@ export const docNavigationItems = [
     ],
   },
   {
-    name: "Tools",
-    items: [
-      {
-        name: "AI tools",
-        href: "/docs/ai-tools",
-        done: 100,
-      },
-      {
-        name: "create-jazz-app",
-        href: "/docs/tools/create-jazz-app",
-        done: 100,
-      },
-      {
-        name: "Inspector",
-        href: "/docs/inspector",
-        done: 100,
-      },
-    ],
-  },
-  {
-    name: "Server-side",
-    items: [
-      {
-        name: "Setup",
-        href: "/docs/server-side/setup",
-        done: 100,
-      },
-      {
-        name: "Communicating with workers",
-        href: "/docs/server-side/communicating-with-workers",
-        done: 100,
-      },
-      {
-        name: "HTTP requests",
-        href: "/docs/server-side/http-requests",
-        done: 100,
-      },
-      {
-        name: "Inbox",
-        href: "/docs/server-side/inbox",
-        done: 100,
-      },
-    ],
-  },
-  {
     name: "Upgrade guides",
     // collapse: true,
     prefix: "/docs/upgrade",
@@ -335,6 +290,31 @@ export const docNavigationItems = [
     ],
   },
   {
+    name: "Server-side",
+    items: [
+      {
+        name: "Setup",
+        href: "/docs/server-side/setup",
+        done: 100,
+      },
+      {
+        name: "Communicating with workers",
+        href: "/docs/server-side/communicating-with-workers",
+        done: 100,
+      },
+      {
+        name: "HTTP requests",
+        href: "/docs/server-side/http-requests",
+        done: 100,
+      },
+      {
+        name: "Inbox",
+        href: "/docs/server-side/inbox",
+        done: 100,
+      },
+    ],
+  },
+  {
     name: "Design patterns",
     items: [
       {
@@ -350,6 +330,26 @@ export const docNavigationItems = [
       {
         name: "History Patterns",
         href: "/docs/design-patterns/history-patterns",
+        done: 100,
+      },
+    ],
+  },
+  {
+    name: "Tools",
+    items: [
+      {
+        name: "AI tools",
+        href: "/docs/ai-tools",
+        done: 100,
+      },
+      {
+        name: "create-jazz-app",
+        href: "/docs/tools/create-jazz-app",
+        done: 100,
+      },
+      {
+        name: "Inspector",
+        href: "/docs/inspector",
         done: 100,
       },
     ],


### PR DESCRIPTION
# Description

The current order feels kind of awkward to me. Reorganized sections in the order I think most people would need to consult the docs when building an app.

Feel free to start a holy war in here or just close this PR if you prefer to do a more comprehensive refactor in the future.