### PR TITLE
Fix: BetterAuth provider on React Native

### DIFF
--- a/.changeset/yellow-crabs-travel.md
+++ b/.changeset/yellow-crabs-travel.md
@@ -1,0 +1,5 @@
+---
+"jazz-tools": patch
+---
+
+fix: removed unwanted browser dependency in order to make better-auth provider works on react-native

--- a/packages/jazz-tools/src/better-auth/auth/react.tsx
+++ b/packages/jazz-tools/src/better-auth/auth/react.tsx
@@ -1,21 +1,9 @@
 "use client";
 
-import type { ClientOptions } from "better-auth";
 import { createAuthClient } from "better-auth/client";
-import type {
-  Account,
-  AccountClass,
-  AnyAccountSchema,
-  CoValueFromRaw,
-} from "jazz-tools";
-import {
-  type JazzProviderProps,
-  JazzReactProvider,
-  useAuthSecretStorage,
-  useJazzContext,
-} from "jazz-tools/react";
+import { useAuthSecretStorage, useJazzContext } from "jazz-tools/react-core";
 import { useEffect } from "react";
-import { type PropsWithChildren, createContext } from "react";
+import { type PropsWithChildren } from "react";
 import { jazzPluginClient } from "./client.js";
 
 type AuthClient = ReturnType<
@@ -23,8 +11,6 @@ type AuthClient = ReturnType<
     plugins: [ReturnType<typeof jazzPluginClient>];
   }>
 >;
-
-export const AuthContext = createContext<AuthClient | null>(null);
 
 /**
  * @param props.children - The children to render.
@@ -68,38 +54,3 @@ export function AuthProvider({
 
   return children;
 }
-
-/**
- * @param props - The props for the JazzReactProvider.
- * @param props.betterAuth - The options for the BetterAuth client.
- * @returns The JazzReactProvider with the BetterAuth plugin.
- *
- * @example
- * ```ts
- * <JazzReactProviderWithBetterAuth
- *  betterAuth={{
- *    baseURL: "http://localhost:3000",
- *  }}
- *  sync={{
- *    peer: "ws://localhost:4200",
- *  }}
- * >
- *   <App />
- * </JazzReactProviderWithBetterAuth>
- * ```
- */
-export const JazzReactProviderWithBetterAuth = <
-  S extends
-    | (AccountClass<Account> & CoValueFromRaw<Account>)
-    | AnyAccountSchema,
->(
-  props: { betterAuthClient: AuthClient } & JazzProviderProps<S>,
-) => {
-  return (
-    <JazzReactProvider {...props}>
-      <AuthProvider betterAuthClient={props.betterAuthClient}>
-        {props.children}
-      </AuthProvider>
-    </JazzReactProvider>
-  );
-};

--- a/packages/jazz-tools/src/better-auth/auth/tests/react.test.tsx
+++ b/packages/jazz-tools/src/better-auth/auth/tests/react.test.tsx
@@ -1,0 +1,43 @@
+// @vitest-environment jsdom
+import { render } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { AuthProvider } from "../react";
+import { createAuthClient } from "better-auth/client";
+import { jazzPluginClient } from "../client";
+import { JazzReactProvider } from "jazz-tools/react";
+
+describe("AuthProvider", () => {
+  it("should throw if no JazzContext is set", () => {
+    const betterAuthClient = createAuthClient({
+      plugins: [jazzPluginClient()],
+    });
+
+    expect(() => {
+      render(
+        <AuthProvider betterAuthClient={betterAuthClient}>
+          <div />
+        </AuthProvider>,
+      );
+    }).toThrow(
+      "You need to set up a JazzProvider on top of your app to use this hook.",
+    );
+  });
+
+  it("should render with JazzReactProvider", () => {
+    const betterAuthClient = createAuthClient({
+      plugins: [jazzPluginClient()],
+    });
+
+    render(
+      <JazzReactProvider
+        // @ts-expect-error - no memory storage
+        storage={["memory"]}
+        sync={{ peer: "ws://", when: "never" }}
+      >
+        <AuthProvider betterAuthClient={betterAuthClient}>
+          <div />
+        </AuthProvider>
+      </JazzReactProvider>,
+    );
+  });
+});


### PR DESCRIPTION
# Description
Initially, there was a trivial `JazzReactProviderWithBetterAuth` utility component, but it caused a runtime error in react-native due to [this function](https://github.com/garden-co/jazz/blob/main/packages/jazz-tools/src/browser/index.ts#L12C1-L12C18) invocation.

The export has been simplified to have a single implementation for both React and React Native.
