### PR TITLE
feat: `Account.$jazz.set`

### DIFF
--- a/examples/community-todo-vue/src/schema.ts
+++ b/examples/community-todo-vue/src/schema.ts
@@ -45,8 +45,8 @@ export const TodoAccount = co
      *  You can use it to set up the account root and any other initial CoValues you need.
      */
     if (account.root === undefined) {
-      account.root = TodoAccountRoot.create({
-        projects: co.list(TodoProject).create([], { owner: account }),
+      account.$jazz.set("root", {
+        projects: [],
       });
     }
   });

--- a/examples/file-share-svelte/src/lib/schema.ts
+++ b/examples/file-share-svelte/src/lib/schema.ts
@@ -23,9 +23,15 @@ export const FileShareAccount = co.account({
     const publicGroup = Group.create({ owner: account });
     publicGroup.addMember('everyone', 'reader');
 
-    account.root = FileShareAccountRoot.create({
-      type: 'file-share-account',
-      sharedFiles: co.list(SharedFile).create([], publicGroup),
-    }, publicGroup);
+    account.$jazz.set(
+      'root',
+      FileShareAccountRoot.create(
+        {
+          type: 'file-share-account',
+          sharedFiles: co.list(SharedFile).create([], publicGroup)
+        },
+        publicGroup
+      )
+    );
   }
 });

--- a/examples/form/src/schema.ts
+++ b/examples/form/src/schema.ts
@@ -71,9 +71,9 @@ export const JazzAccount = co
   })
   .withMigration((account) => {
     if (!account.root) {
-      account.root = AccountRoot.create(
-        { draft: { addOns: [], instructions: "" }, orders: [] },
-        account,
-      );
+      account.$jazz.set("root", {
+        draft: { addOns: [], instructions: "" },
+        orders: [],
+      });
     }
   });

--- a/examples/multi-cursors/src/schema.ts
+++ b/examples/multi-cursors/src/schema.ts
@@ -38,11 +38,14 @@ export const CursorAccount = co
       const group = Group.create();
       group.makePublic(); // The profile info is visible to everyone
 
-      account.profile = CursorProfile.create(
-        {
-          name: "Anonymous user",
-        },
-        group,
+      account.$jazz.set(
+        "profile",
+        CursorProfile.create(
+          {
+            name: "Anonymous user",
+          },
+          group,
+        ),
       );
     }
   });

--- a/examples/multi-cursors/src/schema.ts
+++ b/examples/multi-cursors/src/schema.ts
@@ -23,14 +23,14 @@ export const CursorAccount = co
   })
   .withMigration((account) => {
     if (account.root === undefined) {
-      account.root = CursorRoot.create({
+      account.$jazz.set("root", {
         camera: {
           position: {
             x: 0,
             y: 0,
           },
         },
-        cursors: CursorFeed.create([]),
+        cursors: [],
       });
     }
 

--- a/examples/music-player/src/1_schema.ts
+++ b/examples/music-player/src/1_schema.ts
@@ -105,11 +105,14 @@ export const MusicaAccount = co
     }
 
     if (account.profile === undefined) {
-      account.profile = MusicaAccountProfile.create(
-        {
-          name: "",
-        },
-        Group.create().makePublic(),
+      account.$jazz.set(
+        "profile",
+        MusicaAccountProfile.create(
+          {
+            name: "",
+          },
+          Group.create().makePublic(),
+        ),
       );
     }
   });

--- a/examples/music-player/src/1_schema.ts
+++ b/examples/music-player/src/1_schema.ts
@@ -95,7 +95,7 @@ export const MusicaAccount = co
         title: "",
       });
 
