### PR TITLE
codemod for jazz 0.18

### DIFF
--- a/homepage/homepage/content/docs/upgrade/0-18-0.mdx
+++ b/homepage/homepage/content/docs/upgrade/0-18-0.mdx
@@ -185,3 +185,27 @@ of viewing CoValues as JSON objects.
 
 #### Group Property Removal
 The `root` and `profile` fields have been removed from the Group class. These fields were not documented and were not intended to be used by users.
+
+### Codemod
+
+We provide a codemod to make the upgrade to the new `$jazz` field quicker.
+
+The codemod is type-aware, and it is required to have `jazz-tools` already upgraded to 0.18.
+
+```bash
+npx jazz-tools-codemod-0-18@latest
+```
+
+Or if you want to run it on a specific path or file:
+
+```bash
+npx jazz-tools-codemod-0-18@latest ./path/to/your/src
+```
+
+<Alert type="warning">
+Be sure to run the codemod on a clean project, without any other changes.
+</Alert>
+
+The codemod gets you through the 90% of the work, as there are some cases where it is not possible to automatically upgrade the code.
+
+Running a TypeScript check after the codemod will help you to find the remaining issues.

--- a/homepage/homepage/content/docs/upgrade/0-18-0.mdx
+++ b/homepage/homepage/content/docs/upgrade/0-18-0.mdx
@@ -206,6 +206,6 @@ npx jazz-tools-codemod-0-18@latest ./path/to/your/src
 Be sure to run the codemod on a clean project, without any other changes.
 </Alert>
 
-The codemod gets you through the 90% of the work, as there are some cases where it is not possible to automatically upgrade the code.
+The goal of this codemod is to get you through the 90% of the work quickly, running a TypeScript check after the codemod will help you to find the remaining issues.
 
-Running a TypeScript check after the codemod will help you to find the remaining issues.
+Expect situations where code is migrated the wrong way or legacy code that isn't detected by the codemod.

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "@vitest/ui": "catalog:default",
     "happy-dom": "^17.4.4",
     "jazz-run": "workspace:*",
+    "jazz-tools-codemod-0-18": "workspace:*",
     "jazz-tools": "workspace:*",
     "lefthook": "^1.8.2",
     "pkg-pr-new": "^0.0.39",

--- a/packages/codemod-upgrade-0-18/.gitignore
+++ b/packages/codemod-upgrade-0-18/.gitignore
@@ -1,0 +1,4 @@
+node_modules
+dist
+*.log
+.DS_Store

--- a/packages/codemod-upgrade-0-18/LICENSE
+++ b/packages/codemod-upgrade-0-18/LICENSE
@@ -1,0 +1,19 @@
+Copyright 2025, Garden Computing, Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/codemod-upgrade-0-18/README.md
+++ b/packages/codemod-upgrade-0-18/README.md
@@ -1,0 +1,71 @@
+# Jazz Codemods
+
+This repository contains codemods for upgrading Jazz projects to newer versions. Codemods are automated tools that help migrate your codebase to be compatible with newer versions of Jazz.
+
+## What are Codemods?
+
+Codemods are automated refactoring tools that help you upgrade your codebase. 
+
+They rewrite your code using AST modification.
+
+We use ts-morph under the hood, so we do also some typechecks to target Jazz specific values in our migrations.
+
+Codemods modify your code, not always in the correct way.
+Be sure that everything important is committed in your repo and there aren't unstaged changes that might get lost in the process.
+
+## Available Codemods
+
+### Jazz 0.18 Upgrade
+
+The main codemod available in this repository is for upgrading to Jazz 0.18.
+
+## Usage
+
+### Running the Jazz 0.18 Codemod
+
+To run the Jazz 0.18 codemod upgrade the jazz-tools version to 0.18 and then execute:
+
+```bash
+npx jazz-tools-codemod-0-18
+```
+
+### How it Works
+
+By default, the codemod will:
+
+1. **Try to use the tsconfig.json in the current working directory** to resolve project files
+2. **Fall back to glob search** if no tsconfig.json is found or if it can't resolve the project structure
+
+## Prerequisites
+
+- Node.js (version 14 or higher)
+- npm, yarn, or pnpm
+
+## Installation
+
+The codemod is available as an npm package and can be run directly with npx, so no local installation is required.
+
+## Running on Specific Files
+
+If you want to run the codemod on specific files or directories, you can pass them as arguments:
+
+```bash
+npx jazz-tools-codemod-0-18 src/
+```
+
+## Contributing
+
+If you find issues with the codemod or want to contribute improvements, please:
+
+1. Open an issue describing the problem
+2. Fork the repository
+3. Make your changes
+4. Submit a pull request
+
+## License
+
+MIT
+
+## Support
+
+For issues related to the codemod itself, please open an issue in this repository. For general Jazz support, please refer to the official Jazz documentation.

--- a/packages/codemod-upgrade-0-18/README.md
+++ b/packages/codemod-upgrade-0-18/README.md
@@ -8,7 +8,7 @@ Codemods are automated refactoring tools that help you upgrade your codebase.
 
 They rewrite your code using AST modification.
 
-We use ts-morph under the hood, so we do also some typechecks to target Jazz specific values in our migrations.
+We use `ts-morph` under the hood, to target specific Jazz types in our migrations.
 
 Codemods modify your code, not always in the correct way.
 Be sure that everything important is committed in your repo and there aren't unstaged changes that might get lost in the process.

--- a/packages/codemod-upgrade-0-18/package.json
+++ b/packages/codemod-upgrade-0-18/package.json
@@ -1,0 +1,36 @@
+{
+  "name": "jazz-tools-codemod-0-18",
+  "version": "0.1.0",
+  "description": "Codemod to migrate from Jazz Tools 0.17 to 0.18",
+  "type": "module",
+  "license": "MIT",
+  "files": [
+    "dist"
+  ],
+  "main": "./dist/index.js",
+  "module": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": "./dist/index.js",
+    "./package.json": "./package.json"
+  },
+  "bin": {
+    "jazz-tools-codemod-0-18": "./dist/index.js"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "dependencies": {
+    "ts-morph": "^26.0.0"
+  },
+  "scripts": {
+    "build": "tsdown && chmod +x dist/index.js",
+    "dev": "tsdown --watch",
+    "test": "vitest",
+    "typecheck": "tsc --noEmit"
+  },
+  "devDependencies": {
+    "tsdown": "^0.11.9",
+    "typescript": "catalog:default"
+  }
+}

--- a/packages/codemod-upgrade-0-18/src/index.ts
+++ b/packages/codemod-upgrade-0-18/src/index.ts
@@ -1,0 +1,10 @@
+#!/usr/bin/env node
+
+import { runTransform } from "./transform.js";
+
+const args = process.argv.slice(2);
+const projectPath = args[0] || process.cwd();
+
+console.log(`Running Jazz API migration transform on: ${projectPath}`);
+runTransform(projectPath);
+console.log("Transform completed!");

--- a/packages/codemod-upgrade-0-18/src/transform.ts
+++ b/packages/codemod-upgrade-0-18/src/transform.ts
@@ -582,7 +582,20 @@ function singleRun(projectPath: string) {
     });
   } else {
     project = new Project();
-    project.addSourceFilesAtPaths(`${projectPath}/**/*.{ts,tsx,js,jsx}`);
+
+    // Check if projectPath ends with a supported file extension
+    const supportedExtensions = [".ts", ".tsx", ".js", ".jsx"];
+    const hasSupportedExtension = supportedExtensions.some((ext) =>
+      projectPath.endsWith(ext),
+    );
+
+    if (hasSupportedExtension) {
+      // If it's a specific file, add it directly
+      project.addSourceFilesAtPaths(projectPath);
+    } else {
+      // If it's a directory, add with glob pattern
+      project.addSourceFilesAtPaths(`${projectPath}/**/*.{ts,tsx,js,jsx}`);
+    }
   }
 
   const sourceFiles = project.getSourceFiles();

--- a/packages/codemod-upgrade-0-18/src/transform.ts
+++ b/packages/codemod-upgrade-0-18/src/transform.ts
@@ -197,6 +197,26 @@ function transformPropertyAccess(sourceFile: SourceFile) {
     }
   });
 
