### PR TITLE
Better Auth: ensure email-otp uniqueness

### DIFF
--- a/.changeset/sharp-snails-fix.md
+++ b/.changeset/sharp-snails-fix.md
@@ -1,0 +1,5 @@
+---
+"jazz-tools": minor
+---
+
+fix: ensure better-auth email-otp verification uniqueness

--- a/packages/jazz-tools/src/better-auth/auth/server.ts
+++ b/packages/jazz-tools/src/better-auth/auth/server.ts
@@ -95,10 +95,14 @@ export const jazzPlugin: () => JazzPlugin = () => {
                     contextContainsJazzAuth(context) &&
                     verification.identifier.startsWith("sign-in-otp-")
                   ) {
+                    const identifier = `jazz-auth-${verification.identifier}`;
+                    await context.context.internalAdapter.deleteVerificationValue(
+                      identifier,
+                    );
                     await context.context.internalAdapter.createVerificationValue(
                       {
                         value: JSON.stringify({ jazzAuth: context.jazzAuth }),
-                        identifier: `${verification.identifier}-jazz-auth`,
+                        identifier: identifier,
                         expiresAt: verification.expiresAt,
                       },
                     );
@@ -166,7 +170,7 @@ export const jazzPlugin: () => JazzPlugin = () => {
           handler: createAuthMiddleware(async (ctx) => {
             const state = ctx.query?.state || ctx.body?.state;
 
-            const identifier = `${state}-jazz-auth`;
+            const identifier = `jazz-auth-${state}`;
 
             const data =
               await ctx.context.internalAdapter.findVerificationValue(
@@ -207,7 +211,7 @@ export const jazzPlugin: () => JazzPlugin = () => {
           },
           handler: createAuthMiddleware(async (ctx) => {
             const email = ctx.body.email;
-            const identifier = `sign-in-otp-${email}-jazz-auth`;
+            const identifier = `jazz-auth-sign-in-otp-${email}`;
 
             const data =
               await ctx.context.internalAdapter.findVerificationValue(
@@ -292,7 +296,7 @@ export const jazzPlugin: () => JazzPlugin = () => {
 
             await ctx.context.internalAdapter.createVerificationValue({
               value,
-              identifier: `${state}-jazz-auth`,
+              identifier: `jazz-auth-${state}`,
               expiresAt,
             });
           }),

--- a/packages/jazz-tools/src/better-auth/auth/tests/server.test.ts
+++ b/packages/jazz-tools/src/better-auth/auth/tests/server.test.ts
@@ -293,7 +293,7 @@ describe("Better-Auth server plugin", async () => {
 
       expect(verificationCreationSpy).toHaveBeenCalledTimes(2);
       expect(verificationCreationSpy.mock.calls[1]?.[0]).toMatchObject({
-        identifier: expect.stringMatching("-jazz-auth"),
+        identifier: expect.stringMatching("jazz-auth-"),
         value: expect.stringContaining('"accountID":"123"'),
       });
     });
@@ -412,7 +412,7 @@ describe("Better-Auth server plugin", async () => {
       expect(verificationCreationSpy).toHaveBeenCalledTimes(2);
       expect(verificationCreationSpy.mock.calls[0]?.[0]).toMatchObject(
         expect.objectContaining({
-          identifier: "sign-in-otp-email@email.it-jazz-auth",
+          identifier: "jazz-auth-sign-in-otp-email@email.it",
           value: expect.stringContaining('"accountID":"123"'),
         }),
       );


### PR DESCRIPTION
# Description
Requesting verification via OTP twice might result in the jazz-auth verification code being written twice in the table, breaking the uniqueness constraint on `identifier`.
This PR addresses this issue, ensuring a single `jazz-auth-sign-in-otp` identifier. 

Note: can't reproduce it easily in tests because the InMemory adapter overrides the identifier even in creation.