### PR TITLE
new asActiveAccount option on startWorker

### DIFF
--- a/homepage/homepage/content/docs/server-side/setup.mdx
+++ b/homepage/homepage/content/docs/server-side/setup.mdx
@@ -71,6 +71,8 @@ It will implicitly become the current account, and you can avoid mentioning it i
 
 For this reason we also recommend running a single worker instance per server, because it makes your code much more predictable.
 
+In case you want to avoid setting the current account, you can pass `asActiveAccount: false` to `startWorker`.
+
 ## Storing & providing credentials
 
 Server Worker credentials are typically stored and provided as environment variables.

--- a/packages/jazz-run/package.json
+++ b/packages/jazz-run/package.json
@@ -18,6 +18,7 @@
     "format-and-lint": "biome check .",
     "format-and-lint:fix": "biome check . --write",
     "build": "rm -rf ./dist && tsc --sourceMap --outDir dist && chmod +x ./dist/index.js",
+    "test": "vitest --run --root ../../ --project jazz-run",
     "dev": "tsc --watch --sourceMap --outDir dist",
     "build-and-run": "pnpm turbo build && ./dist/index.js sync --in-memory"
   },

--- a/packages/jazz-tools/src/tools/implementation/createContext.ts
+++ b/packages/jazz-tools/src/tools/implementation/createContext.ts
@@ -96,6 +96,7 @@ export async function createJazzContextFromExistingCredentials<
   AccountSchema: PropsAccountSchema,
   sessionProvider,
   onLogOut,
+  asActiveAccount,
 }: {
   credentials: Credentials;
   peersToLoadFrom: Peer[];
@@ -104,6 +105,7 @@ export async function createJazzContextFromExistingCredentials<
   sessionProvider: SessionProvider;
   onLogOut?: () => void;
   storage?: StorageAPI;
+  asActiveAccount: boolean;
 }): Promise<JazzContextWithAccount<InstanceOfSchema<S>>> {
   const { sessionID, sessionDone } = await sessionProvider(
     credentials.accountID,
@@ -125,14 +127,18 @@ export async function createJazzContextFromExistingCredentials<
     storage,
     migration: async (rawAccount, _node, creationProps) => {
       const account = AccountClass.fromRaw(rawAccount) as InstanceOfSchema<S>;
-      activeAccountContext.set(account);
+      if (asActiveAccount) {
+        activeAccountContext.set(account);
+      }
 
       await account.applyMigration(creationProps);
     },
   });
 
   const account = AccountClass.fromNode(node);
-  activeAccountContext.set(account);
+  if (asActiveAccount) {
+    activeAccountContext.set(account);
+  }
 
   return {
     node,
@@ -245,6 +251,7 @@ export async function createJazzContext<
         authSecretStorage.clearWithoutNotify();
       },
       storage: options.storage,