+  // Transform obj._raw to obj.$jazz.raw
+  sourceFile.forEachDescendant((node) => {
+    if (node.getKind() === SyntaxKind.PropertyAccessExpression) {
+      const propertyAccess = node as PropertyAccessExpression;
+      const propertyName = propertyAccess.getNameNode();
+
+      if (propertyName.getText() === "_raw") {
+        const object = propertyAccess.getExpression();
+        const hasOptional = hasOptionalChaining(propertyAccess);
+        let newText = createPropertyAccessText(
+          object,
+          "$jazz.raw",
+          hasOptional,
+        );
+
+        propertyAccess.replaceWithText(newText);
+      }
+    }
+  });
+
   // Transform obj._type to obj.$type$
   sourceFile.forEachDescendant((node) => {
     if (node.getKind() === SyntaxKind.PropertyAccessExpression) {
@@ -269,6 +289,7 @@ function transformDestructuringAssignments(sourceFile: SourceFile) {
                 return (
                   name === "id" ||
                   name === "_owner" ||
+                  name === "_raw" ||
                   name === "_type" ||
                   name === "_createdAt" ||
                   name === "_lastUpdatedAt"
@@ -292,6 +313,7 @@ function transformDestructuringAssignments(sourceFile: SourceFile) {
                 return (
                   name === "id" ||
                   name === "_owner" ||
+                  name === "_raw" ||
                   name === "_createdAt" ||
                   name === "_lastUpdatedAt"
                 );
@@ -317,6 +339,7 @@ function transformDestructuringAssignments(sourceFile: SourceFile) {
                   return (
                     name === "id" ||
                     name === "_owner" ||
+                    name === "_raw" ||
                     name === "_createdAt" ||
                     name === "_lastUpdatedAt"
                   );
@@ -340,6 +363,7 @@ function transformDestructuringAssignments(sourceFile: SourceFile) {
                   return ![
                     "id",
                     "_owner",
+                    "_raw",
                     "_type",
                     "_createdAt",
                     "_lastUpdatedAt",
@@ -360,6 +384,8 @@ function transformDestructuringAssignments(sourceFile: SourceFile) {
                       const propText = propertyName.getText();
                       if (propText === "_owner") {
                         return name !== "owner" ? `owner: ${name}` : "owner";
+                      } else if (propText === "_raw") {
+                        return name !== "raw" ? `raw: ${name}` : "raw";
                       } else if (propText === "_createdAt") {
                         return name !== "createdAt"
                           ? `createdAt: ${name}`
@@ -413,6 +439,8 @@ function transformDestructuringAssignments(sourceFile: SourceFile) {
                     const propText = propertyName.getText();
                     if (propText === "_owner") {
                       return name !== "owner" ? `owner: ${name}` : "owner";
+                    } else if (propText === "_raw") {
+                      return name !== "raw" ? `raw: ${name}` : "raw";
                     } else if (propText === "_createdAt") {
                       return name !== "createdAt"
                         ? `createdAt: ${name}`

--- a/packages/codemod-upgrade-0-18/src/transform.ts
+++ b/packages/codemod-upgrade-0-18/src/transform.ts
@@ -537,6 +537,10 @@ function transformMethodCalls(sourceFile: SourceFile) {
               callee as PropertyAccessExpression
             ).getExpression();
 
+            if (!isJazzValue(baseObject)) {
+              return;
+            }
+
             if (baseObject.getText().includes(".$jazz")) {
               return;
             }

--- a/packages/codemod-upgrade-0-18/src/transform.ts
+++ b/packages/codemod-upgrade-0-18/src/transform.ts
@@ -1,0 +1,628 @@
+import {
+  Project,
+  SyntaxKind,
+  Node,
+  PropertyAccessExpression,
+  CallExpression,
+  BinaryExpression,
+  ElementAccessExpression,
+  DeleteExpression,
+  SourceFile,
+} from "ts-morph";
+import fs from "node:fs";
+
+// Helper function to check if a property access has optional chaining
+function hasOptionalChaining(node: PropertyAccessExpression): boolean {
+  return node.hasQuestionDotToken();
+}
+
+// Helper function to check if an element access has optional chaining
+function hasOptionalChainingElement(node: ElementAccessExpression): boolean {
+  return node.hasQuestionDotToken();
+}
+
+// Helper function to check if any node in a chain has optional chaining
+function hasOptionalChainingInChain(node: Node): boolean {
+  if (node.getKind() === SyntaxKind.PropertyAccessExpression) {
+    const propAccess = node as PropertyAccessExpression;
+    return (
+      hasOptionalChaining(propAccess) ||
+      hasOptionalChainingInChain(propAccess.getExpression())
+    );
+  } else if (node.getKind() === SyntaxKind.ElementAccessExpression) {
+    const elementAccess = node as ElementAccessExpression;
+    return (
+      hasOptionalChainingElement(elementAccess) ||
+      hasOptionalChainingInChain(elementAccess.getExpression())
+    );
+  }
+  return false;
+}
+
+// Helper function to get the text with optional chaining preserved
+function getTextWithOptionalChaining(node: Node): string {
+  if (node.getKind() === SyntaxKind.PropertyAccessExpression) {
+    const propAccess = node as PropertyAccessExpression;
+    const expressionText = getTextWithOptionalChaining(
+      propAccess.getExpression(),
+    );
+    if (hasOptionalChaining(propAccess)) {
+      return `${expressionText}?.${propAccess.getNameNode().getText()}`;
+    }
+    return `${expressionText}.${propAccess.getNameNode().getText()}`;
+  } else if (node.getKind() === SyntaxKind.ElementAccessExpression) {
+    const elementAccess = node as ElementAccessExpression;
+    const expressionText = getTextWithOptionalChaining(
+      elementAccess.getExpression(),
+    );
+    const argument = elementAccess.getArgumentExpression();
+    if (argument) {
+      return `${expressionText}[${argument.getText()}]`;
+    }
+    return expressionText;
+  }
+  return node.getText();
+}
+
+// Helper function to create property access text with optional chaining preserved
+function createPropertyAccessText(
+  object: Node,
+  propertyName: string,
+  useOptionalChaining: boolean = false,
+): string {
+  const objectText = getTextWithOptionalChaining(object);
+  if (useOptionalChaining) {
+    // If the property name contains dots, only apply optional chaining to the first part
+    if (propertyName.includes(".")) {
+      const [firstPart, ...rest] = propertyName.split(".");
+      return `${objectText}?.${firstPart}.${rest.join(".")}`;
+    }
+    return `${objectText}?.${propertyName}`;
+  }
+  return `${objectText}.${propertyName}`;
+}
+
+export function transformFile(sourceFile: SourceFile): string {
+  // 1. Transform property access patterns
+  transformPropertyAccess(sourceFile);
+
+  // 2. Transform _refs.property to $jazz.refs.property
+  transformRefsAccess(sourceFile);
+
+  // 3. Transform _edits.property to $jazz.getEdits().property
+  transformEditsAccess(sourceFile);
+
+  // 4. Transform method calls
+  transformMethodCalls(sourceFile);
+
+  // 5. Transform array operations
+  transformArrayOperations(sourceFile);
+
+  // 6. Transform property assignments
+  transformPropertyAssignments(sourceFile);
+
+  // 7. Transform array index assignments
+  transformArrayIndexAssignments(sourceFile);
+
+  // 8. Transform delete statements
+  transformDeleteStatements(sourceFile);
+
+  // 9. Transform splice operations
+  transformSpliceOperations(sourceFile);
+
+  // 10. Remove .castAs() calls
+  removeCastAsCalls(sourceFile);
+
+  return sourceFile.getFullText();
+}
+
+function isJazzValue(object: Node) {
+  // When transformed to text the import path is shown
+  // Then we check that this is something that comes from jazz-tools
+  return (
+    object.getType().getText().includes("jazz-tools") ||
+    object.getType().isAny()
+  );
+}
+
+function transformPropertyAccess(sourceFile: SourceFile) {
+  // Transform obj.id to obj.$jazz.id
+  sourceFile.forEachDescendant((node) => {
+    if (node.getKind() === SyntaxKind.PropertyAccessExpression) {
+      const propertyAccess = node as PropertyAccessExpression;
+      const propertyName = propertyAccess.getNameNode();
+
+      if (node.getType().isString() || node.getType().isNumber()) {
+        return;
+      }
+
+      if (propertyName.getText() === "id") {
+        const object = propertyAccess.getExpression();
+
+        if (
+          !isJazzValue(object) ||
+          object.getType().getText().includes(".Ref<")
+        ) {
+          return;
+        }
+
+        if (object.getText().includes(".$jazz")) {
+          return;
+        }
+
+        if (object.getKind() === SyntaxKind.PropertyAccessExpression) {
+          const objProperty = (
+            object as PropertyAccessExpression
+          ).getNameNode();
+          if (objProperty.getText() === "$jazz") {
+            return; // Already transformed
+          }
+        }
+
+        // Preserve optional chaining
+        const hasOptional = hasOptionalChaining(propertyAccess);
+        const newText = createPropertyAccessText(
+          object,
+          "$jazz.id",
+          hasOptional,
+        );
+        propertyAccess.replaceWithText(newText);
+      }
+    }
+  });
+
+  // Transform obj._owner to obj.$jazz.owner
+  sourceFile.forEachDescendant((node) => {
+    if (node.getKind() === SyntaxKind.PropertyAccessExpression) {
+      const propertyAccess = node as PropertyAccessExpression;
+      const propertyName = propertyAccess.getNameNode();
+
+      if (propertyName.getText() === "_owner") {
+        const object = propertyAccess.getExpression();
+        const hasOptional = hasOptionalChaining(propertyAccess);
+        let newText = createPropertyAccessText(
+          object,
+          "$jazz.owner",
+          hasOptional,
+        );
+
+        propertyAccess.replaceWithText(newText);
+      }
+    }
+  });
+
+  // Transform obj._type to obj.$jazz.$type$
+  sourceFile.forEachDescendant((node) => {
+    if (node.getKind() === SyntaxKind.PropertyAccessExpression) {
+      const propertyAccess = node as PropertyAccessExpression;
+      const propertyName = propertyAccess.getNameNode();
+
+      if (propertyName.getText() === "_type") {
+        const object = propertyAccess.getExpression();
+        const hasOptional = hasOptionalChaining(propertyAccess);
+        const newText = createPropertyAccessText(object, "$type$", hasOptional);
+        propertyAccess.replaceWithText(newText);
+      }
+    }
+  });
+
+  // Transform obj._createdAt to obj.$jazz.createdAt
+  sourceFile.forEachDescendant((node) => {
+    if (node.getKind() === SyntaxKind.PropertyAccessExpression) {
+      const propertyAccess = node as PropertyAccessExpression;
+      const propertyName = propertyAccess.getNameNode();
+
+      if (propertyName.getText() === "_createdAt") {
+        const object = propertyAccess.getExpression();
+        const hasOptional = hasOptionalChaining(propertyAccess);
+        const newText = createPropertyAccessText(
+          object,
+          "$jazz.createdAt",
+          hasOptional,
+        );
+        propertyAccess.replaceWithText(newText);
+      } else if (propertyName.getText() === "_lastUpdatedAt") {
+        const object = propertyAccess.getExpression();
+        const hasOptional = hasOptionalChaining(propertyAccess);
+        const newText = createPropertyAccessText(
+          object,
+          "$jazz.lastUpdatedAt",
+          hasOptional,
+        );
+        propertyAccess.replaceWithText(newText);
+      }
+    }
+  });
+}
+
+function transformRefsAccess(sourceFile: SourceFile) {
+  sourceFile.forEachDescendant((node) => {
+    if (node.getKind() === SyntaxKind.PropertyAccessExpression) {
+      const propertyAccess = node as PropertyAccessExpression;
+      const object = propertyAccess.getExpression();
+
+      if (object.getKind() === SyntaxKind.PropertyAccessExpression) {
+        const objProperty = (object as PropertyAccessExpression).getNameNode();
+        if (objProperty.getText() === "_refs") {
+          const baseObject = (
+            object as PropertyAccessExpression
+          ).getExpression();
+          const property = propertyAccess.getNameNode();
+          const hasOptional = hasOptionalChaining(propertyAccess);
+          const newText = createPropertyAccessText(
+            baseObject,
+            `$jazz.refs.${property.getText()}`,
+            hasOptional,
+          );
+          propertyAccess.replaceWithText(newText);
+        }
+      }
+    }
+  });
+}
+
+function transformEditsAccess(sourceFile: SourceFile) {
+  sourceFile.forEachDescendant((node) => {
+    if (node.getKind() === SyntaxKind.PropertyAccessExpression) {
+      const propertyAccess = node as PropertyAccessExpression;
+      const object = propertyAccess.getExpression();
+
+      if (object.getKind() === SyntaxKind.PropertyAccessExpression) {
+        const objProperty = (object as PropertyAccessExpression).getNameNode();
+        if (objProperty.getText() === "_edits") {
+          const baseObject = (
+            object as PropertyAccessExpression
+          ).getExpression();
+          const property = propertyAccess.getNameNode();
+          const hasOptional = hasOptionalChaining(propertyAccess);
+          const newText = createPropertyAccessText(
+            baseObject,
+            `$jazz.getEdits().${property.getText()}`,
+            hasOptional,
+          );
+          propertyAccess.replaceWithText(newText);
+        }
+      }
+    }
+  });
+}
+
+function transformMethodCalls(sourceFile: SourceFile) {
+  const methodNames = [
+    "waitForSync",
+    "waitForAllCoValuesSync",
+    "subscribe",
+    "ensureLoaded",
+    "applyDiff",
+  ];
+
+  methodNames.forEach((methodName) => {
+    sourceFile.forEachDescendant((node) => {
+      if (node.getKind() === SyntaxKind.CallExpression) {
+        const callExpression = node as CallExpression;
+        const callee = callExpression.getExpression();
+
+        if (callee.getKind() === SyntaxKind.PropertyAccessExpression) {
+          const property = (callee as PropertyAccessExpression).getNameNode();
+
+          if (property.getText() === methodName) {
+            const baseObject = (
+              callee as PropertyAccessExpression
+            ).getExpression();
+
+            if (baseObject.getText().includes(".$jazz")) {
+              return;
+            }
+
+            const args = callExpression
+              .getArguments()
+              .map((arg) => arg.getText())
+              .join(", ");
+
+            // Preserve optional chaining from the method call
+            const hasOptional = hasOptionalChaining(
+              callee as PropertyAccessExpression,
+            );
+            const newText = createPropertyAccessText(
+              baseObject,
+              `$jazz.${methodName}(${args})`,
+              hasOptional,
+            );
+            callExpression.replaceWithText(newText);
+          }
+        }
+      }
+    });
+  });
+}
+
+function transformArrayOperations(sourceFile: SourceFile) {
+  sourceFile.forEachDescendant((node) => {
+    if (node.getKind() === SyntaxKind.CallExpression) {
+      const callExpression = node as CallExpression;
+      const callee = callExpression.getExpression();
+
+      if (callee.getKind() === SyntaxKind.PropertyAccessExpression) {
+        const property = (callee as PropertyAccessExpression).getNameNode();
+        if (property.getText() === "push") {
+          const baseObject = (
+            callee as PropertyAccessExpression
+          ).getExpression();
+
+          if (!isJazzValue(baseObject)) {
+            return;
+          }
+
+          if (baseObject.getText().includes(".$jazz")) {
+            return;
+          }
+
+          const args = callExpression
+            .getArguments()
+            .map((arg) => arg.getText())
+            .join(", ");
+
+          // Preserve optional chaining from the method call
+          const hasOptional = hasOptionalChaining(
+            callee as PropertyAccessExpression,
+          );
+          const newText = createPropertyAccessText(
+            baseObject,
+            `$jazz.push(${args})`,
+            hasOptional,
+          );
+          callExpression.replaceWithText(newText);
+        }
+      }
+    }
+  });
+}
+
+function transformPropertyAssignments(sourceFile: SourceFile) {
+  sourceFile.forEachDescendant((node) => {
+    if (node.getKind() === SyntaxKind.BinaryExpression) {
+      const binaryExpression = node as BinaryExpression;
+      if (binaryExpression.getOperatorToken().getText() === "=") {
+        const left = binaryExpression.getLeft();
+        const right = binaryExpression.getRight();
+
+        if (left.getKind() === SyntaxKind.PropertyAccessExpression) {
+          const leftPropertyAccess = left as PropertyAccessExpression;
+
+          // Skip if it's already a $jazz.set call
+          const leftObject = leftPropertyAccess.getExpression();
+
+          if (!isJazzValue(leftObject)) {
+            return;
+          }
+
+          if (leftObject.getKind() === SyntaxKind.PropertyAccessExpression) {
+            const objProperty = (
+              leftObject as PropertyAccessExpression
+            ).getNameNode();
+            if (objProperty.getText() === "$jazz") {
+              return;
+            }
+          }
+
+          const propertyName = leftPropertyAccess.getNameNode().getText();
+          const object = leftPropertyAccess.getExpression();
+
+          // Handle undefined assignments as delete
+          if (
+            right.getKind() === SyntaxKind.Identifier &&
+            right.getText() === "undefined"
+          ) {
+            const hasOptional = hasOptionalChaining(leftPropertyAccess);
+            const newText = createPropertyAccessText(
+              object,
+              `$jazz.delete("${propertyName}")`,
+              hasOptional,
+            );
+            binaryExpression.replaceWithText(newText);
+          } else {
+            const leftObject = leftPropertyAccess.getExpression();
+            const hasOptional = hasOptionalChaining(leftPropertyAccess);
+            if (leftObject.getType().isUnion()) {
+              const newText = createPropertyAccessText(
+                object,
+                `$jazz.applyDiff({"${propertyName}": ${right.getText()}})`,
+                hasOptional,
+              );
+              binaryExpression.replaceWithText(newText);
+            } else {
+              // Handle regular assignments as set
+              const newText = createPropertyAccessText(
+                object,
+                `$jazz.set("${propertyName}", ${right.getText()})`,
+                hasOptional,
+              );
+              binaryExpression.replaceWithText(newText);
+            }
+          }
+        }
+      }
+    }
+  });
+}
+
+function transformArrayIndexAssignments(sourceFile: SourceFile) {
+  sourceFile.forEachDescendant((node) => {
+    if (node.getKind() === SyntaxKind.BinaryExpression) {
+      const binaryExpression = node as BinaryExpression;
+      if (binaryExpression.getOperatorToken().getText() === "=") {
+        const left = binaryExpression.getLeft();
+        const right = binaryExpression.getRight();
+
+        if (left.getKind() === SyntaxKind.ElementAccessExpression) {
+          const elementAccess = left as ElementAccessExpression;
+          const object = elementAccess.getExpression();
+          const index = elementAccess.getArgumentExpression();
+
+          if (!isJazzValue(object)) {
+            return;
+          }
+
+          if (index) {
+            // For array index assignments, we need to check if the parent property access has optional chaining
+            // Since this is an element access, we'll check the object for optional chaining
+            const hasOptional = hasOptionalChainingInChain(object);
+            const newText = createPropertyAccessText(
+              object,
+              `$jazz.set(${index.getText()}, ${right.getText()})`,
+              hasOptional,
+            );
+            binaryExpression.replaceWithText(newText);
+          }
+        }
+      }
+    }
+  });
+}
+
+function transformDeleteStatements(sourceFile: SourceFile) {
+  sourceFile.forEachDescendant((node) => {
+    if (node.getKind() === SyntaxKind.DeleteExpression) {
+      const deleteExpression = node as DeleteExpression;
+      const argument = deleteExpression.getExpression();
+
+      if (argument.getKind() === SyntaxKind.PropertyAccessExpression) {
+        const property = (argument as PropertyAccessExpression).getNameNode();
+        const object = (argument as PropertyAccessExpression).getExpression();
+
+        if (!isJazzValue(object)) {
+          return;
+        }
+
+        const hasOptional = hasOptionalChaining(
+          argument as PropertyAccessExpression,
+        );
+        const newText = createPropertyAccessText(
+          object,
+          `$jazz.delete("${property.getText()}")`,
+          hasOptional,
+        );
+        deleteExpression.replaceWithText(newText);
+      }
+    }
+  });
+}
+
+function transformSpliceOperations(sourceFile: SourceFile) {
+  sourceFile.forEachDescendant((node) => {
+    if (node.getKind() === SyntaxKind.CallExpression) {
+      const callExpression = node as CallExpression;
+      const callee = callExpression.getExpression();
+
+      if (callee.getKind() === SyntaxKind.PropertyAccessExpression) {
+        const property = (callee as PropertyAccessExpression).getNameNode();
+        if (property.getText() === "splice") {
+          const baseObject = (
+            callee as PropertyAccessExpression
+          ).getExpression();
+
+          if (!isJazzValue(baseObject)) {
+            return;
+          }
+
+          if (baseObject.getText().includes(".$jazz")) {
+            return;
+          }
+
+          const args = callExpression
+            .getArguments()
+            .map((arg) => arg.getText())
+            .join(", ");
+
+          // Preserve optional chaining from the method call
+          const hasOptional = hasOptionalChaining(
+            callee as PropertyAccessExpression,
+          );
+          const newText = createPropertyAccessText(
+            baseObject,
+            `$jazz.splice(${args})`,
+            hasOptional,
+          );
+          callExpression.replaceWithText(newText);
+        }
+      }
+    }
+  });
+}
+
+function removeCastAsCalls(sourceFile: SourceFile) {
+  sourceFile.forEachDescendant((node) => {
+    if (node.getKind() === SyntaxKind.CallExpression) {
+      const callExpression = node as CallExpression;
+      const callee = callExpression.getExpression();
+
+      if (callee.getKind() === SyntaxKind.PropertyAccessExpression) {
+        const property = (callee as PropertyAccessExpression).getNameNode();
+        if (property.getText() === "castAs") {
+          const baseObject = (
+            callee as PropertyAccessExpression
+          ).getExpression();
+
+          // Replace the entire call expression with just the base object
+          // This removes .castAs(Group) and keeps just the object
+          callExpression.replaceWithText(baseObject.getText());
+        }
+      }
+    }
+  });
+}
+
+// Main function to run the transform
+function singleRun(projectPath: string) {
+  let project: Project;
+
+  if (fs.existsSync(`${projectPath}/tsconfig.json`)) {
+    project = new Project({
+      tsConfigFilePath: `${projectPath}/tsconfig.json`,
+    });
+  } else {
+    project = new Project();
+    project.addSourceFilesAtPaths(`${projectPath}/**/*.{ts,tsx,js,jsx}`);
+  }
+
+  const sourceFiles = project.getSourceFiles();
+
+  let changed = false;
+
+  sourceFiles.forEach((sourceFile) => {
+    if (sourceFile.getFilePath().includes("node_modules")) {
+      return;
+    }
+
+    try {
+      const originalText = sourceFile.getFullText();
+      const transformedText = transformFile(sourceFile);
+
+      if (originalText !== transformedText) {
+        sourceFile.saveSync();
+        console.log(`Transformed: ${sourceFile.getFilePath()}`);
+        changed = true;
+      }
+    } catch (error) {
+      console.error(`Error transforming ${sourceFile.getFilePath()}:`, error);
+    }
+  });
+
+  return changed;
+}
+
+// Run multiple times, because the resolved types gets fixed after each run
+export function runTransform(projectPath: string): void {
+  let runCount = 1;
+
+  while (singleRun(projectPath)) {
+    runCount++;
+
+    if (runCount > 5) {
+      console.log("Ran 5 times, stopping");
+      break;
+    }
+  }
+
+  console.log(`Ran ${runCount} times`);
+}

--- a/packages/codemod-upgrade-0-18/tests/__snapshots__/codemod.test.ts.snap
+++ b/packages/codemod-upgrade-0-18/tests/__snapshots__/codemod.test.ts.snap
@@ -30,6 +30,7 @@ function examplePropertyAccess() {
   const chat = Chat.create([], Group.create());
   const chatId = chat.$jazz.id; // Will become: chat.$jazz.id
   const owner = chat.$jazz.owner; // Will become: chat.$jazz.owner
+  const raw = chat.$jazz.raw; // Will become: chat.$jazz.raw
   const refs = chat.$jazz.refs.messages; // Will become: chat.$jazz.refs.messages
   const edits = chat.$jazz.getEdits().title; // Will become: chat.$jazz.getEdits().title
   const type = chat.$type$; // Will become: chat.$type$
@@ -42,6 +43,7 @@ function examplePropertyAccess() {
   return {
     chatId,
     owner,
+    raw,
     refs,
     edits,
     type,
@@ -181,6 +183,42 @@ function exampleTimestamps() {
   const lastEdit = message?.$jazz.getEdits().text?.madeAt; // Will become: message.$jazz.getEdits()?.text?.madeAt
 }
 
+// Example 11: Destructuring assignments
+function exampleDestructuring() {
+  const chat = Chat.create([], Group.create());
+  const message = Message.create({ text: "Hello" }, Group.create());
+
+  // Simple id destructuring
+  const { id } = chat; // Will become: const { id } = chat.$jazz
+
+  // Multiple properties from $jazz
+  const { id: chatId, _owner, _raw, _createdAt } = chat.$jazz // Will become: const { id: chatId, owner: _owner, raw: _raw, createdAt: _createdAt } = chat.$jazz
+
+  // Type property destructuring
+  const { _type } = message; // Will become: const { $type$: _type } = message
+
+  // Mixed properties (should split into multiple statements)
+  const { id: messageId, owner: messageOwner, raw: messageRaw } = message.$jazz;
+    const { $type$: messageType } = message; // Will split into separate statements
+
+  // Regular properties should not be transformed
+  const { text } = message; // Should remain unchanged
+
+  return {
+    id,
+    chatId,
+    _owner,
+    _raw,
+    _createdAt,
+    _type,
+    messageId,
+    messageType,
+    messageOwner,
+    messageRaw,
+    text,
+  };
+}
+
 export {
   examplePropertyAccess,
   examplePropertyAssignments,
@@ -192,6 +230,7 @@ export {
   exampleDeleteOperations,
   exampleTypeChecking,
   exampleTimestamps,
+  exampleDestructuring,
   invalidSimilarCode,
 };
 "

--- a/packages/codemod-upgrade-0-18/tests/__snapshots__/codemod.test.ts.snap
+++ b/packages/codemod-upgrade-0-18/tests/__snapshots__/codemod.test.ts.snap
@@ -1,0 +1,191 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`runTransform 1`] = `
+"// @ts-nocheck
+
+// Test file demonstrating old Jazz API patterns that will be migrated
+// This file shows examples of what the codemod will transform
+
+import { Account, co, Group, z } from "jazz-tools";
+
+const Message = co.map({
+  text: z.string(),
+});
+const Chat = co.list(Message);
+
+const Union = co.discriminatedUnion("type", [
+  co.map({
+    type: z.literal("a"),
+    name: z.string(),
+  }),
+  co.map({
+    type: z.literal("b"),
+    name: z.string(),
+  }),
+]);
+type Union = co.loaded<typeof Union>;
+
+// Example 1: Property access patterns
+function examplePropertyAccess() {
+  const chat = Chat.create([], Group.create());
+  const chatId = chat.$jazz.id; // Will become: chat.$jazz.id
+  const owner = chat.$jazz.owner; // Will become: chat.$jazz.owner
+  const refs = chat.$jazz.refs.messages; // Will become: chat.$jazz.refs.messages
+  const edits = chat.$jazz.getEdits().title; // Will become: chat.$jazz.getEdits().title
+  const type = chat.$type$; // Will become: chat.$type$
+  const createdAt = chat.$jazz.createdAt; // Will become: chat.$jazz.createdAt
+  const lastUpdatedAt = chat.$jazz.lastUpdatedAt; // Will become: chat.$jazz.lastUpdatedAt
+
+  // Should keep conditionals
+  const id = chat?.$jazz.id;
+
+  return {
+    chatId,
+    owner,
+    refs,
+    edits,
+    type,
+    createdAt,
+    lastUpdatedAt,
+  };
+}
+
+function invalidSimilarCode() {
+  const arr = [1, 2, 3];
+  arr.push(4);
+  arr.splice(0, 1);
+  arr[0] = 5;
+  delete arr[0];
+
+  const obj: Record<string, string> = {
+    name: "John",
+    age: "30",
+    city: "New York",
+  };
+  obj.name = "Jane";
+  delete obj.age;
+}
+
+function invalidSimilarCode2(args: { id: string; message: Message }) {
+  return args.id;
+}
+
+// Example 2: Property assignments
+function examplePropertyAssignments(union: Union) {
+  const me = Account.getMe();
+
+  if (me.profile) {
+    me.profile.$jazz.set("name", "New Name"); // Will become: me.profile.$jazz.set("name", "New Name")
+    me.profile.$jazz.delete("avatar"); // Will become: me.profile.$jazz.delete("avatar")
+  }
+
+  const chat = Message.create({ text: "Hello" }, Group.create());
+  chat.$jazz.set("text", "My Chat");
+
+  union.$jazz.applyDiff({"name": "John"}); // Will become: union.$jazz.applyDiff({"name": "John"}) because unions do not support set
+}
+
+// Example 3: Array operations
+function exampleArrayOperations() {
+  const chat = Chat.create([], Group.create());
+  const message = Message.create({ text: "Hello" }, chat.$jazz.owner);
+
+  chat.$jazz.push(message); // Will become: chat.messages.$jazz.push(message)
+  chat.$jazz.splice(0, 1); // Will become: chat.messages.$jazz.splice(0, 1)
+}
+
+// Example 4: Method calls
+async function exampleMethodCalls() {
+  const chat = Chat.create([], Group.create());
+
+  await chat.$jazz.waitForSync(); // Will become: await chat.$jazz.waitForSync()
+  await chat.$jazz.waitForAllCoValuesSync(); // Will become: await chat.$jazz.waitForAllCoValuesSync()
+
+  const unsubscribe = chat.$jazz.subscribe({}, (updatedChat) => {
+      console.log("Chat updated:", updatedChat.$jazz.id);
+    }); // Will become: chat.$jazz.subscribe({}, callback)
+
+  const loadedChat = await chat.$jazz.ensureLoaded({
+      resolve: { messages: true },
+    }); // Will become: chat.$jazz.ensureLoaded(options)
+}
+
+// Example 5: Rich text operations
+function exampleRichTextOperations() {
+  const richText = co.richText().create("Initial text", Group.create());
+
+  richText.$jazz.applyDiff("Updated text"); // Will become: richText.$jazz.applyDiff("Updated text")
+}
+
+// Example 6: Complex property chains
+function exampleComplexChains() {
+  const chat = Chat.create([], Group.create());
+  const message = chat[0];
+
+  if (message && message?.$jazz.getEdits().text?.by?.profile?.name) {
+    const authorName = message.$jazz.getEdits().text.by.profile.name;
+    // Will become: message.$jazz.getEdits()?.text?.by?.profile?.name
+  }
+
+  const messageOwner = message?.$jazz.owner; // Will become: message?.$jazz.owner
+  const messageRefs = message?.$jazz.refs.text; // Will become: message?.$jazz.refs?.text
+}
+
+// Example 7: Conditional expressions
+function exampleConditionals() {
+  const chat = Chat.create([], Group.create());
+
+  if (chat?.$jazz.getEdits().title) {
+    // Will become: chat.$jazz.getEdits()?.title
+    console.log("Chat has title edits");
+  }
+
+  const hasOwner = chat.$jazz.owner ? true : false; // Will become: chat.$jazz.owner ? true : false
+}
+
+// Example 8: Delete operations
+function exampleDeleteOperations() {
+  const me = Account.getMe();
+
+  me.profile.$jazz.delete("avatar"); // Will become: me.profile.$jazz.delete("avatar")
+  me.profile.$jazz.delete("bio"); // Will become: me.profile.$jazz.delete("bio")
+}
+
+// Example 9: Type checking
+function exampleTypeChecking() {
+  const obj = Chat.create([], Group.create());
+
+  if (obj.$type$ === "Group") {
+    // Will become: obj.$type$ === 'Group'
+    console.log("This is a Group");
+  }
+
+  if (obj.$type$ === "Chat") {
+    // Will become: obj.$type$ === 'Chat'
+    console.log("This is a Chat");
+  }
+}
+
+// Example 10: Timestamp access
+function exampleTimestamps() {
+  const message = Message.create({ text: "Hello" }, Group.create());
+
+  const created = message.$jazz.createdAt; // Will become: message.$jazz.createdAt
+  const lastEdit = message?.$jazz.getEdits().text?.madeAt; // Will become: message.$jazz.getEdits()?.text?.madeAt
+}
+
+export {
+  examplePropertyAccess,
+  examplePropertyAssignments,
+  exampleArrayOperations,
+  exampleMethodCalls,
+  exampleRichTextOperations,
+  exampleComplexChains,
+  exampleConditionals,
+  exampleDeleteOperations,
+  exampleTypeChecking,
+  exampleTimestamps,
+  invalidSimilarCode,
+};
+"
+`;

--- a/packages/codemod-upgrade-0-18/tests/__snapshots__/codemod.test.ts.snap
+++ b/packages/codemod-upgrade-0-18/tests/__snapshots__/codemod.test.ts.snap
@@ -189,17 +189,17 @@ function exampleDestructuring() {
   const message = Message.create({ text: "Hello" }, Group.create());
 
   // Simple id destructuring
-  const { id } = chat; // Will become: const { id } = chat.$jazz
+  const { id } = chat.$jazz // Will become: const { id } = chat.$jazz
 
   // Multiple properties from $jazz
-  const { id: chatId, _owner, _raw, _createdAt } = chat.$jazz // Will become: const { id: chatId, owner: _owner, raw: _raw, createdAt: _createdAt } = chat.$jazz
+  const { id: chatId, owner: _owner, raw: _raw, createdAt: _createdAt } = chat.$jazz // Will become: const { id: chatId, owner: _owner, raw: _raw, createdAt: _createdAt } = chat.$jazz
 
   // Type property destructuring
-  const { _type } = message; // Will become: const { $type$: _type } = message
+  const { $type$: _type } = message // Will become: const { $type$: _type } = message
 
   // Mixed properties (should split into multiple statements)
   const { id: messageId, owner: messageOwner, raw: messageRaw } = message.$jazz;
-    const { $type$: messageType } = message; // Will split into separate statements
+    const { $type$: messageType } = message // Will split into separate statements
 
   // Regular properties should not be transformed
   const { text } = message; // Should remain unchanged

--- a/packages/codemod-upgrade-0-18/tests/__snapshots__/codemod.test.ts.snap
+++ b/packages/codemod-upgrade-0-18/tests/__snapshots__/codemod.test.ts.snap
@@ -61,9 +61,13 @@ function invalidSimilarCode() {
     name: "John",
     age: "30",
     city: "New York",
+    castAs() {
+      return this;
+    },
   };
   obj.name = "Jane";
   delete obj.age;
+  obj.castAs(Group);
 }
 
 function invalidSimilarCode2(args: { id: string; message: Message }) {
@@ -92,6 +96,9 @@ function exampleArrayOperations() {
 
   chat.$jazz.push(message); // Will become: chat.messages.$jazz.push(message)
   chat.$jazz.splice(0, 1); // Will become: chat.messages.$jazz.splice(0, 1)
+  chat.$jazz.unshift(message); // Will become: chat.messages.$jazz.unshift(message)
+  chat.$jazz.shift(); // Will become: chat.messages.$jazz.shift()
+  chat.$jazz.pop(); // Will become: chat.messages.$jazz.pop()
 }
 
 // Example 4: Method calls

--- a/packages/codemod-upgrade-0-18/tests/codemod.test.ts
+++ b/packages/codemod-upgrade-0-18/tests/codemod.test.ts
@@ -1,0 +1,25 @@
+import { expect, onTestFinished, test } from "vitest";
+import { runTransform } from "../src/transform";
+import { readFileSync, writeFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+
+const currentDir = fileURLToPath(new URL(".", import.meta.url));
+
+test("runTransform", () => {
+  const fixturesBefore = readFileSync(
+    `${currentDir}/fixtures/test-example.ts`,
+    "utf-8",
+  );
+  runTransform(`${currentDir}/fixtures`);
+
+  const result = readFileSync(
+    `${currentDir}/fixtures/test-example.ts`,
+    "utf-8",
+  );
+
+  onTestFinished(() => {
+    writeFileSync(`${currentDir}/fixtures/test-example.ts`, fixturesBefore);
+  });
+
+  expect(result).toMatchSnapshot();
+});

--- a/packages/codemod-upgrade-0-18/tests/fixtures/test-example.ts
+++ b/packages/codemod-upgrade-0-18/tests/fixtures/test-example.ts
@@ -27,6 +27,7 @@ function examplePropertyAccess() {
   const chat = Chat.create([], Group.create());
   const chatId = chat.id; // Will become: chat.$jazz.id
   const owner = chat._owner.castAs(Group); // Will become: chat.$jazz.owner
+  const raw = chat._raw; // Will become: chat.$jazz.raw
   const refs = chat._refs.messages; // Will become: chat.$jazz.refs.messages
   const edits = chat._edits.title; // Will become: chat.$jazz.getEdits().title
   const type = chat._type; // Will become: chat.$type$
@@ -39,6 +40,7 @@ function examplePropertyAccess() {
   return {
     chatId,
     owner,
+    raw,
     refs,
     edits,
     type,
@@ -187,13 +189,18 @@ function exampleDestructuring() {
   const { id } = chat; // Will become: const { id } = chat.$jazz
 
   // Multiple properties from $jazz
-  const { id: chatId, _owner, _createdAt } = chat; // Will become: const { id: chatId, owner: _owner, createdAt: _createdAt } = chat.$jazz
+  const { id: chatId, _owner, _raw, _createdAt } = chat; // Will become: const { id: chatId, owner: _owner, raw: _raw, createdAt: _createdAt } = chat.$jazz
 
   // Type property destructuring
   const { _type } = message; // Will become: const { $type$: _type } = message
 
   // Mixed properties (should split into multiple statements)
-  const { id: messageId, _type: messageType, _owner: messageOwner } = message; // Will split into separate statements
+  const {
+    id: messageId,
+    _type: messageType,
+    _owner: messageOwner,
+    _raw: messageRaw,
+  } = message; // Will split into separate statements
 
   // Regular properties should not be transformed
   const { text } = message; // Should remain unchanged
@@ -202,11 +209,13 @@ function exampleDestructuring() {
     id,
     chatId,
     _owner,
+    _raw,
     _createdAt,
     _type,
     messageId,
     messageType,
     messageOwner,
+    messageRaw,
     text,
   };
 }

--- a/packages/codemod-upgrade-0-18/tests/fixtures/test-example.ts
+++ b/packages/codemod-upgrade-0-18/tests/fixtures/test-example.ts
@@ -1,0 +1,186 @@
+// @ts-nocheck
+
+// Test file demonstrating old Jazz API patterns that will be migrated
+// This file shows examples of what the codemod will transform
+
+import { Account, co, Group, z } from "jazz-tools";
+
+const Message = co.map({
+  text: z.string(),
+});
+const Chat = co.list(Message);
+
+const Union = co.discriminatedUnion("type", [
+  co.map({
+    type: z.literal("a"),
+    name: z.string(),
+  }),
+  co.map({
+    type: z.literal("b"),
+    name: z.string(),
+  }),
+]);
+type Union = co.loaded<typeof Union>;
+
+// Example 1: Property access patterns
+function examplePropertyAccess() {
+  const chat = Chat.create([], Group.create());
+  const chatId = chat.id; // Will become: chat.$jazz.id
+  const owner = chat._owner.castAs(Group); // Will become: chat.$jazz.owner
+  const refs = chat._refs.messages; // Will become: chat.$jazz.refs.messages
+  const edits = chat._edits.title; // Will become: chat.$jazz.getEdits().title
+  const type = chat._type; // Will become: chat.$type$
+  const createdAt = chat._createdAt; // Will become: chat.$jazz.createdAt
+  const lastUpdatedAt = chat._lastUpdatedAt; // Will become: chat.$jazz.lastUpdatedAt
+
+  // Should keep conditionals
+  const id = chat?.id;
+
+  return {
+    chatId,
+    owner,
+    refs,
+    edits,
+    type,
+    createdAt,
+    lastUpdatedAt,
+  };
+}
+
+function invalidSimilarCode() {
+  const arr = [1, 2, 3];
+  arr.push(4);
+  arr.splice(0, 1);
+  arr[0] = 5;
+  delete arr[0];
+
+  const obj: Record<string, string> = {
+    name: "John",
+    age: "30",
+    city: "New York",
+  };
+  obj.name = "Jane";
+  delete obj.age;
+}
+
+function invalidSimilarCode2(args: { id: string; message: Message }) {
+  return args.id;
+}
+
+// Example 2: Property assignments
+function examplePropertyAssignments(union: Union) {
+  const me = Account.getMe();
+
+  if (me.profile) {
+    me.profile.name = "New Name"; // Will become: me.profile.$jazz.set("name", "New Name")
+    me.profile.avatar = undefined; // Will become: me.profile.$jazz.delete("avatar")
+  }
+
+  const chat = Message.create({ text: "Hello" }, Group.create());
+  chat.text = "My Chat";
+
+  union.name = "John"; // Will become: union.$jazz.applyDiff({"name": "John"}) because unions do not support set
+}
+
+// Example 3: Array operations
+function exampleArrayOperations() {
+  const chat = Chat.create([], Group.create());
+  const message = Message.create({ text: "Hello" }, chat._owner);
+
+  chat.push(message); // Will become: chat.messages.$jazz.push(message)
+  chat.splice(0, 1); // Will become: chat.messages.$jazz.splice(0, 1)
+}
+
+// Example 4: Method calls
+async function exampleMethodCalls() {
+  const chat = Chat.create([], Group.create());
+
+  await chat.waitForSync(); // Will become: await chat.$jazz.waitForSync()
+  await chat.waitForAllCoValuesSync(); // Will become: await chat.$jazz.waitForAllCoValuesSync()
+
+  const unsubscribe = chat.subscribe({}, (updatedChat) => {
+    console.log("Chat updated:", updatedChat.id);
+  }); // Will become: chat.$jazz.subscribe({}, callback)
+
+  const loadedChat = await chat.ensureLoaded({
+    resolve: { messages: true },
+  }); // Will become: chat.$jazz.ensureLoaded(options)
+}
+
+// Example 5: Rich text operations
+function exampleRichTextOperations() {
+  const richText = co.richText().create("Initial text", Group.create());
+
+  richText.applyDiff("Updated text"); // Will become: richText.$jazz.applyDiff("Updated text")
+}
+
+// Example 6: Complex property chains
+function exampleComplexChains() {
+  const chat = Chat.create([], Group.create());
+  const message = chat[0];
+
+  if (message && message._edits?.text?.by?.profile?.name) {
+    const authorName = message._edits.text.by.profile.name;
+    // Will become: message.$jazz.getEdits()?.text?.by?.profile?.name
+  }
+
+  const messageOwner = message?._owner; // Will become: message?.$jazz.owner
+  const messageRefs = message?._refs?.text; // Will become: message?.$jazz.refs?.text
+}
+
+// Example 7: Conditional expressions
+function exampleConditionals() {
+  const chat = Chat.create([], Group.create());
+
+  if (chat._edits?.title) {
+    // Will become: chat.$jazz.getEdits()?.title
+    console.log("Chat has title edits");
+  }
+
+  const hasOwner = chat._owner ? true : false; // Will become: chat.$jazz.owner ? true : false
+}
+
+// Example 8: Delete operations
+function exampleDeleteOperations() {
+  const me = Account.getMe();
+
+  delete me.profile.avatar; // Will become: me.profile.$jazz.delete("avatar")
+  delete me.profile.bio; // Will become: me.profile.$jazz.delete("bio")
+}
+
+// Example 9: Type checking
+function exampleTypeChecking() {
+  const obj = Chat.create([], Group.create());
+
+  if (obj._type === "Group") {
+    // Will become: obj.$type$ === 'Group'
+    console.log("This is a Group");
+  }
+
+  if (obj._type === "Chat") {
+    // Will become: obj.$type$ === 'Chat'
+    console.log("This is a Chat");
+  }
+}
+
+// Example 10: Timestamp access
+function exampleTimestamps() {
+  const message = Message.create({ text: "Hello" }, Group.create());
+
+  const created = message._createdAt; // Will become: message.$jazz.createdAt
+  const lastEdit = message._edits?.text?.madeAt; // Will become: message.$jazz.getEdits()?.text?.madeAt
+}
+
+export {
+  examplePropertyAccess,
+  examplePropertyAssignments,
+  exampleArrayOperations,
+  exampleMethodCalls,
+  exampleRichTextOperations,
+  exampleComplexChains,
+  exampleConditionals,
+  exampleDeleteOperations,
+  exampleTypeChecking,
+  exampleTimestamps,
+  invalidSimilarCode,
+};

--- a/packages/codemod-upgrade-0-18/tests/fixtures/test-example.ts
+++ b/packages/codemod-upgrade-0-18/tests/fixtures/test-example.ts
@@ -58,9 +58,13 @@ function invalidSimilarCode() {
     name: "John",
     age: "30",
     city: "New York",
+    castAs() {
+      return this;
+    },
   };
   obj.name = "Jane";
   delete obj.age;
+  obj.castAs(Group);
 }
 
 function invalidSimilarCode2(args: { id: string; message: Message }) {
@@ -89,6 +93,9 @@ function exampleArrayOperations() {
 
   chat.push(message); // Will become: chat.messages.$jazz.push(message)
   chat.splice(0, 1); // Will become: chat.messages.$jazz.splice(0, 1)
+  chat.unshift(message); // Will become: chat.messages.$jazz.unshift(message)
+  chat.shift(); // Will become: chat.messages.$jazz.shift()
+  chat.pop(); // Will become: chat.messages.$jazz.pop()
 }
 
 // Example 4: Method calls

--- a/packages/codemod-upgrade-0-18/tests/fixtures/test-example.ts
+++ b/packages/codemod-upgrade-0-18/tests/fixtures/test-example.ts
@@ -178,6 +178,39 @@ function exampleTimestamps() {
   const lastEdit = message._edits?.text?.madeAt; // Will become: message.$jazz.getEdits()?.text?.madeAt
 }
 
+// Example 11: Destructuring assignments
+function exampleDestructuring() {
+  const chat = Chat.create([], Group.create());
+  const message = Message.create({ text: "Hello" }, Group.create());
+
+  // Simple id destructuring
+  const { id } = chat; // Will become: const { id } = chat.$jazz
+
+  // Multiple properties from $jazz
+  const { id: chatId, _owner, _createdAt } = chat; // Will become: const { id: chatId, owner: _owner, createdAt: _createdAt } = chat.$jazz
+
+  // Type property destructuring
+  const { _type } = message; // Will become: const { $type$: _type } = message
+
+  // Mixed properties (should split into multiple statements)
+  const { id: messageId, _type: messageType, _owner: messageOwner } = message; // Will split into separate statements
+
+  // Regular properties should not be transformed
+  const { text } = message; // Should remain unchanged
+
+  return {
+    id,
+    chatId,
+    _owner,
+    _createdAt,
+    _type,
+    messageId,
+    messageType,
+    messageOwner,
+    text,
+  };
+}
+
 export {
   examplePropertyAccess,
   examplePropertyAssignments,
@@ -189,5 +222,6 @@ export {
   exampleDeleteOperations,
   exampleTypeChecking,
   exampleTimestamps,
+  exampleDestructuring,
   invalidSimilarCode,
 };

--- a/packages/codemod-upgrade-0-18/tsconfig.json
+++ b/packages/codemod-upgrade-0-18/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "lib": ["ESNext"],
+    "module": "esnext",
+    "target": "ES2020",
+    "moduleResolution": "bundler",
+    "moduleDetection": "force",
+    "strict": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "noUncheckedIndexedAccess": true,
+    "esModuleInterop": true,
+    "declaration": true,
+    "declarationMap": true
+  },
+  "include": ["./src/**/*.ts"],
+  "exclude": ["./node_modules"]
+}

--- a/packages/codemod-upgrade-0-18/tsdown.config.ts
+++ b/packages/codemod-upgrade-0-18/tsdown.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from "tsdown";
+
+export default defineConfig([
+  {
+    entry: ["./src/index.ts"],
+    platform: "neutral",
+    dts: true,
+  },
+]);

--- a/packages/codemod-upgrade-0-18/vitest.config.ts
+++ b/packages/codemod-upgrade-0-18/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineProject } from "vitest/config";
+
+export default defineProject({
+  test: {
+    name: "codemod-upgrade-0-18",
+    testTimeout: 10_000,
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -93,10 +93,10 @@ importers:
         version: 1.50.1
       '@vitejs/plugin-react':
         specifier: ^4.5.1
-        version: 4.5.1(vite@6.3.5(@types/node@24.3.0)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.6.1))
+        version: 4.5.1(vite@6.3.5(@types/node@24.3.0)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.6.1))
       '@vitest/browser':
         specifier: catalog:default
-        version: 3.2.4(msw@2.10.4(@types/node@24.3.0)(typescript@5.9.2))(playwright@1.50.1)(vite@6.3.5(@types/node@24.3.0)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.6.1))(vitest@3.2.4)(webdriverio@8.41.0)
+        version: 3.2.4(msw@2.10.4(@types/node@24.3.0)(typescript@5.9.2))(playwright@1.50.1)(vite@6.3.5(@types/node@24.3.0)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.6.1))(vitest@3.2.4)(webdriverio@8.41.0)
       '@vitest/coverage-istanbul':
         specifier: catalog:default
         version: 3.2.4(vitest@3.2.4)
@@ -115,6 +115,9 @@ importers:
       jazz-tools:
         specifier: workspace:*
         version: link:packages/jazz-tools
+      jazz-tools-codemod-0-18:
+        specifier: workspace:*
+        version: link:packages/codemod-upgrade-0-18
       lefthook:
         specifier: ^1.8.2
         version: 1.10.0
@@ -132,7 +135,7 @@ importers:
         version: 0.25.13(typescript@5.9.2)
       vitest:
         specifier: catalog:default
-        version: 3.2.4(@types/debug@4.1.12)(@types/node@24.3.0)(@vitest/browser@3.2.4)(@vitest/ui@3.2.4)(happy-dom@17.4.4)(jiti@2.4.2)(jsdom@25.0.1)(lightningcss@1.30.1)(msw@2.10.4(@types/node@24.3.0)(typescript@5.9.2))(terser@5.43.1)(tsx@4.20.3)(yaml@2.6.1)
+        version: 3.2.4(@types/debug@4.1.12)(@types/node@24.3.0)(@vitest/browser@3.2.4)(@vitest/ui@3.2.4)(happy-dom@17.4.4)(jiti@2.5.1)(jsdom@25.0.1)(lightningcss@1.30.1)(msw@2.10.4(@types/node@24.3.0)(typescript@5.9.2))(terser@5.43.1)(tsx@4.20.3)(yaml@2.6.1)
 
   bench:
     dependencies:
@@ -281,7 +284,7 @@ importers:
         version: 19.1.0(@types/react@19.1.0)
       '@vitejs/plugin-react-swc':
         specifier: ^3.10.1
-        version: 3.10.1(@swc/helpers@0.5.17)(vite@6.3.5(@types/node@24.3.0)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.6.1))
+        version: 3.10.1(@swc/helpers@0.5.17)(vite@6.3.5(@types/node@24.3.0)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.6.1))
       is-ci:
         specifier: ^3.0.1
         version: 3.0.1
@@ -296,7 +299,7 @@ importers:
         version: 5.6.2
       vite:
         specifier: 6.3.5
-        version: 6.3.5(@types/node@24.3.0)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.6.1)
+        version: 6.3.5(@types/node@24.3.0)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.6.1)
 
   examples/chat-rn:
     dependencies:
@@ -457,7 +460,7 @@ importers:
     dependencies:
       '@tailwindcss/vite':
         specifier: ^4.1.7
-        version: 4.1.10(vite@6.3.5(@types/node@24.3.0)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.6.1))
+        version: 4.1.10(vite@6.3.5(@types/node@24.3.0)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.6.1))
       jazz-tools:
         specifier: workspace:*
         version: link:../../packages/jazz-tools
@@ -467,25 +470,25 @@ importers:
     devDependencies:
       '@sveltejs/adapter-auto':
         specifier: ^3.3.1
-        version: 3.3.1(@sveltejs/kit@2.36.1(@opentelemetry/api@1.9.0)(@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.38.2)(vite@6.3.5(@types/node@24.3.0)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.6.1)))(svelte@5.38.2)(vite@6.3.5(@types/node@24.3.0)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.6.1)))
+        version: 3.3.1(@sveltejs/kit@2.36.1(@opentelemetry/api@1.9.0)(@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.38.2)(vite@6.3.5(@types/node@24.3.0)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.6.1)))(svelte@5.38.2)(vite@6.3.5(@types/node@24.3.0)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.6.1)))
       '@sveltejs/kit':
         specifier: catalog:svelte
-        version: 2.36.1(@opentelemetry/api@1.9.0)(@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.38.2)(vite@6.3.5(@types/node@24.3.0)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.6.1)))(svelte@5.38.2)(vite@6.3.5(@types/node@24.3.0)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.6.1))
+        version: 2.36.1(@opentelemetry/api@1.9.0)(@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.38.2)(vite@6.3.5(@types/node@24.3.0)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.6.1)))(svelte@5.38.2)(vite@6.3.5(@types/node@24.3.0)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.6.1))
       '@sveltejs/vite-plugin-svelte':
         specifier: catalog:svelte
