### PR TITLE
chore: bump version

### DIFF
--- a/.changeset/few-eyes-vanish.md
+++ b/.changeset/few-eyes-vanish.md
@@ -1,0 +1,5 @@
+---
+"jazz-tools": patch
+---
+
+Set 18.x as latest


### PR DESCRIPTION
Just bumps version to tag 18.x as latest again