### PR TITLE
feat: add co.group

### DIFF
--- a/.changeset/shaggy-walls-develop.md
+++ b/.changeset/shaggy-walls-develop.md
@@ -1,0 +1,5 @@
+---
+"jazz-tools": patch
+---
+
+Add co.group schema definer

--- a/packages/jazz-tools/src/tools/coValues/group.ts
+++ b/packages/jazz-tools/src/tools/coValues/group.ts
@@ -262,7 +262,10 @@ export class Group extends CoValueBase implements CoValue {
     return this;
   }
 
-  /** @category Subscription & Loading */
+  /** @category Subscription & Loading
+   *
+   * @deprecated Use `co.group(...).load` instead.
+   */
   static load<G extends Group, const R extends RefsToResolve<G>>(
     this: CoValueClass<G>,
     id: ID<G>,
@@ -271,7 +274,10 @@ export class Group extends CoValueBase implements CoValue {
     return loadCoValueWithoutMe(this, id, options);
   }
 
-  /** @category Subscription & Loading */
+  /** @category Subscription & Loading
+   *
+   * @deprecated Use `co.group(...).subscribe` instead.
+   */
   static subscribe<G extends Group, const R extends RefsToResolve<G>>(
     this: CoValueClass<G>,
     id: ID<G>,

--- a/packages/jazz-tools/src/tools/implementation/zodSchema/coExport.ts
+++ b/packages/jazz-tools/src/tools/implementation/zodSchema/coExport.ts
@@ -12,6 +12,7 @@ export {
   AccountSchema as Account,
   CoProfileSchema as Profile,
 } from "./schemaTypes/AccountSchema.js";
+export { GroupSchema as Group } from "./schemaTypes/GroupSchema.js";
 export { CoOptionalSchema as Optional } from "./schemaTypes/CoOptionalSchema.js";
 export { CoDiscriminatedUnionSchema as DiscriminatedUnion } from "./schemaTypes/CoDiscriminatedUnionSchema.js";
 export {
@@ -24,6 +25,7 @@ export {
   coFileStreamDefiner as fileStream,
   coImageDefiner as image,
   coAccountDefiner as account,
+  coGroupDefiner as group,
   coProfileDefiner as profile,
   coOptionalDefiner as optional,
   coDiscriminatedUnionDefiner as discriminatedUnion,

--- a/packages/jazz-tools/src/tools/implementation/zodSchema/runtimeConverters/coValueSchemaTransformation.ts
+++ b/packages/jazz-tools/src/tools/implementation/zodSchema/runtimeConverters/coValueSchemaTransformation.ts
@@ -134,8 +134,7 @@ export function hydrateCoreCoValueSchema<S extends AnyCoreCoValueSchema>(
     const coValueSchema = new CoDiscriminatedUnionSchema(schema, coValueClass);
     return coValueSchema as CoValueSchemaFromCoreSchema<S>;
   } else if (schema.builtin === "Group") {
-    const coValueClass = Group;
-    return new GroupSchema(coValueClass) as CoValueSchemaFromCoreSchema<S>;
+    return new GroupSchema() as CoValueSchemaFromCoreSchema<S>;
   } else {
     const notReachable: never = schema;
     throw new Error(

--- a/packages/jazz-tools/src/tools/implementation/zodSchema/runtimeConverters/coValueSchemaTransformation.ts
+++ b/packages/jazz-tools/src/tools/implementation/zodSchema/runtimeConverters/coValueSchemaTransformation.ts
@@ -17,11 +17,13 @@ import {
   enrichAccountSchema,
   enrichCoMapSchema,
   isCoValueClass,
+  Group,
 } from "../../../internal.js";
 import { coField } from "../../schema.js";
 
 import { CoreCoValueSchema } from "../schemaTypes/CoValueSchema.js";
 import { RichTextSchema } from "../schemaTypes/RichTextSchema.js";
+import { GroupSchema } from "../schemaTypes/GroupSchema.js";
 import { schemaUnionDiscriminatorFor } from "../unionUtils.js";
 import {
   AnyCoreCoValueSchema,
@@ -131,6 +133,9 @@ export function hydrateCoreCoValueSchema<S extends AnyCoreCoValueSchema>(
     const coValueClass = SchemaUnion.Of(schemaUnionDiscriminatorFor(schema));
     const coValueSchema = new CoDiscriminatedUnionSchema(schema, coValueClass);
     return coValueSchema as CoValueSchemaFromCoreSchema<S>;
+  } else if (schema.builtin === "Group") {
+    const coValueClass = Group;
+    return new GroupSchema(coValueClass) as CoValueSchemaFromCoreSchema<S>;
   } else {
     const notReachable: never = schema;
     throw new Error(

--- a/packages/jazz-tools/src/tools/implementation/zodSchema/schemaTypes/GroupSchema.ts
+++ b/packages/jazz-tools/src/tools/implementation/zodSchema/schemaTypes/GroupSchema.ts
@@ -1,0 +1,80 @@
+import { Role } from "cojson";
+import { Group } from "../../../coValues/group.js";
+import {
+  CoValueClass,
+  ID,
+  SubscribeListenerOptions,
+  SubscribeRestArgs,
+} from "../../../coValues/interfaces.js";
+import {
+  Account,
+  CoreCoMapSchema,
+  RefsToResolve,
+  RefsToResolveStrict,
+  Resolved,
+  ResolveQuery,
+  AnonymousJazzAgent,
+  Loaded,
+} from "../../../internal.js";
+import { co } from "../../../internal.js";
+import { CoreCoValueSchema } from "./CoValueSchema.js";
+import { z } from "../zodReExport.js";
+import { coOptionalDefiner } from "../zodCo.js";
+import { CoOptionalSchema } from "./CoOptionalSchema.js";
+
+export interface CoreGroupSchema extends CoreCoValueSchema {
+  builtin: "Group";
+}
+
+export function createCoreGroupSchema(): CoreGroupSchema {
+  return {
+    collaborative: true as const,
+    builtin: "Group" as const,
+  };
+}
+
+export class GroupSchema implements CoreGroupSchema {
+  readonly collaborative = true as const;
+  readonly builtin = "Group" as const;
+
+  constructor(private coValueClass: typeof Group) {}
+
+  getCoValueClass(): typeof Group {
+    return this.coValueClass;
+  }
+
+  optional(): CoOptionalSchema<this> {
+    return coOptionalDefiner(this);
+  }
+
+  create(options?: { owner: Account } | Account) {
+    return this.coValueClass.create(options);
+  }
+
+  load<R extends ResolveQuery<GroupSchema>>(
+    id: string,
+    options?: {
+      loadAs?: Account;
+      resolve?: RefsToResolveStrict<Group, R>;
+    },
+  ): Promise<Group | null> {
+    return this.coValueClass.load(id, options);
+  }
+
+  subscribe<G extends Group, const R extends RefsToResolve<G>>(
+    id: ID<G>,
+    listener: (value: Resolved<G, R>, unsubscribe: () => void) => void,
+  ): () => void;
+  subscribe<G extends Group, const R extends RefsToResolve<G>>(
+    id: ID<G>,
+    options: SubscribeListenerOptions<G, R>,
+    listener: (value: Resolved<G, R>, unsubscribe: () => void) => void,
+  ): () => void;
+  subscribe<G extends Group, const R extends RefsToResolve<G>>(
+    id: ID<G>,
+    ...args: SubscribeRestArgs<G, R>
+  ): () => void {
+    // @ts-expect-error
+    return this.coValueClass.subscribe<G, R>(id, ...args);
+  }
+}

--- a/packages/jazz-tools/src/tools/implementation/zodSchema/schemaTypes/GroupSchema.ts
+++ b/packages/jazz-tools/src/tools/implementation/zodSchema/schemaTypes/GroupSchema.ts
@@ -1,24 +1,17 @@
-import { Role } from "cojson";
 import { Group } from "../../../coValues/group.js";
 import {
-  CoValueClass,
   ID,
   SubscribeListenerOptions,
   SubscribeRestArgs,
 } from "../../../coValues/interfaces.js";
 import {
   Account,
-  CoreCoMapSchema,
   RefsToResolve,
   RefsToResolveStrict,
   Resolved,
   ResolveQuery,
-  AnonymousJazzAgent,
-  Loaded,
 } from "../../../internal.js";
-import { co } from "../../../internal.js";
 import { CoreCoValueSchema } from "./CoValueSchema.js";
-import { z } from "../zodReExport.js";
 import { coOptionalDefiner } from "../zodCo.js";
 import { CoOptionalSchema } from "./CoOptionalSchema.js";
 
@@ -51,8 +44,8 @@ export class GroupSchema implements CoreGroupSchema {
     return this.coValueClass.create(options);
   }
 
-  load<R extends ResolveQuery<GroupSchema>>(
-    id: string,
+  load<G extends Group, R extends ResolveQuery<GroupSchema>>(
+    id: ID<G>,
     options?: {
       loadAs?: Account;
       resolve?: RefsToResolveStrict<Group, R>;

--- a/packages/jazz-tools/src/tools/implementation/zodSchema/schemaTypes/GroupSchema.ts
+++ b/packages/jazz-tools/src/tools/implementation/zodSchema/schemaTypes/GroupSchema.ts
@@ -66,6 +66,6 @@ export class GroupSchema implements CoreGroupSchema {
     ...args: SubscribeRestArgs<G, R>
   ): () => void {
     // @ts-expect-error
-    return this.coValueClass.subscribe<G, R>(id, ...args);
+    return Group.subscribe<G, R>(id, ...args);
   }
 }

--- a/packages/jazz-tools/src/tools/implementation/zodSchema/schemaTypes/GroupSchema.ts
+++ b/packages/jazz-tools/src/tools/implementation/zodSchema/schemaTypes/GroupSchema.ts
@@ -30,10 +30,8 @@ export class GroupSchema implements CoreGroupSchema {
   readonly collaborative = true as const;
   readonly builtin = "Group" as const;
 
-  constructor(private coValueClass: typeof Group) {}
-
   getCoValueClass(): typeof Group {
-    return this.coValueClass;
+    return Group;
   }
 
   optional(): CoOptionalSchema<this> {
@@ -41,7 +39,7 @@ export class GroupSchema implements CoreGroupSchema {
   }
 
   create(options?: { owner: Account } | Account) {
-    return this.coValueClass.create(options);
+    return Group.create(options);
   }
 
   load<G extends Group, R extends ResolveQuery<GroupSchema>>(
@@ -51,7 +49,7 @@ export class GroupSchema implements CoreGroupSchema {
       resolve?: RefsToResolveStrict<Group, R>;
     },
   ): Promise<Group | null> {
-    return this.coValueClass.load(id, options);
+    return Group.load(id, options);
   }
 
   subscribe<G extends Group, const R extends RefsToResolve<G>>(

--- a/packages/jazz-tools/src/tools/implementation/zodSchema/typeConverters/InstanceOfSchema.ts
+++ b/packages/jazz-tools/src/tools/implementation/zodSchema/typeConverters/InstanceOfSchema.ts
@@ -11,7 +11,9 @@ import {
   CoreAccountSchema,
   CoreCoRecordSchema,
   FileStream,
+  Group,
 } from "../../../internal.js";
+import { CoreGroupSchema } from "../schemaTypes/GroupSchema.js";
 import { CoreCoFeedSchema } from "../schemaTypes/CoFeedSchema.js";
 import { CoreCoListSchema } from "../schemaTypes/CoListSchema.js";
 import { CoreCoMapSchema } from "../schemaTypes/CoMapSchema.js";
@@ -31,37 +33,41 @@ export type InstanceOfSchema<S extends CoValueClass | AnyZodOrCoValueSchema> =
             Shape[key]
           >;
         } & Account
-      : S extends CoreCoRecordSchema<infer K, infer V>
-        ? {
-            readonly [key in z.output<K> &
-              string]: InstanceOrPrimitiveOfSchema<V>;
-          } & CoMap
-        : S extends CoreCoMapSchema<infer Shape, infer CatchAll>
+      : S extends CoreGroupSchema
+        ? Group
+        : S extends CoreCoRecordSchema<infer K, infer V>
           ? {
-              readonly [key in keyof Shape]: InstanceOrPrimitiveOfSchema<
-                Shape[key]
-              >;
-            } & (CatchAll extends AnyZodOrCoValueSchema
-              ? {
-                  readonly [key: string]: InstanceOrPrimitiveOfSchema<CatchAll>;
-                }
-              : {}) &
-              CoMap
-          : S extends CoreCoListSchema<infer T>
-            ? CoList<InstanceOrPrimitiveOfSchema<T>>
-            : S extends CoreCoFeedSchema<infer T>
-              ? CoFeed<InstanceOrPrimitiveOfSchema<T>>
-              : S extends CorePlainTextSchema
-                ? CoPlainText
-                : S extends CoreRichTextSchema
-                  ? CoRichText
-                  : S extends CoreFileStreamSchema
-                    ? FileStream
-                    : S extends CoreCoOptionalSchema<infer T>
-                      ? InstanceOrPrimitiveOfSchema<T> | undefined
-                      : S extends CoDiscriminatedUnionSchema<infer Members>
-                        ? InstanceOrPrimitiveOfSchema<Members[number]>
-                        : never
+              readonly [key in z.output<K> &
+                string]: InstanceOrPrimitiveOfSchema<V>;
+            } & CoMap
+          : S extends CoreCoMapSchema<infer Shape, infer CatchAll>
+            ? {
+                readonly [key in keyof Shape]: InstanceOrPrimitiveOfSchema<
+                  Shape[key]
+                >;
+              } & (CatchAll extends AnyZodOrCoValueSchema
+                ? {
+                    readonly [
+                      key: string
+                    ]: InstanceOrPrimitiveOfSchema<CatchAll>;
+                  }
+                : {}) &
+                CoMap
+            : S extends CoreCoListSchema<infer T>
+              ? CoList<InstanceOrPrimitiveOfSchema<T>>
+              : S extends CoreCoFeedSchema<infer T>
+                ? CoFeed<InstanceOrPrimitiveOfSchema<T>>
+                : S extends CorePlainTextSchema
+                  ? CoPlainText
+                  : S extends CoreRichTextSchema
+                    ? CoRichText
+                    : S extends CoreFileStreamSchema
+                      ? FileStream
+                      : S extends CoreCoOptionalSchema<infer T>
+                        ? InstanceOrPrimitiveOfSchema<T> | undefined
+                        : S extends CoDiscriminatedUnionSchema<infer Members>
+                          ? InstanceOrPrimitiveOfSchema<Members[number]>
+                          : never
     : S extends CoValueClass
       ? InstanceType<S>
       : never;

--- a/packages/jazz-tools/src/tools/implementation/zodSchema/typeConverters/InstanceOfSchemaCoValuesNullable.ts
+++ b/packages/jazz-tools/src/tools/implementation/zodSchema/typeConverters/InstanceOfSchemaCoValuesNullable.ts
@@ -14,12 +14,14 @@ import {
   CoreCoMapSchema,
   CoreCoRecordSchema,
   FileStream,
+  Group,
 } from "../../../internal.js";
 import { CoreCoOptionalSchema } from "../schemaTypes/CoOptionalSchema.js";
 import { CoreCoValueSchema } from "../schemaTypes/CoValueSchema.js";
 import { CoreFileStreamSchema } from "../schemaTypes/FileStreamSchema.js";
 import { CorePlainTextSchema } from "../schemaTypes/PlainTextSchema.js";
 import { CoreRichTextSchema } from "../schemaTypes/RichTextSchema.js";
+import { CoreGroupSchema } from "../schemaTypes/GroupSchema.js";
 import { z } from "../zodReExport.js";
 import { InstanceOrPrimitiveOfSchemaCoValuesNullable } from "./InstanceOrPrimitiveOfSchemaCoValuesNullable.js";
 
@@ -34,47 +36,49 @@ export type InstanceOfSchemaCoValuesNullable<
             >;
           } & Account)
         | null
-    : S extends CoreCoRecordSchema<infer K, infer V>
-      ?
-          | ({
-              readonly [key in z.output<K> &
-                string]: InstanceOrPrimitiveOfSchemaCoValuesNullable<V>;
-            } & CoMap)
-          | null
-      : S extends CoreCoMapSchema<infer Shape, infer CatchAll>
+    : S extends CoreGroupSchema
+      ? Group | null
+      : S extends CoreCoRecordSchema<infer K, infer V>
         ?
             | ({
-                readonly [key in keyof Shape]: InstanceOrPrimitiveOfSchemaCoValuesNullable<
-                  Shape[key]
-                >;
-              } & (CatchAll extends AnyZodOrCoValueSchema
-                ? {
-                    readonly [
-                      key: string
-                    ]: InstanceOrPrimitiveOfSchemaCoValuesNullable<CatchAll>;
-                  }
-                : {}) &
-                CoMap)
+                readonly [key in z.output<K> &
+                  string]: InstanceOrPrimitiveOfSchemaCoValuesNullable<V>;
+              } & CoMap)
             | null
-        : S extends CoreCoListSchema<infer T>
-          ? CoList<InstanceOrPrimitiveOfSchemaCoValuesNullable<T>> | null
-          : S extends CoreCoFeedSchema<infer T>
-            ? CoFeed<InstanceOrPrimitiveOfSchemaCoValuesNullable<T>> | null
-            : S extends CorePlainTextSchema
-              ? CoPlainText | null
-              : S extends CoreRichTextSchema
-                ? CoRichText | null
-                : S extends CoreFileStreamSchema
-                  ? FileStream | null
-                  : S extends CoreCoOptionalSchema<infer Inner>
-                    ?
-                        | InstanceOrPrimitiveOfSchemaCoValuesNullable<Inner>
-                        | undefined
-                    : S extends CoreCoDiscriminatedUnionSchema<infer Members>
-                      ? InstanceOrPrimitiveOfSchemaCoValuesNullable<
-                          Members[number]
-                        >
-                      : never
+        : S extends CoreCoMapSchema<infer Shape, infer CatchAll>
+          ?
+              | ({
+                  readonly [key in keyof Shape]: InstanceOrPrimitiveOfSchemaCoValuesNullable<
+                    Shape[key]
+                  >;
+                } & (CatchAll extends AnyZodOrCoValueSchema
+                  ? {
+                      readonly [
+                        key: string
+                      ]: InstanceOrPrimitiveOfSchemaCoValuesNullable<CatchAll>;
+                    }
+                  : {}) &
+                  CoMap)
+              | null
+          : S extends CoreCoListSchema<infer T>
+            ? CoList<InstanceOrPrimitiveOfSchemaCoValuesNullable<T>> | null
+            : S extends CoreCoFeedSchema<infer T>
+              ? CoFeed<InstanceOrPrimitiveOfSchemaCoValuesNullable<T>> | null
+              : S extends CorePlainTextSchema
+                ? CoPlainText | null
+                : S extends CoreRichTextSchema
+                  ? CoRichText | null
+                  : S extends CoreFileStreamSchema
+                    ? FileStream | null
+                    : S extends CoreCoOptionalSchema<infer Inner>
+                      ?
+                          | InstanceOrPrimitiveOfSchemaCoValuesNullable<Inner>
+                          | undefined
+                      : S extends CoreCoDiscriminatedUnionSchema<infer Members>
+                        ? InstanceOrPrimitiveOfSchemaCoValuesNullable<
+                            Members[number]
+                          >
+                        : never
   : S extends CoValueClass
     ? InstanceType<S> | null
     : never;

--- a/packages/jazz-tools/src/tools/implementation/zodSchema/zodCo.ts
+++ b/packages/jazz-tools/src/tools/implementation/zodSchema/zodCo.ts
@@ -35,6 +35,10 @@ import {
   createCoreCoRichTextSchema,
 } from "./schemaTypes/RichTextSchema.js";
 import { z } from "./zodReExport.js";
+import {
+  createCoreGroupSchema,
+  GroupSchema,
+} from "./schemaTypes/GroupSchema.js";
 
 /**
  * Checking for the presence of the `_zod` property is the recommended way
@@ -123,6 +127,11 @@ export const coAccountDefiner = <Shape extends BaseAccountShape>(
   } as unknown as Shape,
 ): AccountSchema<Shape> => {
   const coreSchema = createCoreAccountSchema(shape);
+  return hydrateCoreCoValueSchema(coreSchema);
+};
+
+export const coGroupDefiner = (): GroupSchema => {
+  const coreSchema = createCoreGroupSchema();
   return hydrateCoreCoValueSchema(coreSchema);
 };
 

--- a/packages/jazz-tools/src/tools/implementation/zodSchema/zodSchema.ts
+++ b/packages/jazz-tools/src/tools/implementation/zodSchema/zodSchema.ts
@@ -43,6 +43,8 @@ import {
 } from "./schemaTypes/RichTextSchema.js";
 import { InstanceOfSchemaCoValuesNullable } from "./typeConverters/InstanceOfSchemaCoValuesNullable.js";
 import { z } from "./zodReExport.js";
+import { CoreGroupSchema } from "./schemaTypes/GroupSchema.js";
+import { GroupSchema } from "./schemaTypes/GroupSchema.js";
 
 export type ZodPrimitiveSchema =
   | z.core.$ZodString
@@ -57,25 +59,27 @@ export type CoValueClassOrSchema = CoValueClass | CoreCoValueSchema;
 export type CoValueSchemaFromCoreSchema<S extends CoreCoValueSchema> =
   S extends CoreAccountSchema<infer Shape extends BaseAccountShape>
     ? AccountSchema<Shape>
-    : S extends CoreCoRecordSchema<infer K, infer V>
-      ? CoRecordSchema<K, V>
-      : S extends CoreCoMapSchema<infer Shape, infer Config>
-        ? CoMapSchema<Shape, Config>
-        : S extends CoreCoListSchema<infer T>
-          ? CoListSchema<T>
-          : S extends CoreCoFeedSchema<infer T>
-            ? CoFeedSchema<T>
-            : S extends CorePlainTextSchema
-              ? PlainTextSchema
-              : S extends CoreRichTextSchema
-                ? RichTextSchema
-                : S extends CoreFileStreamSchema
-                  ? FileStreamSchema
-                  : S extends CoreCoOptionalSchema<infer Inner>
-                    ? CoOptionalSchema<Inner>
-                    : S extends CoreCoDiscriminatedUnionSchema<infer Members>
-                      ? CoDiscriminatedUnionSchema<Members>
-                      : never;
+    : S extends CoreGroupSchema
+      ? GroupSchema
+      : S extends CoreCoRecordSchema<infer K, infer V>
+        ? CoRecordSchema<K, V>
+        : S extends CoreCoMapSchema<infer Shape, infer Config>
+          ? CoMapSchema<Shape, Config>
+          : S extends CoreCoListSchema<infer T>
+            ? CoListSchema<T>
+            : S extends CoreCoFeedSchema<infer T>
+              ? CoFeedSchema<T>
+              : S extends CorePlainTextSchema
+                ? PlainTextSchema
+                : S extends CoreRichTextSchema
+                  ? RichTextSchema
+                  : S extends CoreFileStreamSchema
+                    ? FileStreamSchema
+                    : S extends CoreCoOptionalSchema<infer Inner>
+                      ? CoOptionalSchema<Inner>
+                      : S extends CoreCoDiscriminatedUnionSchema<infer Members>
+                        ? CoDiscriminatedUnionSchema<Members>
+                        : never;
 
 export type CoValueClassFromAnySchema<S extends CoValueClassOrSchema> =
   S extends CoValueClass<any>
@@ -92,6 +96,7 @@ type AccountClassEssentials = {
 export type AnyCoreCoValueSchema =
   | CoreCoMapSchema
   | CoreAccountSchema
+  | CoreGroupSchema
   | CoreCoRecordSchema
   | CoreCoListSchema
   | CoreCoFeedSchema

--- a/packages/jazz-tools/src/tools/tests/group.test.ts
+++ b/packages/jazz-tools/src/tools/tests/group.test.ts
@@ -59,5 +59,19 @@ describe("Group", () => {
       expectTypeOf(g.create).toBeCallableWith(Account.getMe());
       expectTypeOf(g.create).toBeCallableWith(undefined);
     });
+
+    it("should allow optional group fields in schemas", () => {
+      const Schema = co.map({
+        group: co.group().optional(),
+      });
+
+      const SchemaWithRequiredGroup = co.map({
+        group: co.group(),
+      });
+
+      expectTypeOf(Schema.create).toBeCallableWith({});
+      // @ts-expect-error - the group field is required
+      expectTypeOf(SchemaWithRequiredGroup.create).toBeCallableWith({});
+    });
   });
 });

--- a/packages/jazz-tools/src/tools/tests/group.test.ts
+++ b/packages/jazz-tools/src/tools/tests/group.test.ts
@@ -1,0 +1,63 @@
+import { beforeEach, describe, expect, expectTypeOf, it } from "vitest";
+import { Account, co, Group, Loaded, Ref } from "../internal";
+import { createJazzTestAccount, setupJazzTestSync } from "../testing";
+
+beforeEach(async () => {
+  await setupJazzTestSync();
+
+  await createJazzTestAccount({
+    isCurrentActiveAccount: true,
+  });
+});
+
+describe("Group", () => {
+  it("should create a group", () => {
+    const group = co.group().create();
+    expect(group).toBeDefined();
+
+    // Group methods are available , testing only for a few ones
+    expect(group.addMember).toBeDefined();
+    expect(group.removeMember).toBeDefined();
+    expect(group.getRoleOf).toBeDefined();
+    expect(group.makePublic).toBeDefined();
+  });
+
+  it("should make a group public", () => {
+    const group = co.group().create();
+    expect(group.getRoleOf("everyone")).toBeUndefined();
+
+    group.makePublic();
+    expect(group.getRoleOf("everyone")).toBe("reader");
+  });
+
+  describe("TypeScript", () => {
+    it("should correctly type the resolve query", async () => {
+      const group = co.group().create();
+      co.group().load(group.$jazz.id, {
+        resolve: {},
+      });
+      co.group().load(group.$jazz.id, {
+        resolve: true,
+      });
+
+      await expect(
+        co.group().load(group.$jazz.id, {
+          resolve: {
+            // @ts-expect-error - members is not a valid resolve query
+            members: {
+              $each: true,
+            },
+          },
+        }),
+      ).rejects.toThrow();
+    });
+
+    it("should correctly type the create function", () => {
+      const g = co.group();
+
+      expectTypeOf(g.create).toBeCallableWith({ owner: Account.getMe() });
+      expectTypeOf(g.create).toBeCallableWith(Account.getMe());
+      expectTypeOf(g.create).toBeCallableWith(undefined);
+    });
+  });
+});


### PR DESCRIPTION
# Description
exposes `co.group` as API to build schemas.

I've left out `fromRaw` from the Group static methods as it's ineternal, although i see other definer implement it (?).

Fixes https://github.com/garden-co/jazz/issues/2277

## Manual testing instructions

<!-- Add any actions required to manually test the changes -->

## Tests

- [x] Tests have been added and/or updated
- [ ] Tests have not been updated, because: <!-- Insert reason for not updating tests here -->
- [ ] I need help with writing tests


## Checklist

- [ ] I've updated the part of the docs that are affected the PR changes
- [x] I've generated a changeset, if a version bump is required
- [ ] I've updated the jsDoc comments to the public APIs I've modified, or added them when missing