-        version: 5.1.1(svelte@5.38.2)(vite@6.3.5(@types/node@24.3.0)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.6.1))
+        version: 5.1.1(svelte@5.38.2)(vite@6.3.5(@types/node@24.3.0)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.6.1))
       '@types/eslint':
         specifier: ^9.6.1
         version: 9.6.1
       eslint:
         specifier: ^9.27.0
-        version: 9.28.0(jiti@2.4.2)
+        version: 9.28.0(jiti@2.5.1)
       eslint-config-prettier:
         specifier: ^9.1.0
-        version: 9.1.0(eslint@9.28.0(jiti@2.4.2))
+        version: 9.1.0(eslint@9.28.0(jiti@2.5.1))
       eslint-plugin-svelte:
         specifier: ^2.46.1
-        version: 2.46.1(eslint@9.28.0(jiti@2.4.2))(svelte@5.38.2)(ts-node@10.9.2(@swc/core@1.11.29(@swc/helpers@0.5.17))(@types/node@24.3.0)(typescript@5.6.2))
+        version: 2.46.1(eslint@9.28.0(jiti@2.5.1))(svelte@5.38.2)(ts-node@10.9.2(@swc/core@1.11.29(@swc/helpers@0.5.17))(@types/node@24.3.0)(typescript@5.6.2))
       globals:
         specifier: ^15.15.0
         version: 15.15.0
@@ -506,10 +509,10 @@ importers:
         version: 5.6.2
       typescript-eslint:
         specifier: ^8.32.1
-        version: 8.34.0(eslint@9.28.0(jiti@2.4.2))(typescript@5.6.2)
+        version: 8.34.0(eslint@9.28.0(jiti@2.5.1))(typescript@5.6.2)
       vite:
         specifier: 6.3.5
-        version: 6.3.5(@types/node@24.3.0)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.6.1)
+        version: 6.3.5(@types/node@24.3.0)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.6.1)
 
   examples/clerk:
     dependencies:
@@ -540,7 +543,7 @@ importers:
         version: 19.1.0(@types/react@19.1.0)
       '@vitejs/plugin-react':
         specifier: ^4.5.1
-        version: 4.5.1(vite@6.3.5(@types/node@24.3.0)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.6.1))
+        version: 4.5.1(vite@6.3.5(@types/node@24.3.0)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.6.1))
       globals:
         specifier: ^15.11.0
         version: 15.15.0
@@ -549,7 +552,7 @@ importers:
         version: 5.6.2
       vite:
         specifier: 6.3.5
-        version: 6.3.5(@types/node@24.3.0)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.6.1)
+        version: 6.3.5(@types/node@24.3.0)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.6.1)
 
   examples/clerk-expo:
     dependencies:
@@ -638,19 +641,19 @@ importers:
         version: 22.16.5
       '@vitejs/plugin-vue':
         specifier: ^5.1.4
-        version: 5.2.4(vite@6.3.5(@types/node@22.16.5)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.6.1))(vue@3.5.13(typescript@5.6.2))
+        version: 5.2.4(vite@6.3.5(@types/node@22.16.5)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.6.1))(vue@3.5.13(typescript@5.6.2))
       '@vitejs/plugin-vue-jsx':
         specifier: ^4.0.1
-        version: 4.2.0(vite@6.3.5(@types/node@22.16.5)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.6.1))(vue@3.5.13(typescript@5.6.2))
+        version: 4.2.0(vite@6.3.5(@types/node@22.16.5)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.6.1))(vue@3.5.13(typescript@5.6.2))
       '@vue/tsconfig':
         specifier: ^0.5.1
         version: 0.5.1
       eslint:
         specifier: ^9.7.0
-        version: 9.28.0(jiti@2.4.2)
+        version: 9.28.0(jiti@2.5.1)
       eslint-plugin-vue:
         specifier: ^9.28.0
-        version: 9.33.0(eslint@9.28.0(jiti@2.4.2))
+        version: 9.33.0(eslint@9.28.0(jiti@2.5.1))
       npm-run-all2:
         specifier: ^6.2.3
         version: 6.2.6
@@ -665,10 +668,10 @@ importers:
         version: 5.6.2
       vite:
         specifier: 6.3.5
-        version: 6.3.5(@types/node@22.16.5)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.6.1)
+        version: 6.3.5(@types/node@22.16.5)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.6.1)
       vite-plugin-vue-devtools:
         specifier: ^7.4.6
-        version: 7.7.7(rollup@4.41.1)(vite@6.3.5(@types/node@22.16.5)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.6.1))(vue@3.5.13(typescript@5.6.2))
+        version: 7.7.7(rollup@4.41.1)(vite@6.3.5(@types/node@22.16.5)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.6.1))(vue@3.5.13(typescript@5.6.2))
       vue-tsc:
         specifier: ^2.1.6
         version: 2.2.12(typescript@5.6.2)
@@ -702,7 +705,7 @@ importers:
         version: 1.50.1
       '@vitejs/plugin-vue':
         specifier: ^5.2.1
-        version: 5.2.4(vite@6.3.5(@types/node@24.3.0)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.6.1))(vue@3.5.13(typescript@5.6.2))
+        version: 5.2.4(vite@6.3.5(@types/node@24.3.0)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.6.1))(vue@3.5.13(typescript@5.6.2))
       globals:
         specifier: ^15.11.0
         version: 15.15.0
@@ -711,7 +714,7 @@ importers:
         version: 5.6.2
       vite:
         specifier: 6.3.5
-        version: 6.3.5(@types/node@24.3.0)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.6.1)
+        version: 6.3.5(@types/node@24.3.0)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.6.1)
 
   examples/community-todo-vue:
     dependencies:
@@ -739,19 +742,19 @@ importers:
         version: 22.16.5
       '@vitejs/plugin-vue':
         specifier: ^5.1.4
-        version: 5.2.4(vite@6.3.5(@types/node@22.16.5)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.6.1))(vue@3.5.13(typescript@5.6.2))
+        version: 5.2.4(vite@6.3.5(@types/node@22.16.5)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.6.1))(vue@3.5.13(typescript@5.6.2))
       '@vitejs/plugin-vue-jsx':
         specifier: ^4.0.1
-        version: 4.2.0(vite@6.3.5(@types/node@22.16.5)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.6.1))(vue@3.5.13(typescript@5.6.2))
+        version: 4.2.0(vite@6.3.5(@types/node@22.16.5)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.6.1))(vue@3.5.13(typescript@5.6.2))
       '@vue/tsconfig':
         specifier: ^0.5.1
         version: 0.5.1
       eslint:
         specifier: ^9.7.0
-        version: 9.28.0(jiti@2.4.2)
+        version: 9.28.0(jiti@2.5.1)
       eslint-plugin-vue:
         specifier: ^9.28.0
-        version: 9.33.0(eslint@9.28.0(jiti@2.4.2))
+        version: 9.33.0(eslint@9.28.0(jiti@2.5.1))
       npm-run-all2:
         specifier: ^6.2.3
         version: 6.2.6
@@ -766,10 +769,10 @@ importers:
         version: 5.6.2
       vite:
         specifier: 6.3.5
-        version: 6.3.5(@types/node@22.16.5)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.6.1)
+        version: 6.3.5(@types/node@22.16.5)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.6.1)
       vite-plugin-vue-devtools:
         specifier: ^7.4.6
-        version: 7.7.7(rollup@4.41.1)(vite@6.3.5(@types/node@22.16.5)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.6.1))(vue@3.5.13(typescript@5.6.2))
+        version: 7.7.7(rollup@4.41.1)(vite@6.3.5(@types/node@22.16.5)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.6.1))(vue@3.5.13(typescript@5.6.2))
       vue-tsc:
         specifier: ^2.1.6
         version: 2.2.12(typescript@5.6.2)
@@ -791,13 +794,13 @@ importers:
     devDependencies:
       '@sveltejs/adapter-vercel':
         specifier: ^5.5.0
-        version: 5.5.2(@sveltejs/kit@2.36.1(@opentelemetry/api@1.9.0)(@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.38.2)(vite@6.3.5(@types/node@24.3.0)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.6.1)))(svelte@5.38.2)(vite@6.3.5(@types/node@24.3.0)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.6.1)))(rollup@4.41.1)
+        version: 5.5.2(@sveltejs/kit@2.36.1(@opentelemetry/api@1.9.0)(@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.38.2)(vite@6.3.5(@types/node@24.3.0)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.6.1)))(svelte@5.38.2)(vite@6.3.5(@types/node@24.3.0)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.6.1)))(rollup@4.41.1)
       '@sveltejs/kit':
         specifier: catalog:svelte
-        version: 2.36.1(@opentelemetry/api@1.9.0)(@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.38.2)(vite@6.3.5(@types/node@24.3.0)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.6.1)))(svelte@5.38.2)(vite@6.3.5(@types/node@24.3.0)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.6.1))
+        version: 2.36.1(@opentelemetry/api@1.9.0)(@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.38.2)(vite@6.3.5(@types/node@24.3.0)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.6.1)))(svelte@5.38.2)(vite@6.3.5(@types/node@24.3.0)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.6.1))
       '@sveltejs/vite-plugin-svelte':
         specifier: catalog:svelte
-        version: 5.1.1(svelte@5.38.2)(vite@6.3.5(@types/node@24.3.0)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.6.1))
+        version: 5.1.1(svelte@5.38.2)(vite@6.3.5(@types/node@24.3.0)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.6.1))
       '@tailwindcss/postcss':
         specifier: ^4.1.10
         version: 4.1.10
@@ -806,13 +809,13 @@ importers:
         version: 3.0.4
       eslint:
         specifier: ^9.7.0
-        version: 9.28.0(jiti@2.4.2)
+        version: 9.28.0(jiti@2.5.1)
       eslint-config-prettier:
         specifier: ^9.1.0
-        version: 9.1.0(eslint@9.28.0(jiti@2.4.2))
+        version: 9.1.0(eslint@9.28.0(jiti@2.5.1))
       eslint-plugin-svelte:
         specifier: ^2.36.0
-        version: 2.46.1(eslint@9.28.0(jiti@2.4.2))(svelte@5.38.2)(ts-node@10.9.2(@swc/core@1.11.29(@swc/helpers@0.5.17))(@types/node@24.3.0)(typescript@5.6.2))
+        version: 2.46.1(eslint@9.28.0(jiti@2.5.1))(svelte@5.38.2)(ts-node@10.9.2(@swc/core@1.11.29(@swc/helpers@0.5.17))(@types/node@24.3.0)(typescript@5.6.2))
       globals:
         specifier: ^15.11.0
         version: 15.15.0
@@ -842,10 +845,10 @@ importers:
         version: 5.6.2
       typescript-eslint:
         specifier: ^8.0.0
-        version: 8.34.0(eslint@9.28.0(jiti@2.4.2))(typescript@5.6.2)
+        version: 8.34.0(eslint@9.28.0(jiti@2.5.1))(typescript@5.6.2)
       vite:
         specifier: 6.3.5
-        version: 6.3.5(@types/node@24.3.0)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.6.1)
+        version: 6.3.5(@types/node@24.3.0)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.6.1)
 
   examples/filestream:
     dependencies:
@@ -873,7 +876,7 @@ importers:
         version: 19.1.0(@types/react@19.1.0)
       '@vitejs/plugin-react':
         specifier: ^4.5.1
-        version: 4.5.1(vite@6.3.5(@types/node@24.3.0)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.6.1))
+        version: 4.5.1(vite@6.3.5(@types/node@24.3.0)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.6.1))
       globals:
         specifier: ^15.11.0
         version: 15.15.0
@@ -891,7 +894,7 @@ importers:
         version: 5.6.2
       vite:
         specifier: 6.3.5
-        version: 6.3.5(@types/node@24.3.0)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.6.1)
+        version: 6.3.5(@types/node@24.3.0)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.6.1)
 
   examples/form:
     dependencies:
@@ -928,7 +931,7 @@ importers:
         version: 19.1.0(@types/react@19.1.0)
       '@vitejs/plugin-react':
         specifier: ^4.5.1
-        version: 4.5.1(vite@6.3.5(@types/node@24.3.0)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.6.1))
+        version: 4.5.1(vite@6.3.5(@types/node@24.3.0)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.6.1))
       globals:
         specifier: ^15.11.0
         version: 15.15.0
@@ -946,7 +949,7 @@ importers:
         version: 5.6.2
       vite:
         specifier: 6.3.5
-        version: 6.3.5(@types/node@24.3.0)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.6.1)
+        version: 6.3.5(@types/node@24.3.0)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.6.1)
 
   examples/image-upload:
     dependencies:
@@ -974,7 +977,7 @@ importers:
         version: 19.1.0(@types/react@19.1.0)
       '@vitejs/plugin-react':
         specifier: ^4.5.1
-        version: 4.5.1(vite@6.3.5(@types/node@24.3.0)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.6.1))
+        version: 4.5.1(vite@6.3.5(@types/node@24.3.0)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.6.1))
       globals:
         specifier: ^15.11.0
         version: 15.15.0
@@ -989,7 +992,7 @@ importers:
         version: 5.6.2
       vite:
         specifier: 6.3.5
-        version: 6.3.5(@types/node@24.3.0)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.6.1)
+        version: 6.3.5(@types/node@24.3.0)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.6.1)
 
   examples/inspector:
     dependencies:
@@ -1032,7 +1035,7 @@ importers:
         version: 19.1.0(@types/react@19.1.0)
       '@vitejs/plugin-react-swc':
         specifier: ^3.10.1
-        version: 3.10.1(@swc/helpers@0.5.17)(vite@6.3.5(@types/node@24.3.0)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.6.1))
+        version: 3.10.1(@swc/helpers@0.5.17)(vite@6.3.5(@types/node@24.3.0)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.6.1))
       postcss:
         specifier: ^8.4.40
         version: 8.5.4
@@ -1044,7 +1047,7 @@ importers:
         version: 5.6.2
       vite:
         specifier: 6.3.5
-        version: 6.3.5(@types/node@24.3.0)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.6.1)
+        version: 6.3.5(@types/node@24.3.0)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.6.1)
 
   examples/jazz-nextjs:
     dependencies:
