### PR TITLE
feat: add `$jazz.id` to `toJSON` in Account, CoMap, CoFeed & FileStream

### DIFF
--- a/.changeset/early-scissors-sell.md
+++ b/.changeset/early-scissors-sell.md
@@ -1,0 +1,5 @@
+---
+"jazz-tools": patch
+---
+
+Add `$jazz.id` to `toJSON` in Account, CoMap, CoFeed & FileStream

--- a/homepage/homepage/content/docs/upgrade/0-18-0.mdx
+++ b/homepage/homepage/content/docs/upgrade/0-18-0.mdx
@@ -181,8 +181,9 @@ Accounts as CoValue owners will be phased out in a future release.
 The `castAs()` method has been completely removed as it was an unsafe operation that bypassed type checking and enabled using CoValues in unsupported ways.
 
 #### toJSON() Changes
-The `id` and `_type` fields have been removed from `toJSON()` output for Account, CoMap, CoFeed, and FileStream classes. This aligns with the idea
-of viewing CoValues as JSON objects.
+The `_type` fields has been removed from `toJSON()` output for Account, CoMap, CoFeed, and FileStream classes, and the `id` field has been moved to the `$jazz` namespace.
+
+Note: before `0.18.4`, the `id` field was also removed from the `toJSON()` output. This has since been reverted.
 
 #### Group Property Removal
 The `root` and `profile` fields have been removed from the Group class. These fields were not documented and were not intended to be used by users.

