### PR TITLE
feat: deprecate `co.map().catchall`

### DIFF
--- a/.changeset/little-moles-drive.md
+++ b/.changeset/little-moles-drive.md
@@ -1,0 +1,5 @@
+---
+"jazz-tools": patch
+---
+
+Deprecate `co.map().catchall`. Use a `co.record` nested inside a `co.map` if you need to store key-value properties.

--- a/packages/jazz-tools/src/tools/implementation/zodSchema/schemaTypes/CoMapSchema.ts
+++ b/packages/jazz-tools/src/tools/implementation/zodSchema/schemaTypes/CoMapSchema.ts
@@ -131,6 +131,11 @@ export interface CoMapSchema<
     R
   > | null>;
 
+  /**
+   * @deprecated Use `co.map().catchall` will be removed in an upcoming version.
+   *
+   * Use a `co.record` nested inside a `co.map` if you need to store key-value properties.
+   */
   catchall<T extends AnyZodOrCoValueSchema>(schema: T): CoMapSchema<Shape, T>;
 
   withMigration(

--- a/packages/jazz-tools/src/tools/implementation/zodSchema/schemaTypes/CoMapSchema.ts
+++ b/packages/jazz-tools/src/tools/implementation/zodSchema/schemaTypes/CoMapSchema.ts
@@ -135,6 +135,20 @@ export interface CoMapSchema<
    * @deprecated Use `co.map().catchall` will be removed in an upcoming version.
    *
    * Use a `co.record` nested inside a `co.map` if you need to store key-value properties.
+   *
+   * @example
+   * ```ts
+   * // Instead of:
+   * const Image = co.map({
+   *   original: co.fileStream(),
+   * }).catchall(co.fileStream());
+   *
+   * // Use:
+   * const Image = co.map({
+   *   original: co.fileStream(),
+   *   resolutions: co.record(z.string(), co.fileStream()),
+   * });
+   * ```
    */
   catchall<T extends AnyZodOrCoValueSchema>(schema: T): CoMapSchema<Shape, T>;
 


### PR DESCRIPTION
# Description

Marks the `co.map().catchall` method as deprecated.

See https://github.com/garden-co/jazz/pull/2837 for the motivation behind this change.

## Checklist

- [ ] I've updated the part of the docs that are affected the PR changes
- [x] I've generated a changeset, if a version bump is required
- [ ] I've updated the jsDoc comments to the public APIs I've modified, or added them when missing