@@ -1112,7 +1115,7 @@ importers:
         version: 19.1.0(@types/react@19.1.0)
       '@vitejs/plugin-react':
         specifier: ^4.5.1
-        version: 4.5.1(vite@6.3.5(@types/node@24.3.0)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.6.1))
+        version: 4.5.1(vite@6.3.5(@types/node@24.3.0)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.6.1))
       globals:
         specifier: ^15.11.0
         version: 15.15.0
@@ -1130,10 +1133,10 @@ importers:
         version: 5.6.2
       vite:
         specifier: 6.3.5
-        version: 6.3.5(@types/node@24.3.0)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.6.1)
+        version: 6.3.5(@types/node@24.3.0)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.6.1)
       vitest:
         specifier: catalog:default
-        version: 3.2.4(@types/debug@4.1.12)(@types/node@24.3.0)(@vitest/browser@3.2.4)(@vitest/ui@3.2.4)(happy-dom@17.4.4)(jiti@2.4.2)(jsdom@25.0.1)(lightningcss@1.30.1)(msw@2.10.4(@types/node@24.3.0)(typescript@5.6.2))(terser@5.43.1)(tsx@4.20.3)(yaml@2.6.1)
+        version: 3.2.4(@types/debug@4.1.12)(@types/node@24.3.0)(@vitest/browser@3.2.4)(@vitest/ui@3.2.4)(happy-dom@17.4.4)(jiti@2.5.1)(jsdom@25.0.1)(lightningcss@1.30.1)(msw@2.10.4(@types/node@24.3.0)(typescript@5.6.2))(terser@5.43.1)(tsx@4.20.3)(yaml@2.6.1)
 
   examples/multiauth:
     dependencies:
@@ -1164,7 +1167,7 @@ importers:
         version: 19.1.0(@types/react@19.1.0)
       '@vitejs/plugin-react':
         specifier: ^4.5.1
-        version: 4.5.1(vite@6.3.5(@types/node@24.3.0)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.6.1))
+        version: 4.5.1(vite@6.3.5(@types/node@24.3.0)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.6.1))
       globals:
         specifier: ^15.11.0
         version: 15.15.0
@@ -1173,7 +1176,7 @@ importers:
         version: 5.6.2
       vite:
         specifier: 6.3.5
-        version: 6.3.5(@types/node@24.3.0)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.6.1)
+        version: 6.3.5(@types/node@24.3.0)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.6.1)
 
   examples/music-player:
     dependencies:
@@ -1240,7 +1243,7 @@ importers:
         version: 19.1.0(@types/react@19.1.0)
       '@vitejs/plugin-react-swc':
         specifier: ^3.10.1
-        version: 3.10.1(@swc/helpers@0.5.17)(vite@6.3.5(@types/node@24.3.0)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.6.1))
+        version: 3.10.1(@swc/helpers@0.5.17)(vite@6.3.5(@types/node@24.3.0)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.6.1))
       postcss:
         specifier: ^8.4.27
         version: 8.5.4
@@ -1252,10 +1255,10 @@ importers:
         version: 5.6.2
       vite:
         specifier: 6.3.5
-        version: 6.3.5(@types/node@24.3.0)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.6.1)
+        version: 6.3.5(@types/node@24.3.0)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.6.1)
       vite-plugin-pwa:
         specifier: ^1.0.2
-        version: 1.0.2(vite@6.3.5(@types/node@24.3.0)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.6.1))(workbox-build@7.3.0(@types/babel__core@7.20.5))(workbox-window@7.3.0)
+        version: 1.0.2(vite@6.3.5(@types/node@24.3.0)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.6.1))(workbox-build@7.3.0(@types/babel__core@7.20.5))(workbox-window@7.3.0)
 
   examples/organization:
     dependencies:
@@ -1298,7 +1301,7 @@ importers:
         version: 19.1.0(@types/react@19.1.0)
       '@vitejs/plugin-react':
         specifier: ^4.5.1
-        version: 4.5.1(vite@6.3.5(@types/node@24.3.0)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.6.1))
+        version: 4.5.1(vite@6.3.5(@types/node@24.3.0)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.6.1))
       globals:
         specifier: ^15.11.0
         version: 15.15.0
@@ -1313,7 +1316,7 @@ importers:
         version: 5.6.2
       vite:
         specifier: 6.3.5
-        version: 6.3.5(@types/node@24.3.0)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.6.1)
+        version: 6.3.5(@types/node@24.3.0)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.6.1)
 
   examples/passphrase:
     dependencies:
@@ -1341,7 +1344,7 @@ importers:
         version: 19.1.0(@types/react@19.1.0)
       '@vitejs/plugin-react':
         specifier: ^4.5.1
-        version: 4.5.1(vite@6.3.5(@types/node@24.3.0)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.6.1))
+        version: 4.5.1(vite@6.3.5(@types/node@24.3.0)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.6.1))
       globals:
         specifier: ^15.11.0
         version: 15.15.0
@@ -1350,7 +1353,7 @@ importers:
         version: 5.6.2
       vite:
         specifier: 6.3.5
-        version: 6.3.5(@types/node@24.3.0)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.6.1)
+        version: 6.3.5(@types/node@24.3.0)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.6.1)
 
   examples/reactions:
     dependencies:
@@ -1381,7 +1384,7 @@ importers:
         version: 19.1.0(@types/react@19.1.0)
       '@vitejs/plugin-react':
         specifier: ^4.5.1
-        version: 4.5.1(vite@6.3.5(@types/node@24.3.0)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.6.1))
+        version: 4.5.1(vite@6.3.5(@types/node@24.3.0)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.6.1))
       globals:
         specifier: ^15.11.0
         version: 15.15.0
@@ -1390,7 +1393,7 @@ importers:
         version: 5.6.2
       vite:
         specifier: 6.3.5
-        version: 6.3.5(@types/node@24.3.0)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.6.1)
+        version: 6.3.5(@types/node@24.3.0)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.6.1)
 
   examples/richtext-prosekit:
     dependencies:
@@ -1421,7 +1424,7 @@ importers:
         version: 19.1.0(@types/react@19.1.0)
       '@vitejs/plugin-react':
         specifier: ^4.5.0
-        version: 4.5.1(vite@6.3.5(@types/node@24.3.0)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.6.1))
+        version: 4.5.1(vite@6.3.5(@types/node@24.3.0)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.6.1))
       postcss:
         specifier: ^8.5.4
         version: 8.5.4
@@ -1433,7 +1436,7 @@ importers:
         version: 5.6.2
       vite:
         specifier: 6.3.5
-        version: 6.3.5(@types/node@24.3.0)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.6.1)
+        version: 6.3.5(@types/node@24.3.0)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.6.1)
 
   examples/richtext-prosemirror:
     dependencies:
@@ -1482,7 +1485,7 @@ importers:
         version: 19.1.0(@types/react@19.1.0)
       '@vitejs/plugin-react':
         specifier: ^4.5.1
-        version: 4.5.1(vite@6.3.5(@types/node@24.3.0)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.6.1))
+        version: 4.5.1(vite@6.3.5(@types/node@24.3.0)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.6.1))
       globals:
         specifier: ^15.11.0
         version: 15.15.0
@@ -1500,7 +1503,7 @@ importers:
         version: 5.6.2
       vite:
         specifier: 6.3.5
-        version: 6.3.5(@types/node@24.3.0)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.6.1)
+        version: 6.3.5(@types/node@24.3.0)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.6.1)
 
   examples/richtext-tiptap:
     dependencies:
@@ -1558,7 +1561,7 @@ importers:
         version: 19.1.0(@types/react@19.1.0)
       '@vitejs/plugin-react':
         specifier: ^4.5.1
-        version: 4.5.1(vite@6.3.5(@types/node@24.3.0)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.6.1))
+        version: 4.5.1(vite@6.3.5(@types/node@24.3.0)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.6.1))
       globals:
         specifier: ^15.11.0
         version: 15.15.0
@@ -1576,7 +1579,7 @@ importers:
         version: 5.6.2
       vite:
         specifier: 6.3.5
-        version: 6.3.5(@types/node@24.3.0)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.6.1)
+        version: 6.3.5(@types/node@24.3.0)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.6.1)
 
   examples/server-worker-http:
     dependencies:
@@ -1661,7 +1664,7 @@ importers:
         version: 1.2.3(@types/react@19.1.0)(react@19.1.0)
       '@tailwindcss/vite':
         specifier: ^4.0.17
-        version: 4.1.10(vite@6.3.5(@types/node@24.3.0)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.19.3)(yaml@2.6.1))
+        version: 4.1.10(vite@6.3.5(@types/node@24.3.0)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.19.3)(yaml@2.6.1))
       '@tanstack/react-router':
         specifier: ^1.115.0
         version: 1.129.4(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
@@ -1670,7 +1673,7 @@ importers:
         version: 1.129.4(@tanstack/react-router@1.129.4(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(@tanstack/router-core@1.129.4)(csstype@3.1.3)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(solid-js@1.9.5)(tiny-invariant@1.3.3)
       '@tanstack/router-plugin':
         specifier: ^1.114.30
-        version: 1.129.4(@tanstack/react-router@1.129.4(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(vite@6.3.5(@types/node@24.3.0)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.19.3)(yaml@2.6.1))
+        version: 1.129.4(@tanstack/react-router@1.129.4(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(vite@6.3.5(@types/node@24.3.0)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.19.3)(yaml@2.6.1))
       class-variance-authority:
         specifier: ^0.7.1
         version: 0.7.1
@@ -1707,7 +1710,7 @@ importers:
         version: 19.1.0(@types/react@19.1.0)
       '@vitejs/plugin-react':
         specifier: ^4.3.4
-        version: 4.5.1(vite@6.3.5(@types/node@24.3.0)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.19.3)(yaml@2.6.1))
+        version: 4.5.1(vite@6.3.5(@types/node@24.3.0)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.19.3)(yaml@2.6.1))
       jazz-run:
         specifier: workspace:*
         version: link:../../packages/jazz-run
@@ -1722,7 +1725,7 @@ importers:
         version: 5.6.2
       vite:
         specifier: 6.3.5
-        version: 6.3.5(@types/node@24.3.0)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.19.3)(yaml@2.6.1)
+        version: 6.3.5(@types/node@24.3.0)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.19.3)(yaml@2.6.1)
 
   examples/todo:
     dependencies:
@@ -1786,7 +1789,7 @@ importers:
         version: 19.1.0(@types/react@19.1.0)
       '@vitejs/plugin-react-swc':
         specifier: ^3.10.1
-        version: 3.10.1(@swc/helpers@0.5.17)(vite@6.3.5(@types/node@24.3.0)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.6.1))
+        version: 3.10.1(@swc/helpers@0.5.17)(vite@6.3.5(@types/node@24.3.0)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.6.1))
       postcss:
         specifier: ^8.4.27
         version: 8.5.4
@@ -1798,7 +1801,7 @@ importers:
         version: 5.6.2
       vite:
         specifier: 6.3.5
-        version: 6.3.5(@types/node@24.3.0)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.6.1)
+        version: 6.3.5(@types/node@24.3.0)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.6.1)
 
   examples/version-history:
     dependencies:
@@ -1829,7 +1832,7 @@ importers:
         version: 19.1.0(@types/react@19.1.0)
       '@vitejs/plugin-react':
         specifier: ^4.5.1
-        version: 4.5.1(vite@6.3.5(@types/node@24.3.0)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.6.1))
+        version: 4.5.1(vite@6.3.5(@types/node@24.3.0)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.6.1))
       globals:
         specifier: ^15.11.0
         version: 15.15.0
@@ -1841,7 +1844,20 @@ importers:
         version: 5.6.2
       vite:
         specifier: 6.3.5
-        version: 6.3.5(@types/node@24.3.0)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.6.1)
+        version: 6.3.5(@types/node@24.3.0)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.6.1)
+
+  packages/codemod-upgrade-0-18:
+    dependencies:
+      ts-morph:
+        specifier: ^26.0.0
+        version: 26.0.0
+    devDependencies:
+      tsdown:
+        specifier: ^0.11.9
+        version: 0.11.13(typescript@5.6.2)(vue-tsc@2.2.12(typescript@5.6.2))
+      typescript:
+        specifier: catalog:default
+        version: 5.6.2
 
   packages/cojson:
     dependencies:
@@ -1948,10 +1964,10 @@ importers:
         version: 1.5.0
       '@vitejs/plugin-vue':
         specifier: ^5.1.4
-        version: 5.2.4(vite@6.3.5(@types/node@24.3.0)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.6.1))(vue@3.5.13(typescript@5.6.2))
+        version: 5.2.4(vite@6.3.5(@types/node@24.3.0)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.6.1))(vue@3.5.13(typescript@5.6.2))
       '@vitejs/plugin-vue-jsx':
         specifier: ^4.2.0
-        version: 4.2.0(vite@6.3.5(@types/node@24.3.0)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.6.1))(vue@3.5.13(typescript@5.6.2))
+        version: 4.2.0(vite@6.3.5(@types/node@24.3.0)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.6.1))(vue@3.5.13(typescript@5.6.2))
       rollup-plugin-node-externals:
         specifier: ^8.0.0
         version: 8.0.1(rollup@4.41.1)
@@ -1960,10 +1976,10 @@ importers:
         version: 5.6.2
       vite:
         specifier: 6.3.5
-        version: 6.3.5(@types/node@24.3.0)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.6.1)
+        version: 6.3.5(@types/node@24.3.0)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.6.1)
       vite-plugin-dts:
         specifier: ^4.2.4
-        version: 4.5.4(@types/node@24.3.0)(rollup@4.41.1)(typescript@5.6.2)(vite@6.3.5(@types/node@24.3.0)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.6.1))
+        version: 4.5.4(@types/node@24.3.0)(rollup@4.41.1)(typescript@5.6.2)(vite@6.3.5(@types/node@24.3.0)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.6.1))
       vue:
         specifier: ^3.5.11
         version: 3.5.13(typescript@5.6.2)
@@ -2006,7 +2022,7 @@ importers:
         version: 5.6.2
       vitest:
         specifier: catalog:default
-        version: 3.2.4(@types/debug@4.1.12)(@types/node@24.3.0)(@vitest/browser@3.2.4)(@vitest/ui@3.2.4)(happy-dom@17.4.4)(jiti@2.4.2)(jsdom@25.0.1)(lightningcss@1.30.1)(msw@2.10.4(@types/node@24.3.0)(typescript@5.6.2))(terser@5.43.1)(tsx@4.20.3)(yaml@2.6.1)
+        version: 3.2.4(@types/debug@4.1.12)(@types/node@24.3.0)(@vitest/browser@3.2.4)(@vitest/ui@3.2.4)(happy-dom@17.4.4)(jiti@2.5.1)(jsdom@25.0.1)(lightningcss@1.30.1)(msw@2.10.4(@types/node@24.3.0)(typescript@5.6.2))(terser@5.43.1)(tsx@4.20.3)(yaml@2.6.1)
 
   packages/cursor-docs: {}
 
@@ -2248,7 +2264,7 @@ importers:
         version: 2.3.7(svelte@5.34.6)(typescript@5.6.2)
       '@sveltejs/vite-plugin-svelte':
         specifier: ^6.1.0
-        version: 6.1.0(svelte@5.34.6)(vite@6.3.5(@types/node@24.3.0)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.6.1))
+        version: 6.1.0(svelte@5.34.6)(vite@6.3.5(@types/node@24.3.0)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.6.1))
       '@testing-library/dom':
         specifier: ^10.4.0
         version: 10.4.0
@@ -2260,7 +2276,7 @@ importers:
         version: 16.2.0(@testing-library/dom@10.4.0)(@types/react-dom@19.1.0(@types/react@19.1.0))(@types/react@19.1.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       '@testing-library/svelte':
         specifier: ^5.2.6
-        version: 5.2.6(svelte@5.34.6)(vite@6.3.5(@types/node@24.3.0)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.6.1))(vitest@3.2.4)
+        version: 5.2.6(svelte@5.34.6)(vite@6.3.5(@types/node@24.3.0)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.6.1))(vitest@3.2.4)
       '@types/react':
         specifier: 19.1.0
         version: 19.1.0
@@ -2269,7 +2285,7 @@ importers:
         version: 19.1.0(@types/react@19.1.0)
       '@vitest/browser':
         specifier: ^3.2.4
-        version: 3.2.4(msw@2.10.3(@types/node@24.3.0)(typescript@5.6.2))(playwright@1.50.1)(vite@6.3.5(@types/node@24.3.0)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.6.1))(vitest@3.2.4)(webdriverio@8.41.0)
+        version: 3.2.4(msw@2.10.3(@types/node@24.3.0)(typescript@5.6.2))(playwright@1.50.1)(vite@6.3.5(@types/node@24.3.0)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.6.1))(vitest@3.2.4)(webdriverio@8.41.0)
       msw:
         specifier: ^2.10.3
         version: 2.10.3(@types/node@24.3.0)(typescript@5.6.2)
@@ -2281,13 +2297,13 @@ importers:
         version: 4.1.2
       tsup:
         specifier: 8.5.0
-        version: 8.5.0(@microsoft/api-extractor@7.52.10(@types/node@24.3.0))(@swc/core@1.11.29(@swc/helpers@0.5.17))(jiti@2.4.2)(postcss@8.5.6)(tsx@4.20.3)(typescript@5.6.2)(yaml@2.6.1)
+        version: 8.5.0(@microsoft/api-extractor@7.52.10(@types/node@24.3.0))(@swc/core@1.11.29(@swc/helpers@0.5.17))(jiti@2.5.1)(postcss@8.5.6)(tsx@4.20.3)(typescript@5.6.2)(yaml@2.6.1)
       typescript:
         specifier: catalog:default
         version: 5.6.2
       vitest:
         specifier: catalog:default
-        version: 3.2.4(@types/debug@4.1.12)(@types/node@24.3.0)(@vitest/browser@3.2.4)(@vitest/ui@3.2.4)(happy-dom@17.4.4)(jiti@2.4.2)(jsdom@25.0.1)(lightningcss@1.30.1)(msw@2.10.3(@types/node@24.3.0)(typescript@5.6.2))(terser@5.43.1)(tsx@4.20.3)(yaml@2.6.1)
+        version: 3.2.4(@types/debug@4.1.12)(@types/node@24.3.0)(@vitest/browser@3.2.4)(@vitest/ui@3.2.4)(happy-dom@17.4.4)(jiti@2.5.1)(jsdom@25.0.1)(lightningcss@1.30.1)(msw@2.10.3(@types/node@24.3.0)(typescript@5.6.2))(terser@5.43.1)(tsx@4.20.3)(yaml@2.6.1)
       ws:
         specifier: ^8.14.2
         version: 8.18.1
@@ -2370,7 +2386,7 @@ importers:
         version: 19.1.0(@types/react@19.1.0)
       '@vitejs/plugin-react':
         specifier: ^4.5.1
-        version: 4.5.1(vite@6.3.5(@types/node@24.3.0)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.6.1))
+        version: 4.5.1(vite@6.3.5(@types/node@24.3.0)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.6.1))
       globals:
         specifier: ^15.11.0
         version: 15.15.0
@@ -2388,7 +2404,7 @@ importers:
         version: 5.6.2
       vite:
         specifier: 6.3.5
-        version: 6.3.5(@types/node@24.3.0)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.6.1)
+        version: 6.3.5(@types/node@24.3.0)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.6.1)
 
   starters/svelte-passkey-auth:
     dependencies:
@@ -2401,13 +2417,13 @@ importers:
         version: 1.50.1
       '@sveltejs/adapter-auto':
         specifier: ^6.0.1
-        version: 6.0.1(@sveltejs/kit@2.36.1(@opentelemetry/api@1.9.0)(@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.38.2)(vite@6.3.5(@types/node@24.3.0)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.6.1)))(svelte@5.38.2)(vite@6.3.5(@types/node@24.3.0)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.6.1)))
+        version: 6.0.1(@sveltejs/kit@2.36.1(@opentelemetry/api@1.9.0)(@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.38.2)(vite@6.3.5(@types/node@24.3.0)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.6.1)))(svelte@5.38.2)(vite@6.3.5(@types/node@24.3.0)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.6.1)))
       '@sveltejs/kit':
         specifier: catalog:svelte
-        version: 2.36.1(@opentelemetry/api@1.9.0)(@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.38.2)(vite@6.3.5(@types/node@24.3.0)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.6.1)))(svelte@5.38.2)(vite@6.3.5(@types/node@24.3.0)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.6.1))
+        version: 2.36.1(@opentelemetry/api@1.9.0)(@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.38.2)(vite@6.3.5(@types/node@24.3.0)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.6.1)))(svelte@5.38.2)(vite@6.3.5(@types/node@24.3.0)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.6.1))
       '@sveltejs/vite-plugin-svelte':
         specifier: catalog:svelte
-        version: 5.1.1(svelte@5.38.2)(vite@6.3.5(@types/node@24.3.0)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.6.1))
+        version: 5.1.1(svelte@5.38.2)(vite@6.3.5(@types/node@24.3.0)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.6.1))
       '@tailwindcss/postcss':
         specifier: ^4.1.11
         version: 4.1.11
@@ -2416,13 +2432,13 @@ importers:
         version: 9.6.1
       eslint:
         specifier: ^9.7.0
-        version: 9.28.0(jiti@2.4.2)
+        version: 9.28.0(jiti@2.5.1)
       eslint-config-prettier:
         specifier: ^9.1.0
-        version: 9.1.0(eslint@9.28.0(jiti@2.4.2))
+        version: 9.1.0(eslint@9.28.0(jiti@2.5.1))
       eslint-plugin-svelte:
         specifier: ^2.36.0
-        version: 2.46.1(eslint@9.28.0(jiti@2.4.2))(svelte@5.38.2)(ts-node@10.9.2(@swc/core@1.11.29(@swc/helpers@0.5.17))(@types/node@24.3.0)(typescript@5.6.2))
+        version: 2.46.1(eslint@9.28.0(jiti@2.5.1))(svelte@5.38.2)(ts-node@10.9.2(@swc/core@1.11.29(@swc/helpers@0.5.17))(@types/node@24.3.0)(typescript@5.6.2))
       globals:
         specifier: ^15.11.0
         version: 15.15.0
@@ -2452,10 +2468,10 @@ importers:
         version: 5.6.2
       typescript-eslint:
         specifier: ^8.0.0
-        version: 8.34.0(eslint@9.28.0(jiti@2.4.2))(typescript@5.6.2)
+        version: 8.34.0(eslint@9.28.0(jiti@2.5.1))(typescript@5.6.2)
       vite:
         specifier: 6.3.5
-        version: 6.3.5(@types/node@24.3.0)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.6.1)
+        version: 6.3.5(@types/node@24.3.0)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.6.1)
 
   tests/browser-integration:
     dependencies:
@@ -2467,7 +2483,7 @@ importers:
         version: 16.2.0(@testing-library/dom@10.4.0)(@types/react-dom@19.1.0(@types/react@19.1.0))(@types/react@19.1.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       '@vitejs/plugin-react-swc':
         specifier: ^3.10.1
-        version: 3.10.1(@swc/helpers@0.5.17)(vite@6.3.5(@types/node@24.3.0)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.6.1))
+        version: 3.10.1(@swc/helpers@0.5.17)(vite@6.3.5(@types/node@24.3.0)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.6.1))
       cojson:
         specifier: workspace:*
         version: link:../../packages/cojson
@@ -2563,7 +2579,7 @@ importers:
         version: 19.1.0(@types/react@19.1.0)
       '@vitejs/plugin-react-swc':
         specifier: ^3.10.1
-        version: 3.10.1(@swc/helpers@0.5.17)(vite@6.3.5(@types/node@22.15.18)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.6.1))
+        version: 3.10.1(@swc/helpers@0.5.17)(vite@6.3.5(@types/node@22.15.18)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.6.1))
       jazz-run:
         specifier: workspace:*
         version: link:../../packages/jazz-run
@@ -2575,7 +2591,7 @@ importers:
         version: 5.6.2
       vite:
         specifier: 6.3.5
-        version: 6.3.5(@types/node@22.15.18)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.6.1)
+        version: 6.3.5(@types/node@22.15.18)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.6.1)
 
   tests/jazz-svelte:
     dependencies:
@@ -2588,19 +2604,19 @@ importers:
     devDependencies:
       '@sveltejs/adapter-vercel':
         specifier: ^5.5.0
-        version: 5.5.2(@sveltejs/kit@2.36.1(@opentelemetry/api@1.9.0)(@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.38.2)(vite@6.3.5(@types/node@24.3.0)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.6.1)))(svelte@5.38.2)(vite@6.3.5(@types/node@24.3.0)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.6.1)))(rollup@4.41.1)
+        version: 5.5.2(@sveltejs/kit@2.36.1(@opentelemetry/api@1.9.0)(@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.38.2)(vite@6.3.5(@types/node@24.3.0)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.6.1)))(svelte@5.38.2)(vite@6.3.5(@types/node@24.3.0)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.6.1)))(rollup@4.41.1)
       '@sveltejs/kit':
         specifier: catalog:svelte
