### PR TITLE
Better-Auth email otp plugin support

### DIFF
--- a/.changeset/serious-shoes-notice.md
+++ b/.changeset/serious-shoes-notice.md
@@ -1,0 +1,5 @@
+---
+"jazz-tools": patch
+---
+
+feat: Better Auth EmailOTP plugin is now supported

--- a/homepage/homepage/content/docs/authentication/better-auth.mdx
+++ b/homepage/homepage/content/docs/authentication/better-auth.mdx
@@ -7,7 +7,7 @@ import { Alert } from "@garden-co/design-system/src/components/atoms/Alert";
 
 # Better Auth authentication
 
-[Better Auth](https://better-auth.com/) is a self-hosted, framework-agnostic authentication and authorisation framework for TypeScript. 
+[Better Auth](https://better-auth.com/) is a self-hosted, framework-agnostic authentication and authorisation framework for TypeScript.
 
 You can integrate Better Auth with your Jazz app, allowing your Jazz user's account keys to be saved with the corresponding Better Auth user.
 
@@ -59,7 +59,7 @@ Better Auth supports several authentication methods and plugins. The Jazz plugin
     </tr>
     <tr>
       <td>Email OTP</td>
-      <td>❓</td>
+      <td>✅</td>
     </tr>
     <tr>
       <td>Passkey</td>

--- a/packages/jazz-tools/src/better-auth/auth/client.ts
+++ b/packages/jazz-tools/src/better-auth/auth/client.ts
@@ -7,6 +7,13 @@ import type {
 } from "jazz-tools";
 import type { jazzPlugin } from "./server.js";
 
+const SIGNUP_URLS = [
+  "/sign-up",
+  "/sign-in/social",
+  "/sign-in/oauth2",
+  "/email-otp/send-verification-otp",
+];
+
 /**
  * @example
  * ```ts
@@ -83,8 +90,7 @@ export const jazzPluginClient = () => {
         hooks: {
           async onRequest(context) {
             if (
-              context.url.toString().includes("/sign-up") ||
-              context.url.toString().includes("/sign-in/social")
+              SIGNUP_URLS.some((url) => context.url.toString().includes(url))
             ) {
               const credentials = await authSecretStorage.get();
 

--- a/packages/jazz-tools/src/better-auth/auth/tests/server.test.ts
+++ b/packages/jazz-tools/src/better-auth/auth/tests/server.test.ts
@@ -12,100 +12,44 @@ import {
 } from "vitest";
 import { OAuth2Server } from "oauth2-mock-server";
 import { jazzPlugin } from "../server.js";
-import { genericOAuth } from "better-auth/plugins";
+import { emailOTP, genericOAuth } from "better-auth/plugins";
 
-describe("Better Auth - Signup and Login Tests", async () => {
-  const providerId = "test";
-  const clientId = "test-client-id";
-  const clientSecret = "test-client-secret";
-  const server = new OAuth2Server();
-  await server.start();
-  const oauthPort = Number(server.issuer.url?.split(":")[2]!);
+describe("Better-Auth server plugin", async () => {
+  describe("Email & Password", () => {
+    let auth: ReturnType<
+      typeof betterAuth<{
+        plugins: ReturnType<typeof jazzPlugin>[];
+      }>
+    >;
 
-  let auth: ReturnType<
-    typeof betterAuth<{
-      plugins: ReturnType<typeof jazzPlugin | typeof genericOAuth>[];
-    }>
-  >;
-  let accountCreationSpy: Mock;
-  let verificationCreationSpy: Mock;
+    let accountCreationSpy: Mock;
 
-  beforeAll(async () => {
-    await server.issuer.keys.generate("RS256");
+    beforeEach(() => {
+      accountCreationSpy = vi.fn();
 
-    server.service.on("beforeUserinfo", (userInfoResponse) => {
-      userInfoResponse.body = {
-        email: "oauth2@test.com",
-        name: "OAuth2 Test",
-        sub: "oauth2",
-        picture: "https://test.com/picture.png",
-        email_verified: true,
-      };
-      userInfoResponse.statusCode = 200;
-    });
-  });
-
-  afterAll(async () => {
-    await server.stop();
-  });
-
-  beforeEach(() => {
-    accountCreationSpy = vi.fn();
-    verificationCreationSpy = vi.fn();
-
-    // Create auth instance with in-memory database
-    auth = betterAuth({
-      database: memoryAdapter({
-        user: [],
-        session: [],
-        verification: [],
-        account: [],
-      }),
-      baseURL: "http://localhost:3000",
-      plugins: [
-        jazzPlugin(),
-        genericOAuth({
-          config: [
-            {
-              providerId,
-              discoveryUrl: `http://localhost:${oauthPort}/.well-known/openid-configuration`,
-              authorizationUrl: `http://localhost:${oauthPort}/authorize`,
-              clientId: clientId,
-              clientSecret: clientSecret,
-              pkce: true,
-            },
-          ],
+      // Create auth instance with in-memory database
+      auth = betterAuth({
+        database: memoryAdapter({
+          user: [],
+          session: [],
+          verification: [],
+          account: [],
         }),
-      ],
-      emailAndPassword: {
-        enabled: true,
-        requireEmailVerification: false, // Disable for testing
-      },
-      socialProviders: {
-        github: {
-          clientId: "123",
-          clientSecret: "123",
+        plugins: [jazzPlugin()],
+        emailAndPassword: {
+          enabled: true,
+          requireEmailVerification: false, // Disable for testing
         },
-      },
-      databaseHooks: {
-        user: {
-          create: {
-            after: accountCreationSpy,
+        databaseHooks: {
+          user: {
+            create: {
+              after: accountCreationSpy,
+            },
           },
         },
-        verification: {
-          create: {
-            after: verificationCreationSpy,
-          },
-        },
-      },
-      session: {
-        expiresIn: 60 * 60 * 24 * 7, // 7 days
-      },
+      });
     });
-  });
 
-  describe("User Registration (Signup)", () => {
     it("should successfully register a new user with email and password", async () => {
       const userData = {
         name: "test",
@@ -203,9 +147,7 @@ describe("Better Auth - Signup and Login Tests", async () => {
         expect.any(Object),
       );
     });
-  });
 
-  describe("User login (Signin)", () => {
     it("should successfully login a new user with email and password", async () => {
       const userData = {
         name: "test",
@@ -250,7 +192,90 @@ describe("Better Auth - Signup and Login Tests", async () => {
     });
   });
 
-  describe("Social Login", () => {
+  describe("OAuth/Social plugin", async () => {
+    const providerId = "test";
+    const clientId = "test-client-id";
+    const clientSecret = "test-client-secret";
+    const server = new OAuth2Server();
+    await server.start();
+    const oauthPort = Number(server.issuer.url?.split(":")[2]!);
+
+    let auth: ReturnType<
+      typeof betterAuth<{
+        plugins: ReturnType<typeof jazzPlugin | typeof genericOAuth>[];
+      }>
+    >;
+    let accountCreationSpy: Mock;
+    let verificationCreationSpy: Mock;
+
+    beforeAll(async () => {
+      await server.issuer.keys.generate("RS256");
+
+      server.service.on("beforeUserinfo", (userInfoResponse) => {
+        userInfoResponse.body = {
+          email: "oauth2@test.com",
+          name: "OAuth2 Test",
+          sub: "oauth2",
+          picture: "https://test.com/picture.png",
+          email_verified: true,
+        };
+        userInfoResponse.statusCode = 200;
+      });
+    });
+
+    afterAll(async () => {
+      await server.stop();
+    });
+
+    beforeEach(() => {
+      accountCreationSpy = vi.fn();
+      verificationCreationSpy = vi.fn();
+
+      // Create auth instance with in-memory database
+      auth = betterAuth({
+        database: memoryAdapter({
+          user: [],
+          session: [],
+          verification: [],
+          account: [],
+        }),
+        baseURL: "http://localhost:3000",
+        plugins: [
+          jazzPlugin(),
+          genericOAuth({
+            config: [
+              {
+                providerId,
+                discoveryUrl: `http://localhost:${oauthPort}/.well-known/openid-configuration`,
+                authorizationUrl: `http://localhost:${oauthPort}/authorize`,
+                clientId: clientId,
+                clientSecret: clientSecret,
+                pkce: true,
+              },
+            ],
+          }),
+        ],
+        socialProviders: {
+          github: {
+            clientId: "123",
+            clientSecret: "123",
+          },
+        },
+        databaseHooks: {
+          user: {
+            create: {
+              after: accountCreationSpy,
+            },
+          },
+          verification: {
+            create: {
+              after: verificationCreationSpy,
+            },
+          },
+        },
+      });
+    });
+
     it("should store jazzAuth in verification table when using social provider", async () => {
       await auth.api.signInSocial({
         body: {
@@ -266,13 +291,11 @@ describe("Better Auth - Signup and Login Tests", async () => {
         },
       });
 
-      expect(verificationCreationSpy).toHaveBeenCalledTimes(1);
-      expect(verificationCreationSpy).toHaveBeenCalledWith(
-        expect.objectContaining({
-          value: expect.stringContaining('"accountID":"123"'),
-        }),
-        expect.any(Object),
-      );
+      expect(verificationCreationSpy).toHaveBeenCalledTimes(2);
+      expect(verificationCreationSpy.mock.calls[1]?.[0]).toMatchObject({
+        identifier: expect.stringMatching("-jazz-auth"),
+        value: expect.stringContaining('"accountID":"123"'),
+      });
     });
 
     it("should create a new account with jazz auth when using social provider", async () => {
@@ -309,6 +332,161 @@ describe("Better Auth - Signup and Login Tests", async () => {
         expect.objectContaining({ accountID: "123" }),
         expect.any(Object),
       );
+    });
+  });
+
+  describe("Email OTP plugin", () => {
+    let auth: ReturnType<
+      typeof betterAuth<{
+        plugins: ReturnType<typeof jazzPlugin | typeof emailOTP>[];
+      }>
+    >;
+
+    let accountCreationSpy: Mock;
+    let verificationCreationSpy: Mock;
+    let sendVerificationOTPSpy: Mock;
+
+    beforeEach(() => {
+      accountCreationSpy = vi.fn();
+      verificationCreationSpy = vi.fn();
+      sendVerificationOTPSpy = vi.fn();
+      // Create auth instance with in-memory database
+      auth = betterAuth({
+        database: memoryAdapter({
+          user: [],
+          session: [],
+          verification: [],
+          account: [],
+        }),
+        plugins: [
+          jazzPlugin(),
+          emailOTP({
+            allowedAttempts: 5,
+            otpLength: 6,
+            expiresIn: 600,
+            sendVerificationOTP: sendVerificationOTPSpy,
+          }),
+        ],
+        emailAndPassword: {
+          enabled: true,
+          requireEmailVerification: false, // Disable for testing
+        },
+        databaseHooks: {
+          user: {
+            create: {
+              after: accountCreationSpy,
+            },
+          },
+          verification: {
+            create: {
+              after: verificationCreationSpy,
+            },
+          },
+        },
+      });
+    });
+
+    it("should create a new account with jazz auth when using email OTP", async () => {
+      let OTP: string = "";
+
+      sendVerificationOTPSpy.mockImplementationOnce(({ otp }) => {
+        OTP = otp;
+      });
+
+      await auth.api.sendVerificationOTP({
+        headers: {
+          "x-jazz-auth": JSON.stringify({
+            accountID: "123",
+            secretSeed: [1, 2, 3],
+            accountSecret: "123",
+          }),
+        },
+        body: {
+          email: "email@email.it",
+          type: "sign-in",
+        },
+      });
+
+      expect(accountCreationSpy).toHaveBeenCalledTimes(0);
+      expect(sendVerificationOTPSpy).toHaveBeenCalledTimes(1);
+      expect(verificationCreationSpy).toHaveBeenCalledTimes(2);
+      expect(verificationCreationSpy.mock.calls[0]?.[0]).toMatchObject(
+        expect.objectContaining({
+          identifier: "sign-in-otp-email@email.it-jazz-auth",
+          value: expect.stringContaining('"accountID":"123"'),
+        }),
+      );
+
+      await auth.api.signInEmailOTP({
+        body: {
+          email: "email@email.it",
+          otp: OTP,
+        },
+      });
+
+      expect(accountCreationSpy).toHaveBeenCalledTimes(1);
+      expect(accountCreationSpy).toHaveBeenCalledWith(
+        expect.objectContaining({ accountID: "123" }),
+        expect.any(Object),
+      );
+    });
+
+    it("should not expect Jazz's credentials using Email OTP for sign-in an already registered user", async () => {
+      // 1. User registration
+      const userData = {
+        name: "test",
+        email: "test@example.com",
+        password: "securePassword123",
+      };
+
+      const jazzAuth = {
+        accountID: "123",
+        secretSeed: [1, 2, 3],
+        accountSecret: "123",
+        provider: "better-auth",
+      };
+
+      await auth.api.signUpEmail({
+        body: userData,
+        headers: {
+          "x-jazz-auth": JSON.stringify(jazzAuth),
+        },
+      });
+
+      expect(accountCreationSpy).toHaveBeenCalledTimes(1);
+
+      // 2. Try to sign-in with OTP
+      let OTP: string = "";
+
+      sendVerificationOTPSpy.mockImplementationOnce(({ otp }) => {
+        OTP = otp;
+      });
+
+      await auth.api.sendVerificationOTP({
+        body: {
+          email: "test@example.com",
+          type: "sign-in",
+        },
+      });
+
+      expect(sendVerificationOTPSpy).toHaveBeenCalledTimes(1);
+      expect(verificationCreationSpy).toHaveBeenCalledTimes(1);
+
+      const result = await auth.api.signInEmailOTP({
+        body: {
+          email: "test@example.com",
+          otp: OTP,
+        },
+      });
+
+      expect(accountCreationSpy).toHaveBeenCalledTimes(1); // still only 1
+      expect(result).toMatchObject({
+        user: {
+          id: expect.any(String),
+          email: "test@example.com",
+          name: "test",
+        },
+      });
     });
   });
 });


### PR DESCRIPTION
# Description
Together with Social/OAuth2 providers, [Email OTP](https://www.better-auth.com/docs/plugins/email-otp) is one of the most used. This PR introduces support for the plugin.

To simplify the support of new plugins and authentication systems, a new `VerificationCode` is created using Jazz's secrets. It also affects Social/Oauth2 plugins, but tests are covering.

Will close #2844

## Tests
- [x] Tests have been added and/or updated

## Checklist

- [x] I've updated the part of the docs that are affected the PR changes
- [x] I've generated a changeset, if a version bump is required