### PR TITLE
Minor improvements to docs on recursive references

### DIFF
--- a/homepage/homepage/content/docs/schemas/covalues.mdx
+++ b/homepage/homepage/content/docs/schemas/covalues.mdx
@@ -377,7 +377,7 @@ const Person = co.map({
 
 #### Recursive References
 
-You can refer to the same schema from within itself using getters:
+You can wrap references in getters. This allows you to defer evaluation until the property is accessed. This technique is particularly useful for defining circular references, including recursive (self-referencing) schemas, or mutually recursive schemas. 
 
 <CodeGroup>
 ```ts twoslash
@@ -410,6 +410,8 @@ const ListOfPeople = co.list(Person);
 ```
 
 </CodeGroup>
+
+If you try to reference `ListOfPeople` in `Person` without using a getter, you'll run into a `ReferenceError` because of the [temporal dead zone](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/let#temporal_dead_zone_tdz).
 
 ### Helper methods
 

--- a/homepage/homepage/content/docs/using-covalues/comaps.mdx
+++ b/homepage/homepage/content/docs/using-covalues/comaps.mdx
@@ -185,7 +185,7 @@ if (project.coordinator) {
 
 ### Recursive references
 
-CoMaps can reference themselves recursively:
+You can wrap references in getters. This allows you to defer evaluation until the property is accessed. This technique is particularly useful for defining circular references, including recursive (self-referencing) schemas, or mutually recursive schemas. 
 
 <CodeGroup>
 ```ts twoslash


### PR DESCRIPTION
# Description
Expands wording around recursive references to include keywords like 'self-referencing' and 'circular' and 'ReferenceError' to improve discoverability through search.

## Manual testing instructions

N/A

## Tests

- [ ] Tests have been added and/or updated
- [ ] Tests have not been updated, because: Docs only.
- [ ] I need help with writing tests


## Checklist

- [ ] I've updated the part of the docs that are affected the PR changes
- [ ] I've generated a changeset, if a version bump is required
- [ ] I've updated the jsDoc comments to the public APIs I've modified, or added them when missing