### PR TITLE
fix: fix peer role to be client when connecting the test accounts to the test sync server

### DIFF
--- a/.changeset/spicy-pigs-prove.md
+++ b/.changeset/spicy-pigs-prove.md
@@ -1,0 +1,5 @@
+---
+"jazz-tools": patch
+---
+
+Fix peer role to be client when connecting the test accounts to the test sync server

--- a/packages/jazz-tools/src/tools/testing.ts
+++ b/packages/jazz-tools/src/tools/testing.ts
@@ -56,7 +56,7 @@ export function getPeerConnectedToTestSyncServer() {
     Math.random().toString(),
     Math.random().toString(),
     {
-      peer1role: "server",
+      peer1role: "client",
       peer2role: "server",
     },
   );

--- a/packages/jazz-tools/src/tools/tests/coList.test.ts
+++ b/packages/jazz-tools/src/tools/tests/coList.test.ts
@@ -963,17 +963,19 @@ describe("CoList subscription", async () => {
 
     expect(spy).toHaveBeenCalledTimes(1);
 
-    expect(updates[0]?.[0]?.name).toEqual("Item 1");
-    expect(updates[0]?.[1]?.name).toEqual("Item 2");
+    await waitFor(() => {
+      expect(updates[0]?.[0]?.name).toEqual("Item 1");
+      expect(updates[0]?.[1]?.name).toEqual("Item 2");
+    });
 
     list[0]!.$jazz.set("name", "Updated Item 1");
 
-    await waitFor(() => expect(spy).toHaveBeenCalledTimes(2));
+    await waitFor(() => expect(spy).toHaveBeenCalledTimes(4));
 
     expect(updates[1]?.[0]?.name).toEqual("Updated Item 1");
     expect(updates[1]?.[1]?.name).toEqual("Item 2");
 
-    expect(spy).toHaveBeenCalledTimes(2);
+    expect(spy).toHaveBeenCalledTimes(4);
   });
 
   test("replacing list items triggers updates", async () => {

--- a/packages/jazz-tools/src/tools/tests/coMap.test.ts
+++ b/packages/jazz-tools/src/tools/tests/coMap.test.ts
@@ -1009,7 +1009,10 @@ describe("CoMap resolution", async () => {
     });
 
     assert(loadedPerson);
-    expect(loadedPerson.dog?.name).toEqual("Rex");
+
+    await waitFor(() => {
+      expect(loadedPerson.dog?.name).toEqual("Rex");
+    });
   });
 
   test("loading a remotely available map with skipRetry set to true", async () => {
@@ -1118,7 +1121,10 @@ describe("CoMap resolution", async () => {
 
     expect(resolved).toBe(true);
     assert(loadedPerson);
-    expect(loadedPerson.dog?.name).toEqual("Rex");
+
+    await waitFor(() => {
+      expect(loadedPerson.dog?.name).toEqual("Rex");
+    });
   });
 
   test("accessing the value refs", async () => {
@@ -1396,15 +1402,17 @@ describe("CoMap resolution", async () => {
 
     expect(spy).toHaveBeenCalledTimes(1);
 
-    expect(updates[0]?.dog?.name).toEqual("Rex");
+    await waitFor(() => {
+      expect(updates[0]?.dog?.name).toEqual("Rex");
+    });
 
     person.dog!.$jazz.set("name", "Fido");
 
-    await waitFor(() => expect(spy).toHaveBeenCalledTimes(2));
+    await waitFor(() => expect(spy).toHaveBeenCalledTimes(3));
 
     expect(updates[1]?.dog?.name).toEqual("Fido");
 
-    expect(spy).toHaveBeenCalledTimes(2);
+    expect(spy).toHaveBeenCalledTimes(3);
   });
 
   test("replacing nested object triggers updates", async () => {

--- a/packages/jazz-tools/src/tools/tests/exportImport.test.ts
+++ b/packages/jazz-tools/src/tools/tests/exportImport.test.ts
@@ -525,7 +525,9 @@ describe("importContentPieces", () => {
       resolve: {
         posts: {
           $each: {
-            comments: true,
+            comments: {
+              $each: true,
+            },
           },
         },
       },


### PR DESCRIPTION
# Description

Looking at some failing tests, I've noticed that the test account role where server/server instead of being client/server when connecting to the test sync server.

This affectes the results when doing autoloading, and lead to unexpected failures when changing how to sync with server peers.

## Tests

- [x] Tests have been added and/or updated
- [ ] Tests have not been updated, because: <!-- Insert reason for not updating tests here -->
- [ ] I need help with writing tests
