### PR TITLE
CI: avoid 'latest' dist tag when publishing backports

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,10 +24,22 @@ jobs:
 
       - name: Create Release Pull Request or Publish to npm
         id: changesets
+        if: github.ref_name == 'main'
         uses: changesets/action@v1
         with:
           version: pnpm changeset-version
           publish: pnpm release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Create Release Pull Request or Publish to npm (backports)
+        id: changesets-backport
+        if: startsWith(github.ref_name, 'backport/')
+        uses: changesets/action@v1
+        with:
+          version: pnpm changeset-version
+          publish: pnpm release:backports
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "changeset": "changeset",
     "changeset-version": "changeset version && pnpm i --no-frozen-lockfile",
     "release": "turbo run build --filter='./packages/*' && pnpm changeset publish && git push --follow-tags",
+    "release:backports": "turbo run build --filter='./packages/*' && pnpm changeset publish --tag backport && git push --follow-tags",
     "clean": "rm -rf ./packages/*/dist && rm -rf ./packages/*/node_modules && rm -rf ./examples/*/node_modules && rm -rf ./examples/*/dist",
     "postinstall": "lefthook install"
   },


### PR DESCRIPTION
changeset by default publishes on nom using the latest tag, this causes backports to be marked as latest even when there's a "newer version". this PR modifies the workflow so that when running it from a backport branch it uses a different tag, thus avoiding setting latest for anything that is not published from the main branch.

from changesets docs:

> --tag TAGNAME - for packages that are published, the chosen tag will be used instead of latest, allowing you to publish changes intended for testing and validation, not main consumption. This will most likely be used with snapshot releases.