-        version: 2.36.1(@opentelemetry/api@1.9.0)(@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.38.2)(vite@6.3.5(@types/node@24.3.0)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.6.1)))(svelte@5.38.2)(vite@6.3.5(@types/node@24.3.0)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.6.1))
+        version: 2.36.1(@opentelemetry/api@1.9.0)(@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.38.2)(vite@6.3.5(@types/node@24.3.0)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.6.1)))(svelte@5.38.2)(vite@6.3.5(@types/node@24.3.0)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.6.1))
       '@sveltejs/vite-plugin-svelte':
         specifier: catalog:svelte
-        version: 5.1.1(svelte@5.38.2)(vite@6.3.5(@types/node@24.3.0)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.6.1))
+        version: 5.1.1(svelte@5.38.2)(vite@6.3.5(@types/node@24.3.0)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.6.1))
       '@testing-library/jest-dom':
         specifier: ^6.6.3
         version: 6.6.3
       '@testing-library/svelte':
         specifier: ^5.2.6
-        version: 5.2.6(svelte@5.38.2)(vite@6.3.5(@types/node@24.3.0)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.6.1))(vitest@3.2.4)
+        version: 5.2.6(svelte@5.38.2)(vite@6.3.5(@types/node@24.3.0)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.6.1))(vitest@3.2.4)
       '@testing-library/user-event':
         specifier: ^14.6.1
         version: 14.6.1(@testing-library/dom@10.4.0)
@@ -2624,7 +2640,7 @@ importers:
         version: 0.41.5(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(solid-js@1.9.5)(svelte@5.38.2)(vue@3.5.13(typescript@5.6.2))
       vite:
         specifier: 6.3.5
-        version: 6.3.5(@types/node@24.3.0)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.6.1)
+        version: 6.3.5(@types/node@24.3.0)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.6.1)
 
   tests/stress-test:
     dependencies:
@@ -2664,13 +2680,13 @@ importers:
         version: 19.1.0(@types/react@19.1.0)
       '@vitejs/plugin-react-swc':
         specifier: ^3.10.1
-        version: 3.10.1(@swc/helpers@0.5.17)(vite@6.3.5(@types/node@24.3.0)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.6.1))
+        version: 3.10.1(@swc/helpers@0.5.17)(vite@6.3.5(@types/node@24.3.0)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.6.1))
       typescript:
         specifier: 5.6.2
         version: 5.6.2
       vite:
         specifier: 6.3.5
-        version: 6.3.5(@types/node@24.3.0)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.6.1)
+        version: 6.3.5(@types/node@24.3.0)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.6.1)
 
 packages:
 
@@ -4376,11 +4392,17 @@ packages:
     peerDependencies:
       tailwindcss: '*'
 
+  '@emnapi/core@1.4.5':
+    resolution: {integrity: sha512-XsLw1dEOpkSX/WucdqUhPWP7hDxSvZiY+fsUC14h+FtQ2Ifni4znbBt8punRX+Uj2JG/uDb8nEHVKvrVlvdZ5Q==}
+
   '@emnapi/runtime@1.4.3':
     resolution: {integrity: sha512-pBPWdu6MLKROBX05wSNKcNb++m5Er+KQ9QkB+WVM+pW2Kx9hoSrVTnu3BdkI5eBLZoKu/J6mW/B6i6bJB2ytXQ==}
 
   '@emnapi/runtime@1.4.5':
     resolution: {integrity: sha512-++LApOtY0pEEz1zrd9vy1/zXVaVJJ/EbAF3u0fXIzPJEDtnITsBGbbK0EkM72amhl/R5b+5xx0Y/QhcVOpuulg==}
+
+  '@emnapi/wasi-threads@1.0.4':
+    resolution: {integrity: sha512-PJR+bOmMOPH8AtcTGAyYNiuJ3/Fcoj2XN/gBEWzDIKh254XO+mM9XoXHk5GNEhodxeMznbg7BlRojVbKN+gC6g==}
 
   '@emotion/babel-plugin@11.13.5':
     resolution: {integrity: sha512-pxHCpT2ex+0q+HH91/zsdHkw/lXd468DIN2zvfvLtPKLLMo6gQj7oLObq8PhkrxOZb/gGCq03S3Z7PDhS8pduQ==}
@@ -5474,6 +5496,9 @@ packages:
     resolution: {integrity: sha512-bndDP83naYYkfayr/qhBHMhk0YGwS1iv6vaEGcr0SQbO0IZtbOPqjKjds/WcG+bJA+1T5vCx6kprKOzn5Bg+Vw==}
     engines: {node: '>=18'}
 
+  '@napi-rs/wasm-runtime@0.2.12':
+    resolution: {integrity: sha512-ZVWUcfwY4E/yPitQJl481FjFo3K22D6qF0DuFH6Y/nbnE11GY5uguDxZMGXPQ8WQ0128MXQD7TnfHyK4oWoIJQ==}
+
   '@neon-rs/load@0.0.4':
     resolution: {integrity: sha512-kTPhdZyTQxB+2wpiRcFWrDcejc4JI6tkPuS7UZCG4l6Zvc5kU/gGQ/ozvHTh1XR5tS+UlfAfGuPajjzQjCiHCw==}
 
@@ -5719,6 +5744,9 @@ packages:
     resolution: {integrity: sha512-4VlGgo32k2EQ2wcCY3vEU28A0O13aOtHz3Xt2/2U5FAh9EfhD6t6DqL5Z6yAnRCntbTFDU4YfbpyzSlHNWycPw==}
     engines: {node: '>=14'}
 
+  '@oxc-project/types@0.70.0':
+    resolution: {integrity: sha512-ngyLUpUjO3dpqygSRQDx7nMx8+BmXbWOU4oIwTJFV2MVIDG7knIZwgdwXlQWLg3C3oxg1lS7ppMtPKqKFb7wzw==}
+
   '@parcel/watcher-android-arm64@2.5.0':
     resolution: {integrity: sha512-qlX4eS28bUcQCdribHkg/herLe+0A9RyYC+mm2PXpncit8z5b3nSqGVzMNR3CmtAOgRutiZ02eIJJgP/b1iEFQ==}
     engines: {node: '>= 10.0.0'}
@@ -5954,6 +5982,9 @@ packages:
     resolution: {integrity: sha512-PuvK6xZzGhKPvlx3fpfdM2kYY3P/hB1URtK8wA7XUJ6prn6pp22zvJHu48th0SGcHL9SutbPHrFuQgfXTFobWA==}
     engines: {node: '>=16.3.0'}
     hasBin: true
+
+  '@quansync/fs@0.1.5':
+    resolution: {integrity: sha512-lNS9hL2aS2NZgNW7BBj+6EBl4rOf8l+tQ0eRY6JWCI8jI2kc53gSoqbjojU0OnAWhzoXiOjFyGsHcDGePB3lhA==}
 
   '@radix-ui/primitive@1.1.2':
     resolution: {integrity: sha512-XnbHrrprsNqZKQhStrSwgRUQzoCI1glLzdw79xiZPoofhGICeZRSQ3dIxAKH1gb3OHfNf4d6f+vAv3kil2eggA==}
@@ -6626,6 +6657,66 @@ packages:
   '@rnx-kit/tools-workspaces@0.2.2':
     resolution: {integrity: sha512-6Km4tkP3WgqsNasr4rTDh7/+ZgkFobuP1fe1LT0ZMyBJ7zkadau8HpqYCF6+J60CoorCgxcA8hlEUhw9T/vPwA==}
     engines: {node: '>=16.17'}
+
+  '@rolldown/binding-darwin-arm64@1.0.0-beta.9':
+    resolution: {integrity: sha512-geUG/FUpm+membLC0NQBb39vVyOfguYZ2oyXc7emr6UjH6TeEECT4b0CPZXKFnELareTiU/Jfl70/eEgNxyQeA==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@rolldown/binding-darwin-x64@1.0.0-beta.9':
+    resolution: {integrity: sha512-7wPXDwcOtv2I+pWTL2UNpNAxMAGukgBT90Jz4DCfwaYdGvQncF7J0S7IWrRVsRFhBavxM+65RcueE3VXw5UIbg==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@rolldown/binding-freebsd-x64@1.0.0-beta.9':
+    resolution: {integrity: sha512-agO5mONTNKVrcIt4SRxw5Ni0FOVV3gaH8dIiNp1A4JeU91b9kw7x+JRuNJAQuM2X3pYqVvA6qh13UTNOsaqM/Q==}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@rolldown/binding-linux-arm-gnueabihf@1.0.0-beta.9':
+    resolution: {integrity: sha512-dDNDV9p/8WYDriS9HCcbH6y6+JP38o3enj/pMkdkmkxEnZ0ZoHIfQ9RGYWeRYU56NKBCrya4qZBJx49Jk9LRug==}
+    cpu: [arm]
+    os: [linux]
+
+  '@rolldown/binding-linux-arm64-gnu@1.0.0-beta.9':
+    resolution: {integrity: sha512-kZKegmHG1ZvfsFIwYU6DeFSxSIcIliXzeznsJHUo9D9/dlVSDi/PUvsRKcuJkQjZoejM6pk8MHN/UfgGdIhPHw==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@rolldown/binding-linux-arm64-musl@1.0.0-beta.9':
+    resolution: {integrity: sha512-f+VL8mO31pyMJiJPr2aA1ryYONkP2UqgbwK7fKtKHZIeDd/AoUGn3+ujPqDhuy2NxgcJ5H8NaSvDpG1tJMHh+g==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@rolldown/binding-linux-x64-gnu@1.0.0-beta.9':
+    resolution: {integrity: sha512-GiUEZ0WPjX5LouDoC3O8aJa4h6BLCpIvaAboNw5JoRour/3dC6rbtZZ/B5FC3/ySsN3/dFOhAH97ylQxoZJi7A==}
+    cpu: [x64]
+    os: [linux]
+
+  '@rolldown/binding-linux-x64-musl@1.0.0-beta.9':
+    resolution: {integrity: sha512-AMb0dicw+QHh6RxvWo4BRcuTMgS0cwUejJRMpSyIcHYnKTbj6nUW4HbWNQuDfZiF27l6F5gEwBS+YLUdVzL9vg==}
+    cpu: [x64]
+    os: [linux]
+
+  '@rolldown/binding-wasm32-wasi@1.0.0-beta.9':
+    resolution: {integrity: sha512-+pdaiTx7L8bWKvsAuCE0HAxP1ze1WOLoWGCawcrZbMSY10dMh2i82lJiH6tXGXbfYYwsNWhWE2NyG4peFZvRfQ==}
+    engines: {node: '>=14.21.3'}
+    cpu: [wasm32]
+
+  '@rolldown/binding-win32-arm64-msvc@1.0.0-beta.9':
+    resolution: {integrity: sha512-A7kN248viWvb8eZMzQu024TBKGoyoVYBsDG2DtoP8u2pzwoh5yDqUL291u01o4f8uzpUHq8mfwQJmcGChFu8KQ==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@rolldown/binding-win32-ia32-msvc@1.0.0-beta.9':
+    resolution: {integrity: sha512-DzKN7iEYjAP8AK8F2G2aCej3fk43Y/EQrVrR3gF0XREes56chjQ7bXIhw819jv74BbxGdnpPcslhet/cgt7WRA==}
+    cpu: [ia32]
+    os: [win32]
+
+  '@rolldown/binding-win32-x64-msvc@1.0.0-beta.9':
+    resolution: {integrity: sha512-GMWgTvvbZ8TfBsAiJpoz4SRq3IN3aUMn0rYm8q4I8dcEk4J1uISyfb6ZMzvqW+cvScTWVKWZNqnrmYOKLLUt4w==}
+    cpu: [x64]
+    os: [win32]
 
   '@rolldown/pluginutils@1.0.0-beta.9':
     resolution: {integrity: sha512-e9MeMtVWo186sgvFFJOPGy7/d2j2mZhLJIdVW0C/xDluuOvymEATqz6zKsP0ZmXGzQtqlyjz5sC1sYQUoJG98w==}
@@ -7501,6 +7592,9 @@ packages:
   '@tootallnate/quickjs-emscripten@0.23.0':
     resolution: {integrity: sha512-C5Mc6rdnsaJDjO3UpGW/CQTHtCKaYlScZTly4JIu97Jxo/odCiH0ITnDXSJPTOrEKk/ycSZ0AOgTmkDtkOsvIA==}
 
+  '@ts-morph/common@0.27.0':
+    resolution: {integrity: sha512-Wf29UqxWDpc+i61k3oIOzcUfQt79PIT9y/MWfAGlrkjg6lBC1hwDECLXPVJAhWjiGbfBCxZd65F/LIZF3+jeJQ==}
+
   '@tsconfig/node10@1.0.11':
     resolution: {integrity: sha512-DcRjDCujK/kCk/cUe8Xz8ZSpm8mS3mNNpta+jGCA6USEDfktlNvm1+IuZ9eTcDbNk41BHwpHHeW+N1lKCz4zOw==}
 
@@ -7518,6 +7612,9 @@ packages:
 
   '@tsconfig/node22@22.0.2':
     resolution: {integrity: sha512-Kmwj4u8sDRDrMYRoN9FDEcXD8UpBSaPQQ24Gz+Gamqfm7xxn+GBR7ge/Z7pK8OXNGyUzbSwJj+TH6B+DS/epyA==}
+
+  '@tybys/wasm-util@0.10.0':
+    resolution: {integrity: sha512-VyyPYFlOMNylG45GoAe0xDoLwWuowvf92F9kySqzYh8vmYm7D2u4iUJKa1tOUpS70Ku13ASrOkS4ScXFsTaCNQ==}
 
   '@types/argparse@1.0.38':
     resolution: {integrity: sha512-ebDJ9b0e702Yr7pWgB0jzm+CX4Srzz8RcXtLJDJB+BSccqMa36uyH/zUsSYao5+BD1ytv3k3rPYCq4mAE1hsXA==}
@@ -8365,6 +8462,10 @@ packages:
     resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
     engines: {node: '>=12'}
 
+  ast-kit@2.1.2:
+    resolution: {integrity: sha512-cl76xfBQM6pztbrFWRnxbrDm9EOqDr1BF6+qQnnDZG2Co2LjyUktkN9GTJfBAfdae+DbT2nJf2nCGAdDDN7W2g==}
+    engines: {node: '>=20.18.0'}
+
   ast-types@0.13.4:
     resolution: {integrity: sha512-x1FCFnFifvYDDzTaLII71vG5uvDwgtmDTEVWAxrgeiR8VjMONcCXJx7E+USjDtHlwFmt9MysbqgF9b9Vjr6w+w==}
     engines: {node: '>=4'}
@@ -8890,6 +8991,9 @@ packages:
     resolution: {integrity: sha512-QVb0dM5HvG+uaxitm8wONl7jltx8dqhfU33DcqtOZcLSVIKSDDLDi7+0LbAKiyI8hD9u42m2YxXSkMGWThaecQ==}
     engines: {iojs: '>= 1.0.0', node: '>= 0.12.0'}
 
+  code-block-writer@13.0.3:
+    resolution: {integrity: sha512-Oofo0pq3IKnsFtuHqSF7TqBfr71aeyZDVJ0HpmqB7FBM2qEigL0iPONSCZSO9pE9dZTAxANe5XHG9Uy0YMv8cg==}
+
   cojson-storage-indexeddb@0.17.9:
     resolution: {integrity: sha512-aOKoYHTUwxwEr08n6dXqMmpEciE8w0DaMuP8wAUg/8ijRz9uTBATZHHiUE4LM+0sZjA/3RbvfnAh8FSgR2MiIQ==}
 
@@ -9413,6 +9517,15 @@ packages:
     resolution: {integrity: sha512-kQhDYKZecqnM0fCnzI5eIv5L4cAe/iRI+HqMbO/hbRdTAeXDG+M9FjipUxNfbARuEg4iHIbhnhs78BCHNbSxEQ==}
     engines: {node: '>=12'}
 
+  dts-resolver@2.1.2:
+    resolution: {integrity: sha512-xeXHBQkn2ISSXxbJWD828PFjtyg+/UrMDo7W4Ffcs7+YWCquxU8YjV1KoxuiL+eJ5pg3ll+bC6flVv61L3LKZg==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      oxc-resolver: '>=11.0.0'
+    peerDependenciesMeta:
+      oxc-resolver:
+        optional: true
+
   dunder-proto@1.0.1:
     resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
     engines: {node: '>= 0.4'}
@@ -9463,6 +9576,10 @@ packages:
 
   emoji-regex@9.2.2:
     resolution: {integrity: sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==}
+
+  empathic@1.1.0:
+    resolution: {integrity: sha512-rsPft6CK3eHtrlp9Y5ALBb+hfK+DWnA4WFebbazxjWyx8vSm3rZeoM3z9irsjcqO3PYRzlfv27XIB4tz2DV7RA==}
+    engines: {node: '>=14'}
 
   encodeurl@1.0.2:
     resolution: {integrity: sha512-TPJXq8JqFaVYm2CWmPvnP2Iyo4ZSM7/QKcSmuMLDObfpH5fi7RUGmd/rTDf+rut/saiDiQEeVTNgAmJEdAOx0w==}
@@ -10279,6 +10396,9 @@ packages:
   get-tsconfig@4.10.0:
     resolution: {integrity: sha512-kGzZ3LWWQcGIAmg6iWvXn0ei6WDtV26wzHRMwDSzmAbcXrTEXxHy6IehI6/4eT6VRKyMP1eF1VqwrVUmE/LR7A==}
 
+  get-tsconfig@4.10.1:
+    resolution: {integrity: sha512-auHyJ4AgMz7vgS8Hp3N6HXSmlMdUyhSUrfBF16w153rxtLIEOE+HGqaBppczZvnHLqQJfiHotCYpNhl0lUROFQ==}
+
   get-uri@6.0.4:
     resolution: {integrity: sha512-E1b1lFFLvLgak2whF2xDBcOy6NLVGZBqqjJjsIhvopKfWWEi64pLVTWWehV8KlLerZkfNTA95sTe2OdJKm1OzQ==}
     engines: {node: '>= 14'}
@@ -11077,6 +11197,10 @@ packages:
 
   jiti@2.4.2:
     resolution: {integrity: sha512-rg9zJN+G4n2nfJl5MW3BMygZX56zKPNVEYYqq7adpmMh4Jn2QNEwhvQlFy6jPVdcod7txZtKHWnyZiA3a0zP7A==}
+    hasBin: true
+
+  jiti@2.5.1:
+    resolution: {integrity: sha512-twQoecYPiVA5K/h6SxtORw/Bs3ar+mLUtoPSc7iMXzQzK8d7eJ/R09wmTwAjiamETn1cXYPGfNnu7DMoHgu12w==}
     hasBin: true
 
   jju@1.4.0:
@@ -13011,6 +13135,9 @@ packages:
   quansync@0.2.10:
     resolution: {integrity: sha512-t41VRkMYbkHyCYmOvx/6URnN80H7k4X0lLdBMGsz+maAwrJQYB1djpV6vHrQIBE0WBSGqhtEHrK9U3DWWH8v7A==}
 
+  quansync@0.2.11:
+    resolution: {integrity: sha512-AifT7QEbW9Nri4tAwR5M/uzpBuqfZf+zwaEM/QkzEjj7NBuFD2rBuy0K3dE+8wltbezDV7JMA0WfnCPYRSYbXA==}
+
   query-registry@3.0.1:
     resolution: {integrity: sha512-M9RxRITi2mHMVPU5zysNjctUT8bAPx6ltEXo/ir9+qmiM47Y7f0Ir3+OxUO5OjYAWdicBQRew7RtHtqUXydqlg==}
     engines: {node: '>=20'}
@@ -13486,6 +13613,31 @@ packages:
   rimraf@5.0.10:
     resolution: {integrity: sha512-l0OE8wL34P4nJH/H2ffoaniAokM2qSmrtXHmlpvYr5AVVX8msAyW0l8NVJFDxlSK4u3Uh/f41cQheDVdnYijwQ==}
     hasBin: true
+
+  rolldown-plugin-dts@0.13.14:
+    resolution: {integrity: sha512-wjNhHZz9dlN6PTIXyizB6u/mAg1wEFMW9yw7imEVe3CxHSRnNHVyycIX0yDEOVJfDNISLPbkCIPEpFpizy5+PQ==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      '@typescript/native-preview': '>=7.0.0-dev.20250601.1'
+      rolldown: ^1.0.0-beta.9
+      typescript: ^5.0.0
+      vue-tsc: ^2.2.0 || ^3.0.0
+    peerDependenciesMeta:
+      '@typescript/native-preview':
+        optional: true
+      typescript:
+        optional: true
+      vue-tsc:
+        optional: true
+
+  rolldown@1.0.0-beta.9:
+    resolution: {integrity: sha512-ZgZky52n6iF0UainGKjptKGrOG4Con2S5sdc4C4y2Oj25D5PHAY8Y8E5f3M2TSd/zlhQs574JlMeTe3vREczSg==}
+    hasBin: true
+    peerDependencies:
+      '@oxc-project/runtime': 0.70.0
+    peerDependenciesMeta:
+      '@oxc-project/runtime':
+        optional: true
 
   rollup-plugin-inject@3.0.2:
     resolution: {integrity: sha512-ptg9PQwzs3orn4jkgXJ74bfs5vYz1NCZlSQMBUA0wKcGp5i5pA1AO3fOUEte8enhGUC+iapTCzEWw2jEFFUO/w==}
@@ -14401,6 +14553,9 @@ packages:
   ts-interface-checker@0.1.13:
     resolution: {integrity: sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==}
 
+  ts-morph@26.0.0:
+    resolution: {integrity: sha512-ztMO++owQnz8c/gIENcM9XfCEzgoGphTv+nKpYNM1bgsdOVC/jRZuEBf6N+mLLDNg68Kl+GgUZfOySaRiG1/Ug==}
+
   ts-node@10.9.2:
     resolution: {integrity: sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==}
     hasBin: true
@@ -14413,6 +14568,25 @@ packages:
       '@swc/core':
         optional: true
       '@swc/wasm':
+        optional: true
+
+  tsdown@0.11.13:
+    resolution: {integrity: sha512-VSfoNm8MJXFdg7PJ4p2javgjMRiQQHpkP9N3iBBTrmCixcT6YZ9ZtqYMW3NDHczqR0C0Qnur1HMQr1ZfZcmrng==}
+    engines: {node: '>=18.0.0'}
+    hasBin: true
+    peerDependencies:
+      publint: ^0.3.0
+      typescript: ^5.0.0
+      unplugin-lightningcss: ^0.4.0
+      unplugin-unused: ^0.5.0
+    peerDependenciesMeta:
+      publint:
+        optional: true
+      typescript:
+        optional: true
+      unplugin-lightningcss:
+        optional: true
+      unplugin-unused:
         optional: true
 
   tslib@1.14.1:
@@ -14608,6 +14782,9 @@ packages:
 
   unbzip2-stream@1.4.3:
     resolution: {integrity: sha512-mlExGW4w71ebDJviH16lQLtZS32VKqsSfk80GCfUlwT/4/hNRFsoscrF/c++9xinkMzECL1uL9DDwXqFWkruPg==}
+
+  unconfig@7.3.3:
+    resolution: {integrity: sha512-QCkQoOnJF8L107gxfHL0uavn7WD9b3dpBcFX6HtfQYmjw2YzWxGuFQ0N0J6tE9oguCBJn9KOvfqYDCMPHIZrBA==}
 
   uncrypto@0.1.3:
     resolution: {integrity: sha512-Ql87qFHB3s/De2ClA9e0gsnS6zXG27SkTiSJwjCc9MebbfapQfuPzumMIUMi38ezPZVNFcHI9sUIepeQfw8J8Q==}
@@ -18693,12 +18870,23 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@emnapi/core@1.4.5':
+    dependencies:
+      '@emnapi/wasi-threads': 1.0.4
+      tslib: 2.8.1
+    optional: true
+
   '@emnapi/runtime@1.4.3':
     dependencies:
       tslib: 2.8.1
     optional: true
 
   '@emnapi/runtime@1.4.5':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
+  '@emnapi/wasi-threads@1.0.4':
     dependencies:
       tslib: 2.8.1
     optional: true
@@ -18856,9 +19044,9 @@ snapshots:
       eslint: 8.57.1
       eslint-visitor-keys: 3.4.3
 
-  '@eslint-community/eslint-utils@4.7.0(eslint@9.28.0(jiti@2.4.2))':
+  '@eslint-community/eslint-utils@4.7.0(eslint@9.28.0(jiti@2.5.1))':
     dependencies:
-      eslint: 9.28.0(jiti@2.4.2)
+      eslint: 9.28.0(jiti@2.5.1)
       eslint-visitor-keys: 3.4.3
 
   '@eslint-community/regexpp@4.12.1': {}
@@ -20349,6 +20537,13 @@ snapshots:
       strict-event-emitter: 0.5.1
     optional: true
 
+  '@napi-rs/wasm-runtime@0.2.12':
+    dependencies:
+      '@emnapi/core': 1.4.5
+      '@emnapi/runtime': 1.4.5
+      '@tybys/wasm-util': 0.10.0
+    optional: true
+
   '@neon-rs/load@0.0.4': {}
 
   '@next/env@15.3.2': {}
@@ -20550,6 +20745,8 @@ snapshots:
       '@opentelemetry/resources': 2.0.0(@opentelemetry/api@1.9.0)
 
   '@opentelemetry/semantic-conventions@1.30.0': {}
+
+  '@oxc-project/types@0.70.0': {}
 
   '@parcel/watcher-android-arm64@2.5.0':
     optional: true
@@ -20956,6 +21153,10 @@ snapshots:
       yargs: 17.7.2
     transitivePeerDependencies:
       - supports-color
+
+  '@quansync/fs@0.1.5':
+    dependencies:
+      quansync: 0.2.11
 
   '@radix-ui/primitive@1.1.2': {}
 
@@ -22100,6 +22301,44 @@ snapshots:
       read-yaml-file: 2.1.0
       strip-json-comments: 3.1.1
 
+  '@rolldown/binding-darwin-arm64@1.0.0-beta.9':
+    optional: true
+
+  '@rolldown/binding-darwin-x64@1.0.0-beta.9':
+    optional: true
+
+  '@rolldown/binding-freebsd-x64@1.0.0-beta.9':
+    optional: true
+
+  '@rolldown/binding-linux-arm-gnueabihf@1.0.0-beta.9':
+    optional: true
+
+  '@rolldown/binding-linux-arm64-gnu@1.0.0-beta.9':
+    optional: true
+
+  '@rolldown/binding-linux-arm64-musl@1.0.0-beta.9':
+    optional: true
+
+  '@rolldown/binding-linux-x64-gnu@1.0.0-beta.9':
+    optional: true
+
+  '@rolldown/binding-linux-x64-musl@1.0.0-beta.9':
+    optional: true
+
+  '@rolldown/binding-wasm32-wasi@1.0.0-beta.9':
+    dependencies:
+      '@napi-rs/wasm-runtime': 0.2.12
+    optional: true
+
+  '@rolldown/binding-win32-arm64-msvc@1.0.0-beta.9':
+    optional: true
+
+  '@rolldown/binding-win32-ia32-msvc@1.0.0-beta.9':
+    optional: true
+
+  '@rolldown/binding-win32-x64-msvc@1.0.0-beta.9':
+    optional: true
+
   '@rolldown/pluginutils@1.0.0-beta.9': {}
 
   '@rollup/plugin-babel@5.3.1(@babel/core@7.28.3)(@types/babel__core@7.20.5)(rollup@2.79.2)':
@@ -22356,18 +22595,18 @@ snapshots:
     dependencies:
       acorn: 8.15.0
 
-  '@sveltejs/adapter-auto@3.3.1(@sveltejs/kit@2.36.1(@opentelemetry/api@1.9.0)(@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.38.2)(vite@6.3.5(@types/node@24.3.0)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.6.1)))(svelte@5.38.2)(vite@6.3.5(@types/node@24.3.0)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.6.1)))':
+  '@sveltejs/adapter-auto@3.3.1(@sveltejs/kit@2.36.1(@opentelemetry/api@1.9.0)(@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.38.2)(vite@6.3.5(@types/node@24.3.0)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.6.1)))(svelte@5.38.2)(vite@6.3.5(@types/node@24.3.0)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.6.1)))':
     dependencies:
-      '@sveltejs/kit': 2.36.1(@opentelemetry/api@1.9.0)(@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.38.2)(vite@6.3.5(@types/node@24.3.0)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.6.1)))(svelte@5.38.2)(vite@6.3.5(@types/node@24.3.0)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.6.1))
+      '@sveltejs/kit': 2.36.1(@opentelemetry/api@1.9.0)(@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.38.2)(vite@6.3.5(@types/node@24.3.0)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.6.1)))(svelte@5.38.2)(vite@6.3.5(@types/node@24.3.0)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.6.1))
       import-meta-resolve: 4.1.0
 
-  '@sveltejs/adapter-auto@6.0.1(@sveltejs/kit@2.36.1(@opentelemetry/api@1.9.0)(@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.38.2)(vite@6.3.5(@types/node@24.3.0)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.6.1)))(svelte@5.38.2)(vite@6.3.5(@types/node@24.3.0)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.6.1)))':
+  '@sveltejs/adapter-auto@6.0.1(@sveltejs/kit@2.36.1(@opentelemetry/api@1.9.0)(@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.38.2)(vite@6.3.5(@types/node@24.3.0)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.6.1)))(svelte@5.38.2)(vite@6.3.5(@types/node@24.3.0)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.6.1)))':
     dependencies:
-      '@sveltejs/kit': 2.36.1(@opentelemetry/api@1.9.0)(@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.38.2)(vite@6.3.5(@types/node@24.3.0)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.6.1)))(svelte@5.38.2)(vite@6.3.5(@types/node@24.3.0)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.6.1))
+      '@sveltejs/kit': 2.36.1(@opentelemetry/api@1.9.0)(@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.38.2)(vite@6.3.5(@types/node@24.3.0)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.6.1)))(svelte@5.38.2)(vite@6.3.5(@types/node@24.3.0)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.6.1))
 
