### PR TITLE
feat: expose ReactNativeContextManager

### DIFF
--- a/packages/jazz-tools/src/react-native-core/index.ts
+++ b/packages/jazz-tools/src/react-native-core/index.ts
@@ -7,3 +7,4 @@ export * from "./media/image.js";
 export { SQLiteDatabaseDriverAsync } from "cojson";
 export { parseInviteLink } from "jazz-tools";
 export { createInviteLink, setupKvStore } from "./platform.js";
+export { ReactNativeContextManager, type JazzContextManagerProps } from "./ReactNativeContextManager.js"


### PR DESCRIPTION
# Description
This export is useful to create jazz context outside react 

```ts
import type {
	Account,
	AccountClass,
	AnyAccountSchema,
	CoValueFromRaw,
} from "jazz-tools"

import { ExpoSQLiteAdapter, ExpoSecureStoreAdapter } from "jazz-tools/expo"
import { ReactNativeContextManager, setupKvStore, type JazzContextManagerProps } from "jazz-tools/react-native-core"
import { invariant } from "../asserts"

export type ExpoJazzApp = Awaited<ReturnType<typeof createExpoJazzApp>>

export async function createExpoJazzApp<
	S extends
	| (AccountClass<Account> & CoValueFromRaw<Account>)
	| AnyAccountSchema,
>(opts: Pick<JazzContextManagerProps<S>, "sync" | "AccountSchema">) {
	const storage = new ExpoSQLiteAdapter()
	const kvStore = new ExpoSecureStoreAdapter()

	setupKvStore(kvStore)

	const contextManager = new ReactNativeContextManager<S>()

	await contextManager.createContext({
		guestMode: false,
		storage,
		...opts,
	})

	const context = contextManager.getCurrentValue()
	invariant(context && "me" in context, "Failed to get me from jazz context")

	const authSecretStorage = contextManager.getAuthSecretStorage()

	return {
		me: context.me,
		context,
		logOut: contextManager.logOut,
		authSecretStorage,
	}
}
```

## Tests

- [ ] Tests have been added and/or updated
- [ ] Tests have not been updated, because: <!-- Insert reason for not updating tests here -->
- [ ] I need help with writing tests


## Checklist

- [ ] I've updated the part of the docs that are affected the PR changes
- [ ] I've generated a changeset, if a version bump is required
- [ ] I've updated the jsDoc comments to the public APIs I've modified, or added them when missing