### PR TITLE
feat: improve merge to track the source txID and keep the views consistent

### DIFF
--- a/packages/cojson/src/coValueCore/SessionMap.ts
+++ b/packages/cojson/src/coValueCore/SessionMap.ts
@@ -92,12 +92,12 @@ export class SessionMap {
     keyID: KeyID,
     keySecret: KeySecret,
     meta: JsonObject | undefined,
+    madeAt: number,
   ): { signature: Signature; transaction: Transaction } {
     const sessionLog = this.getOrCreateSessionLog(
       sessionID,
       signerAgent.currentSignerID(),
     );
-    const madeAt = Date.now();
 
     const result = sessionLog.impl.addNewPrivateTransaction(
       signerAgent,
@@ -122,12 +122,12 @@ export class SessionMap {
     signerAgent: ControlledAccountOrAgent,
     changes: JsonValue[],
     meta: JsonObject | undefined,
+    madeAt: number,
   ): { signature: Signature; transaction: Transaction } {
     const sessionLog = this.getOrCreateSessionLog(
       sessionID,
       signerAgent.currentSignerID(),
     );
-    const madeAt = Date.now();
 
     const result = sessionLog.impl.addNewTrustingTransaction(
       signerAgent,

--- a/packages/cojson/src/coValueCore/branching.ts
+++ b/packages/cojson/src/coValueCore/branching.ts
@@ -254,10 +254,6 @@ export function mergeBranch(branch: CoValueCore): CoValueCore {
     target.makeTransaction(tx.changes, tx.tx.privacy, mergeMeta, tx.madeAt);
     lastSessionId = tx.txID.sessionID;
     lastBranchId = tx.txID.branch;
-
-    if (tx.txID.txIndex === 0) {
-      mergeMeta.b = branch.id;
-    }
   }
 
   // Track the merged transactions for the branch, so future merges will know which transactions have already been merged

--- a/packages/cojson/src/coValueCore/branching.ts
+++ b/packages/cojson/src/coValueCore/branching.ts
@@ -49,21 +49,16 @@ export function getBranchId(
     );
   }
 
-  if (!ownerId) {
-    const header = coValue.verified.header;
+  const currentOwnerId = ownerId ?? getBranchOwnerId(coValue);
 
-    // Group and account coValues can't have branches, so we return the source id
-    if (header.ruleset.type !== "ownedByGroup") {
-      return coValue.id;
-    }
-
-    ownerId = header.ruleset.group;
+  if (!currentOwnerId) {
+    return coValue.id;
   }
 
   const header = getBranchHeader({
     type: coValue.verified.header.type,
     branchName: name,
-    ownerId,
+    ownerId: currentOwnerId,
     sourceId: coValue.id,
   });
 
@@ -71,8 +66,29 @@ export function getBranchId(
 }
 
 export type BranchCommit = {
-  branch: CoValueKnownState["sessions"];
+  from: CoValueKnownState["sessions"];
 };
+
+export type BranchPointerCommit = {
+  branch: string;
+  ownerId?: RawCoID;
+};
+
+export function getBranchOwnerId(coValue: CoValueCore) {
+  if (!coValue.verified) {
+    throw new Error(
+      "CoValueCore: getBranchOwnerId called on coValue without verified state",
+    );
+  }
+
+  const header = coValue.verified.header;
+
+  if (header.ruleset.type !== "ownedByGroup") {
+    return undefined;
+  }
+
+  return header.ruleset.group;
+}
 
 /**
  * Given a coValue, a branch name and an owner id, creates a new branch CoValue
@@ -88,32 +104,34 @@ export function createBranch(
     );
   }
 
-  if (!ownerId) {
-    const header = coValue.verified.header;
+  const branchOwnerId = ownerId ?? getBranchOwnerId(coValue);
 
-    // Group and account coValues can't have branches, so we return the source coValue
-    if (header.ruleset.type !== "ownedByGroup") {
-      return coValue;
-    }
-
-    ownerId = header.ruleset.group;
+  if (!branchOwnerId) {
+    return coValue;
   }
 
   const header = getBranchHeader({
     type: coValue.verified.header.type,
     branchName: name,
-    ownerId,
+    ownerId: branchOwnerId,
     sourceId: coValue.id,
   });
 
-  const value = coValue.node.createCoValue(header);
+  const branch = coValue.node.createCoValue(header);
+  const sessions = { ...coValue.knownState().sessions };
 
   // Create a branch commit to identify the starting point of the branch
-  value.makeTransaction([], "private", {
-    branch: coValue.knownState().sessions,
+  branch.makeTransaction([], "private", {
+    from: sessions,
   } satisfies BranchCommit);
 
-  return value;
+  // Create a branch pointer, to identify that we created a branch
+  coValue.makeTransaction([], "private", {
+    branch: name,
+    ownerId,
+  } satisfies BranchPointerCommit);
+
+  return branch;
 }
 
 /**
@@ -142,12 +160,21 @@ export function getBranchSource(
 }
 
 export type MergeCommit = {
-  // The point where the branch was merged
-  merge: CoValueKnownState["sessions"];
-  // The id of the branch that was merged
-  id: RawCoID;
-  // The number of transactions that were merged, will be used in the future to handle the edits history properly
-  count: number;
+  i: number;
+  s?: SessionID;
+  b?: RawCoID;
+  mergeEnd?: 1;
+};
+
+export type MergeStartCommit = {
+  mergeStart: RawCoID;
+  b?: RawCoID;
+  s: SessionID;
+  i: number;
+};
+
+export type BranchMergedCommit = {
+  merged: CoValueKnownState["sessions"];
 };
 
 /**
@@ -164,12 +191,6 @@ export function mergeBranch(branch: CoValueCore): CoValueCore {
     return branch;
   }
 
-  const sourceId = branch.getCurrentBranchSourceId();
-
-  if (!sourceId) {
-    throw new Error("CoValueCore: mergeBranch called on a non-branch coValue");
-  }
-
   const target = getBranchSource(branch);
 
   if (!target) {
@@ -178,13 +199,9 @@ export function mergeBranch(branch: CoValueCore): CoValueCore {
 
   // Look for previous merge commits, to see which transactions needs to be merged
   // Done mostly for performance reasons, as we could merge all the transactions every time and nothing would change
-  const mergedTransactions = target.mergeCommits.reduce(
-    (acc, { commit }) => {
-      if (commit.id !== branch.id) {
-        return acc;
-      }
-
-      for (const [sessionID, count] of Object.entries(commit.merge) as [
+  const mergedTransactions = branch.getMergeCommits().reduce(
+    (acc, { merged }) => {
+      for (const [sessionID, count] of Object.entries(merged) as [
         SessionID,
         number,
       ][]) {
@@ -210,111 +227,42 @@ export function mergeBranch(branch: CoValueCore): CoValueCore {
     return target;
   }
 
-  // Create a merge commit to identify the merge point
-  target.makeTransaction([], "private", {
-    merge: { ...branch.knownState().sessions },
-    id: branch.id,
-    count: branchValidTransactions.length,
-  } satisfies MergeCommit);
+  // We do track in the meta information the original txID to make sure that
+  // the CoList opid still point to the correct transaction
+  // To reduce the cost of the meta we skip the repeated information
+  let lastSessionId: string | undefined = undefined;
+  let lastBranchId: string | undefined = undefined;
+  branchValidTransactions.forEach((tx, i) => {
+    const mergeMeta: MergeCommit & Partial<MergeStartCommit> = {
+      i: tx.txID.txIndex,
+    };
 
-  const currentSessionID = target.node.currentSessionID;
-
-  if (
-    target.verified.header.type === "colist" ||
-    target.verified.header.type === "coplaintext"
-  ) {
-    const mapping: Record<`${SessionID}:${number}`, number> = {};
-
-    const session = target.verified.sessions.get(currentSessionID);
-    let txIdx = session ? session.transactions.length : 0;
-
-    // Create a mapping from the branch transactions to the target transactions
-    for (const { txID } of branchValidTransactions) {
-      mapping[`${txID.sessionID}:${txID.txIndex}`] = txIdx;
-      txIdx++;
+    if (i === 0) {
+      mergeMeta.mergeStart = branch.id;
+      lastBranchId = branch.id;
     }
 
-    for (const { tx, changes } of branchValidTransactions) {
-      target.makeTransaction(
-        mapCoListChangesToTarget(
-          changes as ListOpPayload<JsonValue>[],
-          currentSessionID,
-          mapping,
-        ),
-        tx.privacy,
-      );
+    if (i === branchValidTransactions.length - 1) {
+      mergeMeta.mergeEnd = 1;
     }
-  } else {
-    for (const { tx, changes } of branchValidTransactions) {
-      target.makeTransaction(changes, tx.privacy);
+
+    if (lastSessionId !== tx.txID.sessionID) {
+      mergeMeta.s = tx.txID.sessionID;
     }
-  }
+
+    if (lastBranchId !== tx.txID.branch) {
+      mergeMeta.b = branch.id;
+    }
+
+    target.makeTransaction(tx.changes, tx.tx.privacy, mergeMeta, tx.madeAt);
+    lastSessionId = tx.txID.sessionID;
+    lastBranchId = tx.txID.branch;
+  });
+
+  // Track the merged transactions for the branch, so future merges will know which transactions have already been merged
+  branch.makeTransaction([], "private", {
+    merged: branch.knownState().sessions,
+  } satisfies BranchMergedCommit);
 
   return target;
-}
-
-/**
- * Given a list of changes, maps the opIDs to the target transactions
- */
-function mapCoListChangesToTarget(
-  changes: ListOpPayload<JsonValue>[],
-  currentSessionID: SessionID,
-  mapping: Record<`${SessionID}:${number}`, number>,
-) {
-  return changes.map((change) => {
-    if (change.op === "app") {
-      if (change.after === "start") {
-        return change;
-      }
-
-      return {
-        ...change,
-        after: convertOpID(change.after, currentSessionID, mapping),
-      };
-    }
-
-    if (change.op === "del") {
-      return {
-        ...change,
-        insertion: convertOpID(change.insertion, currentSessionID, mapping),
-      };
-    }
-
-    if (change.op === "pre") {
-      if (change.before === "end") {
-        return change;
-      }
-
-      return {
-        ...change,
-        before: convertOpID(change.before, currentSessionID, mapping),
-      };
-    }
-
-    return change;
-  });
-}
-
-function convertOpID(
-  opID: OpID,
-  sessionID: SessionID,
-  mapping: Record<`${SessionID}:${number}`, number>,
-) {
-  // If the opID comes from the source branch, we don't need to map it
-  if (!opID.branch) {
-    return opID;
-  }
-
-  const mappedIndex = mapping[`${opID.sessionID}:${opID.txIndex}`];
-
-  // If the opID doesn't exist in the mapping, we don't need to map it
-  if (mappedIndex === undefined) {
-    return opID;
-  }
-
-  return {
-    sessionID: sessionID,
-    txIndex: mappedIndex,
-    changeIdx: opID.changeIdx,
-  };
 }

--- a/packages/cojson/src/coValueCore/branching.ts
+++ b/packages/cojson/src/coValueCore/branching.ts
@@ -1,9 +1,41 @@
-import type { CoValueCore, JsonValue } from "../exports.js";
-import type { RawCoID, SessionID, TransactionID } from "../ids.js";
+import type { CoValueCore } from "../exports.js";
+import type { RawCoID, SessionID } from "../ids.js";
 import { type AvailableCoValueCore, idforHeader } from "./coValueCore.js";
 import type { CoValueHeader } from "./verifiedState.js";
 import type { CoValueKnownState } from "../sync.js";
-import type { ListOpPayload, OpID } from "../coValues/coList.js";
+
+/**
+ * Commit to identify the starting point of the branch
+ *
+ * In case of clonflicts, the first commit of this kind is considered the source of truth
+ */
+export type BranchStartCommit = {
+  from: CoValueKnownState["sessions"];
+};
+
+/**
+ * Commit that tracks a branch creation
+ */
+export type BranchPointerCommit = {
+  branch: string;
+  ownerId?: RawCoID;
+};
+
+/**
+ * Meta information attached to each merged transaction to retrieve the original transaction ID
+ */
+export type MergedTransactionMetadata = {
+  mi: number; // Transaction index and marker of a merge commit
+  s?: SessionID;
+  b?: RawCoID;
+};
+
+/**
+ * Merge commit located in a branch to track how many transactions have already been merged
+ */
+export type MergeCommit = {
+  merged: CoValueKnownState["sessions"];
+};
 
 export function getBranchHeader({
   type,
@@ -65,15 +97,6 @@ export function getBranchId(
   return idforHeader(header, coValue.node.crypto);
 }
 
-export type BranchCommit = {
-  from: CoValueKnownState["sessions"];
-};
-
-export type BranchPointerCommit = {
-  branch: string;
-  ownerId?: RawCoID;
-};
-
 export function getBranchOwnerId(coValue: CoValueCore) {
   if (!coValue.verified) {
     throw new Error(
@@ -123,7 +146,7 @@ export function createBranch(
   // Create a branch commit to identify the starting point of the branch
   branch.makeTransaction([], "private", {
     from: sessions,
-  } satisfies BranchCommit);
+  } satisfies BranchStartCommit);
 
   // Create a branch pointer, to identify that we created a branch
   coValue.makeTransaction([], "private", {
@@ -158,24 +181,6 @@ export function getBranchSource(
 
   return source;
 }
-
-export type MergeCommit = {
-  i: number;
-  s?: SessionID;
-  b?: RawCoID;
-  mergeEnd?: 1;
-};
-
-export type MergeStartCommit = {
-  mergeStart: RawCoID;
-  b?: RawCoID;
-  s: SessionID;
-  i: number;
-};
-
-export type BranchMergedCommit = {
-  merged: CoValueKnownState["sessions"];
-};
 
 /**
  * Given a branch coValue, merges the branch into the source coValue
@@ -232,37 +237,33 @@ export function mergeBranch(branch: CoValueCore): CoValueCore {
   // To reduce the cost of the meta we skip the repeated information
   let lastSessionId: string | undefined = undefined;
   let lastBranchId: string | undefined = undefined;
-  branchValidTransactions.forEach((tx, i) => {
-    const mergeMeta: MergeCommit & Partial<MergeStartCommit> = {
-      i: tx.txID.txIndex,
+
+  for (const tx of branchValidTransactions) {
+    const mergeMeta: MergedTransactionMetadata = {
+      mi: tx.txID.txIndex,
     };
-
-    if (i === 0) {
-      mergeMeta.mergeStart = branch.id;
-      lastBranchId = branch.id;
-    }
-
-    if (i === branchValidTransactions.length - 1) {
-      mergeMeta.mergeEnd = 1;
-    }
 
     if (lastSessionId !== tx.txID.sessionID) {
       mergeMeta.s = tx.txID.sessionID;
     }
 
     if (lastBranchId !== tx.txID.branch) {
-      mergeMeta.b = branch.id;
+      mergeMeta.b = tx.txID.branch;
     }
 
     target.makeTransaction(tx.changes, tx.tx.privacy, mergeMeta, tx.madeAt);
     lastSessionId = tx.txID.sessionID;
     lastBranchId = tx.txID.branch;
-  });
+
+    if (tx.txID.txIndex === 0) {
+      mergeMeta.b = branch.id;
+    }
+  }
 
   // Track the merged transactions for the branch, so future merges will know which transactions have already been merged
   branch.makeTransaction([], "private", {
     merged: branch.knownState().sessions,
-  } satisfies BranchMergedCommit);
+  } satisfies MergeCommit);
 
   return target;
 }

--- a/packages/cojson/src/coValueCore/coValueCore.ts
+++ b/packages/cojson/src/coValueCore/coValueCore.ts
@@ -77,9 +77,6 @@ export type VerifiedTransaction = {
 
   // The previous verified transaction for the same session
   previous: VerifiedTransaction | undefined;
-
-  // True if part of the merge operation, last transaction of the merge operation will have this set to false
-  merging: boolean;
 };
 
 export type DecryptedTransaction = {
@@ -780,7 +777,6 @@ export class CoValueCore {
           hasInvalidChanges: false,
           hasInvalidMeta: false,
           hasMetaBeenParsed: false,
-          merging: false,
           tx,
           previous: this.lastVerifiedTransactionBySessionID[sessionID],
         };

--- a/packages/cojson/src/coValueCore/verifiedState.ts
+++ b/packages/cojson/src/coValueCore/verifiedState.ts
@@ -59,6 +59,8 @@ export class VerifiedState {
   private _cachedNewContentSinceEmpty: NewContentMessage[] | undefined;
   private streamingKnownState?: CoValueKnownState["sessions"];
   public lastAccessed: number | undefined;
+  public branchSourceId?: RawCoID;
+  public branchName?: string;
 
   constructor(
     id: RawCoID,
@@ -74,6 +76,8 @@ export class VerifiedState {
     this.streamingKnownState = streamingKnownState
       ? { ...streamingKnownState }
       : undefined;
+    this.branchSourceId = header.meta?.source as RawCoID | undefined;
+    this.branchName = header.meta?.branch as string | undefined;
   }
 
   clone(): VerifiedState {
@@ -114,12 +118,14 @@ export class VerifiedState {
     signerAgent: ControlledAccountOrAgent,
     changes: JsonValue[],
     meta: JsonObject | undefined,
+    madeAt: number,
   ) {
     const result = this.sessions.makeNewTrustingTransaction(
       sessionID,
       signerAgent,
       changes,
       meta,
+      madeAt,
     );
 
     this._cachedNewContentSinceEmpty = undefined;
@@ -135,6 +141,7 @@ export class VerifiedState {
     keyID: KeyID,
     keySecret: KeySecret,
     meta: JsonObject | undefined,
+    madeAt: number,
   ) {
     const result = this.sessions.makeNewPrivateTransaction(
       sessionID,
@@ -143,6 +150,7 @@ export class VerifiedState {
       keyID,
       keySecret,
       meta,
+      madeAt,
     );
 
     this._cachedNewContentSinceEmpty = undefined;

--- a/packages/cojson/src/localNode.ts
+++ b/packages/cojson/src/localNode.ts
@@ -479,8 +479,14 @@ export class LocalNode {
       return branch.getCurrentContent() as T;
     }
 
-    // Passing skipRetry to true because otherwise creating a new branch would always take 1 retry delay
-    await this.loadCoValueCore(branch.id, undefined, true);
+    // Do a synchronous check to see if the branch exists, if not we don't need to try to load the branch
+    if (!source.hasBranch(branchName, branchOwnerID)) {
+      return source
+        .createBranch(branchName, branchOwnerID)
+        .getCurrentContent() as T;
+    }
+
+    await this.loadCoValueCore(branch.id);
 
     if (!branch.isAvailable()) {
       return source

--- a/packages/cojson/src/tests/branching.test.ts
+++ b/packages/cojson/src/tests/branching.test.ts
@@ -1,10 +1,11 @@
-import { beforeEach, describe, expect, test } from "vitest";
+import { assert, beforeEach, describe, expect, test } from "vitest";
 import {
   createTestNode,
   setupTestNode,
   loadCoValueOrFail,
 } from "./testUtils.js";
 import { expectList, expectMap, expectPlainText } from "../coValue.js";
+import { RawCoMap } from "../exports.js";
 
 let jazzCloud: ReturnType<typeof setupTestNode>;
 
@@ -94,7 +95,7 @@ describe("Branching Logic", () => {
       const result = expectMap(branch.core.mergeBranch().getCurrentContent());
 
       // Verify only one merge commit was created
-      expect(result.core.mergeCommits.length).toBe(1);
+      expect(branch.core.mergeCommits.length).toBe(1);
 
       // Verify source contains branch transactions
       expect(result.get("key1")).toBe("branchValue1");
@@ -154,7 +155,7 @@ describe("Branching Logic", () => {
       branch.core.mergeBranch();
 
       // Verify two merge commits exist
-      expect(originalMap.core.mergeCommits.length).toBe(2);
+      expect(branch.core.mergeCommits.length).toBe(2);
 
       // Verify both changes are now in original map
       expect(originalMap.get("key1")).toBe("branchValue1");
@@ -210,6 +211,8 @@ describe("Branching Logic", () => {
           .getCurrentContent(),
       );
 
+      await new Promise((resolve) => setTimeout(resolve, 5));
+
       // Add different items to second branch
       branch2.appendItems(["apples", "oranges", "carrots"]);
 
@@ -233,18 +236,20 @@ describe("Branching Logic", () => {
 
       expect(list.toJSON()).toEqual([
         "bread",
-        "cheese",
         "apples",
         "oranges",
         "carrots",
         "tomatoes",
         "cucumber",
+        "cheese",
       ]);
     });
 
-    test("should work with co.plainText when branching from different session", async () => {
-      const node = createTestNode();
-      const group = node.createGroup();
+    test("should work with co.plainText when merging the same branch twice on different sessions", async () => {
+      const client = setupTestNode({
+        connected: true,
+      });
+      const group = client.node.createGroup();
       const plainText = group.createPlainText();
 
       plainText.insertAfter(0, "hello");
@@ -255,12 +260,28 @@ describe("Branching Logic", () => {
           .getCurrentContent(),
       );
 
+      branch.insertAfter("hello".length, " world");
+
+      const anotherSession = client.spawnNewSession();
+
+      const loadedBranch = await loadCoValueOrFail(
+        anotherSession.node,
+        branch.id,
+      );
+      assert(loadedBranch);
+
+      anotherSession.connectToSyncServer().peerState.gracefulShutdown();
+
       // Add more items to the branch
-      branch.insertAfter("hello".length, "world");
+      loadedBranch.insertAfter("hello world".length, " people");
 
       branch.core.mergeBranch();
+      const loadedBranchMergeResult = loadedBranch.core.mergeBranch();
 
-      expect(plainText.toString()).toEqual("helloworld");
+      anotherSession.connectToSyncServer();
+      await loadedBranchMergeResult.waitForSync();
+
+      expect(plainText.toString()).toEqual("hello world people");
     });
   });
 
@@ -525,6 +546,134 @@ describe("Branching Logic", () => {
       // Verify both branches now contain data from the other
       expect(bobBranch.get("alice")).toBe(true);
       expect(aliceBranch.get("bob")).toBe(true);
+    });
+  });
+
+  describe("hasBranch", () => {
+    test("should work when the branch owner is the source owner", () => {
+      const client = setupTestNode({
+        connected: true,
+      });
+      const group = client.node.createGroup();
+      const map = group.createMap();
+
+      map.set("key", "value");
+
+      const branch = map.core.createBranch("feature-branch", group.id);
+
+      expect(map.core.hasBranch("feature-branch")).toBe(true);
+      expect(map.core.hasBranch("feature-branch", group.id)).toBe(true);
+      expect(branch.hasBranch("feature-branch")).toBe(false);
+    });
+
+    test("should work when the branch onwer is implicit", () => {
+      const client = setupTestNode({
+        connected: true,
+      });
+      const group = client.node.createGroup();
+      const map = group.createMap();
+
+      map.set("key", "value");
+
+      const branch = map.core.createBranch("feature-branch");
+
+      expect(map.core.hasBranch("feature-branch")).toBe(true);
+      expect(map.core.hasBranch("feature-branch", group.id)).toBe(true);
+      expect(branch.hasBranch("feature-branch")).toBe(false);
+    });
+
+    test("should return false for non-existent branch name", () => {
+      const client = setupTestNode({
+        connected: true,
+      });
+      const group = client.node.createGroup();
+      const map = group.createMap();
+
+      map.set("key", "value");
+
+      expect(map.core.hasBranch("non-existent-branch")).toBe(false);
+    });
+
+    test("should work with explicit ownerId parameter", () => {
+      const client = setupTestNode({
+        connected: true,
+      });
+      const group = client.node.createGroup();
+      const map = group.createMap();
+
+      map.set("key", "value");
+
+      const differentGroup = client.node.createGroup();
+
+      map.core.createBranch("feature-branch", differentGroup.id);
+
+      // Test with explicit ownerId
+      expect(map.core.hasBranch("feature-branch", differentGroup.id)).toBe(
+        true,
+      );
+      expect(map.core.hasBranch("feature-branch")).toBe(false);
+    });
+
+    test("should work when the transactions have not been parsed yet", async () => {
+      const client = setupTestNode({
+        connected: true,
+      });
+      const group = client.node.createGroup();
+      const map = group.createMap();
+
+      map.set("key", "value");
+
+      map.core.createBranch("feature-branch", group.id);
+
+      await map.core.waitForSync();
+
+      const newSession = client.spawnNewSession();
+      const loadedMapCore = await newSession.node.loadCoValueCore(map.core.id);
+
+      expect(loadedMapCore.hasBranch("feature-branch", group.id)).toBe(true);
+    });
+
+    test("should alias the txID when a transaction comes from a merge", async () => {
+      const client = setupTestNode({
+        connected: true,
+      });
+      const group = client.node.createGroup();
+      const map = group.createMap();
+
+      map.set("key", "value");
+
+      const branch = map.core
+        .createBranch("feature-branch", group.id)
+        .getCurrentContent() as RawCoMap;
+      branch.set("branchKey", "branchValue");
+
+      const originalTxID = branch.core
+        .getValidTransactions({
+          skipBranchSource: true,
+          ignorePrivateTransactions: false,
+        })
+        .at(-1)?.txID;
+
+      branch.core.mergeBranch();
+
+      map.set("key2", "value2");
+
+      const validSortedTransactions = map.core.getValidSortedTransactions();
+
+      // Only the merged transaction should have the txId changed
+      const mergedTransactionIdx = validSortedTransactions.findIndex(
+        (tx) => tx.txID.branch,
+      );
+
+      expect(
+        validSortedTransactions[mergedTransactionIdx - 1]?.txID.branch,
+      ).toBe(undefined);
+      expect(validSortedTransactions[mergedTransactionIdx]?.txID).toEqual(
+        originalTxID,
+      );
+      expect(
+        validSortedTransactions[mergedTransactionIdx + 1]?.txID.branch,
+      ).toBe(undefined);
     });
   });
 });

--- a/packages/cojson/src/tests/coValueCore.test.ts
+++ b/packages/cojson/src/tests/coValueCore.test.ts
@@ -57,6 +57,7 @@ test("transactions with wrong signature are rejected", () => {
       node.getCurrentAgent(),
       [{ hello: "world" }],
       undefined,
+      Date.now(),
     );
 
   transaction.madeAt = Date.now() + 1000;

--- a/packages/cojson/src/tests/sync.load.test.ts
+++ b/packages/cojson/src/tests/sync.load.test.ts
@@ -171,10 +171,10 @@ describe("loading coValues from server", () => {
       [
         "client -> server | LOAD Branch sessions: empty",
         "server -> client | CONTENT Group header: true new: After: 0 New: 5",
-        "server -> client | CONTENT Map header: true new: After: 0 New: 2",
+        "server -> client | CONTENT Map header: true new: After: 0 New: 3",
         "server -> client | CONTENT Branch header: true new: After: 0 New: 2",
         "client -> server | KNOWN Group sessions: header/5",
-        "client -> server | KNOWN Map sessions: header/2",
+        "client -> server | KNOWN Map sessions: header/3",
         "client -> server | KNOWN Branch sessions: header/2",
       ]
     `);

--- a/packages/cojson/src/tests/sync.storage.test.ts
+++ b/packages/cojson/src/tests/sync.storage.test.ts
@@ -238,7 +238,7 @@ describe("client with storage syncs with server", () => {
       [
         "client -> storage | LOAD Branch sessions: empty",
         "storage -> client | CONTENT Group header: true new: After: 0 New: 3",
-        "storage -> client | CONTENT Map header: true new: After: 0 New: 2",
+        "storage -> client | CONTENT Map header: true new: After: 0 New: 3",
         "storage -> client | CONTENT Branch header: true new: After: 0 New: 2",
       ]
     `);

--- a/packages/cojson/src/tests/sync.upload.test.ts
+++ b/packages/cojson/src/tests/sync.upload.test.ts
@@ -92,11 +92,11 @@ describe("client to server upload", () => {
         "server -> client | CONTENT Map header: true new: After: 0 New: 2",
         "client -> server | KNOWN Group sessions: header/5",
         "client -> server | KNOWN Map sessions: header/2",
-        "client -> server | LOAD Branch sessions: empty",
-        "server -> client | KNOWN Branch sessions: empty",
         "client -> server | CONTENT Branch header: true new: After: 0 New: 1",
+        "client -> server | CONTENT Map header: false new: After: 0 New: 1",
         "client -> server | CONTENT Branch header: false new: After: 1 New: 1",
         "server -> client | KNOWN Branch sessions: header/1",
+        "server -> client | KNOWN Map sessions: header/3",
         "server -> client | KNOWN Branch sessions: header/2",
       ]
     `);


### PR DESCRIPTION
# Description

Refactored the merge commits to:
- carry the txID of merged commits on the source branch. This fixes the content processing on co.list and co.feed
- store the merged checkpoints in the branch. This way the cost of keeping track of the merged sessions is paid on the branches, which should be more disposable.
- fixed the madeAt value to be the same as the original transaction before the merge. This affects the conflicts resolution, aligning them to our spec

## Tests

- [x] Tests have been added and/or updated
- [ ] Tests have not been updated, because: <!-- Insert reason for not updating tests here -->
- [ ] I need help with writing tests