+      asActiveAccount: true,
     });
   } else {
     const secretSeed = options.crypto.newRandomSecretSeed();

--- a/packages/jazz-tools/src/tools/tests/coPlainText.test.ts
+++ b/packages/jazz-tools/src/tools/tests/coPlainText.test.ts
@@ -183,6 +183,7 @@ describe("CoPlainText", () => {
           sessionProvider: randomSessionProvider,
           peersToLoadFrom: [initialAsPeer],
           crypto: Crypto,
+          asActiveAccount: true,
         });
 
       // Load the text on the second peer
@@ -214,6 +215,7 @@ describe("CoPlainText", () => {
         sessionProvider: randomSessionProvider,
         peersToLoadFrom: [initialAsPeer],
         crypto: Crypto,
+        asActiveAccount: true,
       });
 
     const queue = new Channel();

--- a/packages/jazz-tools/src/tools/tests/createContext.test.ts
+++ b/packages/jazz-tools/src/tools/tests/createContext.test.ts
@@ -54,6 +54,7 @@ describe("createContext methods", () => {
         peersToLoadFrom: [getPeerConnectedToTestSyncServer()],
         crypto: Crypto,
         sessionProvider: randomSessionProvider,
+        asActiveAccount: true,
       });
 
       expect(context.node).toBeDefined();
@@ -86,6 +87,7 @@ describe("createContext methods", () => {
         crypto: Crypto,
         AccountSchema: CustomAccount,
         sessionProvider: randomSessionProvider,
+        asActiveAccount: true,
       });
 
       expect(context.account).toBeInstanceOf(
@@ -109,6 +111,7 @@ describe("createContext methods", () => {
         crypto: Crypto,
         sessionProvider: randomSessionProvider,
         onLogOut,
+        asActiveAccount: true,
       });
 
       context.logOut();
@@ -131,6 +134,7 @@ describe("createContext methods", () => {
         peersToLoadFrom: [getPeerConnectedToTestSyncServer()],
         crypto: Crypto,
         sessionProvider: randomSessionProvider,
+        asActiveAccount: true,
       });
 
       const loadedMap = await loadCoValueOrFail(context.node, coMap.id);
@@ -151,9 +155,29 @@ describe("createContext methods", () => {
         peersToLoadFrom: [getPeerConnectedToTestSyncServer()],
         crypto: Crypto,
         sessionProvider: randomSessionProvider,
+        asActiveAccount: true,
       });
 
       expect(activeAccountContext.get()).toBe(context.account);
+    });
+
+    test("does not set the active account when asActiveAccount is false", async () => {
+      const account = await createJazzTestAccount({
+        isCurrentActiveAccount: false,
+      });
+
+      const context = await createJazzContextFromExistingCredentials({
+        credentials: {
+          accountID: account.$jazz.id,
+          secret: account.$jazz.localNode.getCurrentAgent().agentSecret,
+        },
+        peersToLoadFrom: [getPeerConnectedToTestSyncServer()],
+        crypto: Crypto,
+        sessionProvider: randomSessionProvider,
+        asActiveAccount: false,
+      });
+
+      expect(activeAccountContext.get()).not.toBe(context.account);
     });
   });
 

--- a/packages/jazz-tools/src/tools/tests/deepLoading.test.ts
+++ b/packages/jazz-tools/src/tools/tests/deepLoading.test.ts
@@ -57,6 +57,7 @@ describe("Deep loading with depth arg", async () => {
       sessionProvider: randomSessionProvider,
       peersToLoadFrom: [initialAsPeer],
       crypto: Crypto,
+      asActiveAccount: true,
     });
 
   const ownership = { owner: me };
@@ -287,6 +288,7 @@ test("Deep loading a record-like coMap", async () => {
       sessionProvider: randomSessionProvider,
       peersToLoadFrom: [initialAsPeer],
       crypto: Crypto,
+      asActiveAccount: true,
     });
 
   const record = RecordLike.create(

--- a/packages/jazz-tools/src/tools/tests/utils.ts
+++ b/packages/jazz-tools/src/tools/tests/utils.ts
@@ -40,6 +40,7 @@ export async function setupAccount() {
       sessionProvider: randomSessionProvider,
       peersToLoadFrom: [initialAsPeer],
       crypto: Crypto,
+      asActiveAccount: true,
     });
 
   return { me, meOnSecondPeer };

--- a/packages/jazz-tools/src/worker/index.ts
+++ b/packages/jazz-tools/src/worker/index.ts
@@ -31,6 +31,10 @@ type WorkerOptions<
    * If true, the inbox will not be loaded.
    */
   skipInboxLoad?: boolean;
+  /**
+   * If false, the worker will not set in the global account context
+   */
+  asActiveAccount?: boolean;
 };
 
 /** @category Context Creation */
@@ -45,6 +49,7 @@ export async function startWorker<
     syncServer = "wss://cloud.jazz.tools",
     AccountSchema = Account as unknown as S,
     skipInboxLoad = false,
+    asActiveAccount = true,
   } = options;
 
   let node: LocalNode | undefined = undefined;
@@ -90,6 +95,7 @@ export async function startWorker<
     sessionProvider: randomSessionProvider,
     peersToLoadFrom,
     crypto: options.crypto ?? (await WasmCrypto.create()),
+    asActiveAccount,
   });
 
   const account = context.account as InstanceOfSchema<S>;


### PR DESCRIPTION
# Description

`startWorker` implicitly sets the worker as the current account. I added an option to `createJazzContextFromExistingCredentials` to specify whether you want to set the account as active for the current context, and reflected this change in startWorker.

The default behavior has been kept, but you can now avoid the implicit side-effect in case of two different workers in the same process.

## Tests

- [x] Tests have been added and/or updated



## Checklist

- [x] I've updated the part of the docs that are affected the PR changes
- [x] I've generated a changeset, if a version bump is required
- [ ] I've updated the jsDoc comments to the public APIs I've modified, or added them when missing