-      account.root = MusicaAccountRoot.create({
+      account.$jazz.set("root", {
         rootPlaylist,
         playlists: [],
         activeTrack: undefined,

--- a/examples/organization/src/schema.ts
+++ b/examples/organization/src/schema.ts
@@ -42,11 +42,14 @@ export const JazzAccount = co
   .withMigration(async (account) => {
     if (account.profile === undefined) {
       const group = Group.create();
-      account.profile = co.profile().create(
-        {
-          name: getRandomUsername(),
-        },
-        group,
+      account.$jazz.set(
+        "profile",
+        co.profile().create(
+          {
+            name: getRandomUsername(),
+          },
+          group,
+        ),
       );
       group.addMember("everyone", "reader");
     }

--- a/examples/organization/src/schema.ts
+++ b/examples/organization/src/schema.ts
@@ -78,7 +78,7 @@ export const JazzAccount = co
         ),
       ]);
 
-      account.root = JazzAccountRoot.create({
+      account.$jazz.set("root", {
         draftOrganization,
         organizations,
       });

--- a/examples/richtext-prosekit/src/schema.ts
+++ b/examples/richtext-prosekit/src/schema.ts
@@ -34,29 +34,27 @@ export const JazzAccount = co
      *  You can use it to set up the account root and any other initial CoValues you need.
      */
     if (account.root === undefined) {
-      const group = Group.create();
-
-      account.root = AccountRoot.create(
-        {
-          dateOfBirth: new Date("1/1/1990"),
-        },
-        group,
-      );
+      account.$jazz.set("root", {
+        dateOfBirth: new Date("1/1/1990"),
+      });
     }
 
     if (account.profile === undefined) {
       const group = Group.create();
       group.addMember("everyone", "reader"); // The profile info is visible to everyone
 
-      account.profile = JazzProfile.create(
-        {
-          name: "Anonymous user",
-          firstName: "",
-          bio: co
-            .richText()
-            .create("<p>A <strong>hu<em>man</strong></em>.</p>", group),
-        },
-        group,
+      account.$jazz.set(
+        "profile",
+        JazzProfile.create(
+          {
+            name: "Anonymous user",
+            firstName: "",
+            bio: co
+              .richText()
+              .create("<p>A <strong>hu<em>man</strong></em>.</p>", group),
+          },
+          group,
+        ),
       );
     }
   });

--- a/examples/richtext-prosemirror/src/schema.ts
+++ b/examples/richtext-prosemirror/src/schema.ts
@@ -34,29 +34,27 @@ export const JazzAccount = co
      *  You can use it to set up the account root and any other initial CoValues you need.
      */
     if (account.root === undefined) {
-      const group = Group.create();
-
-      account.root = AccountRoot.create(
-        {
-          dateOfBirth: new Date("1/1/1990"),
-        },
-        group,
-      );
+      account.$jazz.set("root", {
+        dateOfBirth: new Date("1/1/1990"),
+      });
     }
 
     if (account.profile === undefined) {
       const group = Group.create();
       group.makePublic(); // The profile info is visible to everyone
 
-      account.profile = JazzProfile.create(
-        {
-          name: "Anonymous user",
-          firstName: "",
-          bio: co
-            .richText()
-            .create("<p>A <strong>hu<em>man</strong></em>.</p>", group),
-        },
-        group,
+      account.$jazz.set(
+        "profile",
+        JazzProfile.create(
+          {
+            name: "Anonymous user",
+            firstName: "",
+            bio: co
+              .richText()
+              .create("<p>A <strong>hu<em>man</strong></em>.</p>", group),
+          },
+          group,
+        ),
       );
     }
   });

--- a/examples/richtext-tiptap/src/schema.ts
+++ b/examples/richtext-tiptap/src/schema.ts
@@ -34,27 +34,28 @@ export const JazzAccount = co
      *  You can use it to set up the account root and any other initial CoValues you need.
      */
     if (account.root === undefined) {
-      const group = Group.create();
-
-      account.root = AccountRoot.create(
-        { dateOfBirth: new Date("1/1/1990") },
-        group,
-      );
+      account.$jazz.set("root", { dateOfBirth: new Date("1/1/1990") });
     }
 
     if (account.profile === undefined) {
       const group = Group.create();
       group.makePublic(); // The profile info is visible to everyone
 
-      account.profile = JazzProfile.create(
-        {
-          name: "Anonymous user",
-          firstName: "",
-          bio: CoRichText.create("<p>A <strong>hu<em>man</strong></em>.</p>", {
-            owner: group,
-          }),
-        },
-        group,
+      account.$jazz.set(
+        "profile",
+        JazzProfile.create(
+          {
+            name: "Anonymous user",
+            firstName: "",
+            bio: CoRichText.create(
+              "<p>A <strong>hu<em>man</strong></em>.</p>",
+              {
+                owner: group,
+              },
+            ),
+          },
+          group,
+        ),
       );
     }
   });

--- a/examples/todo/src/1_schema.ts
+++ b/examples/todo/src/1_schema.ts
@@ -54,8 +54,8 @@ export const TodoAccount = co
      *  You can use it to set up the account root and any other initial CoValues you need.
      */
     if (account.root === undefined) {
-      account.root = TodoAccountRoot.create({
-        projects: co.list(TodoProject).create([], { owner: account }),
+      account.$jazz.set("root", {
+        projects: [],
       });
     }
   });

--- a/homepage/homepage/content/docs/design-patterns/form.mdx
+++ b/homepage/homepage/content/docs/design-patterns/form.mdx
@@ -390,9 +390,7 @@ export const JazzAccount = co.account({
   profile: co.map({ name: z.string() }),
 }).withMigration((account, creationProps?: { name: string }) => {
   if (account.root === undefined) {
-    const draft = DraftBubbleTeaOrder.create({});
-
-    account.root = AccountRoot.create({ draft });
+    account.$jazz.set("root", { draft: {} });
   }
 });
 ```
@@ -421,9 +419,7 @@ export const JazzAccount = co.account({
   profile: co.map({ name: z.string() }),
 }).withMigration((account, creationProps?: { name: string }) => {
   if (account.root === undefined) {
-    const draft = DraftBubbleTeaOrder.create({});
-
-    account.root = AccountRoot.create({ draft });
+    account.$jazz.set("root", { draft: {} });
   }
 });
 
@@ -480,9 +476,7 @@ export const JazzAccount = co.account({
   profile: co.map({ name: z.string() }),
 }).withMigration((account, creationProps?: { name: string }) => {
   if (account.root === undefined) {
-    const draft = DraftBubbleTeaOrder.create({});
-
-    account.root = AccountRoot.create({ draft });
+    account.$jazz.set("root", { draft: {} });
   }
 });
 
@@ -642,9 +636,7 @@ export const JazzAccount = co.account({
   profile: co.map({ name: z.string() }),
 }).withMigration((account, creationProps?: { name: string }) => {
   if (account.root === undefined) {
-    const draft = DraftBubbleTeaOrder.create({});
-
-    account.root = AccountRoot.create({ draft });
+    account.$jazz.set("root", { draft: {} });
   }
 });
 

--- a/homepage/homepage/content/docs/design-patterns/organization.mdx
+++ b/homepage/homepage/content/docs/design-patterns/organization.mdx
@@ -84,7 +84,7 @@ export const JazzAccount = co
           organizationGroup,
         ),
       ]);
-      account.root = JazzAccountRoot.create({ organizations });
+      account.$jazz.set("root", { organizations });
     }
   });
 ```

--- a/homepage/homepage/content/docs/schemas/accounts-and-migrations.mdx
+++ b/homepage/homepage/content/docs/schemas/accounts-and-migrations.mdx
@@ -212,10 +212,13 @@ export const MyAppAccount = co.account({
     // Unlike the root, we want the profile to be publicly readable.
     profileGroup.makePublic();
 
-    account.profile = MyAppProfile.create({
-      name: creationProps?.name ?? "New user",
-      bookmarks: co.list(Bookmark).create([], profileGroup),
-    }, profileGroup);
+    account.$jazz.set(
+      "profile",
+      MyAppProfile.create({
+        name: creationProps?.name ?? "New user",
+        bookmarks: co.list(Bookmark).create([], profileGroup),
+      }, profileGroup),
+    );
   }
 });
 ```

--- a/homepage/homepage/content/docs/schemas/accounts-and-migrations.mdx
+++ b/homepage/homepage/content/docs/schemas/accounts-and-migrations.mdx
@@ -3,6 +3,7 @@ export const metadata = {
 };
 
 import { CodeGroup, ComingSoon, ContentByFramework } from "@/components/forMdx";
+import { Alert } from "@garden-co/design-system/src/components/atoms/Alert";
 
 # Accounts & Migrations
 
@@ -98,6 +99,11 @@ export const MyAppAccount = co.account({
 });
 ```
 </CodeGroup>
+
+<Alert variant="info" className="mt-4 flex gap-2 items-center">
+  When using custom profile schemas, you need to take care of initializing the `profile` field in a migration,
+  and set up the correct permissions for it. See [Adding/changing fields to root and profile](#addingchanging-fields-to-root-and-profile).
+</Alert>
 
 ## Resolving CoValues starting at `profile` or `root`
 

--- a/homepage/homepage/content/docs/schemas/accounts-and-migrations.mdx
+++ b/homepage/homepage/content/docs/schemas/accounts-and-migrations.mdx
@@ -202,11 +202,8 @@ export const MyAppAccount = co.account({
   // we specifically need to check for undefined,
   // because the root might simply be not loaded (`null`) yet
   if (account.root === undefined) {
-    account.root = MyAppRoot.create({
-      // Using a group to set the owner is always a good idea.
-      // This way if in the future we want to share
-      // this coValue we can do so easily.
-      myChats: co.list(Chat).create([], Group.create()),
+    account.$jazz.set("root", {
+      myChats: [],
     });
   }
 
@@ -256,8 +253,8 @@ export const MyAppAccount = co.account({
   profile: MyAppProfile,
 }).withMigration(async (account) => {
   if (account.root === undefined) {
-    account.root = MyAppRoot.create({
-      myChats: co.list(Chat).create([], Group.create()),
+    account.$jazz.set("root", {
+      myChats: [],
     });
   }
 

--- a/packages/community-jazz-vue/src/tests/proxyBehavior.test.ts
+++ b/packages/community-jazz-vue/src/tests/proxyBehavior.test.ts
@@ -30,15 +30,10 @@ const AccountSchema = co
   })
   .withMigration((account) => {
     if (!account.root) {
-      account.root = AccountRoot.create({ value: "test" }, { owner: account });
+      account.$jazz.set("root", { value: "test" });
     }
     if (!account.profile) {
-      // Profile must be owned by a Group, not the account itself
-      const group = Group.create();
-      account.profile = AccountProfile.create(
-        { name: "Test User" },
-        { owner: group },
-      );
+      account.$jazz.set("profile", { name: "Test User" });
     }
   });
 
@@ -97,7 +92,7 @@ describe("Proxy Behavior Verification", () => {
     );
 
     // Update account root
-    sharedAccountWithSchema.root = rootMap;
+    sharedAccountWithSchema.$jazz.set("root", rootMap);
 
     const [accountResult] = withJazzTestSetup(
       () => useAccount(AccountSchema, { resolve: { root: { testMap: true } } }),

--- a/packages/community-jazz-vue/src/tests/useAccount.test.ts
+++ b/packages/community-jazz-vue/src/tests/useAccount.test.ts
@@ -21,15 +21,12 @@ const AccountSchema = co
   })
   .withMigration((account) => {
     if (!account.root) {
-      account.root = AccountRoot.create({ value: "123" }, { owner: account });
+      account.$jazz.set("root", { value: "123" });
     }
     if (!account.profile) {
       // Profile must be owned by a Group, not the account itself
       const group = Group.create();
-      account.profile = AccountProfile.create(
-        { name: "Test User" },
-        { owner: group },
-      );
+      account.$jazz.set("profile", { name: "Test User" });
     }
   });
 

--- a/packages/jazz-run/src/tests/startWorker.test.ts
+++ b/packages/jazz-run/src/tests/startWorker.test.ts
@@ -139,12 +139,9 @@ describe("startWorker integration", () => {
 
           shouldReloadPreviousAccount = true;
 
-          account.root = AccountRoot.create(
-            {
-              value: "test",
-            },
-            account,
-          );
+          account.$jazz.set("root", {
+            value: "test",
+          });
         }
       });
 

--- a/packages/jazz-tools/src/react-core/tests/useAccount.test.ts
+++ b/packages/jazz-tools/src/react-core/tests/useAccount.test.ts
@@ -38,9 +38,9 @@ describe("useAccount", () => {
       })
       .withMigration((account, creationProps) => {
         if (!account.$jazz.refs.root) {
-          account.root = AccountRoot.create(
-            { value: "123" },
-            { owner: account },
+          account.$jazz.set(
+            "root",
+            AccountRoot.create({ value: "123" }, { owner: account }),
           );
         }
       });
@@ -201,10 +201,7 @@ describe("useAccount", () => {
       })
       .withMigration((account, creationProps) => {
         if (!account.$jazz.refs.root) {
-          account.root = AccountRoot.create(
-            { value: "123" },
-            { owner: account },
-          );
+          account.$jazz.set("root", AccountRoot.create({ value: "123" }));
         }
       });
 

--- a/packages/jazz-tools/src/react-core/tests/useAccount.test.ts
+++ b/packages/jazz-tools/src/react-core/tests/useAccount.test.ts
@@ -38,10 +38,7 @@ describe("useAccount", () => {
       })
       .withMigration((account, creationProps) => {
         if (!account.$jazz.refs.root) {
-          account.$jazz.set(
-            "root",
-            AccountRoot.create({ value: "123" }, { owner: account }),
-          );
+          account.$jazz.set("root", { value: "123" });
         }
       });
 
@@ -201,7 +198,7 @@ describe("useAccount", () => {
       })
       .withMigration((account, creationProps) => {
         if (!account.$jazz.refs.root) {
-          account.$jazz.set("root", AccountRoot.create({ value: "123" }));
+          account.$jazz.set("root", { value: "123" });
         }
       });
 

--- a/packages/jazz-tools/src/tools/coValues/account.ts
+++ b/packages/jazz-tools/src/tools/coValues/account.ts
@@ -15,6 +15,7 @@ import {
 } from "cojson";
 import {
   AnonymousJazzAgent,
+  CoFieldInit,
   type CoMap,
   type CoValue,
   CoValueBase,
@@ -80,8 +81,8 @@ export class Account extends CoValueBase implements CoValue {
     } satisfies RefEncoded<CoMap>,
   };
 
-  declare profile: Profile | null;
-  declare root: CoMap | null;
+  declare readonly profile: Profile | null;
+  declare readonly root: CoMap | null;
 
   constructor(options: { fromRaw: RawAccount }) {
     super();
@@ -103,7 +104,7 @@ export class Account extends CoValueBase implements CoValue {
   /**
    * Whether this account is the currently active account.
    */
-  get isMe() {
+  get isMe(): boolean {
     return activeAccountContext.get().$jazz.id === this.$jazz.id;
   }
 
@@ -281,7 +282,10 @@ export class Account extends CoValueBase implements CoValue {
     if (this.profile === undefined && creationProps) {
       const profileGroup = RegisteredSchemas["Group"].create({ owner: this });
 
-      this.profile = Profile.create({ name: creationProps.name }, profileGroup);
+      this.$jazz.set(
+        "profile",
+        Profile.create({ name: creationProps.name }, profileGroup),
+      );
       profileGroup.addMember("everyone", "reader");
     }
 
@@ -370,6 +374,31 @@ class AccountJazzApi<A extends Account> extends CoValueJazzApi<A> {
    */
   get id(): ID<A> {
     return this.raw.id;
+  }
+
+  /**
+   * Accounts have no owner. They can be accessed by everyone.
+   */
+  get owner(): undefined {
+    return undefined;
+  }
+
+  /**
+   * Set the value of a key in the account.
+   *
+   * @param key The key to set.
+   * @param value The value to set.
+   *
+   * @category Content
+   */
+  set<K extends "root" | "profile">(key: K, value: NonNullable<Account[K]>) {
+    if (value) {
+      this.raw.set(
+        key,
+        value.$jazz.id as unknown as CoID<RawCoMap>,
+        "trusting",
+      );
+    }
   }
 
   /**
@@ -483,13 +512,6 @@ class AccountJazzApi<A extends Account> extends CoValueJazzApi<A> {
     return (this.account.constructor as typeof Account)._schema;
   }
 
-  /**
-   * Accounts have no owner. They can be accessed by everyone.
-   */
-  get owner(): undefined {
-    return undefined;
-  }
-
   get loadedAs(): Account | AnonymousJazzAgent {
     if (this.isLocalNodeOwner) return this.account;
 
@@ -521,6 +543,7 @@ export const AccountAndGroupProxyHandler: ProxyHandler<Account | Group> = {
   },
   set(target, key, value, receiver) {
     if (
+      target instanceof Account &&
       (key === "profile" || key === "root") &&
       typeof value === "object" &&
       SchemaInit in value
@@ -528,24 +551,14 @@ export const AccountAndGroupProxyHandler: ProxyHandler<Account | Group> = {
       (target.constructor as typeof Account)._schema ||= {};
       (target.constructor as typeof Account)._schema[key] = value[SchemaInit];
       return true;
-    } else if (key === "profile") {
+    } else if (
+      target instanceof Account &&
+      (key === "profile" || key === "root")
+    ) {
       if (value) {
-        target.$jazz.raw.set(
-          "profile",
-          value.$jazz.id as unknown as CoID<RawCoMap>,
-          "trusting",
-        );
+        target.$jazz.set(key, value);
       }
 
-      return true;
-    } else if (key === "root") {
-      if (value) {
-        target.$jazz.raw.set(
-          "root",
-          value.$jazz.id as unknown as CoID<RawCoMap>,
-          "trusting",
-        );
-      }
       return true;
     } else {
       return Reflect.set(target, key, value, receiver);

--- a/packages/jazz-tools/src/tools/implementation/zodSchema/zodCo.ts
+++ b/packages/jazz-tools/src/tools/implementation/zodSchema/zodCo.ts
@@ -74,10 +74,10 @@ export const coMapDefiner = <Shape extends z.core.$ZodLooseShape>(
  *   // Migration logic for existing accounts
  *   if (account.profile === undefined) {
  *     const group = Group.create();
- *     account.profile = co.profile().create(
+ *     account.$jazz.set("profile", co.profile().create(
  *       { name: getRandomUsername() },
  *       group
- *     );
+ *     ));
  *     group.addMember("everyone", "reader");
  *   }
  * });

--- a/packages/jazz-tools/src/tools/tests/ContextManager.test.ts
+++ b/packages/jazz-tools/src/tools/tests/ContextManager.test.ts
@@ -256,11 +256,14 @@ describe("ContextManager", () => {
         profile: co.profile(),
       })
       .withMigration(async (account) => {
-        account.root = AccountRoot.create(
-          {
-            value: "Hello",
-          },
-          Group.create(this).makePublic(),
+        account.$jazz.set(
+          "root",
+          AccountRoot.create(
+            {
+              value: "Hello",
+            },
+            Group.create(this).makePublic(),
+          ),
         );
       });
 
@@ -323,11 +326,14 @@ describe("ContextManager", () => {
         root: AccountRoot,
         profile: co.profile(),
       })
-      .withMigration(async (account) => {
-        account.root = AccountRoot.create({
-          value: "Hello",
-        });
-        lastRootId = account.root.$jazz.id;
+      .withMigration(async (account: Account) => {
+        account.$jazz.set(
+          "root",
+          AccountRoot.create({
+            value: "Hello",
+          }),
+        );
+        lastRootId = account.root!.$jazz.id;
       });
 
     const customManager = new TestJazzContextManager<
@@ -370,9 +376,12 @@ describe("ContextManager", () => {
       })
       .withMigration(async (account) => {
         if (account.root === undefined) {
-          account.root = AccountRoot.create({
-            value: 1,
-          });
+          account.$jazz.set(
+            "root",
+            AccountRoot.create({
+              value: 1,
+            }),
+          );
         } else {
           const { root } = await account.$jazz.ensureLoaded({
             resolve: { root: true },
@@ -424,9 +433,12 @@ describe("ContextManager", () => {
       })
       .withMigration(async (account) => {
         if (account.root === undefined) {
-          account.root = AccountRoot.create({
-            value: "Hello",
-          });
+          account.$jazz.set(
+            "root",
+            AccountRoot.create({
+              value: "Hello",
+            }),
+          );
         }
       });
 

--- a/packages/jazz-tools/src/tools/tests/ContextManager.test.ts
+++ b/packages/jazz-tools/src/tools/tests/ContextManager.test.ts
@@ -327,12 +327,9 @@ describe("ContextManager", () => {
         profile: co.profile(),
       })
       .withMigration(async (account: Account) => {
-        account.$jazz.set(
-          "root",
-          AccountRoot.create({
-            value: "Hello",
-          }),
-        );
+        account.$jazz.set("root", {
+          value: "Hello",
+        });
         lastRootId = account.root!.$jazz.id;
       });
 

--- a/packages/jazz-tools/src/tools/tests/account.test.ts
+++ b/packages/jazz-tools/src/tools/tests/account.test.ts
@@ -170,21 +170,24 @@ test("should support recursive props on co.profile", async () => {
       if (me.profile === undefined) {
         const group = Group.create({ owner: me });
         group.addMember("everyone", "reader");
-        me.profile = User.create(
-          {
-            name: "test 1",
-            created: new Date(),
-            updated: new Date(),
-            anonymous: false,
-            following: co.list(User).create([], group),
-            followers: co.list(User).create([], group),
-          },
-          group,
+        me.$jazz.set(
+          "profile",
+          User.create(
+            {
+              name: "test 1",
+              created: new Date(),
+              updated: new Date(),
+              anonymous: false,
+              following: co.list(User).create([], group),
+              followers: co.list(User).create([], group),
+            },
+            group,
+          ),
         );
       }
 
       if (me.root === undefined) {
-        me.root = co.map({}).create({});
+        me.$jazz.set("root", co.map({}).create({}));
       }
     });
 
@@ -230,25 +233,31 @@ test("root and profile should be trusting by default", async () => {
       const group = Group.create({ owner: me }).makePublic();
 
       if (me.profile === undefined) {
-        me.profile = co.profile().create(
-          {
-            name: creationProps?.name ?? "Anonymous",
-          },
-          group,
-        );
-      }
-
-      if (me.root === undefined) {
-        me.root = co
-          .map({
-            name: z.string(),
-          })
-          .create(
+        me.$jazz.set(
+          "profile",
+          co.profile().create(
             {
               name: creationProps?.name ?? "Anonymous",
             },
             group,
-          );
+          ),
+        );
+      }
+
+      if (me.root === undefined) {
+        me.$jazz.set(
+          "root",
+          co
+            .map({
+              name: z.string(),
+            })
+            .create(
+              {
+                name: creationProps?.name ?? "Anonymous",
+              },
+              group,
+            ),
+        );
       }
     });
 

--- a/packages/jazz-tools/src/tools/tests/account.test.ts
+++ b/packages/jazz-tools/src/tools/tests/account.test.ts
@@ -1,4 +1,4 @@
-import { assert, beforeEach, expect, test } from "vitest";
+import { assert, beforeEach, describe, expect, test } from "vitest";
 import { Account, Group, co, z } from "../exports.js";
 import {
   createJazzTestAccount,
@@ -187,7 +187,7 @@ test("should support recursive props on co.profile", async () => {
       }
 
       if (me.root === undefined) {
-        me.$jazz.set("root", co.map({}).create({}));
+        me.$jazz.set("root", {});
       }
     });
 
@@ -221,70 +221,114 @@ test("cannot update account profile properties directly", async () => {
   expect(account.profile.name).toBe("test 3");
 });
 
-test("root and profile should be trusting by default", async () => {
-  const AccountSchema = co
-    .account({
-      profile: co.profile(),
-      root: co.map({
-        name: z.string(),
-      }),
-    })
-    .withMigration((me, creationProps) => {
-      const group = Group.create({ owner: me }).makePublic();
+describe("root and profile", () => {
+  test("root and profile should be trusting by default", async () => {
+    const AccountSchema = co
+      .account({
+        profile: co.profile(),
+        root: co.map({
+          name: z.string(),
+        }),
+      })
+      .withMigration((me, creationProps) => {
+        const group = Group.create({ owner: me }).makePublic();
 
-      if (me.profile === undefined) {
-        me.$jazz.set(
-          "profile",
-          co.profile().create(
-            {
-              name: creationProps?.name ?? "Anonymous",
-            },
-            group,
-          ),
-        );
-      }
-
-      if (me.root === undefined) {
-        me.$jazz.set(
-          "root",
-          co
-            .map({
-              name: z.string(),
-            })
-            .create(
+        if (me.profile === undefined) {
+          me.$jazz.set(
+            "profile",
+            co.profile().create(
               {
                 name: creationProps?.name ?? "Anonymous",
               },
               group,
             ),
-        );
-      }
+          );
+        }
+
+        if (me.root === undefined) {
+          me.$jazz.set(
+            "root",
+            co
+              .map({
+                name: z.string(),
+              })
+              .create(
+                {
+                  name: creationProps?.name ?? "Anonymous",
+                },
+                group,
+              ),
+          );
+        }
+      });
+
+    const bob = await createJazzTestAccount({
+      AccountSchema,
+      creationProps: {
+        name: "Bob",
+      },
     });
 
-  const bob = await createJazzTestAccount({
-    AccountSchema,
-    creationProps: {
-      name: "Bob",
-    },
+    const alice = await createJazzTestAccount({
+      AccountSchema,
+      creationProps: {
+        name: "Alice",
+      },
+    });
+
+    const bobAccountLoadedFromAlice = await AccountSchema.load(bob.$jazz.id, {
+      loadAs: alice,
+      resolve: {
+        profile: true,
+        root: true,
+      },
+    });
+
+    assert(bobAccountLoadedFromAlice);
+
+    expect(bobAccountLoadedFromAlice.profile.name).toBe("Bob");
+    expect(bobAccountLoadedFromAlice.root.name).toBe("Bob");
   });
 
-  const alice = await createJazzTestAccount({
-    AccountSchema,
-    creationProps: {
-      name: "Alice",
-    },
+  test("can be initialized using JSON objects", async () => {
+    const Avatar = co.map({
+      url: z.string(),
+    });
+    const CustomProfile = co.profile({
+      avatar: Avatar,
+    });
+    const CustomRoot = co.map({
+      name: z.string(),
+    });
+    const AccountSchema = co
+      .account({
+        profile: CustomProfile,
+        root: CustomRoot,
+      })
+      .withMigration((me, creationProps) => {
+        if (me.profile === undefined) {
+          me.$jazz.set("profile", {
+            name: creationProps?.name ?? "Anonymous",
+            avatar: {
+              url: "https://example.com/avatar.png",
+            },
+          });
+        }
+
+        if (me.root === undefined) {
+          me.$jazz.set("root", { name: creationProps?.name ?? "Anonymous" });
+        }
+      });
+
+    const account = await createJazzTestAccount({
+      AccountSchema,
+      creationProps: {
+        name: "test 1",
+      },
+    });
+
+    expect(account.profile.name).toBe("test 1");
+    expect(account.profile.avatar.url).toBe("https://example.com/avatar.png");
+    expect(account.root.name).toBe("test 1");
   });
-
-  const bobAccountLoadedFromAlice = await AccountSchema.load(bob.$jazz.id, {
-    loadAs: alice,
-    resolve: {
-      profile: true,
-      root: true,
-    },
-  });
-
-  assert(bobAccountLoadedFromAlice);
-
-  expect(bobAccountLoadedFromAlice.profile.name).toBe("Bob");
-  expect(bobAccountLoadedFromAlice.root.name).toBe("Bob");
 });

--- a/packages/jazz-tools/src/tools/tests/deepLoading.test.ts
+++ b/packages/jazz-tools/src/tools/tests/deepLoading.test.ts
@@ -205,16 +205,19 @@ const CustomAccount = co
   .withMigration(async (account, creationProps) => {
     if (creationProps) {
       const profileGroup = Group.create(account);
-      account.profile = CustomProfile.create(
-        {
-          name: creationProps.name,
-          stream: TestFeed.create([], account),
-        },
-        profileGroup,
+      account.$jazz.set(
+        "profile",
+        CustomProfile.create(
+          {
+            name: creationProps.name,
+            stream: TestFeed.create([], account),
+          },
+          profileGroup,
+        ),
       );
-      account.root = TestMap.create(
-        { list: TestList.create([], account) },
-        account,
+      account.$jazz.set(
+        "root",
+        TestMap.create({ list: TestList.create([], account) }, account),
       );
     }
 

--- a/packages/jazz-tools/src/tools/tests/deepLoading.test.ts
+++ b/packages/jazz-tools/src/tools/tests/deepLoading.test.ts
@@ -204,21 +204,11 @@ const CustomAccount = co
   })
   .withMigration(async (account, creationProps) => {
     if (creationProps) {
-      const profileGroup = Group.create(account);
-      account.$jazz.set(
-        "profile",
-        CustomProfile.create(
-          {
-            name: creationProps.name,
-            stream: TestFeed.create([], account),
-          },
-          profileGroup,
-        ),
-      );
-      account.$jazz.set(
-        "root",
-        TestMap.create({ list: TestList.create([], account) }, account),
-      );
+      account.$jazz.set("profile", {
+        name: creationProps.name,
+        stream: TestFeed.create([], account),
+      });
+      account.$jazz.set("root", { list: [] });
     }
 
     const accountLoaded = await account.$jazz.ensureLoaded({

--- a/packages/jazz-tools/src/tools/tests/groupsAndAccounts.test.ts
+++ b/packages/jazz-tools/src/tools/tests/groupsAndAccounts.test.ts
@@ -35,7 +35,6 @@ describe("Custom accounts and groups", async () => {
         type P = typeof account.profile;
         const _p: P = {} as Loaded<typeof CustomProfile> | null;
         if (creationProps) {
-          console.log("In migration!");
           const profileGroup = Group.create({ owner: account });
           profileGroup.addMember("everyone", "reader");
           account.$jazz.set(

--- a/packages/jazz-tools/src/tools/tests/groupsAndAccounts.test.ts
+++ b/packages/jazz-tools/src/tools/tests/groupsAndAccounts.test.ts
@@ -38,9 +38,12 @@ describe("Custom accounts and groups", async () => {
           console.log("In migration!");
           const profileGroup = Group.create({ owner: account });
           profileGroup.addMember("everyone", "reader");
-          account.profile = CustomProfile.create(
-            { name: creationProps.name, color: "blue" },
-            profileGroup,
+          account.$jazz.set(
+            "profile",
+            CustomProfile.create(
+              { name: creationProps.name, color: "blue" },
+              profileGroup,
+            ),
           );
         }
       });

--- a/packages/jazz-tools/src/tools/tests/inbox.test.ts
+++ b/packages/jazz-tools/src/tools/tests/inbox.test.ts
@@ -11,9 +11,12 @@ describe("Inbox", () => {
   describe("Private profile", () => {
     it("Should throw if the inbox owner profile is private", async () => {
       const WorkerAccount = co.account().withMigration((account) => {
-        account.profile = co
-          .profile()
-          .create({ name: "Worker" }, Group.create({ owner: account }));
+        account.$jazz.set(
+          "profile",
+          co
+            .profile()
+            .create({ name: "Worker" }, Group.create({ owner: account })),
+        );
       });
 
       const { clientAccount: sender, serverAccount: receiver } =

--- a/packages/jazz-tools/src/tools/tests/patterns/notifications.test.ts
+++ b/packages/jazz-tools/src/tools/tests/patterns/notifications.test.ts
@@ -18,9 +18,12 @@ const WorkerAccount = co
   })
   .withMigration((account) => {
     if (account.root === undefined) {
-      account.root = WorkerRoot.create({
-        notificationQueue: co.list(QueuedNotification).create([]),
-      });
+      account.$jazz.set(
+        "root",
+        WorkerRoot.create({
+          notificationQueue: co.list(QueuedNotification).create([]),
+        }),
+      );
     }
   });
 

--- a/packages/jazz-tools/src/tools/tests/patterns/notifications.test.ts
+++ b/packages/jazz-tools/src/tools/tests/patterns/notifications.test.ts
@@ -18,12 +18,9 @@ const WorkerAccount = co
   })
   .withMigration((account) => {
     if (account.root === undefined) {
-      account.$jazz.set(
-        "root",
-        WorkerRoot.create({
-          notificationQueue: co.list(QueuedNotification).create([]),
-        }),
-      );
+      account.$jazz.set("root", {
+        notificationQueue: [],
+      });
     }
   });
 

--- a/packages/jazz-tools/src/tools/tests/testing.test.ts
+++ b/packages/jazz-tools/src/tools/tests/testing.test.ts
@@ -36,12 +36,7 @@ describe("Jazz Test Sync", () => {
       })
       .withMigration((account) => {
         if (account.root === undefined) {
-          account.$jazz.set(
-            "root",
-            MyRoot.create({
-              value: "ok",
-            }),
-          );
+          account.$jazz.set("root", { value: "ok" });
         }
       });
 
@@ -65,12 +60,7 @@ describe("Jazz Test Sync", () => {
       })
       .withMigration((account) => {
         if (account.root === undefined) {
-          account.$jazz.set(
-            "root",
-            MyRoot.create({
-              value: "ok",
-            }),
-          );
+          account.$jazz.set("root", { value: "ok" });
         }
       });
 

--- a/packages/jazz-tools/src/tools/tests/testing.test.ts
+++ b/packages/jazz-tools/src/tools/tests/testing.test.ts
@@ -36,9 +36,12 @@ describe("Jazz Test Sync", () => {
       })
       .withMigration((account) => {
         if (account.root === undefined) {
-          account.root = MyRoot.create({
-            value: "ok",
-          });
+          account.$jazz.set(
+            "root",
+            MyRoot.create({
+              value: "ok",
+            }),
+          );
         }
       });
 
@@ -62,9 +65,12 @@ describe("Jazz Test Sync", () => {
       })
       .withMigration((account) => {
         if (account.root === undefined) {
-          account.root = MyRoot.create({
-            value: "ok",
-          });
+          account.$jazz.set(
+            "root",
+            MyRoot.create({
+              value: "ok",
+            }),
+          );
         }
       });
 

--- a/starters/react-passkey-auth/src/schema.ts
+++ b/starters/react-passkey-auth/src/schema.ts
@@ -38,26 +38,24 @@ export const JazzAccount = co
      *  You can use it to set up the account root and any other initial CoValues you need.
      */
     if (account.root === undefined) {
-      const group = Group.create();
-
-      account.root = AccountRoot.create(
-        {
-          dateOfBirth: new Date("1/1/1990"),
-        },
-        group,
-      );
+      account.$jazz.set("root", {
+        dateOfBirth: new Date("1/1/1990"),
+      });
     }
 
     if (account.profile === undefined) {
       const group = Group.create();
       group.addMember("everyone", "reader"); // The profile info is visible to everyone
 
-      account.profile = JazzProfile.create(
-        {
-          name: "Anonymous user",
-          firstName: "",
-        },
-        group,
+      account.$jazz.set(
+        "profile",
+        JazzProfile.create(
+          {
+            name: "Anonymous user",
+            firstName: "",
+          },
+          group,
+        ),
       );
     }
   });

--- a/starters/svelte-passkey-auth/src/lib/schema.ts
+++ b/starters/svelte-passkey-auth/src/lib/schema.ts
@@ -53,26 +53,24 @@ export const JazzAccount = co
      *  You can use it to set up the account root and any other initial CoValues you need.
      */
     if (account.root === undefined) {
-      const group = Group.create();
-
-      account.root = AccountRoot.create(
-        {
-          dateOfBirth: new Date("1/1/1990"),
-        },
-        group,
-      );
+      account.$jazz.set("root", {
+        dateOfBirth: new Date("1/1/1990"),
+      });
     }
 
     if (account.profile === undefined) {
       const group = Group.create();
       group.addMember("everyone", "reader"); // The profile info is visible to everyone
 
-      account.profile = JazzProfile.create(
-        {
-          name: "",
-          firstName: "",
-        },
-        group,
+      account.$jazz.set(
+        "profile",
+        JazzProfile.create(
+          {
+            name: "",
+            firstName: "",
+          },
+          group,
+        ),
       );
     }
   });

--- a/tests/browser-integration/src/browserSync.test.ts
+++ b/tests/browser-integration/src/browserSync.test.ts
@@ -20,7 +20,7 @@ const CustomAccount = co
   })
   .withMigration((account) => {
     if (!account.root) {
-      account.root = TestMap.create({ value: "initial" }, { owner: account });
+      account.$jazz.set("root", { value: "initial" });
     }
   });
 

--- a/tests/browser-integration/src/logout.react.test.tsx
+++ b/tests/browser-integration/src/logout.react.test.tsx
@@ -15,10 +15,7 @@ const TestAccount = co
   })
   .withMigration((account) => {
     if (!account.root) {
-      account.root = TestMap.create(
-        { count: TestMap.shape.count.create({ value: 0 }) },
-        { owner: account },
-      );
+      account.$jazz.set("root", { count: { value: 0 } });
     }
   });
 

--- a/tests/browser-integration/src/unstableConnection.test.ts
+++ b/tests/browser-integration/src/unstableConnection.test.ts
@@ -14,7 +14,7 @@ const CustomAccount = co
   })
   .withMigration((me) => {
     if (me.root === undefined) {
-      me.root = TestMAP.create({ value: "initial" }, { owner: me });
+      me.$jazz.set("root", { value: "initial" });
     }
   });
 

--- a/tests/cloudflare-workers/src/index.ts
+++ b/tests/cloudflare-workers/src/index.ts
@@ -16,7 +16,7 @@ class MyAccount extends Account {
 
   migrate(): void {
     if (this.root === undefined) {
-      this.root = MyAccountRoot.create({
+      this.$jazz.set("root", {
         text: "Hello world!",
       });
     }

--- a/tests/jazz-svelte/src/routes/costate/schema.ts
+++ b/tests/jazz-svelte/src/routes/costate/schema.ts
@@ -26,20 +26,17 @@ export const TestAccount = co
       const publicGroup = Group.create();
       publicGroup.makePublic("writer");
 
-      account.root = Root.create(
-        {
-          people: People.create([
-            Person.create(
-              { name: "John", age: 30, dog: Dog.create({ name: "Rex" }) },
-              publicGroup,
-            ),
-            Person.create(
-              { name: "Mathieu", age: 30, dog: Dog.create({ name: "Bibi" }) },
-              publicGroup,
-            ),
-          ]),
-        },
-        publicGroup,
+      account.$jazz.set(
+        "root",
+        Root.create(
+          {
+            people: [
+              { name: "John", age: 30, dog: { name: "Rex" } },
+              { name: "Mathieu", age: 30, dog: { name: "Bibi" } },
+            ],
+          },
+          publicGroup,
+        ),
       );
     }
   });

--- a/tests/jazz-svelte/src/routes/virtual-list/schema.ts
+++ b/tests/jazz-svelte/src/routes/virtual-list/schema.ts
@@ -27,48 +27,30 @@ export const TestAccount = co
       const publicGroup = Group.create();
       publicGroup.makePublic("writer");
 
-      account.root = Root.create(
-        {
-          people: PeopleRecord.create({
-            alice: People.create(
-              Array.from({ length: 50 }, (_, i) =>
-                Person.create(
-                  {
-                    name: `Alice ${i}`,
-                    age: 30,
-                    dog: Dog.create({ name: `Dog ${i}` }),
-                  },
-                  publicGroup,
-                ),
-              ),
-            ),
-            bob: People.create(
-              Array.from({ length: 50 }, (_, i) =>
-                Person.create(
-                  {
-                    name: `Bob ${i}`,
-                    age: 30,
-                    dog: Dog.create({ name: `Dog ${i}` }),
-                  },
-                  publicGroup,
-                ),
-              ),
-            ),
-            john: People.create(
-              Array.from({ length: 50 }, (_, i) =>
-                Person.create(
-                  {
-                    name: `John ${i}`,
-                    age: 30,
-                    dog: Dog.create({ name: `Dog ${i}` }),
-                  },
-                  publicGroup,
-                ),
-              ),
-            ),
-          }),
-        },
-        publicGroup,
+      account.$jazz.set(
+        "root",
+        Root.create(
+          {
+            people: {
+              alice: Array.from({ length: 50 }, (_, i) => ({
+                name: `Alice ${i}`,
+                age: 30,
+                dog: { name: `Dog ${i}` },
+              })),
+              bob: Array.from({ length: 50 }, (_, i) => ({
+                name: `Bob ${i}`,
+                age: 30,
+                dog: { name: `Dog ${i}` },
+              })),
+              john: Array.from({ length: 50 }, (_, i) => ({
+                name: `John ${i}`,
+                age: 30,
+                dog: { name: `Dog ${i}` },
+              })),
+            },
+          },
+          publicGroup,
+        ),
       );
     }
   });

--- a/tests/stress-test/src/1_schema.ts
+++ b/tests/stress-test/src/1_schema.ts
@@ -39,8 +39,8 @@ export const TodoAccount = co
      *  You can use it to set up the account root and any other initial CoValues you need.
      */
     if (account.root === undefined) {
-      account.root = TodoAccountRoot.create({
-        projects: co.list(TodoProject).create([], { owner: account }),
+      account.$jazz.set("root", {
+        projects: [],
         profilingEnabled: false,
       });
     }


### PR DESCRIPTION
# Description

Add `Account.$jazz.set`, to make `root` and `profile` editable the same way as CoMaps. This includes being able to use plain JSON objects as input.

## Tests

- [x] Tests have been added and/or updated

## Checklist

- [x] I've updated the part of the docs that are affected the PR changes
- [ ] I've generated a changeset, if a version bump is required
- [x] I've updated the jsDoc comments to the public APIs I've modified, or added them when missing