### PR TITLE
feat: make CoLists structurally equal to arrays

### DIFF
--- a/.changeset/metal-apples-shave.md
+++ b/.changeset/metal-apples-shave.md
@@ -1,0 +1,5 @@
+---
+"jazz-tools": patch
+---
+
+Make CoLists structurally equal to arrays

--- a/packages/jazz-tools/src/tools/coValues/coList.ts
+++ b/packages/jazz-tools/src/tools/coValues/coList.ts
@@ -971,4 +971,39 @@ const CoListProxyHandler: ProxyHandler<CoList> = {
       return Reflect.has(target, key);
     }
   },
+  ownKeys(target) {
+    const keys = Reflect.ownKeys(target);
+    // Add numeric indices for all entries in the list
+    const indexKeys = target.$jazz.raw.entries().map((_entry, i) => String(i));
+    keys.push(...indexKeys);
+    return keys;
+  },
+  getOwnPropertyDescriptor(target, key) {
+    if (key === TypeSym) {
+      // Make TypeSym non-enumerable so it doesn't show up in Object.keys()
+      return {
+        enumerable: false,
+        configurable: true,
+        writable: false,
+        value: target[TypeSym],
+      };
+    } else if (key in target) {
+      return Reflect.getOwnPropertyDescriptor(target, key);
+    } else if (typeof key === "string" && !isNaN(+key)) {
+      const index = Number(key);
+      if (index >= 0 && index < target.$jazz.raw.entries().length) {
+        return {
+          enumerable: true,
+          configurable: true,
+          writable: true,
+        };
+      }
+    } else if (key === "length") {
+      return {
+        enumerable: false,
+        configurable: false,
+        writable: false,
+      };
+    }
+  },
 };

--- a/packages/jazz-tools/src/tools/tests/coList.test.ts
+++ b/packages/jazz-tools/src/tools/tests/coList.test.ts
@@ -122,6 +122,25 @@ describe("Simple CoList operations", async () => {
     expect(list[0]).toEqual("milk");
   });
 
+  test("CoList keys can be iterated over just like an array's", () => {
+    const TestList = co.list(z.string());
+    const list = ["a", "b", "c", "d", "e"];
+    const coList = TestList.create(list);
+    const keys = [];
+    for (const key in coList) {
+      keys.push(key);
+    }
+    expect(keys).toEqual(Object.keys(list));
+    expect(Object.keys(coList)).toEqual(Object.keys(list));
+  });
+
+  test("a CoList is structurally equal to an array", () => {
+    const TestList = co.list(z.string());
+    const list = ["a", "b", "c", "d", "e"];
+    const coList = TestList.create(list);
+    expect(coList).toEqual(list);
+  });
+
   describe("Mutation", () => {
     test("assignment", () => {
       const list = TestList.create(["bread", "butter", "onion"], {


### PR DESCRIPTION
# Description

I implemented `ownKeys` & `getOwnPropertyDescriptor` in the `CoListProxyHandler` to make the iteration of a CoList's keys the same as an array's.

This means CoLists should be considered structurally equal to arrays in most cases. E.g. this test now passes:
```typescript
const TestList = co.list(z.string());
const list = ["a", "b", "c"];
const coList = TestList.create(list);
expect(coList).toEqual(list);
```

While before it'd fail with a very cryptic `expected ['a', 'b', 'c'] to deeply equal ['a', 'b', 'c']` error.

This was already true for CoMaps and plain JS objects, now it works for CoList as well. We'll need to revisit the approach for both when we remove proxies.

## Tests

- [x] Tests have been added and/or updated

## Checklist

- [ ] I've updated the part of the docs that are affected the PR changes
- [x] I've generated a changeset, if a version bump is required
- [ ] I've updated the jsDoc comments to the public APIs I've modified, or added them when missing