-  '@sveltejs/adapter-vercel@5.5.2(@sveltejs/kit@2.36.1(@opentelemetry/api@1.9.0)(@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.38.2)(vite@6.3.5(@types/node@24.3.0)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.6.1)))(svelte@5.38.2)(vite@6.3.5(@types/node@24.3.0)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.6.1)))(rollup@4.41.1)':
+  '@sveltejs/adapter-vercel@5.5.2(@sveltejs/kit@2.36.1(@opentelemetry/api@1.9.0)(@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.38.2)(vite@6.3.5(@types/node@24.3.0)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.6.1)))(svelte@5.38.2)(vite@6.3.5(@types/node@24.3.0)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.6.1)))(rollup@4.41.1)':
     dependencies:
-      '@sveltejs/kit': 2.36.1(@opentelemetry/api@1.9.0)(@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.38.2)(vite@6.3.5(@types/node@24.3.0)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.6.1)))(svelte@5.38.2)(vite@6.3.5(@types/node@24.3.0)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.6.1))
+      '@sveltejs/kit': 2.36.1(@opentelemetry/api@1.9.0)(@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.38.2)(vite@6.3.5(@types/node@24.3.0)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.6.1)))(svelte@5.38.2)(vite@6.3.5(@types/node@24.3.0)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.6.1))
       '@vercel/nft': 0.27.10(rollup@4.41.1)
       esbuild: 0.24.0
     transitivePeerDependencies:
@@ -22375,11 +22614,11 @@ snapshots:
       - rollup
       - supports-color
 
-  '@sveltejs/kit@2.36.1(@opentelemetry/api@1.9.0)(@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.38.2)(vite@6.3.5(@types/node@24.3.0)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.6.1)))(svelte@5.38.2)(vite@6.3.5(@types/node@24.3.0)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.6.1))':
+  '@sveltejs/kit@2.36.1(@opentelemetry/api@1.9.0)(@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.38.2)(vite@6.3.5(@types/node@24.3.0)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.6.1)))(svelte@5.38.2)(vite@6.3.5(@types/node@24.3.0)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.6.1))':
     dependencies:
       '@standard-schema/spec': 1.0.0
       '@sveltejs/acorn-typescript': 1.0.5(acorn@8.15.0)
-      '@sveltejs/vite-plugin-svelte': 5.1.1(svelte@5.38.2)(vite@6.3.5(@types/node@24.3.0)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.6.1))
+      '@sveltejs/vite-plugin-svelte': 5.1.1(svelte@5.38.2)(vite@6.3.5(@types/node@24.3.0)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.6.1))
       '@types/cookie': 0.6.0
       acorn: 8.15.0
       cookie: 0.6.0
@@ -22392,7 +22631,7 @@ snapshots:
       set-cookie-parser: 2.7.1
       sirv: 3.0.1
       svelte: 5.38.2
-      vite: 6.3.5(@types/node@24.3.0)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.6.1)
+      vite: 6.3.5(@types/node@24.3.0)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.6.1)
     optionalDependencies:
       '@opentelemetry/api': 1.9.0
 
@@ -22407,47 +22646,47 @@ snapshots:
     transitivePeerDependencies:
       - typescript
 
-  '@sveltejs/vite-plugin-svelte-inspector@4.0.1(@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.38.2)(vite@6.3.5(@types/node@24.3.0)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.6.1)))(svelte@5.38.2)(vite@6.3.5(@types/node@24.3.0)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.6.1))':
+  '@sveltejs/vite-plugin-svelte-inspector@4.0.1(@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.38.2)(vite@6.3.5(@types/node@24.3.0)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.6.1)))(svelte@5.38.2)(vite@6.3.5(@types/node@24.3.0)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.6.1))':
     dependencies:
-      '@sveltejs/vite-plugin-svelte': 5.1.1(svelte@5.38.2)(vite@6.3.5(@types/node@24.3.0)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.6.1))
+      '@sveltejs/vite-plugin-svelte': 5.1.1(svelte@5.38.2)(vite@6.3.5(@types/node@24.3.0)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.6.1))
       debug: 4.4.1
       svelte: 5.38.2
-      vite: 6.3.5(@types/node@24.3.0)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.6.1)
+      vite: 6.3.5(@types/node@24.3.0)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.6.1)
     transitivePeerDependencies:
       - supports-color
 
-  '@sveltejs/vite-plugin-svelte-inspector@5.0.0(@sveltejs/vite-plugin-svelte@6.1.0(svelte@5.34.6)(vite@6.3.5(@types/node@24.3.0)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.6.1)))(svelte@5.34.6)(vite@6.3.5(@types/node@24.3.0)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.6.1))':
+  '@sveltejs/vite-plugin-svelte-inspector@5.0.0(@sveltejs/vite-plugin-svelte@6.1.0(svelte@5.34.6)(vite@6.3.5(@types/node@24.3.0)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.6.1)))(svelte@5.34.6)(vite@6.3.5(@types/node@24.3.0)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.6.1))':
     dependencies:
-      '@sveltejs/vite-plugin-svelte': 6.1.0(svelte@5.34.6)(vite@6.3.5(@types/node@24.3.0)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.6.1))
+      '@sveltejs/vite-plugin-svelte': 6.1.0(svelte@5.34.6)(vite@6.3.5(@types/node@24.3.0)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.6.1))
       debug: 4.4.1
       svelte: 5.34.6
-      vite: 6.3.5(@types/node@24.3.0)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.6.1)
+      vite: 6.3.5(@types/node@24.3.0)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.6.1)
     transitivePeerDependencies:
       - supports-color
 
-  '@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.38.2)(vite@6.3.5(@types/node@24.3.0)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.6.1))':
+  '@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.38.2)(vite@6.3.5(@types/node@24.3.0)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.6.1))':
     dependencies:
-      '@sveltejs/vite-plugin-svelte-inspector': 4.0.1(@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.38.2)(vite@6.3.5(@types/node@24.3.0)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.6.1)))(svelte@5.38.2)(vite@6.3.5(@types/node@24.3.0)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.6.1))
+      '@sveltejs/vite-plugin-svelte-inspector': 4.0.1(@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.38.2)(vite@6.3.5(@types/node@24.3.0)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.6.1)))(svelte@5.38.2)(vite@6.3.5(@types/node@24.3.0)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.6.1))
       debug: 4.4.1
       deepmerge: 4.3.1
       kleur: 4.1.5
       magic-string: 0.30.17
       svelte: 5.38.2
-      vite: 6.3.5(@types/node@24.3.0)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.6.1)
-      vitefu: 1.1.1(vite@6.3.5(@types/node@24.3.0)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.6.1))
+      vite: 6.3.5(@types/node@24.3.0)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.6.1)
+      vitefu: 1.1.1(vite@6.3.5(@types/node@24.3.0)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.6.1))
     transitivePeerDependencies:
       - supports-color
 
-  '@sveltejs/vite-plugin-svelte@6.1.0(svelte@5.34.6)(vite@6.3.5(@types/node@24.3.0)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.6.1))':
+  '@sveltejs/vite-plugin-svelte@6.1.0(svelte@5.34.6)(vite@6.3.5(@types/node@24.3.0)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.6.1))':
     dependencies:
-      '@sveltejs/vite-plugin-svelte-inspector': 5.0.0(@sveltejs/vite-plugin-svelte@6.1.0(svelte@5.34.6)(vite@6.3.5(@types/node@24.3.0)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.6.1)))(svelte@5.34.6)(vite@6.3.5(@types/node@24.3.0)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.6.1))
+      '@sveltejs/vite-plugin-svelte-inspector': 5.0.0(@sveltejs/vite-plugin-svelte@6.1.0(svelte@5.34.6)(vite@6.3.5(@types/node@24.3.0)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.6.1)))(svelte@5.34.6)(vite@6.3.5(@types/node@24.3.0)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.6.1))
       debug: 4.4.1
       deepmerge: 4.3.1
       kleur: 4.1.5
       magic-string: 0.30.17
       svelte: 5.34.6
-      vite: 6.3.5(@types/node@24.3.0)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.6.1)
-      vitefu: 1.1.1(vite@6.3.5(@types/node@24.3.0)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.6.1))
+      vite: 6.3.5(@types/node@24.3.0)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.6.1)
+      vitefu: 1.1.1(vite@6.3.5(@types/node@24.3.0)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.6.1))
     transitivePeerDependencies:
       - supports-color
 
@@ -22673,19 +22912,19 @@ snapshots:
       postcss-selector-parser: 6.0.10
       tailwindcss: 4.1.10
 
-  '@tailwindcss/vite@4.1.10(vite@6.3.5(@types/node@24.3.0)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.19.3)(yaml@2.6.1))':
+  '@tailwindcss/vite@4.1.10(vite@6.3.5(@types/node@24.3.0)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.19.3)(yaml@2.6.1))':
     dependencies:
       '@tailwindcss/node': 4.1.10
       '@tailwindcss/oxide': 4.1.10
       tailwindcss: 4.1.10
-      vite: 6.3.5(@types/node@24.3.0)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.19.3)(yaml@2.6.1)
+      vite: 6.3.5(@types/node@24.3.0)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.19.3)(yaml@2.6.1)
 
-  '@tailwindcss/vite@4.1.10(vite@6.3.5(@types/node@24.3.0)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.6.1))':
+  '@tailwindcss/vite@4.1.10(vite@6.3.5(@types/node@24.3.0)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.6.1))':
     dependencies:
       '@tailwindcss/node': 4.1.10
       '@tailwindcss/oxide': 4.1.10
       tailwindcss: 4.1.10
-      vite: 6.3.5(@types/node@24.3.0)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.6.1)
+      vite: 6.3.5(@types/node@24.3.0)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.6.1)
 
   '@tanstack/history@1.121.34': {}
 
@@ -22752,7 +22991,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@tanstack/router-plugin@1.129.4(@tanstack/react-router@1.129.4(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(vite@6.3.5(@types/node@24.3.0)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.19.3)(yaml@2.6.1))':
+  '@tanstack/router-plugin@1.129.4(@tanstack/react-router@1.129.4(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(vite@6.3.5(@types/node@24.3.0)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.19.3)(yaml@2.6.1))':
     dependencies:
       '@babel/core': 7.28.0
       '@babel/plugin-syntax-jsx': 7.27.1(@babel/core@7.28.0)
@@ -22770,7 +23009,7 @@ snapshots:
       zod: 3.25.76
     optionalDependencies:
       '@tanstack/react-router': 1.129.4(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
-      vite: 6.3.5(@types/node@24.3.0)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.19.3)(yaml@2.6.1)
+      vite: 6.3.5(@types/node@24.3.0)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.19.3)(yaml@2.6.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -22820,21 +23059,21 @@ snapshots:
       '@types/react': 19.1.0
       '@types/react-dom': 19.1.0(@types/react@19.1.0)
 
-  '@testing-library/svelte@5.2.6(svelte@5.34.6)(vite@6.3.5(@types/node@24.3.0)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.6.1))(vitest@3.2.4)':
+  '@testing-library/svelte@5.2.6(svelte@5.34.6)(vite@6.3.5(@types/node@24.3.0)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.6.1))(vitest@3.2.4)':
     dependencies:
       '@testing-library/dom': 10.4.0
       svelte: 5.34.6
     optionalDependencies:
-      vite: 6.3.5(@types/node@24.3.0)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.6.1)
-      vitest: 3.2.4(@types/debug@4.1.12)(@types/node@24.3.0)(@vitest/browser@3.2.4)(@vitest/ui@3.2.4)(happy-dom@17.4.4)(jiti@2.4.2)(jsdom@25.0.1)(lightningcss@1.30.1)(msw@2.10.3(@types/node@24.3.0)(typescript@5.6.2))(terser@5.43.1)(tsx@4.20.3)(yaml@2.6.1)
+      vite: 6.3.5(@types/node@24.3.0)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.6.1)
+      vitest: 3.2.4(@types/debug@4.1.12)(@types/node@24.3.0)(@vitest/browser@3.2.4)(@vitest/ui@3.2.4)(happy-dom@17.4.4)(jiti@2.5.1)(jsdom@25.0.1)(lightningcss@1.30.1)(msw@2.10.3(@types/node@24.3.0)(typescript@5.6.2))(terser@5.43.1)(tsx@4.20.3)(yaml@2.6.1)
 
-  '@testing-library/svelte@5.2.6(svelte@5.38.2)(vite@6.3.5(@types/node@24.3.0)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.6.1))(vitest@3.2.4)':
+  '@testing-library/svelte@5.2.6(svelte@5.38.2)(vite@6.3.5(@types/node@24.3.0)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.6.1))(vitest@3.2.4)':
     dependencies:
       '@testing-library/dom': 10.4.0
       svelte: 5.38.2
     optionalDependencies:
-      vite: 6.3.5(@types/node@24.3.0)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.6.1)
-      vitest: 3.2.4(@types/debug@4.1.12)(@types/node@24.3.0)(@vitest/browser@3.2.4)(@vitest/ui@3.2.4)(happy-dom@17.4.4)(jiti@2.4.2)(jsdom@25.0.1)(lightningcss@1.30.1)(msw@2.10.4(@types/node@24.3.0)(typescript@5.6.2))(terser@5.43.1)(tsx@4.20.3)(yaml@2.6.1)
+      vite: 6.3.5(@types/node@24.3.0)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.6.1)
+      vitest: 3.2.4(@types/debug@4.1.12)(@types/node@24.3.0)(@vitest/browser@3.2.4)(@vitest/ui@3.2.4)(happy-dom@17.4.4)(jiti@2.5.1)(jsdom@25.0.1)(lightningcss@1.30.1)(msw@2.10.4(@types/node@24.3.0)(typescript@5.6.2))(terser@5.43.1)(tsx@4.20.3)(yaml@2.6.1)
 
   '@testing-library/user-event@14.6.1(@testing-library/dom@10.4.0)':
     dependencies:
@@ -23001,6 +23240,12 @@ snapshots:
 
   '@tootallnate/quickjs-emscripten@0.23.0': {}
 
+  '@ts-morph/common@0.27.0':
+    dependencies:
+      fast-glob: 3.3.3
+      minimatch: 10.0.3
+      path-browserify: 1.0.1
+
   '@tsconfig/node10@1.0.11':
     optional: true
 
@@ -23016,6 +23261,11 @@ snapshots:
   '@tsconfig/node20@20.1.6': {}
 
   '@tsconfig/node22@22.0.2': {}
+
+  '@tybys/wasm-util@0.10.0':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
 
   '@types/argparse@1.0.38': {}
 
@@ -23246,15 +23496,15 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/eslint-plugin@8.34.0(@typescript-eslint/parser@8.34.0(eslint@9.28.0(jiti@2.4.2))(typescript@5.6.2))(eslint@9.28.0(jiti@2.4.2))(typescript@5.6.2)':
+  '@typescript-eslint/eslint-plugin@8.34.0(@typescript-eslint/parser@8.34.0(eslint@9.28.0(jiti@2.5.1))(typescript@5.6.2))(eslint@9.28.0(jiti@2.5.1))(typescript@5.6.2)':
     dependencies:
       '@eslint-community/regexpp': 4.12.1
-      '@typescript-eslint/parser': 8.34.0(eslint@9.28.0(jiti@2.4.2))(typescript@5.6.2)
+      '@typescript-eslint/parser': 8.34.0(eslint@9.28.0(jiti@2.5.1))(typescript@5.6.2)
       '@typescript-eslint/scope-manager': 8.34.0
-      '@typescript-eslint/type-utils': 8.34.0(eslint@9.28.0(jiti@2.4.2))(typescript@5.6.2)
-      '@typescript-eslint/utils': 8.34.0(eslint@9.28.0(jiti@2.4.2))(typescript@5.6.2)
+      '@typescript-eslint/type-utils': 8.34.0(eslint@9.28.0(jiti@2.5.1))(typescript@5.6.2)
+      '@typescript-eslint/utils': 8.34.0(eslint@9.28.0(jiti@2.5.1))(typescript@5.6.2)
       '@typescript-eslint/visitor-keys': 8.34.0
-      eslint: 9.28.0(jiti@2.4.2)
+      eslint: 9.28.0(jiti@2.5.1)
       graphemer: 1.4.0
       ignore: 7.0.5
       natural-compare: 1.4.0
@@ -23276,14 +23526,14 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/parser@8.34.0(eslint@9.28.0(jiti@2.4.2))(typescript@5.6.2)':
+  '@typescript-eslint/parser@8.34.0(eslint@9.28.0(jiti@2.5.1))(typescript@5.6.2)':
     dependencies:
       '@typescript-eslint/scope-manager': 8.34.0
       '@typescript-eslint/types': 8.34.0
       '@typescript-eslint/typescript-estree': 8.34.0(typescript@5.6.2)
       '@typescript-eslint/visitor-keys': 8.34.0
       debug: 4.4.1
-      eslint: 9.28.0(jiti@2.4.2)
+      eslint: 9.28.0(jiti@2.5.1)
       typescript: 5.6.2
     transitivePeerDependencies:
       - supports-color
@@ -23328,12 +23578,12 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/type-utils@8.34.0(eslint@9.28.0(jiti@2.4.2))(typescript@5.6.2)':
+  '@typescript-eslint/type-utils@8.34.0(eslint@9.28.0(jiti@2.5.1))(typescript@5.6.2)':
     dependencies:
       '@typescript-eslint/typescript-estree': 8.34.0(typescript@5.6.2)
-      '@typescript-eslint/utils': 8.34.0(eslint@9.28.0(jiti@2.4.2))(typescript@5.6.2)
+      '@typescript-eslint/utils': 8.34.0(eslint@9.28.0(jiti@2.5.1))(typescript@5.6.2)
       debug: 4.4.1
-      eslint: 9.28.0(jiti@2.4.2)
+      eslint: 9.28.0(jiti@2.5.1)
       ts-api-utils: 2.1.0(typescript@5.6.2)
       typescript: 5.6.2
     transitivePeerDependencies:
@@ -23416,13 +23666,13 @@ snapshots:
       - supports-color
       - typescript
 
-  '@typescript-eslint/utils@8.34.0(eslint@9.28.0(jiti@2.4.2))(typescript@5.6.2)':
+  '@typescript-eslint/utils@8.34.0(eslint@9.28.0(jiti@2.5.1))(typescript@5.6.2)':
     dependencies:
-      '@eslint-community/eslint-utils': 4.7.0(eslint@9.28.0(jiti@2.4.2))
+      '@eslint-community/eslint-utils': 4.7.0(eslint@9.28.0(jiti@2.5.1))
       '@typescript-eslint/scope-manager': 8.34.0
       '@typescript-eslint/types': 8.34.0
       '@typescript-eslint/typescript-estree': 8.34.0(typescript@5.6.2)
-      eslint: 9.28.0(jiti@2.4.2)
+      eslint: 9.28.0(jiti@2.5.1)
       typescript: 5.6.2
     transitivePeerDependencies:
       - supports-color
@@ -23475,23 +23725,23 @@ snapshots:
       - rollup
       - supports-color
 
-  '@vitejs/plugin-react-swc@3.10.1(@swc/helpers@0.5.17)(vite@6.3.5(@types/node@22.15.18)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.6.1))':
+  '@vitejs/plugin-react-swc@3.10.1(@swc/helpers@0.5.17)(vite@6.3.5(@types/node@22.15.18)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.6.1))':
     dependencies:
       '@rolldown/pluginutils': 1.0.0-beta.9
       '@swc/core': 1.11.29(@swc/helpers@0.5.17)
-      vite: 6.3.5(@types/node@22.15.18)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.6.1)
+      vite: 6.3.5(@types/node@22.15.18)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.6.1)
     transitivePeerDependencies:
       - '@swc/helpers'
 
-  '@vitejs/plugin-react-swc@3.10.1(@swc/helpers@0.5.17)(vite@6.3.5(@types/node@24.3.0)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.6.1))':
+  '@vitejs/plugin-react-swc@3.10.1(@swc/helpers@0.5.17)(vite@6.3.5(@types/node@24.3.0)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.6.1))':
     dependencies:
       '@rolldown/pluginutils': 1.0.0-beta.9
       '@swc/core': 1.11.29(@swc/helpers@0.5.17)
-      vite: 6.3.5(@types/node@24.3.0)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.6.1)
+      vite: 6.3.5(@types/node@24.3.0)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.6.1)
     transitivePeerDependencies:
       - '@swc/helpers'
 
-  '@vitejs/plugin-react@4.5.1(vite@6.3.5(@types/node@24.3.0)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.19.3)(yaml@2.6.1))':
+  '@vitejs/plugin-react@4.5.1(vite@6.3.5(@types/node@24.3.0)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.19.3)(yaml@2.6.1))':
     dependencies:
       '@babel/core': 7.27.1
       '@babel/plugin-transform-react-jsx-self': 7.25.9(@babel/core@7.27.1)
