### PR TITLE
chore: set pnpm minimum release age to 24 hours

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "starters/*",
     "crates/*"
   ],
-  "packageManager": "pnpm@9.15.0+sha512.76e2379760a4328ec4415815bcd6628dee727af3779aaa4c914e3944156c4299921a89f976381ee107d41f12cfa4b66681ca9c718f0668fa0831ed4c6d8ba56c",
+  "packageManager": "pnpm@10.16.1",
   "engines": {
     "node": ">=22.0.0"
   },

--- a/package.json
+++ b/package.json
@@ -85,9 +85,6 @@
       "sharp",
       "wasm-pack",
       "workerd"
-    ],
-    "ignoredBuiltDependencies": [
-      "react-native-nitro-modules"
     ]
   }
 }

--- a/package.json
+++ b/package.json
@@ -23,8 +23,8 @@
     "@vitest/ui": "catalog:default",
     "happy-dom": "^17.4.4",
     "jazz-run": "workspace:*",
-    "jazz-tools-codemod-0-18": "workspace:*",
     "jazz-tools": "workspace:*",
+    "jazz-tools-codemod-0-18": "workspace:*",
     "lefthook": "^1.8.2",
     "pkg-pr-new": "^0.0.39",
     "playwright": "^1.50.1",
@@ -66,6 +66,28 @@
       "react-dom": "catalog:react",
       "vite": "catalog:default",
       "esbuild": "0.24.0"
-    }
+    },
+    "onlyBuiltDependencies": [
+      "@biomejs/biome",
+      "@clerk/shared",
+      "@parcel/watcher",
+      "@swc/core",
+      "@tailwindcss/oxide",
+      "better-sqlite3",
+      "browser-tabs-lock",
+      "core-js",
+      "edgedriver",
+      "esbuild",
+      "geckodriver",
+      "lefthook",
+      "msw",
+      "react-native-nitro-modules",
+      "sharp",
+      "wasm-pack",
+      "workerd"
+    ],
+    "ignoredBuiltDependencies": [
+      "react-native-nitro-modules"
+    ]
   }
 }

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -6,6 +6,7 @@ packages:
   - 'crates/*'
   - 'bench'
 
+minimumReleaseAge: 1440 # 24 hours
 catalogs:
   default:
     "@biomejs/biome": 2.1.3


### PR DESCRIPTION
# Description
in light of recent security incidents on npm, ppdates pnpm to 10.16.1 and set `minimumReleaseAge` to 24 hours.

Compromised packages are usually detected and removed from the registry within a few hours, while it's def not a "we are safe now" solution, it should mitigate the risk a bit. we can also add exceptions for trusted packages in case we need more recent versions for a few of them.

## Manual testing instructions

<!-- Add any actions required to manually test the changes -->

## Tests

- [ ] Tests have been added and/or updated
- [ ] Tests have not been updated, because: <!-- Insert reason for not updating tests here -->
- [ ] I need help with writing tests


## Checklist

- [ ] I've updated the part of the docs that are affected the PR changes
- [ ] I've generated a changeset, if a version bump is required
- [ ] I've updated the jsDoc comments to the public APIs I've modified, or added them when missing