### PR TITLE
fix sign out Jazz account when signing out from Clerk

### DIFF
--- a/.changeset/long-apples-develop.md
+++ b/.changeset/long-apples-develop.md
@@ -1,0 +1,5 @@
+---
+"jazz-tools": patch
+---
+
+fix: sign out Jazz account when signing out from Clerk

--- a/packages/community-jazz-vue/src/auth/useClerkAuth.ts
+++ b/packages/community-jazz-vue/src/auth/useClerkAuth.ts
@@ -13,7 +13,11 @@ export function useClerkAuth(clerk: MinimalClerkClient) {
   // Create auth method similar to React's useMemo pattern
   const authMethod = computed(() => {
     return markRaw(
-      new JazzClerkAuth(context.value.authenticate, authSecretStorage),
+      new JazzClerkAuth(
+        context.value.authenticate,
+        context.value.logOut,
+        authSecretStorage,
+      ),
     );
   });
 

--- a/packages/jazz-tools/src/expo/auth/clerk/index.tsx
+++ b/packages/jazz-tools/src/expo/auth/clerk/index.tsx
@@ -22,7 +22,11 @@ function useJazzClerkAuth(clerk: MinimalClerkClient) {
   }
 
   const authMethod = useMemo(() => {
-    return new JazzClerkAuth(context.authenticate, authSecretStorage);
+    return new JazzClerkAuth(
+      context.authenticate,
+      context.logOut,
+      authSecretStorage,
+    );
   }, []);
 
   useEffect(() => {
@@ -71,7 +75,7 @@ export const JazzExpoProviderWithClerk = <
   }
 
   return (
-    <JazzExpoProvider {...props} logOutReplacement={props.clerk.signOut}>
+    <JazzExpoProvider {...props} onLogOut={props.clerk.signOut}>
       <RegisterClerkAuth clerk={props.clerk}>
         {props.children}
       </RegisterClerkAuth>

--- a/packages/jazz-tools/src/react/auth/Clerk.tsx
+++ b/packages/jazz-tools/src/react/auth/Clerk.tsx
@@ -21,7 +21,11 @@ function useJazzClerkAuth(clerk: MinimalClerkClient) {
   }
 
   const authMethod = useMemo(() => {
-    return new JazzClerkAuth(context.authenticate, authSecretStorage);
+    return new JazzClerkAuth(
+      context.authenticate,
+      context.logOut,
+      authSecretStorage,
+    );
   }, []);
 
   useEffect(() => {
@@ -67,7 +71,7 @@ export const JazzReactProviderWithClerk = <
   }
 
   return (
-    <JazzReactProvider {...props} logOutReplacement={props.clerk.signOut}>
+    <JazzReactProvider {...props} onLogOut={props.clerk.signOut}>
       <RegisterClerkAuth clerk={props.clerk}>
         {props.children}
       </RegisterClerkAuth>

--- a/packages/jazz-tools/src/tools/auth/clerk/index.ts
+++ b/packages/jazz-tools/src/tools/auth/clerk/index.ts
@@ -18,6 +18,7 @@ export { isClerkCredentials };
 export class JazzClerkAuth {
   constructor(
     private authenticate: AuthenticateAccountFunction,
+    private logOut: () => Promise<void> | void,
     private authSecretStorage: AuthSecretStorage,
   ) {}
 
@@ -77,6 +78,7 @@ export class JazzClerkAuth {
     if (!clerkClient.user) {
       if (isAuthenticated) {
         this.authSecretStorage.clear();
+        await this.logOut();
       }
       return;
     }

--- a/packages/jazz-tools/src/tools/auth/clerk/tests/JazzClerkAuth.test.ts
+++ b/packages/jazz-tools/src/tools/auth/clerk/tests/JazzClerkAuth.test.ts
@@ -13,6 +13,7 @@ const authSecretStorage = new AuthSecretStorage();
 
 describe("JazzClerkAuth", () => {
   const mockAuthenticate = vi.fn();
+  const mockLogOut = vi.fn();
   let auth: JazzClerkAuth;
 
   beforeEach(async () => {
@@ -21,7 +22,7 @@ describe("JazzClerkAuth", () => {
     await createJazzTestAccount({
       isCurrentActiveAccount: true,
     });
-    auth = new JazzClerkAuth(mockAuthenticate, authSecretStorage);
+    auth = new JazzClerkAuth(mockAuthenticate, mockLogOut, authSecretStorage);
   });
 
   describe("onClerkUserChange", () => {
@@ -118,6 +119,35 @@ describe("JazzClerkAuth", () => {
         provider: "clerk",
       });
     });
+
+    it("should call LogOut", async () => {
+      // Set up local auth
+      await authSecretStorage.set({
+        accountID: "xxxx" as ID<Account>,
+        secretSeed: new Uint8Array([2, 2, 2]),
+        accountSecret: "xxxx" as AgentSecret,
+        provider: "anonymous",
+      });
+
+      const mockClerk = {
+        user: {
+          fullName: "Guido",
+          unsafeMetadata: {
+            jazzAccountID: "test123",
+            jazzAccountSecret: "secret123",
+            jazzAccountSeed: [1, 2, 3],
+          },
+        },
+        signOut: vi.fn(),
+      } as unknown as MinimalClerkClient;
+
+      await auth.onClerkUserChange(mockClerk);
+
+      await auth.onClerkUserChange({ user: null });
+
+      expect(authSecretStorage.isAuthenticated).toBe(false);
+      expect(mockLogOut).toHaveBeenCalled();
+    });
   });
 
   describe("registerListener", () => {
@@ -147,7 +177,11 @@ describe("JazzClerkAuth", () => {
     it("should call onClerkUserChange on the first trigger", async () => {
       const { client, triggerUserChange } = setupMockClerk(null);
 
-      const auth = new JazzClerkAuth(mockAuthenticate, authSecretStorage);
+      const auth = new JazzClerkAuth(
+        mockAuthenticate,
+        mockLogOut,
+        authSecretStorage,
+      );
       const onClerkUserChangeSpy = vi.spyOn(auth, "onClerkUserChange");
 
       auth.registerListener(client);
@@ -160,7 +194,11 @@ describe("JazzClerkAuth", () => {
     it("should call onClerkUserChange when user changes", async () => {
       const { client, triggerUserChange } = setupMockClerk(null);
 
-      const auth = new JazzClerkAuth(mockAuthenticate, authSecretStorage);
+      const auth = new JazzClerkAuth(
+        mockAuthenticate,
+        mockLogOut,
+        authSecretStorage,
+      );
       const onClerkUserChangeSpy = vi.spyOn(auth, "onClerkUserChange");
 
       auth.registerListener(client);
@@ -181,7 +219,11 @@ describe("JazzClerkAuth", () => {
     it("should call onClerkUserChange when user passes from null to non-null", async () => {
       const { client, triggerUserChange } = setupMockClerk(null);
 
-      const auth = new JazzClerkAuth(mockAuthenticate, authSecretStorage);
+      const auth = new JazzClerkAuth(
+        mockAuthenticate,
+        mockLogOut,
+        authSecretStorage,
+      );
       const onClerkUserChangeSpy = vi.spyOn(auth, "onClerkUserChange");
 
       auth.registerListener(client);
@@ -194,7 +236,11 @@ describe("JazzClerkAuth", () => {
     it("should not call onClerkUserChange when user is the same", async () => {
       const { client, triggerUserChange } = setupMockClerk(null);
 
-      const auth = new JazzClerkAuth(mockAuthenticate, authSecretStorage);
+      const auth = new JazzClerkAuth(
+        mockAuthenticate,
+        mockLogOut,
+        authSecretStorage,
+      );
       const onClerkUserChangeSpy = vi.spyOn(auth, "onClerkUserChange");
 
       auth.registerListener(client);
@@ -221,7 +267,11 @@ describe("JazzClerkAuth", () => {
     it("should not call onClerkUserChange when user switches from undefined to null", async () => {
       const { client, triggerUserChange } = setupMockClerk(null);
 
-      const auth = new JazzClerkAuth(mockAuthenticate, authSecretStorage);
+      const auth = new JazzClerkAuth(
+        mockAuthenticate,
+        mockLogOut,
+        authSecretStorage,
+      );
       const onClerkUserChangeSpy = vi.spyOn(auth, "onClerkUserChange");
 
       auth.registerListener(client);


### PR DESCRIPTION
# Description
When signing out from Clerk, the Jazz plugin cleaned the authSecretStorage, but it didn't wipe the in-memory context. The result was that the user was logged out of Clerk, had no more of their credentials stored locally, but they were still seeing the account's data until the page was refreshed.

Now, when the clerk's user is signed out, we log out the Jazz context too.

To make it work, `logOutReplacement` has been replaced with `onLogOut` to avoid a short-circuit. The original behaviour has been preserved: calling `jazzContext.logOut()` still calls Clerk's signOut.

## Manual testing instructions

Use the clerk's example and call `clerk.user.delete()`. Without any page refreshing, the Jazz AccountID should change to an anonymous user.

No BC intended.


## Tests

- [x] Tests have been added and/or updated


## Checklist

- [ ] I've updated the part of the docs that are affected the PR changes
- [x] I've generated a changeset, if a version bump is required
- [ ] I've updated the jsDoc comments to the public APIs I've modified, or added them when missing