@@ -23499,11 +23749,11 @@ snapshots:
       '@rolldown/pluginutils': 1.0.0-beta.9
       '@types/babel__core': 7.20.5
       react-refresh: 0.17.0
-      vite: 6.3.5(@types/node@24.3.0)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.19.3)(yaml@2.6.1)
+      vite: 6.3.5(@types/node@24.3.0)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.19.3)(yaml@2.6.1)
     transitivePeerDependencies:
       - supports-color
 
-  '@vitejs/plugin-react@4.5.1(vite@6.3.5(@types/node@24.3.0)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.6.1))':
+  '@vitejs/plugin-react@4.5.1(vite@6.3.5(@types/node@24.3.0)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.6.1))':
     dependencies:
       '@babel/core': 7.27.1
       '@babel/plugin-transform-react-jsx-self': 7.25.9(@babel/core@7.27.1)
@@ -23511,52 +23761,52 @@ snapshots:
       '@rolldown/pluginutils': 1.0.0-beta.9
       '@types/babel__core': 7.20.5
       react-refresh: 0.17.0
-      vite: 6.3.5(@types/node@24.3.0)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.6.1)
+      vite: 6.3.5(@types/node@24.3.0)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.6.1)
     transitivePeerDependencies:
       - supports-color
 
-  '@vitejs/plugin-vue-jsx@4.2.0(vite@6.3.5(@types/node@22.16.5)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.6.1))(vue@3.5.13(typescript@5.6.2))':
+  '@vitejs/plugin-vue-jsx@4.2.0(vite@6.3.5(@types/node@22.16.5)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.6.1))(vue@3.5.13(typescript@5.6.2))':
     dependencies:
       '@babel/core': 7.28.0
       '@babel/plugin-transform-typescript': 7.28.0(@babel/core@7.28.0)
       '@rolldown/pluginutils': 1.0.0-beta.9
       '@vue/babel-plugin-jsx': 1.5.0(@babel/core@7.28.0)
-      vite: 6.3.5(@types/node@22.16.5)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.6.1)
+      vite: 6.3.5(@types/node@22.16.5)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.6.1)
       vue: 3.5.13(typescript@5.6.2)
     transitivePeerDependencies:
       - supports-color
 
-  '@vitejs/plugin-vue-jsx@4.2.0(vite@6.3.5(@types/node@24.3.0)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.6.1))(vue@3.5.13(typescript@5.6.2))':
+  '@vitejs/plugin-vue-jsx@4.2.0(vite@6.3.5(@types/node@24.3.0)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.6.1))(vue@3.5.13(typescript@5.6.2))':
     dependencies:
       '@babel/core': 7.28.0
       '@babel/plugin-transform-typescript': 7.28.0(@babel/core@7.28.0)
       '@rolldown/pluginutils': 1.0.0-beta.9
       '@vue/babel-plugin-jsx': 1.5.0(@babel/core@7.28.0)
-      vite: 6.3.5(@types/node@24.3.0)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.6.1)
+      vite: 6.3.5(@types/node@24.3.0)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.6.1)
       vue: 3.5.13(typescript@5.6.2)
     transitivePeerDependencies:
       - supports-color
 
-  '@vitejs/plugin-vue@5.2.4(vite@6.3.5(@types/node@22.16.5)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.6.1))(vue@3.5.13(typescript@5.6.2))':
+  '@vitejs/plugin-vue@5.2.4(vite@6.3.5(@types/node@22.16.5)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.6.1))(vue@3.5.13(typescript@5.6.2))':
     dependencies:
-      vite: 6.3.5(@types/node@22.16.5)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.6.1)
+      vite: 6.3.5(@types/node@22.16.5)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.6.1)
       vue: 3.5.13(typescript@5.6.2)
 
-  '@vitejs/plugin-vue@5.2.4(vite@6.3.5(@types/node@24.3.0)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.6.1))(vue@3.5.13(typescript@5.6.2))':
+  '@vitejs/plugin-vue@5.2.4(vite@6.3.5(@types/node@24.3.0)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.6.1))(vue@3.5.13(typescript@5.6.2))':
     dependencies:
-      vite: 6.3.5(@types/node@24.3.0)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.6.1)
+      vite: 6.3.5(@types/node@24.3.0)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.6.1)
       vue: 3.5.13(typescript@5.6.2)
 
-  '@vitest/browser@3.2.4(msw@2.10.3(@types/node@24.3.0)(typescript@5.6.2))(playwright@1.50.1)(vite@6.3.5(@types/node@24.3.0)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.6.1))(vitest@3.2.4)(webdriverio@8.41.0)':
+  '@vitest/browser@3.2.4(msw@2.10.3(@types/node@24.3.0)(typescript@5.6.2))(playwright@1.50.1)(vite@6.3.5(@types/node@24.3.0)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.6.1))(vitest@3.2.4)(webdriverio@8.41.0)':
     dependencies:
       '@testing-library/dom': 10.4.0
       '@testing-library/user-event': 14.6.1(@testing-library/dom@10.4.0)
-      '@vitest/mocker': 3.2.4(msw@2.10.3(@types/node@24.3.0)(typescript@5.6.2))(vite@6.3.5(@types/node@24.3.0)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.6.1))
+      '@vitest/mocker': 3.2.4(msw@2.10.3(@types/node@24.3.0)(typescript@5.6.2))(vite@6.3.5(@types/node@24.3.0)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.6.1))
       '@vitest/utils': 3.2.4
       magic-string: 0.30.17
       sirv: 3.0.1
       tinyrainbow: 2.0.0
-      vitest: 3.2.4(@types/debug@4.1.12)(@types/node@24.3.0)(@vitest/browser@3.2.4)(@vitest/ui@3.2.4)(happy-dom@17.4.4)(jiti@2.4.2)(jsdom@25.0.1)(lightningcss@1.30.1)(msw@2.10.3(@types/node@24.3.0)(typescript@5.6.2))(terser@5.43.1)(tsx@4.20.3)(yaml@2.6.1)
+      vitest: 3.2.4(@types/debug@4.1.12)(@types/node@24.3.0)(@vitest/browser@3.2.4)(@vitest/ui@3.2.4)(happy-dom@17.4.4)(jiti@2.5.1)(jsdom@25.0.1)(lightningcss@1.30.1)(msw@2.10.3(@types/node@24.3.0)(typescript@5.6.2))(terser@5.43.1)(tsx@4.20.3)(yaml@2.6.1)
       ws: 8.18.2
     optionalDependencies:
       playwright: 1.50.1
@@ -23567,16 +23817,16 @@ snapshots:
       - utf-8-validate
       - vite
 
-  '@vitest/browser@3.2.4(msw@2.10.4(@types/node@24.3.0)(typescript@5.6.2))(playwright@1.50.1)(vite@6.3.5(@types/node@24.3.0)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.6.1))(vitest@3.2.4)(webdriverio@8.41.0)':
+  '@vitest/browser@3.2.4(msw@2.10.4(@types/node@24.3.0)(typescript@5.6.2))(playwright@1.50.1)(vite@6.3.5(@types/node@24.3.0)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.6.1))(vitest@3.2.4)(webdriverio@8.41.0)':
     dependencies:
       '@testing-library/dom': 10.4.0
       '@testing-library/user-event': 14.6.1(@testing-library/dom@10.4.0)
-      '@vitest/mocker': 3.2.4(msw@2.10.4(@types/node@24.3.0)(typescript@5.6.2))(vite@6.3.5(@types/node@24.3.0)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.6.1))
+      '@vitest/mocker': 3.2.4(msw@2.10.4(@types/node@24.3.0)(typescript@5.6.2))(vite@6.3.5(@types/node@24.3.0)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.6.1))
       '@vitest/utils': 3.2.4
       magic-string: 0.30.17
       sirv: 3.0.1
       tinyrainbow: 2.0.0
-      vitest: 3.2.4(@types/debug@4.1.12)(@types/node@24.3.0)(@vitest/browser@3.2.4)(@vitest/ui@3.2.4)(happy-dom@17.4.4)(jiti@2.4.2)(jsdom@25.0.1)(lightningcss@1.30.1)(msw@2.10.4(@types/node@24.3.0)(typescript@5.6.2))(terser@5.43.1)(tsx@4.20.3)(yaml@2.6.1)
+      vitest: 3.2.4(@types/debug@4.1.12)(@types/node@24.3.0)(@vitest/browser@3.2.4)(@vitest/ui@3.2.4)(happy-dom@17.4.4)(jiti@2.5.1)(jsdom@25.0.1)(lightningcss@1.30.1)(msw@2.10.4(@types/node@24.3.0)(typescript@5.6.2))(terser@5.43.1)(tsx@4.20.3)(yaml@2.6.1)
       ws: 8.18.2
     optionalDependencies:
       playwright: 1.50.1
@@ -23588,16 +23838,16 @@ snapshots:
       - vite
     optional: true
 
-  '@vitest/browser@3.2.4(msw@2.10.4(@types/node@24.3.0)(typescript@5.9.2))(playwright@1.50.1)(vite@6.3.5(@types/node@24.3.0)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.6.1))(vitest@3.2.4)(webdriverio@8.41.0)':
+  '@vitest/browser@3.2.4(msw@2.10.4(@types/node@24.3.0)(typescript@5.9.2))(playwright@1.50.1)(vite@6.3.5(@types/node@24.3.0)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.6.1))(vitest@3.2.4)(webdriverio@8.41.0)':
     dependencies:
       '@testing-library/dom': 10.4.0
       '@testing-library/user-event': 14.6.1(@testing-library/dom@10.4.0)
-      '@vitest/mocker': 3.2.4(msw@2.10.4(@types/node@24.3.0)(typescript@5.9.2))(vite@6.3.5(@types/node@24.3.0)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.6.1))
+      '@vitest/mocker': 3.2.4(msw@2.10.4(@types/node@24.3.0)(typescript@5.9.2))(vite@6.3.5(@types/node@24.3.0)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.6.1))
       '@vitest/utils': 3.2.4
       magic-string: 0.30.17
       sirv: 3.0.1
       tinyrainbow: 2.0.0
-      vitest: 3.2.4(@types/debug@4.1.12)(@types/node@24.3.0)(@vitest/browser@3.2.4)(@vitest/ui@3.2.4)(happy-dom@17.4.4)(jiti@2.4.2)(jsdom@25.0.1)(lightningcss@1.30.1)(msw@2.10.4(@types/node@24.3.0)(typescript@5.9.2))(terser@5.43.1)(tsx@4.20.3)(yaml@2.6.1)
+      vitest: 3.2.4(@types/debug@4.1.12)(@types/node@24.3.0)(@vitest/browser@3.2.4)(@vitest/ui@3.2.4)(happy-dom@17.4.4)(jiti@2.5.1)(jsdom@25.0.1)(lightningcss@1.30.1)(msw@2.10.4(@types/node@24.3.0)(typescript@5.9.2))(terser@5.43.1)(tsx@4.20.3)(yaml@2.6.1)
       ws: 8.18.2
     optionalDependencies:
       playwright: 1.50.1
@@ -23620,7 +23870,7 @@ snapshots:
       magicast: 0.3.5
       test-exclude: 7.0.1
       tinyrainbow: 2.0.0
-      vitest: 3.2.4(@types/debug@4.1.12)(@types/node@24.3.0)(@vitest/browser@3.2.4)(@vitest/ui@3.2.4)(happy-dom@17.4.4)(jiti@2.4.2)(jsdom@25.0.1)(lightningcss@1.30.1)(msw@2.10.4(@types/node@24.3.0)(typescript@5.9.2))(terser@5.43.1)(tsx@4.20.3)(yaml@2.6.1)
+      vitest: 3.2.4(@types/debug@4.1.12)(@types/node@24.3.0)(@vitest/browser@3.2.4)(@vitest/ui@3.2.4)(happy-dom@17.4.4)(jiti@2.5.1)(jsdom@25.0.1)(lightningcss@1.30.1)(msw@2.10.4(@types/node@24.3.0)(typescript@5.9.2))(terser@5.43.1)(tsx@4.20.3)(yaml@2.6.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -23639,9 +23889,9 @@ snapshots:
       std-env: 3.9.0
       test-exclude: 7.0.1
       tinyrainbow: 2.0.0
-      vitest: 3.2.4(@types/debug@4.1.12)(@types/node@24.3.0)(@vitest/browser@3.2.4)(@vitest/ui@3.2.4)(happy-dom@17.4.4)(jiti@2.4.2)(jsdom@25.0.1)(lightningcss@1.30.1)(msw@2.10.4(@types/node@24.3.0)(typescript@5.9.2))(terser@5.43.1)(tsx@4.20.3)(yaml@2.6.1)
+      vitest: 3.2.4(@types/debug@4.1.12)(@types/node@24.3.0)(@vitest/browser@3.2.4)(@vitest/ui@3.2.4)(happy-dom@17.4.4)(jiti@2.5.1)(jsdom@25.0.1)(lightningcss@1.30.1)(msw@2.10.4(@types/node@24.3.0)(typescript@5.9.2))(terser@5.43.1)(tsx@4.20.3)(yaml@2.6.1)
     optionalDependencies:
-      '@vitest/browser': 3.2.4(msw@2.10.4(@types/node@24.3.0)(typescript@5.9.2))(playwright@1.50.1)(vite@6.3.5(@types/node@24.3.0)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.6.1))(vitest@3.2.4)(webdriverio@8.41.0)
+      '@vitest/browser': 3.2.4(msw@2.10.4(@types/node@24.3.0)(typescript@5.9.2))(playwright@1.50.1)(vite@6.3.5(@types/node@24.3.0)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.6.1))(vitest@3.2.4)(webdriverio@8.41.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -23653,32 +23903,32 @@ snapshots:
       chai: 5.2.0
       tinyrainbow: 2.0.0
 
-  '@vitest/mocker@3.2.4(msw@2.10.3(@types/node@24.3.0)(typescript@5.6.2))(vite@6.3.5(@types/node@24.3.0)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.6.1))':
+  '@vitest/mocker@3.2.4(msw@2.10.3(@types/node@24.3.0)(typescript@5.6.2))(vite@6.3.5(@types/node@24.3.0)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.6.1))':
     dependencies:
       '@vitest/spy': 3.2.4
       estree-walker: 3.0.3
       magic-string: 0.30.17
     optionalDependencies:
       msw: 2.10.3(@types/node@24.3.0)(typescript@5.6.2)
-      vite: 6.3.5(@types/node@24.3.0)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.6.1)
+      vite: 6.3.5(@types/node@24.3.0)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.6.1)
 
-  '@vitest/mocker@3.2.4(msw@2.10.4(@types/node@24.3.0)(typescript@5.6.2))(vite@6.3.5(@types/node@24.3.0)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.6.1))':
+  '@vitest/mocker@3.2.4(msw@2.10.4(@types/node@24.3.0)(typescript@5.6.2))(vite@6.3.5(@types/node@24.3.0)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.6.1))':
     dependencies:
       '@vitest/spy': 3.2.4
       estree-walker: 3.0.3
       magic-string: 0.30.17
     optionalDependencies:
       msw: 2.10.4(@types/node@24.3.0)(typescript@5.6.2)
-      vite: 6.3.5(@types/node@24.3.0)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.6.1)
+      vite: 6.3.5(@types/node@24.3.0)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.6.1)
 
-  '@vitest/mocker@3.2.4(msw@2.10.4(@types/node@24.3.0)(typescript@5.9.2))(vite@6.3.5(@types/node@24.3.0)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.6.1))':
+  '@vitest/mocker@3.2.4(msw@2.10.4(@types/node@24.3.0)(typescript@5.9.2))(vite@6.3.5(@types/node@24.3.0)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.6.1))':
     dependencies:
       '@vitest/spy': 3.2.4
       estree-walker: 3.0.3
       magic-string: 0.30.17
     optionalDependencies:
       msw: 2.10.4(@types/node@24.3.0)(typescript@5.9.2)
-      vite: 6.3.5(@types/node@24.3.0)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.6.1)
+      vite: 6.3.5(@types/node@24.3.0)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.6.1)
 
   '@vitest/pretty-format@3.2.4':
     dependencies:
@@ -23709,7 +23959,7 @@ snapshots:
       sirv: 3.0.1
       tinyglobby: 0.2.14
       tinyrainbow: 2.0.0
-      vitest: 3.2.4(@types/debug@4.1.12)(@types/node@24.3.0)(@vitest/browser@3.2.4)(@vitest/ui@3.2.4)(happy-dom@17.4.4)(jiti@2.4.2)(jsdom@25.0.1)(lightningcss@1.30.1)(msw@2.10.4(@types/node@24.3.0)(typescript@5.6.2))(terser@5.43.1)(tsx@4.20.3)(yaml@2.6.1)
+      vitest: 3.2.4(@types/debug@4.1.12)(@types/node@24.3.0)(@vitest/browser@3.2.4)(@vitest/ui@3.2.4)(happy-dom@17.4.4)(jiti@2.5.1)(jsdom@25.0.1)(lightningcss@1.30.1)(msw@2.10.4(@types/node@24.3.0)(typescript@5.6.2))(terser@5.43.1)(tsx@4.20.3)(yaml@2.6.1)
 
   '@vitest/utils@3.2.4':
     dependencies:
@@ -23839,14 +24089,14 @@ snapshots:
 
   '@vue/devtools-api@6.6.4': {}
 
-  '@vue/devtools-core@7.7.7(vite@6.3.5(@types/node@22.16.5)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.6.1))(vue@3.5.13(typescript@5.6.2))':
+  '@vue/devtools-core@7.7.7(vite@6.3.5(@types/node@22.16.5)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.6.1))(vue@3.5.13(typescript@5.6.2))':
     dependencies:
       '@vue/devtools-kit': 7.7.7
       '@vue/devtools-shared': 7.7.7
       mitt: 3.0.1
       nanoid: 5.1.5
       pathe: 2.0.3
-      vite-hot-client: 2.1.0(vite@6.3.5(@types/node@22.16.5)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.6.1))
+      vite-hot-client: 2.1.0(vite@6.3.5(@types/node@22.16.5)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.6.1))
       vue: 3.5.13(typescript@5.6.2)
     transitivePeerDependencies:
       - vite
@@ -24237,6 +24487,11 @@ snapshots:
       tslib: 2.8.1
 
   assertion-error@2.0.1: {}
+
+  ast-kit@2.1.2:
+    dependencies:
+      '@babel/parser': 7.28.3
+      pathe: 2.0.3
 
   ast-types@0.13.4:
     dependencies:
@@ -25100,6 +25355,8 @@ snapshots:
   co@4.6.0:
     optional: true
 
+  code-block-writer@13.0.3: {}
+
   cojson-storage-indexeddb@0.17.9:
     dependencies:
       cojson: 0.17.9
@@ -25560,6 +25817,8 @@ snapshots:
 
   dotenv@17.2.1: {}
 
+  dts-resolver@2.1.2: {}
+
   dunder-proto@1.0.1:
     dependencies:
       call-bind-apply-helpers: 1.0.2
@@ -25611,6 +25870,8 @@ snapshots:
   emoji-regex@8.0.0: {}
 
   emoji-regex@9.2.2: {}
+
+  empathic@1.1.0: {}
 
   encodeurl@1.0.2: {}
 
@@ -25875,18 +26136,18 @@ snapshots:
     optionalDependencies:
       source-map: 0.6.1
 
-  eslint-compat-utils@0.5.1(eslint@9.28.0(jiti@2.4.2)):
+  eslint-compat-utils@0.5.1(eslint@9.28.0(jiti@2.5.1)):
     dependencies:
-      eslint: 9.28.0(jiti@2.4.2)
+      eslint: 9.28.0(jiti@2.5.1)
       semver: 7.7.2
 
   eslint-config-prettier@8.10.0(eslint@8.57.1):
     dependencies:
       eslint: 8.57.1
 
-  eslint-config-prettier@9.1.0(eslint@9.28.0(jiti@2.4.2)):
+  eslint-config-prettier@9.1.0(eslint@9.28.0(jiti@2.5.1)):
     dependencies:
-      eslint: 9.28.0(jiti@2.4.2)
+      eslint: 9.28.0(jiti@2.5.1)
 
   eslint-plugin-eslint-comments@3.2.0(eslint@8.57.1):
     dependencies:
@@ -25945,12 +26206,12 @@ snapshots:
       string.prototype.matchall: 4.0.12
       string.prototype.repeat: 1.0.0
 
-  eslint-plugin-svelte@2.46.1(eslint@9.28.0(jiti@2.4.2))(svelte@5.38.2)(ts-node@10.9.2(@swc/core@1.11.29(@swc/helpers@0.5.17))(@types/node@24.3.0)(typescript@5.6.2)):
+  eslint-plugin-svelte@2.46.1(eslint@9.28.0(jiti@2.5.1))(svelte@5.38.2)(ts-node@10.9.2(@swc/core@1.11.29(@swc/helpers@0.5.17))(@types/node@24.3.0)(typescript@5.6.2)):
     dependencies:
-      '@eslint-community/eslint-utils': 4.7.0(eslint@9.28.0(jiti@2.4.2))
+      '@eslint-community/eslint-utils': 4.7.0(eslint@9.28.0(jiti@2.5.1))
       '@jridgewell/sourcemap-codec': 1.5.0
-      eslint: 9.28.0(jiti@2.4.2)
-      eslint-compat-utils: 0.5.1(eslint@9.28.0(jiti@2.4.2))
+      eslint: 9.28.0(jiti@2.5.1)
+      eslint-compat-utils: 0.5.1(eslint@9.28.0(jiti@2.5.1))
       esutils: 2.0.3
       known-css-properties: 0.35.0
       postcss: 8.5.6
@@ -25964,16 +26225,16 @@ snapshots:
     transitivePeerDependencies:
       - ts-node
 
-  eslint-plugin-vue@9.33.0(eslint@9.28.0(jiti@2.4.2)):
+  eslint-plugin-vue@9.33.0(eslint@9.28.0(jiti@2.5.1)):
     dependencies:
-      '@eslint-community/eslint-utils': 4.7.0(eslint@9.28.0(jiti@2.4.2))
-      eslint: 9.28.0(jiti@2.4.2)
+      '@eslint-community/eslint-utils': 4.7.0(eslint@9.28.0(jiti@2.5.1))
+      eslint: 9.28.0(jiti@2.5.1)
       globals: 13.24.0
       natural-compare: 1.4.0
       nth-check: 2.1.1
       postcss-selector-parser: 6.1.2
       semver: 7.7.2
-      vue-eslint-parser: 9.4.3(eslint@9.28.0(jiti@2.4.2))
+      vue-eslint-parser: 9.4.3(eslint@9.28.0(jiti@2.5.1))
       xml-name-validator: 4.0.0
     transitivePeerDependencies:
       - supports-color
@@ -26042,9 +26303,9 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint@9.28.0(jiti@2.4.2):
+  eslint@9.28.0(jiti@2.5.1):
     dependencies:
-      '@eslint-community/eslint-utils': 4.7.0(eslint@9.28.0(jiti@2.4.2))
+      '@eslint-community/eslint-utils': 4.7.0(eslint@9.28.0(jiti@2.5.1))
       '@eslint-community/regexpp': 4.12.1
       '@eslint/config-array': 0.20.1
       '@eslint/config-helpers': 0.2.3
@@ -26080,7 +26341,7 @@ snapshots:
       natural-compare: 1.4.0
       optionator: 0.9.4
     optionalDependencies:
-      jiti: 2.4.2
+      jiti: 2.5.1
     transitivePeerDependencies:
       - supports-color
 
@@ -26861,6 +27122,10 @@ snapshots:
       get-intrinsic: 1.3.0
 
   get-tsconfig@4.10.0:
+    dependencies:
+      resolve-pkg-maps: 1.0.0
+
+  get-tsconfig@4.10.1:
     dependencies:
       resolve-pkg-maps: 1.0.0
 
@@ -27844,6 +28109,8 @@ snapshots:
   jiti@1.21.7: {}
 
   jiti@2.4.2: {}
+
+  jiti@2.5.1: {}
 
   jju@1.4.0: {}
 
@@ -29561,11 +29828,11 @@ snapshots:
       postcss: 8.5.6
       ts-node: 10.9.2(@swc/core@1.11.29(@swc/helpers@0.5.17))(@types/node@24.3.0)(typescript@5.6.2)
 
-  postcss-load-config@6.0.1(jiti@2.4.2)(postcss@8.5.6)(tsx@4.20.3)(yaml@2.6.1):
+  postcss-load-config@6.0.1(jiti@2.5.1)(postcss@8.5.6)(tsx@4.20.3)(yaml@2.6.1):
     dependencies:
       lilconfig: 3.1.3
     optionalDependencies:
-      jiti: 2.4.2
+      jiti: 2.5.1
       postcss: 8.5.6
       tsx: 4.20.3
       yaml: 2.6.1
@@ -29961,6 +30228,8 @@ snapshots:
       side-channel: 1.1.0
 
   quansync@0.2.10: {}
+
+  quansync@0.2.11: {}
 
   query-registry@3.0.1:
     dependencies:
@@ -30712,6 +30981,43 @@ snapshots:
   rimraf@5.0.10:
     dependencies:
       glob: 10.4.5
