### PR TITLE
fix: prevent adding and removing members from Accounts

### DIFF
--- a/.changeset/breezy-hairs-notice.md
+++ b/.changeset/breezy-hairs-notice.md
@@ -1,0 +1,5 @@
+---
+"cojson": patch
+---
+
+Prevent adding and removing members from Account owners.

--- a/packages/cojson/src/coValues/account.ts
+++ b/packages/cojson/src/coValues/account.ts
@@ -19,9 +19,9 @@ import { AgentID } from "../ids.js";
 import { JsonObject } from "../jsonValue.js";
 import { LocalNode } from "../localNode.js";
 import { logger } from "../logger.js";
-import type { AccountRole } from "../permissions.js";
+import type { AccountRole, Role } from "../permissions.js";
 import { RawCoMap } from "./coMap.js";
-import { InviteSecret, RawGroup } from "./group.js";
+import { Everyone, InviteSecret, RawGroup } from "./group.js";
 
 export function accountHeaderForInitialAgentSecret(
   agentSecret: AgentSecret,
@@ -71,8 +71,32 @@ export class RawAccount<
     return agents[0]!;
   }
 
-  createInvite(_: AccountRole): InviteSecret {
+  override createInvite(_: AccountRole): InviteSecret {
     throw new Error("Cannot create invite from an account");
+  }
+
+  override addMember(
+    account: RawAccount | ControlledAccountOrAgent | Everyone,
+    role: Role,
+  ) {
+    throw new Error("Cannot add a member to an account");
+  }
+
+  override removeMember(
+    account: RawAccount | ControlledAccountOrAgent | Everyone,
+  ) {
+    throw new Error("Cannot remove a member from an account");
+  }
+
+  override extend(
+    parent: RawGroup,
+    role: "reader" | "writer" | "admin" | "inherit" = "inherit",
+  ) {
+    throw new Error("Cannot extend an account");
+  }
+
+  override revokeExtend(parent: RawGroup) {
+    throw new Error("Cannot unextend an account");
   }
 }
 

--- a/packages/cojson/src/tests/account.test.ts
+++ b/packages/cojson/src/tests/account.test.ts
@@ -137,6 +137,62 @@ test("Should migrate the root from private to trusting", async () => {
   expect(account3.ops).toEqual(account2.ops); // No new transactions were made
 });
 
+test("throws an error if the user tried to add a member to an account", async () => {
+  const { node, accountID } = await LocalNode.withNewlyCreatedAccount({
+    creationProps: { name: "Hermes Puggington" },
+    crypto: Crypto,
+  });
+
+  const account = await node.load(accountID);
+  if (account === "unavailable") throw new Error("Account unavailable");
+
+  expect(() => account.addMember("everyone", "admin")).toThrow(
+    "Cannot add a member to an account",
+  );
+});
+
+test("throws an error if the user tried to remove a member from an account", async () => {
+  const { node, accountID } = await LocalNode.withNewlyCreatedAccount({
+    creationProps: { name: "Hermes Puggington" },
+    crypto: Crypto,
+  });
+
+  const account = await node.load(accountID);
+  if (account === "unavailable") throw new Error("Account unavailable");
+
+  expect(() => account.removeMember("everyone")).toThrow(
+    "Cannot remove a member from an account",
+  );
+});
+
+test("throws an error if the user tried to extend an account", async () => {
+  const { node, accountID } = await LocalNode.withNewlyCreatedAccount({
+    creationProps: { name: "Hermes Puggington" },
+    crypto: Crypto,
+  });
+
+  const account = await node.load(accountID);
+  if (account === "unavailable") throw new Error("Account unavailable");
+
+  expect(() => account.extend(node.createGroup())).toThrow(
+    "Cannot extend an account",
+  );
+});
+
+test("throws an error if the user tried to revoke extend from an account", async () => {
+  const { node, accountID } = await LocalNode.withNewlyCreatedAccount({
+    creationProps: { name: "Hermes Puggington" },
+    crypto: Crypto,
+  });
+
+  const account = await node.load(accountID);
+  if (account === "unavailable") throw new Error("Account unavailable");
+
+  expect(() => account.revokeExtend(node.createGroup())).toThrow(
+    "Cannot unextend an account",
+  );
+});
+
 test("throws an error if the user tried to create an invite from an account", async () => {
   const { node, accountID } = await LocalNode.withNewlyCreatedAccount({
     creationProps: { name: "Hermes Puggington" },


### PR DESCRIPTION
# Description

Account members should not be modifiable. So we're overriding group-membership-related methods in `RawAccount`, to prevent accounts from getting into an inconsistent state even when using `account.castAs(Group)`.

This change was backported from https://github.com/garden-co/jazz/pull/2778 (which is targeted for `0.18.0`).

## Tests

- [x] Tests have been added and/or updated

## Checklist

- [ ] I've updated the part of the docs that are affected the PR changes
- [x] I've generated a changeset, if a version bump is required
- [ ] I've updated the jsDoc comments to the public APIs I've modified, or added them when missing