### PR TITLE
feat: add rotate inbox command

### DIFF
--- a/.changeset/fresh-panthers-relax.md
+++ b/.changeset/fresh-panthers-relax.md
@@ -1,0 +1,5 @@
+---
+"jazz-run": patch
+---
+
+Add the rotate-worker-inbox command to rotate the worker inbox

--- a/packages/jazz-run/src/index.ts
+++ b/packages/jazz-run/src/index.ts
@@ -6,6 +6,7 @@ import { Console, Effect } from "effect";
 import { createWorkerAccount } from "./createWorkerAccount.js";
 import { startSyncServer } from "./startSyncServer.js";
 import { serverDefaults } from "./config.js";
+import { rotateWorkerInbox } from "./rotateWorkerInbox.js";
 
 const jazzTools = Command.make("jazz-tools");
 
@@ -32,6 +33,18 @@ JAZZ_WORKER_ACCOUNT=${accountID}
 JAZZ_WORKER_SECRET=${agentSecret}
 `);
       }
+    });
+  },
+);
+
+const rotateWorkerInboxCommand = Command.make(
+  "rotate-worker-inbox",
+  { peer: peerOption },
+  ({ peer }) => {
+    return Effect.gen(function* () {
+      yield* Effect.promise(() => rotateWorkerInbox({ peer }));
+
+      yield* Console.log("A new inbox has been created for the worker");
     });
   },
 );
@@ -106,7 +119,11 @@ const startSyncServerCommand = Command.make(
 );
 
 const command = jazzTools.pipe(
-  Command.withSubcommands([accountCommand, startSyncServerCommand]),
+  Command.withSubcommands([
+    accountCommand,
+    startSyncServerCommand,
+    rotateWorkerInboxCommand,
+  ]),
 );
 
 const cli = Command.run(command, {

--- a/packages/jazz-run/src/rotateWorkerInbox.ts
+++ b/packages/jazz-run/src/rotateWorkerInbox.ts
@@ -1,0 +1,55 @@
+import { AgentSecret, LocalNode, RawAccountID, RawCoMap } from "cojson";
+import { createWebSocketPeer } from "cojson-transport-ws";
+import { WasmCrypto } from "cojson/crypto/WasmCrypto";
+import { Account, createInboxRoot } from "jazz-tools";
+import { WebSocket } from "ws";
+import { loadEnvFile } from "node:process";
+
+export const rotateWorkerInbox = async ({
+  peer: peerAddr,
+}: {
+  peer: string;
+}) => {
+  try {
+    loadEnvFile();
+  } catch (error) {
+    // ignore
+  }
+
+  const crypto = await WasmCrypto.create();
+
+  const accountID = process.env.JAZZ_WORKER_ACCOUNT;
+  const accountSecret = process.env.JAZZ_WORKER_SECRET;
+
+  if (!accountID || !accountSecret) {
+    throw new Error(
+      "JAZZ_WORKER_ACCOUNT and JAZZ_WORKER_SECRET environment variables must be set",
+    );
+  }
+
+  const peer = createWebSocketPeer({
+    id: "upstream",
+    websocket: new WebSocket(peerAddr),
+    role: "server",
+  });
+
+  const node = await LocalNode.withLoadedAccount({
+    accountID: accountID as RawAccountID,
+    accountSecret: accountSecret as AgentSecret,
+    peersToLoadFrom: [peer],
+    crypto,
+    sessionID: crypto.newRandomSessionID(accountID as RawAccountID),
+  });
+
+  const account = Account.fromNode(node);
+
+  const profile = node
+    .expectCoValueLoaded(account.$jazz.raw.get("profile")!)
+    .getCurrentContent() as RawCoMap;
+
+  const inboxRoot = createInboxRoot(account);
+  profile.set("inbox", inboxRoot.id);
+  profile.set("inboxInvite", inboxRoot.inviteLink);
+
+  await account.$jazz.waitForAllCoValuesSync({ timeout: 4_000 });
+};

--- a/packages/jazz-run/src/tests/rotateWorkerInbox.test.ts
+++ b/packages/jazz-run/src/tests/rotateWorkerInbox.test.ts
@@ -1,0 +1,234 @@
+import { randomUUID } from "node:crypto";
+import { unlinkSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { LocalNode, RawCoMap } from "cojson";
+import { createWebSocketPeer } from "cojson-transport-ws";
+import { WasmCrypto } from "cojson/crypto/WasmCrypto";
+import { WebSocket } from "ws";
+import { describe, expect, test, afterAll, onTestFinished } from "vitest";
+import { createWorkerAccount } from "../createWorkerAccount.js";
+import { rotateWorkerInbox } from "../rotateWorkerInbox.js";
+import { startSyncServer } from "../startSyncServer.js";
+import { serverDefaults } from "../config.js";
+import { Account } from "jazz-tools";
+import { waitFor } from "./utils.js";
+
+const dbPath = join(tmpdir(), `test-${randomUUID()}.db`);
+
+afterAll(() => {
+  unlinkSync(dbPath);
+});
+
+describe("rotateWorkerInbox", () => {
+  test("should rotate inbox and change inbox ID", async () => {
+    // Set up sync server
+    const server = await startSyncServer({
+      host: serverDefaults.host,
+      port: "0", // Random available port
+      inMemory: false,
+      db: dbPath,
+    });
+
+    onTestFinished(() => {
+      server.close();
+    });
+
+    const address = server.address();
+    if (typeof address !== "object" || address === null) {
+      throw new Error("Server address is not an object");
+    }
+
+    const syncServer = `ws://localhost:${address.port}`;
+
+    // Create worker account
+    const { accountID, agentSecret } = await createWorkerAccount({
+      name: "test-worker",
+      peer: syncServer,
+    });
+
+    // Set up environment variables for rotateWorkerInbox
+    const originalAccount = process.env.JAZZ_WORKER_ACCOUNT;
+    const originalSecret = process.env.JAZZ_WORKER_SECRET;
+
+    process.env.JAZZ_WORKER_ACCOUNT = accountID;
+    process.env.JAZZ_WORKER_SECRET = agentSecret;
+
+    onTestFinished(() => {
+      delete process.env.JAZZ_WORKER_ACCOUNT;
+      delete process.env.JAZZ_WORKER_SECRET;
+    });
+
+    // Get initial inbox state
+    const crypto = await WasmCrypto.create();
+    const peer = createWebSocketPeer({
+      id: "upstream",
+      websocket: new WebSocket(syncServer),
+      role: "server",
+    });
+
+    const node = await LocalNode.withLoadedAccount({
+      accountID: accountID as any,
+      accountSecret: agentSecret as any,
+      peersToLoadFrom: [peer],
+      crypto,
+      sessionID: crypto.newRandomSessionID(accountID as any),
+    });
+
+    const account = Account.fromNode(node);
+
+    const profile = node
+      .expectCoValueLoaded(account.$jazz.raw.get("profile")!)
+      .getCurrentContent() as RawCoMap;
+
+    const initialInboxId = profile.get("inbox");
+    const initialInboxInvite = profile.get("inboxInvite");
+
+    expect(initialInboxId).toBeDefined();
+    expect(initialInboxInvite).toBeDefined();
+
+    // Rotate the inbox
+    await rotateWorkerInbox({ peer: syncServer });
+
+    await waitFor(() => {
+      // Verify that the inbox ID has changed
+      expect(profile.get("inbox")).not.toBe(initialInboxId);
+
+      // Verify that the inbox invite has changed
+      expect(profile.get("inboxInvite")).not.toBe(initialInboxInvite);
+    });
+  });
+
+  test("should throw error when environment variables are not set", async () => {
+    // Set up sync server
+    const server = await startSyncServer({
+      host: serverDefaults.host,
+      port: "0",
+      inMemory: true,
+      db: "",
+    });
+
+    onTestFinished(() => {
+      server.close();
+    });
+
+    const address = server.address();
+    if (typeof address !== "object" || address === null) {
+      throw new Error("Server address is not an object");
+    }
+
+    const syncServer = `ws://localhost:${address.port}`;
+
+    // Clear environment variables
+    const originalAccount = process.env.JAZZ_WORKER_ACCOUNT;
+    const originalSecret = process.env.JAZZ_WORKER_SECRET;
+
+    delete process.env.JAZZ_WORKER_ACCOUNT;
+    delete process.env.JAZZ_WORKER_SECRET;
+
+    try {
+      // Should throw error when environment variables are missing
+      await expect(rotateWorkerInbox({ peer: syncServer })).rejects.toThrow(
+        "JAZZ_WORKER_ACCOUNT and JAZZ_WORKER_SECRET environment variables must be set",
+      );
+    } finally {
+      // Restore original environment variables
+      if (originalAccount !== undefined) {
+        process.env.JAZZ_WORKER_ACCOUNT = originalAccount;
+      }
+      if (originalSecret !== undefined) {
+        process.env.JAZZ_WORKER_SECRET = originalSecret;
+      }
+    }
+  });
+
+  test("should throw error when only JAZZ_WORKER_ACCOUNT is set", async () => {
+    // Set up sync server
+    const server = await startSyncServer({
+      host: serverDefaults.host,
+      port: "0",
+      inMemory: true,
+      db: "",
+    });
+
+    onTestFinished(() => {
+      server.close();
+    });
+
+    const address = server.address();
+    if (typeof address !== "object" || address === null) {
+      throw new Error("Server address is not an object");
+    }
+
+    const syncServer = `ws://localhost:${address.port}`;
+
+    // Set only account ID
+    const originalAccount = process.env.JAZZ_WORKER_ACCOUNT;
+    const originalSecret = process.env.JAZZ_WORKER_SECRET;
+
+    process.env.JAZZ_WORKER_ACCOUNT = "co_test_account";
+    delete process.env.JAZZ_WORKER_SECRET;
+
+    try {
+      // Should throw error when JAZZ_WORKER_SECRET is missing
+      await expect(rotateWorkerInbox({ peer: syncServer })).rejects.toThrow(
+        "JAZZ_WORKER_ACCOUNT and JAZZ_WORKER_SECRET environment variables must be set",
+      );
+    } finally {
+      // Restore original environment variables
+      if (originalAccount !== undefined) {
+        process.env.JAZZ_WORKER_ACCOUNT = originalAccount;
+      } else {
+        delete process.env.JAZZ_WORKER_ACCOUNT;
+      }
+      if (originalSecret !== undefined) {
+        process.env.JAZZ_WORKER_SECRET = originalSecret;
+      }
+    }
+  });
+
+  test("should throw error when only JAZZ_WORKER_SECRET is set", async () => {
+    // Set up sync server
+    const server = await startSyncServer({
+      host: serverDefaults.host,
+      port: "0",
+      inMemory: true,
+      db: "",
+    });
+
+    onTestFinished(() => {
+      server.close();
+    });
+
+    const address = server.address();
+    if (typeof address !== "object" || address === null) {
+      throw new Error("Server address is not an object");
+    }
+
+    const syncServer = `ws://localhost:${address.port}`;
+
+    // Set only secret
+    const originalAccount = process.env.JAZZ_WORKER_ACCOUNT;
+    const originalSecret = process.env.JAZZ_WORKER_SECRET;
+
+    delete process.env.JAZZ_WORKER_ACCOUNT;
+    process.env.JAZZ_WORKER_SECRET = "sealerSecret_test";
+
+    try {
+      // Should throw error when JAZZ_WORKER_ACCOUNT is missing
+      await expect(rotateWorkerInbox({ peer: syncServer })).rejects.toThrow(
+        "JAZZ_WORKER_ACCOUNT and JAZZ_WORKER_SECRET environment variables must be set",
+      );
+    } finally {
+      // Restore original environment variables
+      if (originalAccount !== undefined) {
+        process.env.JAZZ_WORKER_ACCOUNT = originalAccount;
+      }
+      if (originalSecret !== undefined) {
+        process.env.JAZZ_WORKER_SECRET = originalSecret;
+      } else {
+        delete process.env.JAZZ_WORKER_SECRET;
+      }
+    }
+  });
+});

--- a/packages/jazz-tools/src/tools/exports.ts
+++ b/packages/jazz-tools/src/tools/exports.ts
@@ -94,6 +94,7 @@ export {
   type AuthResult,
   type Credentials,
   type JazzContextWithAccount,
+  createInboxRoot,
 } from "./internal.js";
 
 export type * from "./types.js";


### PR DESCRIPTION
# Description

Adding a new command to rotate the worker inbox, to make it possible to start from a clean state without having to update the worker credentials.

## Manual testing instructions

Run `npx https://pkg.pr.new/garden-co/jazz/jazz-run@29de59b5878df8ee5c682f7f1ef772b447abab3e rotate-worker-inbox` on a directory with a `.env` with the worker variables.

## Tests

- [x] Tests have been added and/or updated
- [ ] Tests have not been updated, because: <!-- Insert reason for not updating tests here -->
- [ ] I need help with writing tests


## Checklist

- [ ] I've updated the part of the docs that are affected the PR changes
- [x] I've generated a changeset, if a version bump is required
- [ ] I've updated the jsDoc comments to the public APIs I've modified, or added them when missing