+
+  rolldown-plugin-dts@0.13.14(rolldown@1.0.0-beta.9)(typescript@5.6.2)(vue-tsc@2.2.12(typescript@5.6.2)):
+    dependencies:
+      '@babel/generator': 7.28.3
+      '@babel/parser': 7.28.3
+      '@babel/types': 7.28.2
+      ast-kit: 2.1.2
+      birpc: 2.5.0
+      debug: 4.4.1
+      dts-resolver: 2.1.2
+      get-tsconfig: 4.10.1
+      rolldown: 1.0.0-beta.9
+    optionalDependencies:
+      typescript: 5.6.2
+      vue-tsc: 2.2.12(typescript@5.6.2)
+    transitivePeerDependencies:
+      - oxc-resolver
+      - supports-color
+
+  rolldown@1.0.0-beta.9:
+    dependencies:
+      '@oxc-project/types': 0.70.0
+      '@rolldown/pluginutils': 1.0.0-beta.9
+      ansis: 4.1.0
+    optionalDependencies:
+      '@rolldown/binding-darwin-arm64': 1.0.0-beta.9
+      '@rolldown/binding-darwin-x64': 1.0.0-beta.9
+      '@rolldown/binding-freebsd-x64': 1.0.0-beta.9
+      '@rolldown/binding-linux-arm-gnueabihf': 1.0.0-beta.9
+      '@rolldown/binding-linux-arm64-gnu': 1.0.0-beta.9
+      '@rolldown/binding-linux-arm64-musl': 1.0.0-beta.9
+      '@rolldown/binding-linux-x64-gnu': 1.0.0-beta.9
+      '@rolldown/binding-linux-x64-musl': 1.0.0-beta.9
+      '@rolldown/binding-wasm32-wasi': 1.0.0-beta.9
+      '@rolldown/binding-win32-arm64-msvc': 1.0.0-beta.9
+      '@rolldown/binding-win32-ia32-msvc': 1.0.0-beta.9
+      '@rolldown/binding-win32-x64-msvc': 1.0.0-beta.9
 
   rollup-plugin-inject@3.0.2:
     dependencies:
@@ -31838,6 +32144,11 @@ snapshots:
 
   ts-interface-checker@0.1.13: {}
 
+  ts-morph@26.0.0:
+    dependencies:
+      '@ts-morph/common': 0.27.0
+      code-block-writer: 13.0.3
+
   ts-node@10.9.2(@swc/core@1.11.29(@swc/helpers@0.5.17))(@types/node@22.16.5)(typescript@5.6.2):
     dependencies:
       '@cspotcode/source-map-support': 0.8.1
@@ -31880,13 +32191,37 @@ snapshots:
       '@swc/core': 1.11.29(@swc/helpers@0.5.17)
     optional: true
 
+  tsdown@0.11.13(typescript@5.6.2)(vue-tsc@2.2.12(typescript@5.6.2)):
+    dependencies:
+      ansis: 4.1.0
+      cac: 6.7.14
+      chokidar: 4.0.3
+      debug: 4.4.1
+      diff: 8.0.2
+      empathic: 1.1.0
+      hookable: 5.5.3
+      rolldown: 1.0.0-beta.9
+      rolldown-plugin-dts: 0.13.14(rolldown@1.0.0-beta.9)(typescript@5.6.2)(vue-tsc@2.2.12(typescript@5.6.2))
+      semver: 7.7.2
+      tinyexec: 1.0.1
+      tinyglobby: 0.2.14
+      unconfig: 7.3.3
+    optionalDependencies:
+      typescript: 5.6.2
+    transitivePeerDependencies:
+      - '@oxc-project/runtime'
+      - '@typescript/native-preview'
+      - oxc-resolver
+      - supports-color
+      - vue-tsc
+
   tslib@1.14.1: {}
 
   tslib@2.4.1: {}
 
   tslib@2.8.1: {}
 
-  tsup@8.5.0(@microsoft/api-extractor@7.52.10(@types/node@24.3.0))(@swc/core@1.11.29(@swc/helpers@0.5.17))(jiti@2.4.2)(postcss@8.5.6)(tsx@4.20.3)(typescript@5.6.2)(yaml@2.6.1):
+  tsup@8.5.0(@microsoft/api-extractor@7.52.10(@types/node@24.3.0))(@swc/core@1.11.29(@swc/helpers@0.5.17))(jiti@2.5.1)(postcss@8.5.6)(tsx@4.20.3)(typescript@5.6.2)(yaml@2.6.1):
     dependencies:
       bundle-require: 5.1.0(esbuild@0.24.0)
       cac: 6.7.14
@@ -31897,7 +32232,7 @@ snapshots:
       fix-dts-default-cjs-exports: 1.0.1
       joycon: 3.1.1
       picocolors: 1.1.1
-      postcss-load-config: 6.0.1(jiti@2.4.2)(postcss@8.5.6)(tsx@4.20.3)(yaml@2.6.1)
+      postcss-load-config: 6.0.1(jiti@2.5.1)(postcss@8.5.6)(tsx@4.20.3)(yaml@2.6.1)
       resolve-from: 5.0.0
       rollup: 4.41.1
       source-map: 0.8.0-beta.0
@@ -32038,12 +32373,12 @@ snapshots:
       shiki: 0.14.7
       typescript: 5.9.2
 
-  typescript-eslint@8.34.0(eslint@9.28.0(jiti@2.4.2))(typescript@5.6.2):
+  typescript-eslint@8.34.0(eslint@9.28.0(jiti@2.5.1))(typescript@5.6.2):
     dependencies:
-      '@typescript-eslint/eslint-plugin': 8.34.0(@typescript-eslint/parser@8.34.0(eslint@9.28.0(jiti@2.4.2))(typescript@5.6.2))(eslint@9.28.0(jiti@2.4.2))(typescript@5.6.2)
-      '@typescript-eslint/parser': 8.34.0(eslint@9.28.0(jiti@2.4.2))(typescript@5.6.2)
-      '@typescript-eslint/utils': 8.34.0(eslint@9.28.0(jiti@2.4.2))(typescript@5.6.2)
-      eslint: 9.28.0(jiti@2.4.2)
+      '@typescript-eslint/eslint-plugin': 8.34.0(@typescript-eslint/parser@8.34.0(eslint@9.28.0(jiti@2.5.1))(typescript@5.6.2))(eslint@9.28.0(jiti@2.5.1))(typescript@5.6.2)
+      '@typescript-eslint/parser': 8.34.0(eslint@9.28.0(jiti@2.5.1))(typescript@5.6.2)
+      '@typescript-eslint/utils': 8.34.0(eslint@9.28.0(jiti@2.5.1))(typescript@5.6.2)
+      eslint: 9.28.0(jiti@2.5.1)
       typescript: 5.6.2
     transitivePeerDependencies:
       - supports-color
@@ -32071,6 +32406,13 @@ snapshots:
     dependencies:
       buffer: 5.7.1
       through: 2.3.8
+
+  unconfig@7.3.3:
+    dependencies:
+      '@quansync/fs': 0.1.5
+      defu: 6.1.4
+      jiti: 2.5.1
+      quansync: 0.2.11
 
   uncrypto@0.1.3: {}
 
@@ -32277,17 +32619,17 @@ snapshots:
       svelte: 5.38.2
       vue: 3.5.13(typescript@5.6.2)
 
-  vite-hot-client@2.1.0(vite@6.3.5(@types/node@22.16.5)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.6.1)):
+  vite-hot-client@2.1.0(vite@6.3.5(@types/node@22.16.5)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.6.1)):
     dependencies:
-      vite: 6.3.5(@types/node@22.16.5)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.6.1)
+      vite: 6.3.5(@types/node@22.16.5)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.6.1)
 
-  vite-node@3.2.4(@types/node@24.3.0)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.6.1):
+  vite-node@3.2.4(@types/node@24.3.0)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.6.1):
     dependencies:
       cac: 6.7.14
       debug: 4.4.1
       es-module-lexer: 1.7.0
       pathe: 2.0.3
-      vite: 6.3.5(@types/node@24.3.0)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.6.1)
+      vite: 6.3.5(@types/node@24.3.0)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.6.1)
     transitivePeerDependencies:
       - '@types/node'
       - jiti
@@ -32302,7 +32644,7 @@ snapshots:
       - tsx
       - yaml
 
-  vite-plugin-dts@4.5.4(@types/node@24.3.0)(rollup@4.41.1)(typescript@5.6.2)(vite@6.3.5(@types/node@24.3.0)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.6.1)):
+  vite-plugin-dts@4.5.4(@types/node@24.3.0)(rollup@4.41.1)(typescript@5.6.2)(vite@6.3.5(@types/node@24.3.0)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.6.1)):
     dependencies:
       '@microsoft/api-extractor': 7.52.10(@types/node@24.3.0)
       '@rollup/pluginutils': 5.1.4(rollup@4.41.1)
@@ -32315,13 +32657,13 @@ snapshots:
       magic-string: 0.30.17
       typescript: 5.6.2
     optionalDependencies:
-      vite: 6.3.5(@types/node@24.3.0)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.6.1)
+      vite: 6.3.5(@types/node@24.3.0)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.6.1)
     transitivePeerDependencies:
       - '@types/node'
       - rollup
       - supports-color
 
-  vite-plugin-inspect@0.8.9(rollup@4.41.1)(vite@6.3.5(@types/node@22.16.5)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.6.1)):
+  vite-plugin-inspect@0.8.9(rollup@4.41.1)(vite@6.3.5(@types/node@22.16.5)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.6.1)):
     dependencies:
       '@antfu/utils': 0.7.10
       '@rollup/pluginutils': 5.1.4(rollup@4.41.1)
@@ -32332,39 +32674,39 @@ snapshots:
       perfect-debounce: 1.0.0
       picocolors: 1.1.1
       sirv: 3.0.1
-      vite: 6.3.5(@types/node@22.16.5)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.6.1)
+      vite: 6.3.5(@types/node@22.16.5)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.6.1)
     transitivePeerDependencies:
       - rollup
       - supports-color
 
-  vite-plugin-pwa@1.0.2(vite@6.3.5(@types/node@24.3.0)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.6.1))(workbox-build@7.3.0(@types/babel__core@7.20.5))(workbox-window@7.3.0):
+  vite-plugin-pwa@1.0.2(vite@6.3.5(@types/node@24.3.0)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.6.1))(workbox-build@7.3.0(@types/babel__core@7.20.5))(workbox-window@7.3.0):
     dependencies:
       debug: 4.4.1
       pretty-bytes: 6.1.1
       tinyglobby: 0.2.14
-      vite: 6.3.5(@types/node@24.3.0)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.6.1)
+      vite: 6.3.5(@types/node@24.3.0)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.6.1)
       workbox-build: 7.3.0(@types/babel__core@7.20.5)
       workbox-window: 7.3.0
     transitivePeerDependencies:
       - supports-color
 
-  vite-plugin-vue-devtools@7.7.7(rollup@4.41.1)(vite@6.3.5(@types/node@22.16.5)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.6.1))(vue@3.5.13(typescript@5.6.2)):
+  vite-plugin-vue-devtools@7.7.7(rollup@4.41.1)(vite@6.3.5(@types/node@22.16.5)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.6.1))(vue@3.5.13(typescript@5.6.2)):
     dependencies:
-      '@vue/devtools-core': 7.7.7(vite@6.3.5(@types/node@22.16.5)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.6.1))(vue@3.5.13(typescript@5.6.2))
+      '@vue/devtools-core': 7.7.7(vite@6.3.5(@types/node@22.16.5)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.6.1))(vue@3.5.13(typescript@5.6.2))
       '@vue/devtools-kit': 7.7.7
       '@vue/devtools-shared': 7.7.7
       execa: 9.5.2
       sirv: 3.0.1
-      vite: 6.3.5(@types/node@22.16.5)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.6.1)
-      vite-plugin-inspect: 0.8.9(rollup@4.41.1)(vite@6.3.5(@types/node@22.16.5)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.6.1))
-      vite-plugin-vue-inspector: 5.3.2(vite@6.3.5(@types/node@22.16.5)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.6.1))
+      vite: 6.3.5(@types/node@22.16.5)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.6.1)
+      vite-plugin-inspect: 0.8.9(rollup@4.41.1)(vite@6.3.5(@types/node@22.16.5)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.6.1))
+      vite-plugin-vue-inspector: 5.3.2(vite@6.3.5(@types/node@22.16.5)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.6.1))
     transitivePeerDependencies:
       - '@nuxt/kit'
       - rollup
       - supports-color
       - vue
 
-  vite-plugin-vue-inspector@5.3.2(vite@6.3.5(@types/node@22.16.5)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.6.1)):
+  vite-plugin-vue-inspector@5.3.2(vite@6.3.5(@types/node@22.16.5)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.6.1)):
     dependencies:
       '@babel/core': 7.28.0
       '@babel/plugin-proposal-decorators': 7.25.9(@babel/core@7.28.0)
@@ -32375,11 +32717,11 @@ snapshots:
       '@vue/compiler-dom': 3.5.13
       kolorist: 1.8.0
       magic-string: 0.30.17
-      vite: 6.3.5(@types/node@22.16.5)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.6.1)
+      vite: 6.3.5(@types/node@22.16.5)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.6.1)
     transitivePeerDependencies:
       - supports-color
 
-  vite@6.3.5(@types/node@22.15.18)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.6.1):
+  vite@6.3.5(@types/node@22.15.18)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.6.1):
     dependencies:
       esbuild: 0.24.0
       fdir: 6.4.5(picomatch@4.0.2)
@@ -32390,13 +32732,13 @@ snapshots:
     optionalDependencies:
       '@types/node': 22.15.18
       fsevents: 2.3.3
-      jiti: 2.4.2
+      jiti: 2.5.1
       lightningcss: 1.30.1
       terser: 5.43.1
       tsx: 4.20.3
       yaml: 2.6.1
 
-  vite@6.3.5(@types/node@22.16.5)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.6.1):
+  vite@6.3.5(@types/node@22.16.5)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.6.1):
     dependencies:
       esbuild: 0.24.0
       fdir: 6.4.5(picomatch@4.0.2)
@@ -32407,13 +32749,13 @@ snapshots:
     optionalDependencies:
       '@types/node': 22.16.5
       fsevents: 2.3.3
-      jiti: 2.4.2
+      jiti: 2.5.1
       lightningcss: 1.30.1
       terser: 5.43.1
       tsx: 4.20.3
       yaml: 2.6.1
 
-  vite@6.3.5(@types/node@24.3.0)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.19.3)(yaml@2.6.1):
+  vite@6.3.5(@types/node@24.3.0)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.19.3)(yaml@2.6.1):
     dependencies:
       esbuild: 0.24.0
       fdir: 6.4.5(picomatch@4.0.2)
@@ -32424,13 +32766,13 @@ snapshots:
     optionalDependencies:
       '@types/node': 24.3.0
       fsevents: 2.3.3
-      jiti: 2.4.2
+      jiti: 2.5.1
       lightningcss: 1.30.1
       terser: 5.43.1
       tsx: 4.19.3
       yaml: 2.6.1
 
-  vite@6.3.5(@types/node@24.3.0)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.6.1):
+  vite@6.3.5(@types/node@24.3.0)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.6.1):
     dependencies:
       esbuild: 0.24.0
       fdir: 6.4.5(picomatch@4.0.2)
@@ -32441,21 +32783,21 @@ snapshots:
     optionalDependencies:
       '@types/node': 24.3.0
       fsevents: 2.3.3
-      jiti: 2.4.2
+      jiti: 2.5.1
       lightningcss: 1.30.1
       terser: 5.43.1
       tsx: 4.20.3
       yaml: 2.6.1
 
-  vitefu@1.1.1(vite@6.3.5(@types/node@24.3.0)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.6.1)):
+  vitefu@1.1.1(vite@6.3.5(@types/node@24.3.0)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.6.1)):
     optionalDependencies:
-      vite: 6.3.5(@types/node@24.3.0)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.6.1)
+      vite: 6.3.5(@types/node@24.3.0)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.6.1)
 
-  vitest@3.2.4(@types/debug@4.1.12)(@types/node@24.3.0)(@vitest/browser@3.2.4)(@vitest/ui@3.2.4)(happy-dom@17.4.4)(jiti@2.4.2)(jsdom@25.0.1)(lightningcss@1.30.1)(msw@2.10.3(@types/node@24.3.0)(typescript@5.6.2))(terser@5.43.1)(tsx@4.20.3)(yaml@2.6.1):
+  vitest@3.2.4(@types/debug@4.1.12)(@types/node@24.3.0)(@vitest/browser@3.2.4)(@vitest/ui@3.2.4)(happy-dom@17.4.4)(jiti@2.5.1)(jsdom@25.0.1)(lightningcss@1.30.1)(msw@2.10.3(@types/node@24.3.0)(typescript@5.6.2))(terser@5.43.1)(tsx@4.20.3)(yaml@2.6.1):
     dependencies:
       '@types/chai': 5.2.2
       '@vitest/expect': 3.2.4
-      '@vitest/mocker': 3.2.4(msw@2.10.3(@types/node@24.3.0)(typescript@5.6.2))(vite@6.3.5(@types/node@24.3.0)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.6.1))
+      '@vitest/mocker': 3.2.4(msw@2.10.3(@types/node@24.3.0)(typescript@5.6.2))(vite@6.3.5(@types/node@24.3.0)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.6.1))
       '@vitest/pretty-format': 3.2.4
       '@vitest/runner': 3.2.4
       '@vitest/snapshot': 3.2.4
@@ -32473,13 +32815,13 @@ snapshots:
       tinyglobby: 0.2.14
       tinypool: 1.1.1
       tinyrainbow: 2.0.0
-      vite: 6.3.5(@types/node@24.3.0)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.6.1)
-      vite-node: 3.2.4(@types/node@24.3.0)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.6.1)
+      vite: 6.3.5(@types/node@24.3.0)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.6.1)
+      vite-node: 3.2.4(@types/node@24.3.0)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.6.1)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/debug': 4.1.12
       '@types/node': 24.3.0
-      '@vitest/browser': 3.2.4(msw@2.10.3(@types/node@24.3.0)(typescript@5.6.2))(playwright@1.50.1)(vite@6.3.5(@types/node@24.3.0)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.6.1))(vitest@3.2.4)(webdriverio@8.41.0)
+      '@vitest/browser': 3.2.4(msw@2.10.3(@types/node@24.3.0)(typescript@5.6.2))(playwright@1.50.1)(vite@6.3.5(@types/node@24.3.0)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.6.1))(vitest@3.2.4)(webdriverio@8.41.0)
       '@vitest/ui': 3.2.4(vitest@3.2.4)
       happy-dom: 17.4.4
       jsdom: 25.0.1
@@ -32497,11 +32839,11 @@ snapshots:
       - tsx
       - yaml
 
-  vitest@3.2.4(@types/debug@4.1.12)(@types/node@24.3.0)(@vitest/browser@3.2.4)(@vitest/ui@3.2.4)(happy-dom@17.4.4)(jiti@2.4.2)(jsdom@25.0.1)(lightningcss@1.30.1)(msw@2.10.4(@types/node@24.3.0)(typescript@5.6.2))(terser@5.43.1)(tsx@4.20.3)(yaml@2.6.1):
+  vitest@3.2.4(@types/debug@4.1.12)(@types/node@24.3.0)(@vitest/browser@3.2.4)(@vitest/ui@3.2.4)(happy-dom@17.4.4)(jiti@2.5.1)(jsdom@25.0.1)(lightningcss@1.30.1)(msw@2.10.4(@types/node@24.3.0)(typescript@5.6.2))(terser@5.43.1)(tsx@4.20.3)(yaml@2.6.1):
     dependencies:
       '@types/chai': 5.2.2
       '@vitest/expect': 3.2.4
-      '@vitest/mocker': 3.2.4(msw@2.10.4(@types/node@24.3.0)(typescript@5.6.2))(vite@6.3.5(@types/node@24.3.0)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.6.1))
+      '@vitest/mocker': 3.2.4(msw@2.10.4(@types/node@24.3.0)(typescript@5.6.2))(vite@6.3.5(@types/node@24.3.0)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.6.1))
       '@vitest/pretty-format': 3.2.4
       '@vitest/runner': 3.2.4
       '@vitest/snapshot': 3.2.4
@@ -32519,13 +32861,13 @@ snapshots:
       tinyglobby: 0.2.14
       tinypool: 1.1.1
       tinyrainbow: 2.0.0
-      vite: 6.3.5(@types/node@24.3.0)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.6.1)
-      vite-node: 3.2.4(@types/node@24.3.0)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.6.1)
+      vite: 6.3.5(@types/node@24.3.0)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.6.1)
+      vite-node: 3.2.4(@types/node@24.3.0)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.6.1)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/debug': 4.1.12
       '@types/node': 24.3.0
-      '@vitest/browser': 3.2.4(msw@2.10.4(@types/node@24.3.0)(typescript@5.6.2))(playwright@1.50.1)(vite@6.3.5(@types/node@24.3.0)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.6.1))(vitest@3.2.4)(webdriverio@8.41.0)
+      '@vitest/browser': 3.2.4(msw@2.10.4(@types/node@24.3.0)(typescript@5.6.2))(playwright@1.50.1)(vite@6.3.5(@types/node@24.3.0)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.6.1))(vitest@3.2.4)(webdriverio@8.41.0)
       '@vitest/ui': 3.2.4(vitest@3.2.4)
       happy-dom: 17.4.4
       jsdom: 25.0.1
@@ -32543,11 +32885,11 @@ snapshots:
       - tsx
       - yaml
 
-  vitest@3.2.4(@types/debug@4.1.12)(@types/node@24.3.0)(@vitest/browser@3.2.4)(@vitest/ui@3.2.4)(happy-dom@17.4.4)(jiti@2.4.2)(jsdom@25.0.1)(lightningcss@1.30.1)(msw@2.10.4(@types/node@24.3.0)(typescript@5.9.2))(terser@5.43.1)(tsx@4.20.3)(yaml@2.6.1):
+  vitest@3.2.4(@types/debug@4.1.12)(@types/node@24.3.0)(@vitest/browser@3.2.4)(@vitest/ui@3.2.4)(happy-dom@17.4.4)(jiti@2.5.1)(jsdom@25.0.1)(lightningcss@1.30.1)(msw@2.10.4(@types/node@24.3.0)(typescript@5.9.2))(terser@5.43.1)(tsx@4.20.3)(yaml@2.6.1):
     dependencies:
       '@types/chai': 5.2.2
       '@vitest/expect': 3.2.4
-      '@vitest/mocker': 3.2.4(msw@2.10.4(@types/node@24.3.0)(typescript@5.9.2))(vite@6.3.5(@types/node@24.3.0)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.6.1))
+      '@vitest/mocker': 3.2.4(msw@2.10.4(@types/node@24.3.0)(typescript@5.9.2))(vite@6.3.5(@types/node@24.3.0)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.6.1))
       '@vitest/pretty-format': 3.2.4
       '@vitest/runner': 3.2.4
       '@vitest/snapshot': 3.2.4
@@ -32565,13 +32907,13 @@ snapshots:
       tinyglobby: 0.2.14
       tinypool: 1.1.1
       tinyrainbow: 2.0.0
-      vite: 6.3.5(@types/node@24.3.0)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.6.1)
-      vite-node: 3.2.4(@types/node@24.3.0)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.6.1)
+      vite: 6.3.5(@types/node@24.3.0)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.6.1)
+      vite-node: 3.2.4(@types/node@24.3.0)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.6.1)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/debug': 4.1.12
       '@types/node': 24.3.0
-      '@vitest/browser': 3.2.4(msw@2.10.4(@types/node@24.3.0)(typescript@5.9.2))(playwright@1.50.1)(vite@6.3.5(@types/node@24.3.0)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.6.1))(vitest@3.2.4)(webdriverio@8.41.0)
+      '@vitest/browser': 3.2.4(msw@2.10.4(@types/node@24.3.0)(typescript@5.9.2))(playwright@1.50.1)(vite@6.3.5(@types/node@24.3.0)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.6.1))(vitest@3.2.4)(webdriverio@8.41.0)
       '@vitest/ui': 3.2.4(vitest@3.2.4)
       happy-dom: 17.4.4
       jsdom: 25.0.1
@@ -32597,10 +32939,10 @@ snapshots:
 
   vscode-uri@3.1.0: {}
 
-  vue-eslint-parser@9.4.3(eslint@9.28.0(jiti@2.4.2)):
+  vue-eslint-parser@9.4.3(eslint@9.28.0(jiti@2.5.1)):
     dependencies:
       debug: 4.4.1
-      eslint: 9.28.0(jiti@2.4.2)
+      eslint: 9.28.0(jiti@2.5.1)
       eslint-scope: 7.2.2
       eslint-visitor-keys: 3.4.3
       espree: 9.6.1


### PR DESCRIPTION
Codemod to simplify the upgrade to Jazz v0.18

It uses `ts-morph` which gives us some information on the resolved types.

Since we do some type-aware filtering, the codemod needs to run on top of a Jazz v0.18 installation.

The transform is executed more than one time to iterate over fixes on the types (e.g. when we do fix a `ensureLoaded` the returned type is no more any and we can check that the values are related to Jazz)