--- a/packages/jazz-tools/src/tools/coValues/account.ts
+++ b/packages/jazz-tools/src/tools/coValues/account.ts
@@ -274,7 +274,9 @@ export class Account extends CoValueBase implements CoValue {
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   toJSON(): object | any[] {
-    return {};
+    return {
+      "$jazz.id": this.$jazz.id,
+    };
   }
 
   [inspect]() {

--- a/packages/jazz-tools/src/tools/coValues/account.ts
+++ b/packages/jazz-tools/src/tools/coValues/account.ts
@@ -275,7 +275,7 @@ export class Account extends CoValueBase implements CoValue {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   toJSON(): object | any[] {
     return {
-      "$jazz.id": this.$jazz.id,
+      $jazz: { id: this.$jazz.id },
     };
   }
 

--- a/packages/jazz-tools/src/tools/coValues/coFeed.ts
+++ b/packages/jazz-tools/src/tools/coValues/coFeed.ts
@@ -228,7 +228,7 @@ export class CoFeed<out Item = any> extends CoValueBase implements CoValue {
    * @category
    */
   toJSON(): {
-    "$jazz.id": string;
+    $jazz: { id: string };
     [key: string]: unknown;
     in: { [key: string]: unknown };
   } {
@@ -241,7 +241,7 @@ export class CoFeed<out Item = any> extends CoValueBase implements CoValue {
           : (v: unknown) => v && (v as CoValue).$jazz.id;
 
     return {
-      "$jazz.id": this.$jazz.id,
+      $jazz: { id: this.$jazz.id },
       ...Object.fromEntries(
         Object.entries(this).map(([account, entry]) => [
           account,
@@ -259,7 +259,7 @@ export class CoFeed<out Item = any> extends CoValueBase implements CoValue {
 
   /** @internal */
   [inspect](): {
-    "$jazz.id": string;
+    $jazz: { id: string };
     [key: string]: unknown;
     in: { [key: string]: unknown };
   } {
@@ -931,7 +931,7 @@ export class FileStream extends CoValueBase implements CoValue {
    * @category Content
    */
   toJSON(): {
-    "$jazz.id": string;
+    $jazz: { id: string };
     mimeType?: string;
     totalSizeBytes?: number;
     fileName?: string;
@@ -939,7 +939,7 @@ export class FileStream extends CoValueBase implements CoValue {
     finished?: boolean;
   } {
     return {
-      "$jazz.id": this.$jazz.id,
+      $jazz: { id: this.$jazz.id },
       ...this.getChunks(),
     };
   }

--- a/packages/jazz-tools/src/tools/coValues/coFeed.ts
+++ b/packages/jazz-tools/src/tools/coValues/coFeed.ts
@@ -228,6 +228,7 @@ export class CoFeed<out Item = any> extends CoValueBase implements CoValue {
    * @category
    */
   toJSON(): {
+    "$jazz.id": string;
     [key: string]: unknown;
     in: { [key: string]: unknown };
   } {
@@ -240,6 +241,7 @@ export class CoFeed<out Item = any> extends CoValueBase implements CoValue {
           : (v: unknown) => v && (v as CoValue).$jazz.id;
 
     return {
+      "$jazz.id": this.$jazz.id,
       ...Object.fromEntries(
         Object.entries(this).map(([account, entry]) => [
           account,
@@ -257,6 +259,7 @@ export class CoFeed<out Item = any> extends CoValueBase implements CoValue {
 
   /** @internal */
   [inspect](): {
+    "$jazz.id": string;
     [key: string]: unknown;
     in: { [key: string]: unknown };
   } {
@@ -928,6 +931,7 @@ export class FileStream extends CoValueBase implements CoValue {
    * @category Content
    */
   toJSON(): {
+    "$jazz.id": string;
     mimeType?: string;
     totalSizeBytes?: number;
     fileName?: string;
@@ -935,6 +939,7 @@ export class FileStream extends CoValueBase implements CoValue {
     finished?: boolean;
   } {
     return {
+      "$jazz.id": this.$jazz.id,
       ...this.getChunks(),
     };
   }

--- a/packages/jazz-tools/src/tools/coValues/coMap.ts
+++ b/packages/jazz-tools/src/tools/coValues/coMap.ts
@@ -186,7 +186,7 @@ export class CoMap extends CoValueBase implements CoValue {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   toJSON(_key?: string, processedValues?: ID<CoValue>[]): any {
     const result = {
-      "$jazz.id": this.$jazz.id,
+      $jazz: { id: this.$jazz.id },
     } as Record<string, any>;
 
     for (const key of this.$jazz.raw.keys()) {

--- a/packages/jazz-tools/src/tools/coValues/coMap.ts
+++ b/packages/jazz-tools/src/tools/coValues/coMap.ts
@@ -185,7 +185,9 @@ export class CoMap extends CoValueBase implements CoValue {
    */
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   toJSON(_key?: string, processedValues?: ID<CoValue>[]): any {
-    const result = {} as Record<string, any>;
+    const result = {
+      "$jazz.id": this.$jazz.id,
+    } as Record<string, any>;
 
     for (const key of this.$jazz.raw.keys()) {
       const tKey = key as CoKeys<this>;

--- a/packages/jazz-tools/src/tools/tests/account.test.ts
+++ b/packages/jazz-tools/src/tools/tests/account.test.ts
@@ -393,3 +393,15 @@ describe("account.$jazz.has", () => {
     expect(account.root.settings).toBe("default");
   });
 });
+
+describe("account.toJSON", () => {
+  test("returns only the acccount's Jazz id", async () => {
+    const account = await createJazzTestAccount({
+      creationProps: { name: "John" },
+    });
+
+    expect(account.toJSON()).toEqual({
+      "$jazz.id": account.$jazz.id,
+    });
+  });
+});

--- a/packages/jazz-tools/src/tools/tests/account.test.ts
+++ b/packages/jazz-tools/src/tools/tests/account.test.ts
@@ -401,7 +401,7 @@ describe("account.toJSON", () => {
     });
 
     expect(account.toJSON()).toEqual({
-      "$jazz.id": account.$jazz.id,
+      $jazz: { id: account.$jazz.id },
     });
   });
 });

--- a/packages/jazz-tools/src/tools/tests/coFeed.test.ts
+++ b/packages/jazz-tools/src/tools/tests/coFeed.test.ts
@@ -107,7 +107,7 @@ describe("Simple CoFeed operations", async () => {
 
   test("toJSON", () => {
     expect(stream.toJSON()).toEqual({
-      "$jazz.id": stream.$jazz.id,
+      $jazz: { id: stream.$jazz.id },
       in: {
         [me.$jazz.sessionID]: stream.perSession[me.$jazz.sessionID]?.value,
       },
@@ -320,7 +320,7 @@ describe("Simple FileStream operations", async () => {
       stream.end();
 
       expect(stream.toJSON()).toEqual({
-        "$jazz.id": stream.$jazz.id,
+        $jazz: { id: stream.$jazz.id },
         mimeType: "text/plain",
         chunks: [new Uint8Array([1, 2, 3]), new Uint8Array([4, 5, 6])],
         filename: undefined,

--- a/packages/jazz-tools/src/tools/tests/coFeed.test.ts
+++ b/packages/jazz-tools/src/tools/tests/coFeed.test.ts
@@ -105,6 +105,15 @@ describe("Simple CoFeed operations", async () => {
     expect(stream.perSession[me.$jazz.sessionID]?.value).toEqual("milk");
   });
 
+  test("toJSON", () => {
+    expect(stream.toJSON()).toEqual({
+      "$jazz.id": stream.$jazz.id,
+      in: {
+        [me.$jazz.sessionID]: stream.perSession[me.$jazz.sessionID]?.value,
+      },
+    });
+  });
+
   describe("Mutation", () => {
     test("push element into CoFeed of non-collaborative values", () => {
       stream.$jazz.push("bread");
@@ -302,6 +311,22 @@ describe("Simple FileStream operations", async () => {
   describe("FileStream", () => {
     test("Construction", () => {
       expect(stream.getChunks()).toBe(undefined);
+    });
+
+    test("toJSON", () => {
+      stream.start({ mimeType: "text/plain" });
+      stream.push(new Uint8Array([1, 2, 3]));
+      stream.push(new Uint8Array([4, 5, 6]));
+      stream.end();
+
+      expect(stream.toJSON()).toEqual({
+        "$jazz.id": stream.$jazz.id,
+        mimeType: "text/plain",
+        chunks: [new Uint8Array([1, 2, 3]), new Uint8Array([4, 5, 6])],
+        filename: undefined,
+        finished: true,
+        totalSizeBytes: undefined,
+      });
     });
 
     test("Mutation", () => {

--- a/packages/jazz-tools/src/tools/tests/coMap.record.test.ts
+++ b/packages/jazz-tools/src/tools/tests/coMap.record.test.ts
@@ -140,6 +140,7 @@ describe("CoMap.Record", async () => {
       expect("age" in person).toEqual(false);
 
       expect(person.toJSON()).toEqual({
+        "$jazz.id": person.$jazz.id,
         name: "John",
       });
     });

--- a/packages/jazz-tools/src/tools/tests/coMap.record.test.ts
+++ b/packages/jazz-tools/src/tools/tests/coMap.record.test.ts
@@ -140,7 +140,7 @@ describe("CoMap.Record", async () => {
       expect("age" in person).toEqual(false);
 
       expect(person.toJSON()).toEqual({
-        "$jazz.id": person.$jazz.id,
+        $jazz: { id: person.$jazz.id },
         name: "John",
       });
     });

--- a/packages/jazz-tools/src/tools/tests/coMap.test.ts
+++ b/packages/jazz-tools/src/tools/tests/coMap.test.ts
@@ -289,7 +289,7 @@ describe("CoMap", async () => {
       const person = Person.create({ name: "John" });
 
       expect(JSON.stringify(person)).toEqual(
-        `{"$jazz.id":"${person.$jazz.id}","name":"John"}`,
+        `{"$jazz":{"id":"${person.$jazz.id}"},"name":"John"}`,
       );
     });
 
@@ -304,7 +304,7 @@ describe("CoMap", async () => {
       person.$jazz.raw.set("extra", "extra");
 
       expect(person.toJSON()).toEqual({
-        "$jazz.id": person.$jazz.id,
+        $jazz: { id: person.$jazz.id },
         name: "John",
         age: 20,
       });
@@ -326,11 +326,11 @@ describe("CoMap", async () => {
       });
 
       expect(person.toJSON()).toEqual({
-        "$jazz.id": person.$jazz.id,
+        $jazz: { id: person.$jazz.id },
         name: "John",
         age: 20,
         friend: {
-          "$jazz.id": person.friend?.$jazz.id,
+          $jazz: { id: person.friend?.$jazz.id },
           name: "Jane",
           age: 21,
         },
@@ -354,7 +354,7 @@ describe("CoMap", async () => {
       person.$jazz.set("friend", person);
 
       expect(person.toJSON()).toEqual({
-        "$jazz.id": person.$jazz.id,
+        $jazz: { id: person.$jazz.id },
         name: "John",
         age: 20,
         friend: {
@@ -379,7 +379,7 @@ describe("CoMap", async () => {
       });
 
       expect(john.toJSON()).toMatchObject({
-        "$jazz.id": john.$jazz.id,
+        $jazz: { id: john.$jazz.id },
         name: "John",
         age: 20,
         birthday: birthday.toISOString(),
@@ -414,7 +414,7 @@ describe("CoMap", async () => {
       const john = Person.create({ name: "John", age: 30, x: 1 });
 
       expect(john.toJSON()).toEqual({
-        "$jazz.id": john.$jazz.id,
+        $jazz: { id: john.$jazz.id },
         name: "John",
         age: 30,
       });
@@ -518,7 +518,7 @@ describe("CoMap", async () => {
       expect(john.age).toEqual(undefined);
 
       expect(john.toJSON()).toEqual({
-        "$jazz.id": john.$jazz.id,
+        $jazz: { id: john.$jazz.id },
         name: "John",
       });
       // The CoMap proxy hides the age property from the `in` operator
@@ -550,7 +550,7 @@ describe("CoMap", async () => {
       expect(john.age).not.toBeDefined();
       expect(john.pet).not.toBeDefined();
       expect(john.toJSON()).toEqual({
-        "$jazz.id": john.$jazz.id,
+        $jazz: { id: john.$jazz.id },
         name: "John",
       });
       expect("age" in john).toEqual(false);

--- a/packages/jazz-tools/src/tools/tests/coMap.test.ts
+++ b/packages/jazz-tools/src/tools/tests/coMap.test.ts
@@ -281,14 +281,16 @@ describe("CoMap", async () => {
       expect(person.friend?.age).toEqual(21);
     });
 
-    test("JSON.stringify should not include internal properties", () => {
+    test("JSON.stringify should include user-defined properties + $jazz.id", () => {
       const Person = co.map({
         name: z.string(),
       });
 
       const person = Person.create({ name: "John" });
 
-      expect(JSON.stringify(person)).toEqual('{"name":"John"}');
+      expect(JSON.stringify(person)).toEqual(
+        `{"$jazz.id":"${person.$jazz.id}","name":"John"}`,
+      );
     });
 
     test("toJSON should not fail when there is a key in the raw value not represented in the schema", () => {
@@ -302,6 +304,7 @@ describe("CoMap", async () => {
       person.$jazz.raw.set("extra", "extra");
 
       expect(person.toJSON()).toEqual({
+        "$jazz.id": person.$jazz.id,
         name: "John",
         age: 20,
       });
@@ -323,9 +326,11 @@ describe("CoMap", async () => {
       });
 
       expect(person.toJSON()).toEqual({
+        "$jazz.id": person.$jazz.id,
         name: "John",
         age: 20,
         friend: {
+          "$jazz.id": person.friend?.$jazz.id,
           name: "Jane",
           age: 21,
         },
@@ -349,6 +354,7 @@ describe("CoMap", async () => {
       person.$jazz.set("friend", person);
 
       expect(person.toJSON()).toEqual({
+        "$jazz.id": person.$jazz.id,
         name: "John",
         age: 20,
         friend: {
@@ -373,6 +379,7 @@ describe("CoMap", async () => {
       });
 
       expect(john.toJSON()).toMatchObject({
+        "$jazz.id": john.$jazz.id,
         name: "John",
         age: 20,
         birthday: birthday.toISOString(),
@@ -407,6 +414,7 @@ describe("CoMap", async () => {
       const john = Person.create({ name: "John", age: 30, x: 1 });
 
       expect(john.toJSON()).toEqual({
+        "$jazz.id": john.$jazz.id,
         name: "John",
         age: 30,
       });
@@ -510,6 +518,7 @@ describe("CoMap", async () => {
       expect(john.age).toEqual(undefined);
 
       expect(john.toJSON()).toEqual({
+        "$jazz.id": john.$jazz.id,
         name: "John",
       });
       // The CoMap proxy hides the age property from the `in` operator
@@ -541,6 +550,7 @@ describe("CoMap", async () => {
       expect(john.age).not.toBeDefined();
       expect(john.pet).not.toBeDefined();
       expect(john.toJSON()).toEqual({
+        "$jazz.id": john.$jazz.id,
         name: "John",
       });
       expect("age" in john).toEqual(false);


### PR DESCRIPTION
# Description

In https://github.com/garden-co/jazz/pull/2693 we removed the `id` property from `toJSON`'s output to be consistent with viewing CoValues as plain JSON objects. However, many adopters rely on the `id` being present, and adding it manually is not trivial for nested CoValues. We decided to add the field back as `$jazz.id`, to avoid conflicts with user-defined properties in CoMaps.

## Tests

- [x] Tests have been added and/or updated

## Checklist

- [ ] I've updated the part of the docs that are affected the PR changes
- [x] I've generated a changeset, if a version bump is required
- [ ] I've updated the jsDoc comments to the public APIs I've modified, or added them when missing