### PR TITLE
Add remove action for CoList table in the inspector

### DIFF
--- a/.changeset/chatty-geckos-sleep.md
+++ b/.changeset/chatty-geckos-sleep.md
@@ -1,0 +1,5 @@
+---
+"jazz-tools": patch
+---
+
+Add remove action for CoList table in the inspector

--- a/packages/jazz-tools/src/inspector/viewer/page.tsx
+++ b/packages/jazz-tools/src/inspector/viewer/page.tsx
@@ -90,7 +90,7 @@ function canEdit(value: RawCoValue) {
   try {
     const myRole = value.group.myRole();
 
-    return myRole === "writer" || myRole === "admin" || myRole === "writeOnly";
+    return myRole === "writer" || myRole === "admin";
   } catch (e) {
     return false;
   }
@@ -128,24 +128,26 @@ function View(
     return <CoPlainTextView data={snapshot} />;
   }
 
-  if (type === "colist" || extendedType === "record") {
-    const onRemove =
-      canEdit(value) && type === "colist"
-        ? (index: number) => {
-            if (confirm("Are you sure you want to remove this item?")) {
-              const list = value as RawCoList;
-              list.delete(index);
-            }
-          }
-        : undefined;
+  if (type === "colist") {
+    const handleRemove = (index: number) => {
+      if (confirm("Are you sure you want to remove this item?")) {
+        const list = value as RawCoList;
+        list.delete(index);
+      }
+    };
+
     return (
       <TableView
         data={snapshot}
         node={node}
         onNavigate={onNavigate}
-        onRemove={onRemove}
+        onRemove={canEdit(value) ? handleRemove : undefined}
       />
     );
+  }
+
+  if (extendedType === "record") {
+    return <TableView data={snapshot} node={node} onNavigate={onNavigate} />;
   }
 
   return <GridView data={snapshot} onNavigate={onNavigate} node={node} />;

--- a/packages/jazz-tools/src/inspector/viewer/page.tsx
+++ b/packages/jazz-tools/src/inspector/viewer/page.tsx
@@ -1,4 +1,4 @@
-import { CoID, LocalNode, RawCoStream, RawCoValue } from "cojson";
+import { CoID, LocalNode, RawCoList, RawCoStream, RawCoValue } from "cojson";
 import { styled } from "goober";
 import React from "react";
 import { Badge } from "../ui/badge.js";
@@ -86,6 +86,16 @@ type PageProps = {
   className?: string;
 };
 
+function canEdit(value: RawCoValue) {
+  try {
+    const myRole = value.group.myRole();
+
+    return myRole === "writer" || myRole === "admin" || myRole === "writeOnly";
+  } catch (e) {
+    return false;
+  }
+}
+
 function View(
   props: PageProps & { coValue: Awaited<ReturnType<typeof resolveCoValue>> },
 ) {
@@ -119,7 +129,23 @@ function View(
   }
 
   if (type === "colist" || extendedType === "record") {
-    return <TableView data={snapshot} node={node} onNavigate={onNavigate} />;
+    const onRemove =
+      canEdit(value) && type === "colist"
+        ? (index: number) => {
+            if (confirm("Are you sure you want to remove this item?")) {
+              const list = value as RawCoList;
+              list.delete(index);
+            }
+          }
+        : undefined;
+    return (
+      <TableView
+        data={snapshot}
+        node={node}
+        onNavigate={onNavigate}
+        onRemove={onRemove}
+      />
+    );
   }
 
   return <GridView data={snapshot} onNavigate={onNavigate} node={node} />;

--- a/packages/jazz-tools/src/inspector/viewer/table-viewer.tsx
+++ b/packages/jazz-tools/src/inspector/viewer/table-viewer.tsx
@@ -29,10 +29,12 @@ function CoValuesTableView({
   data,
   node,
   onNavigate,
+  onRemove,
 }: {
   data: JsonObject;
   node: LocalNode;
   onNavigate: (pages: PageInfo[]) => void;
+  onRemove?: (index: number) => void;
 }) {
   const [visibleRowsCount, setVisibleRowsCount] = useState(10);
   const [coIdArray, visibleRows] = useMemo(() => {
@@ -74,6 +76,7 @@ function CoValuesTableView({
             {[...keys, "Action"].map((key) => (
               <TableHeader key={key}>{key}</TableHeader>
             ))}
+            {onRemove && <TableHeader></TableHeader>}
           </TableRow>
         </TableHead>
         <TableBody>
@@ -118,6 +121,13 @@ function CoValuesTableView({
                   View
                 </Button>
               </TableCell>
+              {onRemove && (
+                <TableCell>
+                  <Button variant="secondary" onClick={() => onRemove(index)}>
+                    Remove
+                  </Button>
+                </TableCell>
+              )}
             </TableRow>
           ))}
         </TableBody>
@@ -141,10 +151,12 @@ export function TableView({
   data,
   node,
   onNavigate,
+  onRemove,
 }: {
   data: JsonObject;
   node: LocalNode;
   onNavigate: (pages: PageInfo[]) => void;
+  onRemove?: (index: number) => void;
 }) {
   const isListOfCoValues = useMemo(() => {
     return Array.isArray(data) && data.every((k) => isCoId(k));
@@ -153,7 +165,12 @@ export function TableView({
   // if data is a list of covalue ids, we need to resolve those covalues
   if (isListOfCoValues) {
     return (
-      <CoValuesTableView data={data} node={node} onNavigate={onNavigate} />
+      <CoValuesTableView
+        data={data}
+        node={node}
+        onNavigate={onNavigate}
+        onRemove={onRemove}
+      />
     );
   }
 
@@ -164,6 +181,7 @@ export function TableView({
         <TableRow>
           <TableHeader style={{ width: "5rem" }}>Index</TableHeader>
           <TableHeader>Value</TableHeader>
+          {onRemove && <TableHeader>Action</TableHeader>}
         </TableRow>
       </TableHead>
       <TableBody>
@@ -176,6 +194,13 @@ export function TableView({
               <TableCell>
                 <ValueRenderer json={value} />
               </TableCell>
+              {onRemove && (
+                <TableCell>
+                  <Button variant="secondary" onClick={() => onRemove(index)}>
+                    Remove
+                  </Button>
+                </TableCell>
+              )}
             </TableRow>
           ))}
       </TableBody>


### PR DESCRIPTION
# Description

While doing user-testing for the $jazz upgrade, I've broken my production data for the Music player.

The easiest way to recover it was to build the remove in CoList

## Manual testing instructions

Load a CoList in the inspector:
- With write access the Remove button should be visible
- Without it shouldn't be

## Tests

- [ ] Tests have been added and/or updated
- [x] Tests have not been updated, because: unsure we want to keep this
- [ ] I need help with writing tests
