### PR TITLE
fix(jazz-tools): update Svelte testing path in package.json

### DIFF
--- a/packages/jazz-tools/package.json
+++ b/packages/jazz-tools/package.json
@@ -122,7 +122,7 @@
       "default": "./dist/svelte/index.js"
     },
     "./svelte/testing": {
-      "svelte": "./dist/svelte/index.js",
+      "svelte": "./dist/svelte/testing.js",
       "@jazz-tools/source": "./src/svelte/testing.ts",
       "types": "./dist/svelte/testing.d.ts",
       "default": "./dist/svelte/testing.js"


### PR DESCRIPTION
# Description

Fixes  #2809 

## Manual testing instructions

Create a Svelte App, install Vitest, check that imports from `jazz-tools/svelte/testing` work properly.

## Tests

- [ ] Tests have been added and/or updated
- [x] Tests have not been updated, because: corrects a typo
- [ ] I need help with writing tests


## Checklist

- [ ] I've updated the part of the docs that are affected the PR changes
- [ ] I've generated a changeset, if a version bump is required
- [ ] I've updated the jsDoc comments to the public APIs I've modified, or added them when missing