### PR TITLE
fix: fallback to random session when the origin is non-secure

### DIFF
--- a/.changeset/tame-toys-join.md
+++ b/.changeset/tame-toys-join.md
@@ -1,0 +1,5 @@
+---
+"jazz-tools": patch
+---
+
+Fallback to random session when running Jazz in a browser without navigator.lock support

--- a/packages/jazz-tools/src/browser/createBrowserContext.ts
+++ b/packages/jazz-tools/src/browser/createBrowserContext.ts
@@ -214,6 +214,14 @@ export function provideBrowserLockSession(
   accountID: ID<Account> | AgentID,
   crypto: CryptoProvider,
 ) {
+  if (typeof navigator === "undefined" || !navigator.locks?.request) {
+    // Fallback to random session ID for each tab session
+    return Promise.resolve({
+      sessionID: crypto.newRandomSessionID(accountID as RawAccountID | AgentID),
+      sessionDone: () => {},
+    });
+  }
+
   let sessionDone!: () => void;
   const donePromise = new Promise<void>((resolve) => {
     sessionDone = resolve;


### PR DESCRIPTION
This PR addresses a longstanding issue in a quick way.

We could do better, but this gives us a quick solution to support http hosting, which anyway should be reserved only for development and testing purposes.

fixes #2846 
fixes #1649 