### PR TITLE
feat: change the migration checks to use .$jazz.has

### DIFF
--- a/.changeset/nervous-rules-heal.md
+++ b/.changeset/nervous-rules-heal.md
@@ -2,4 +2,4 @@
 "jazz-tools": patch
 ---
 
-Add `CoMap.$jazz.has` method to check for property existance without loading referenced CoValues or checking permissions
+Add `CoMap.$jazz.has` and `Account.$jazz.has` method to check for property existance without loading referenced CoValues or checking permissions

--- a/examples/community-todo-vue/src/schema.ts
+++ b/examples/community-todo-vue/src/schema.ts
@@ -44,7 +44,7 @@ export const TodoAccount = co
     /** The account migration is run on account creation and on every log-in.
      *  You can use it to set up the account root and any other initial CoValues you need.
      */
-    if (account.root === undefined) {
+    if (!account.$jazz.has("root")) {
       account.$jazz.set("root", {
         projects: [],
       });

--- a/examples/file-share-svelte/src/lib/schema.ts
+++ b/examples/file-share-svelte/src/lib/schema.ts
@@ -19,7 +19,7 @@ export const FileShareAccount = co.account({
   profile: co.profile(),
   root: FileShareAccountRoot,
 }).withMigration((account) => {
-  if (account.root === undefined) {
+  if (!account.$jazz.has("root")) {
     const publicGroup = Group.create({ owner: account });
     publicGroup.addMember('everyone', 'reader');
 

--- a/examples/multi-cursors/src/schema.ts
+++ b/examples/multi-cursors/src/schema.ts
@@ -22,7 +22,7 @@ export const CursorAccount = co
     root: CursorRoot,
   })
   .withMigration((account) => {
-    if (account.root === undefined) {
+    if (!account.$jazz.has("root")) {
       account.$jazz.set("root", {
         camera: {
           position: {
@@ -34,7 +34,7 @@ export const CursorAccount = co
       });
     }
 
-    if (account.profile === undefined) {
+    if (!account.$jazz.has("profile")) {
       const group = Group.create();
       group.makePublic(); // The profile info is visible to everyone
 

--- a/examples/music-player/src/1_schema.ts
+++ b/examples/music-player/src/1_schema.ts
@@ -89,7 +89,7 @@ export const MusicaAccount = co
      *  The account migration is run on account creation and on every log-in.
      *  You can use it to set up the account root and any other initial CoValues you need.
      */
-    if (account.root === undefined) {
+    if (!account.$jazz.has("root")) {
       const rootPlaylist = Playlist.create({
         tracks: [],
         title: "",
@@ -104,7 +104,7 @@ export const MusicaAccount = co
       });
     }
 
-    if (account.profile === undefined) {
+    if (!account.$jazz.has("profile")) {
       account.$jazz.set(
         "profile",
         MusicaAccountProfile.create(

--- a/examples/organization/src/schema.ts
+++ b/examples/organization/src/schema.ts
@@ -40,7 +40,7 @@ export const JazzAccount = co
     root: JazzAccountRoot,
   })
   .withMigration(async (account) => {
-    if (account.profile === undefined) {
+    if (!account.$jazz.has("profile")) {
       const group = Group.create();
       account.$jazz.set(
         "profile",
@@ -54,7 +54,7 @@ export const JazzAccount = co
       group.addMember("everyone", "reader");
     }
 
-    if (account.root === undefined) {
+    if (!account.$jazz.has("root")) {
       const draftOrgGroup = Group.create();
       const draftOrganization = DraftOrganization.create(
         {

--- a/examples/richtext-prosekit/src/schema.ts
+++ b/examples/richtext-prosekit/src/schema.ts
@@ -33,13 +33,13 @@ export const JazzAccount = co
     /** The account migration is run on account creation and on every log-in.
      *  You can use it to set up the account root and any other initial CoValues you need.
      */
-    if (account.root === undefined) {
+    if (!account.$jazz.has("root")) {
       account.$jazz.set("root", {
         dateOfBirth: new Date("1/1/1990"),
       });
     }
 
-    if (account.profile === undefined) {
+    if (!account.$jazz.has("profile")) {
       const group = Group.create();
       group.addMember("everyone", "reader"); // The profile info is visible to everyone
 

--- a/examples/richtext-prosemirror/src/schema.ts
+++ b/examples/richtext-prosemirror/src/schema.ts
@@ -33,13 +33,13 @@ export const JazzAccount = co
     /** The account migration is run on account creation and on every log-in.
      *  You can use it to set up the account root and any other initial CoValues you need.
      */
-    if (account.root === undefined) {
+    if (!account.$jazz.has("root")) {
       account.$jazz.set("root", {
         dateOfBirth: new Date("1/1/1990"),
       });
     }
 
-    if (account.profile === undefined) {
+    if (!account.$jazz.has("profile")) {
       const group = Group.create();
       group.makePublic(); // The profile info is visible to everyone
 

--- a/examples/richtext-tiptap/src/schema.ts
+++ b/examples/richtext-tiptap/src/schema.ts
@@ -33,11 +33,11 @@ export const JazzAccount = co
     /** The account migration is run on account creation and on every log-in.
      *  You can use it to set up the account root and any other initial CoValues you need.
      */
-    if (account.root === undefined) {
+    if (!account.$jazz.has("root")) {
       account.$jazz.set("root", { dateOfBirth: new Date("1/1/1990") });
     }
 
-    if (account.profile === undefined) {
+    if (!account.$jazz.has("profile")) {
       const group = Group.create();
       group.makePublic(); // The profile info is visible to everyone
 

--- a/examples/todo/src/1_schema.ts
+++ b/examples/todo/src/1_schema.ts
@@ -53,7 +53,7 @@ export const TodoAccount = co
     /** The account migration is run on account creation and on every log-in.
      *  You can use it to set up the account root and any other initial CoValues you need.
      */
-    if (account.root === undefined) {
+    if (!account.$jazz.has("root")) {
       account.$jazz.set("root", {
         projects: [],
       });

--- a/homepage/homepage/content/docs/design-patterns/form.mdx
+++ b/homepage/homepage/content/docs/design-patterns/form.mdx
@@ -389,7 +389,7 @@ export const JazzAccount = co.account({
   root: AccountRoot,
   profile: co.map({ name: z.string() }),
 }).withMigration((account, creationProps?: { name: string }) => {
-  if (account.root === undefined) {
+  if (!account.$jazz.has("root")) {
     account.$jazz.set("root", { draft: {} });
   }
 });
@@ -418,7 +418,7 @@ export const JazzAccount = co.account({
   root: AccountRoot,
   profile: co.map({ name: z.string() }),
 }).withMigration((account, creationProps?: { name: string }) => {
-  if (account.root === undefined) {
+  if (!account.$jazz.has("root")) {
     account.$jazz.set("root", { draft: {} });
   }
 });
@@ -475,7 +475,7 @@ export const JazzAccount = co.account({
   root: AccountRoot,
   profile: co.map({ name: z.string() }),
 }).withMigration((account, creationProps?: { name: string }) => {
-  if (account.root === undefined) {
+  if (!account.$jazz.has("root")) {
     account.$jazz.set("root", { draft: {} });
   }
 });
@@ -635,7 +635,7 @@ export const JazzAccount = co.account({
   root: AccountRoot,
   profile: co.map({ name: z.string() }),
 }).withMigration((account, creationProps?: { name: string }) => {
-  if (account.root === undefined) {
+  if (!account.$jazz.has("root")) {
     account.$jazz.set("root", { draft: {} });
   }
 });

--- a/homepage/homepage/content/docs/design-patterns/organization.mdx
+++ b/homepage/homepage/content/docs/design-patterns/organization.mdx
@@ -70,7 +70,7 @@ export const JazzAccount = co
     profile: co.profile(),
   })
   .withMigration((account) => {
-    if (account.root === undefined) {
+    if (!account.$jazz.has("root")) {
       // Using a Group as an owner allows you to give access to other users
       const organizationGroup = Group.create();
 

--- a/homepage/homepage/content/docs/schemas/accounts-and-migrations.mdx
+++ b/homepage/homepage/content/docs/schemas/accounts-and-migrations.mdx
@@ -199,15 +199,14 @@ export const MyAppAccount = co.account({
   root: MyAppRoot,
   profile: MyAppProfile,
 }).withMigration((account, creationProps?: { name: string }) => {
-  // we specifically need to check for undefined,
-  // because the root might simply be not loaded (`null`) yet
-  if (account.root === undefined) {
+  // we use has to check if the root has ever been set
+  if (!account.$jazz.has("root")) {
     account.$jazz.set("root", {
       myChats: [],
     });
   }
 
-  if (account.profile === undefined) {
+  if (!account.$jazz.has("profile")) {
     const profileGroup = Group.create();
     // Unlike the root, we want the profile to be publicly readable.
     profileGroup.makePublic();
@@ -255,7 +254,7 @@ export const MyAppAccount = co.account({
   root: MyAppRoot,
   profile: MyAppProfile,
 }).withMigration(async (account) => {
-  if (account.root === undefined) {
+  if (!account.$jazz.has("root")) {
     account.$jazz.set("root", {
       myChats: [],
     });

--- a/packages/cursor-docs/.cursor/docs/jazz-schema-template.md
+++ b/packages/cursor-docs/.cursor/docs/jazz-schema-template.md
@@ -49,7 +49,7 @@ export const AppAccount = co
   })
   .withMigration((account) => {
     // Initialize root if it doesn't exist
-    if (account.root === undefined) {
+    if (!account.$jazz.has("root")) {
       account.root = AppRoot.create({
         mainData: {
           // Initialize with default values
@@ -64,7 +64,7 @@ export const AppAccount = co
     }
 
     // Initialize profile if it doesn't exist
-    if (account.profile === undefined) {
+    if (!account.$jazz.has("profile")) {
       const group = Group.create();
       group.addMember("everyone", "reader"); // Profile visible to everyone
       
@@ -97,13 +97,13 @@ export const AppAccount = co
 ```typescript
 .withMigration((account) => {
   // Always check if data exists before creating
-  if (account.root === undefined) {
+  if (!account.$jazz.has("root")) {
     account.root = AppRoot.create({
       // Initialize with sensible defaults
     });
   }
   
-  if (account.profile === undefined) {
+  if (!account.$jazz.has("profile")) {
     const group = Group.create();
     group.addMember("everyone", "reader");
     

--- a/packages/cursor-docs/.cursor/docs/llms-full.md
+++ b/packages/cursor-docs/.cursor/docs/llms-full.md
@@ -1839,13 +1839,13 @@ export const MyAppAccount = co.account({
   root: MyAppRoot,
   profile: MyAppProfile,
 }).withMigration((account, creationProps?: { name: string }) => {
-  if (account.root === undefined) {
+  if (!account.$jazz.has("root")) {
     account.root = MyAppRoot.create({
       pets: co.list(Pet).create([]),
     });
   }
 
-  if (account.profile === undefined) {
+  if (!account.$jazz.has("profile")) {
     const profileGroup = Group.create();
     profileGroup.addMember("everyone", "reader");
 
@@ -2535,7 +2535,7 @@ export const MyAppAccount = co.account({
 }).withMigration((account, creationProps?: { name: string }) => {
   // we specifically need to check for undefined,
   // because the root might simply be not loaded (`null`) yet
-  if (account.root === undefined) {
+  if (!account.$jazz.has("root")) {
     account.root = MyAppRoot.create({
       // Using a group to set the owner is always a good idea.
       // This way if in the future we want to share
@@ -2544,7 +2544,7 @@ export const MyAppAccount = co.account({
     });
   }
 
-  if (account.profile === undefined) {
+  if (!account.$jazz.has("profile")) {
     const profileGroup = Group.create();
     // Unlike the root, we want the profile to be publicly readable.
     profileGroup.addMember("everyone", "reader");
@@ -2588,7 +2588,7 @@ export const MyAppAccount = co.account({
   root: MyAppRoot,
   profile: MyAppProfile,
 }).withMigration(async (account) => {
-  if (account.root === undefined) {
+  if (!account.$jazz.has("root")) {
     account.root = MyAppRoot.create({
       myChats: co.list(Chat).create([], Group.create()),
     });
@@ -4942,7 +4942,7 @@ const MyAccount = co.account({
 });
 
 MyAccount.withMigration((account, creationProps) => {
-  if (account.profile === undefined) {
+  if (!account.$jazz.has("profile")) {
     const profileGroup = Group.create();
     profileGroup.addMember("everyone", "reader");
     account.profile = MyProfile.create(
@@ -7518,7 +7518,7 @@ export const JazzAccount = co.account({
   root: AccountRoot,
   profile: co.map({ name: z.string() }),
 }).withMigration((account, creationProps?: { name: string }) => {
-  if (account.root === undefined) {
+  if (!account.$jazz.has("root")) {
     const draft = DraftBubbleTeaOrder.create({});
 
     account.root = AccountRoot.create({ draft });
@@ -7548,7 +7548,7 @@ export const JazzAccount = co.account({
   root: AccountRoot,
   profile: co.map({ name: z.string() }),
 }).withMigration((account, creationProps?: { name: string }) => {
-  if (account.root === undefined) {
+  if (!account.$jazz.has("root")) {
     const draft = DraftBubbleTeaOrder.create({});
 
     account.root = AccountRoot.create({ draft });
@@ -7603,7 +7603,7 @@ export const JazzAccount = co.account({
   root: AccountRoot,
   profile: co.map({ name: z.string() }),
 }).withMigration((account, creationProps?: { name: string }) => {
-  if (account.root === undefined) {
+  if (!account.$jazz.has("root")) {
     const draft = DraftBubbleTeaOrder.create({});
 
     account.root = AccountRoot.create({ draft });
@@ -7755,7 +7755,7 @@ export const JazzAccount = co.account({
   root: AccountRoot,
   profile: co.map({ name: z.string() }),
 }).withMigration((account, creationProps?: { name: string }) => {
-  if (account.root === undefined) {
+  if (!account.$jazz.has("root")) {
     const draft = DraftBubbleTeaOrder.create({});
 
     account.root = AccountRoot.create({ draft });
@@ -7893,7 +7893,7 @@ export const JazzAccount = co
     profile: co.profile(),
   })
   .withMigration((account) => {
-    if (account.root === undefined) {
+    if (!account.$jazz.has("root")) {
       // Using a Group as an owner allows you to give access to other users
       const organizationGroup = Group.create();
 
@@ -8090,7 +8090,7 @@ export const MusicaAccount = co
      *  The account migration is run on account creation and on every log-in.
      *  You can use it to set up the account root and any other initial CoValues you need.
      */
-    if (account.root === undefined) {
+    if (!account.$jazz.has("root")) {
       const tracks = co.list(MusicTrack).create([]);
       const rootPlaylist = Playlist.create({
         tracks,

--- a/packages/jazz-run/src/tests/startWorker.test.ts
+++ b/packages/jazz-run/src/tests/startWorker.test.ts
@@ -132,7 +132,7 @@ describe("startWorker integration", () => {
         profile: co.profile(),
       })
       .withMigration((account) => {
-        if (account.root === undefined) {
+        if (!account.$jazz.has("root")) {
           if (shouldReloadPreviousAccount) {
             throw new Error("Previous account not found");
           }

--- a/packages/jazz-tools/src/tools/coValues/account.ts
+++ b/packages/jazz-tools/src/tools/coValues/account.ts
@@ -418,6 +418,11 @@ class AccountJazzApi<A extends Account> extends CoValueJazzApi<A> {
     }
   }
 
+  has(key: "root" | "profile"): boolean {
+    const entry = this.raw.getRaw(key);
+    return entry?.change !== undefined && entry.change.op !== "del";
+  }
+
   /**
    * Get the descriptor for a given key
    * @internal

--- a/packages/jazz-tools/src/tools/implementation/zodSchema/zodCo.ts
+++ b/packages/jazz-tools/src/tools/implementation/zodSchema/zodCo.ts
@@ -101,7 +101,7 @@ export const coMapDefiner = <Shape extends z.core.$ZodLooseShape>(
  *   }),
  * }).withMigration(async (account) => {
  *   // Migration logic for existing accounts
- *   if (account.profile === undefined) {
+ *   if (!account.$jazz.has("profile")) {
  *     const group = Group.create();
  *     account.$jazz.set("profile", co.profile().create(
  *       { name: getRandomUsername() },

--- a/packages/jazz-tools/src/tools/tests/ContextManager.test.ts
+++ b/packages/jazz-tools/src/tools/tests/ContextManager.test.ts
@@ -372,7 +372,7 @@ describe("ContextManager", () => {
         profile: co.profile(),
       })
       .withMigration(async (account) => {
-        if (account.root === undefined) {
+        if (!account.$jazz.has("root")) {
           account.$jazz.set(
             "root",
             AccountRoot.create({
@@ -429,7 +429,7 @@ describe("ContextManager", () => {
         profile: co.profile(),
       })
       .withMigration(async (account) => {
-        if (account.root === undefined) {
+        if (!account.$jazz.has("root")) {
           account.$jazz.set(
             "root",
             AccountRoot.create({

--- a/packages/jazz-tools/src/tools/tests/patterns/notifications.test.ts
+++ b/packages/jazz-tools/src/tools/tests/patterns/notifications.test.ts
@@ -17,7 +17,7 @@ const WorkerAccount = co
     profile: co.profile(),
   })
   .withMigration((account) => {
-    if (account.root === undefined) {
+    if (!account.$jazz.has("root")) {
       account.$jazz.set("root", {
         notificationQueue: [],
       });

--- a/packages/jazz-tools/src/tools/tests/testing.test.ts
+++ b/packages/jazz-tools/src/tools/tests/testing.test.ts
@@ -35,7 +35,7 @@ describe("Jazz Test Sync", () => {
         profile: co.profile(),
       })
       .withMigration((account) => {
-        if (account.root === undefined) {
+        if (!account.$jazz.has("root")) {
           account.$jazz.set("root", { value: "ok" });
         }
       });
@@ -59,7 +59,7 @@ describe("Jazz Test Sync", () => {
         profile: co.profile(),
       })
       .withMigration((account) => {
-        if (account.root === undefined) {
+        if (!account.$jazz.has("root")) {
           account.$jazz.set("root", { value: "ok" });
         }
       });

--- a/starters/react-passkey-auth/src/schema.ts
+++ b/starters/react-passkey-auth/src/schema.ts
@@ -37,13 +37,13 @@ export const JazzAccount = co
     /** The account migration is run on account creation and on every log-in.
      *  You can use it to set up the account root and any other initial CoValues you need.
      */
-    if (account.root === undefined) {
+    if (!account.$jazz.has("root")) {
       account.$jazz.set("root", {
         dateOfBirth: new Date("1/1/1990"),
       });
     }
 
-    if (account.profile === undefined) {
+    if (!account.$jazz.has("profile")) {
       const group = Group.create();
       group.addMember("everyone", "reader"); // The profile info is visible to everyone
 

--- a/starters/svelte-passkey-auth/src/lib/schema.ts
+++ b/starters/svelte-passkey-auth/src/lib/schema.ts
@@ -52,13 +52,13 @@ export const JazzAccount = co
     /** The account migration is run on account creation and on every log-in.
      *  You can use it to set up the account root and any other initial CoValues you need.
      */
-    if (account.root === undefined) {
+    if (!account.$jazz.has("root")) {
       account.$jazz.set("root", {
         dateOfBirth: new Date("1/1/1990"),
       });
     }
 
-    if (account.profile === undefined) {
+    if (!account.$jazz.has("profile")) {
       const group = Group.create();
       group.addMember("everyone", "reader"); // The profile info is visible to everyone
 

--- a/tests/stress-test/src/1_schema.ts
+++ b/tests/stress-test/src/1_schema.ts
@@ -38,7 +38,7 @@ export const TodoAccount = co
     /** The account migration is run on account creation and on every log-in.
      *  You can use it to set up the account root and any other initial CoValues you need.
      */
-    if (account.root === undefined) {
+    if (!account.$jazz.has("root")) {
       account.$jazz.set("root", {
         projects: [],
         profilingEnabled: false,


### PR DESCRIPTION
Moving away from `account.root === undefined` based checks, because they rely on a subtle detail on how in Jazz `undefined` has a different meaning compared to `null`.

With the new `$jazz` APIs accessing `raw` doesn't look like a sin anymore (before was `_raw` which made it look like accessing an internal prop) so I'm suggesting to use `!account.$jazz.has("root")` to check if a root is setted, regardless of the loading statuses.

We could even start pushing for using `raw` instead of `refs` for accessing references ids without triggering the autoload.