### PR TITLE
Make latency bar red if there's an ongoing outage

### DIFF
--- a/homepage/homepage/app/(others)/status/page.tsx
+++ b/homepage/homepage/app/(others)/status/page.tsx
@@ -267,6 +267,7 @@ export default async function Page() {
                         upOverTime={row.upOverTime}
                         upCountOverTime={row.upCountOverTime}
                         intervalMin={intervalMin}
+                        isUp={row.up}
                       />
                     </td>
                     <td className="whitespace-nowrap px-3 py-2 text-sm">

--- a/homepage/homepage/components/LatencyChart.tsx
+++ b/homepage/homepage/components/LatencyChart.tsx
@@ -43,8 +43,9 @@ interface Props {
   latencyOverTime: [number[], number[]];
   upOverTime: [number[], number[]];
   upCountOverTime: [number[], number[]];
+  isUp?: boolean;
 }
-export default function LatencyChart({ latencyOverTime, upOverTime, upCountOverTime, intervalMin }: Props) {
+export default function LatencyChart({ latencyOverTime, upOverTime, upCountOverTime, intervalMin, isUp = true }: Props) {
   const series = useMemo(() => {
     return latencyOverTime[1].map((value, index) => ({
       ts: latencyOverTime[0][index],
@@ -71,9 +72,12 @@ export default function LatencyChart({ latencyOverTime, upOverTime, upCountOverT
           </p>
         </HoverCard.Content>
       </HoverCard.Root>
-      {series.map(({ value, ts, up, upCount }) => {
+      {series.map(({ value, ts, up, upCount }, index) => {
+        const isLast = index === series.length - 1;
         const upPercentage = up / upCount;
-        const valueClass = getClassForLatencyAndUp(value, upPercentage);
+        
+        // If this is the last bar and we're down, override the colour to red
+        const valueClass = getClassForLatencyAndUp(value, isLast && !isUp ? 0 : upPercentage);
 
         const downtimeMin = (1 - upPercentage) * intervalMin;
 


### PR DESCRIPTION
# Description
It was quite frustrating to see during today's outage a bright green latency indicator next to a 'down' indicator. This update cascades the `isUp` property down to the latency chart, and in case `isUp` is false, the last latency indicator will be red.

Technically this is not accurate. It may be the case that we've got high levels of availability during the interval, and the outage does not meaningfully change the percentage, but nevertheless, as a user, I'd expect to see a red bar.

## Manual testing instructions

Needs a Grafana key to test, and then change one of the cascaded `isUp` props to false.

## Tests

- [ ] Tests have been added and/or updated
- [x] Tests have not been updated, because: not testable
- [ ] I need help with writing tests 


## Checklist

- [ ] I've updated the part of the docs that are affected the PR changes
- [ ] I've generated a changeset, if a version bump is required
- [ ] I've updated the jsDoc comments to the public APIs I've modified, or added them when missing