### PR TITLE
feat: add skipInboxLoad option to startWorker

### DIFF
--- a/.changeset/chilled-bats-run.md
+++ b/.changeset/chilled-bats-run.md
@@ -1,0 +1,5 @@
+---
+"jazz-tools": patch
+---
+
+Fixed the startWorker type to return a shallow loaded worker account.

--- a/.changeset/chilled-bats-run.md
+++ b/.changeset/chilled-bats-run.md
@@ -2,4 +2,4 @@
 "jazz-tools": patch
 ---
 
-Fixed the startWorker type to return a shallow loaded worker account.
+Fixed the startWorker type to return a shallowly-loaded worker account.

--- a/.changeset/cuddly-keys-accept.md
+++ b/.changeset/cuddly-keys-accept.md
@@ -1,0 +1,5 @@
+---
+"jazz-tools": patch
+---
+
+Add skipInboxLoad option to startWorker

--- a/packages/jazz-tools/src/worker/index.ts
+++ b/packages/jazz-tools/src/worker/index.ts
@@ -107,7 +107,7 @@ export async function startWorker<
   };
 
   return {
-    worker: context.account as InstanceOfSchema<S>,
+    worker: context.account as Loaded<S>,
     experimental: {
       inbox: inboxPublicApi,
     },


### PR DESCRIPTION
Add the option of skipping the inbox load when calling `startWorker`

This will become the default in the future, and the inbox will require an esplicit load to be subscribed.

Also fixed the return type to be `co.loaded` instead of `InstanceOfSchema`