### PR TITLE
perf: optimize browser storage with meta preload and limiting the concurrency on load

### DIFF
--- a/packages/cojson-storage-indexeddb/src/idbClient.ts
+++ b/packages/cojson-storage-indexeddb/src/idbClient.ts
@@ -74,8 +74,21 @@ export class IDBClient implements DBClientInterfaceAsync {
     queryIndexedDbStore(this.db, "signatureAfter", (store) =>
       store.getAll(),
     ).then((rows) => {
+      if (rows.length === 0) {
+        return;
+      }
+
+      let currentSession = rows[0].ses;
+      let currentSignatures: SignatureAfterRow[] = [];
+
       for (const row of rows) {
-        this.signatureAfter.set(row.ses, row);
+        if (row.ses !== currentSession) {
+          this.signatureAfter.set(currentSession, currentSignatures);
+          currentSession = row.ses;
+          currentSignatures = [];
+        }
+
+        currentSignatures.push(row);
       }
     });
   }

--- a/packages/cojson-storage-indexeddb/src/tests/storage.indexeddb.test.ts
+++ b/packages/cojson-storage-indexeddb/src/tests/storage.indexeddb.test.ts
@@ -487,7 +487,6 @@ test("large coValue upload streaming", async () => {
     largeMap.set(key, value, "trusting");
   }
 
-  // TODO: Wait for storage to be updated
   await largeMap.core.waitForSync();
 
   const knownState = largeMap.core.knownState();

--- a/packages/cojson/src/queue/Semaphore.ts
+++ b/packages/cojson/src/queue/Semaphore.ts
@@ -1,0 +1,29 @@
+import { LinkedList } from "./LinkedList.js";
+
+export class Semaphore {
+  private permits: number;
+  private waitingQueue = new LinkedList<() => void>();
+
+  constructor(permits: number) {
+    this.permits = permits;
+  }
+
+  acquire(callback: () => void): void {
+    if (this.permits > 0) {
+      this.permits--;
+      callback();
+    } else {
+      this.waitingQueue.push(callback);
+    }
+  }
+
+  release(): void {
+    const next = this.waitingQueue.shift();
+
+    if (next) {
+      next();
+    } else {
+      this.permits++;
+    }
+  }
+}

--- a/packages/cojson/src/storage/sqlite/client.ts
+++ b/packages/cojson/src/storage/sqlite/client.ts
@@ -102,13 +102,10 @@ export class SQLiteClient implements DBClientInterfaceSync {
     }
   }
 
-  getSignatures(
-    sessionRowId: number,
-    firstNewTxIdx: number,
-  ): SignatureAfterRow[] {
+  getSignatures(sessionRowId: number): SignatureAfterRow[] {
     return this.db.query<SignatureAfterRow>(
-      "SELECT * FROM signatureAfter WHERE ses = ? AND idx >= ?",
-      [sessionRowId, firstNewTxIdx],
+      "SELECT * FROM signatureAfter WHERE ses = ?",
+      [sessionRowId],
     ) as SignatureAfterRow[];
   }
 

--- a/packages/cojson/src/storage/sqliteAsync/client.ts
+++ b/packages/cojson/src/storage/sqliteAsync/client.ts
@@ -102,13 +102,10 @@ export class SQLiteClientAsync implements DBClientInterfaceAsync {
     }
   }
 
-  async getSignatures(
-    sessionRowId: number,
-    firstNewTxIdx: number,
-  ): Promise<SignatureAfterRow[]> {
+  async getSignatures(sessionRowId: number): Promise<SignatureAfterRow[]> {
     return this.db.query<SignatureAfterRow>(
-      "SELECT * FROM signatureAfter WHERE ses = ? AND idx >= ?",
-      [sessionRowId, firstNewTxIdx],
+      "SELECT * FROM signatureAfter WHERE ses = ?",
+      [sessionRowId],
     );
   }
 

--- a/packages/cojson/src/storage/storageSync.ts
+++ b/packages/cojson/src/storage/storageSync.ts
@@ -2,7 +2,6 @@ import { UpDownCounter, metrics } from "@opentelemetry/api";
 import {
   createContentMessage,
   exceedsRecommendedSize,
-  getTransactionSize,
 } from "../coValueContentMessage.js";
 import {
   CoValueCore,
@@ -84,7 +83,7 @@ export class StorageApiSync implements StorageAPI {
 
     let contentStreaming = false;
     for (const sessionRow of allCoValueSessions) {
-      const signatures = this.dbClient.getSignatures(sessionRow.rowID, 0);
+      const signatures = this.dbClient.getSignatures(sessionRow.rowID);
 
       if (signatures.length > 0) {
         contentStreaming = true;

--- a/packages/cojson/src/storage/types.ts
+++ b/packages/cojson/src/storage/types.ts
@@ -83,10 +83,7 @@ export interface DBClientInterfaceAsync {
     toIdx: number,
   ): Promise<TransactionRow[]>;
 
-  getSignatures(
-    sessionRowId: number,
-    firstNewTxIdx: number,
-  ): Promise<SignatureAfterRow[]>;
+  getSignatures(sessionRowId: number): Promise<SignatureAfterRow[]>;
 
   addSessionUpdate({
     sessionUpdate,
@@ -135,7 +132,6 @@ export interface DBClientInterfaceSync {
 
   getSignatures(
     sessionRowId: number,
-    firstNewTxIdx: number,
   ): Pick<SignatureAfterRow, "idx" | "signature">[];
 
   addSessionUpdate({

--- a/packages/cojson/src/tests/StorageApiAsync.test.ts
+++ b/packages/cojson/src/tests/StorageApiAsync.test.ts
@@ -134,7 +134,12 @@ describe("StorageApiAsync", () => {
       const initialKnownState = storage.getKnownState(id);
       expect(initialKnownState).toEqual(emptyKnownState(id as `co_z${string}`));
 
-      await storage.load(id, callback, done);
+      await new Promise<void>((r) => {
+        storage.load(id, callback, (found) => {
+          done(found);
+          r();
+        });
+      });
 
       expect(done).toHaveBeenCalledWith(false);
       expect(callback).not.toHaveBeenCalled();
@@ -160,7 +165,12 @@ describe("StorageApiAsync", () => {
       const initialKnownState = storage.getKnownState(group.id);
       expect(initialKnownState).toEqual(emptyKnownState(group.id));
 
-      await storage.load(group.id, callback, done);
+      await new Promise<void>((r) => {
+        storage.load(group.id, callback, (found) => {
+          done(found);
+          r();
+        });
+      });
 
       expect(callback).toHaveBeenCalledWith(
         expect.objectContaining({
@@ -199,7 +209,12 @@ describe("StorageApiAsync", () => {
       const initialKnownState = storage.getKnownState(group.id);
       expect(initialKnownState).toEqual(emptyKnownState(group.id));
 
-      await storage.load(group.id, callback, done);
+      await new Promise<void>((r) => {
+        storage.load(group.id, callback, (found) => {
+          done(found);
+          r();
+        });
+      });
 
       expect(callback).toHaveBeenCalledWith(
         expect.objectContaining({
@@ -704,7 +719,12 @@ describe("StorageApiAsync", () => {
       expect(initialMapKnownState).toEqual(emptyKnownState(map.id));
 
       // Load the map, which should also load the group dependency first
-      await storage.load(map.id, callback, done);
+      await new Promise<void>((r) => {
+        storage.load(map.id, callback, (found) => {
+          done(found);
+          r();
+        });
+      });
 
       expect(callback).toHaveBeenCalledTimes(2); // Group first, then map
       expect(callback).toHaveBeenNthCalledWith(
@@ -756,7 +776,12 @@ describe("StorageApiAsync", () => {
       expect(initialMapKnownState).toEqual(emptyKnownState(map.id));
 
       // First load the group
-      await storage.load(group.id, callback, done);
+      await new Promise<void>((r) => {
+        storage.load(group.id, callback, (found) => {
+          done(found);
+          r();
+        });
+      });
       callback.mockClear();
       done.mockClear();
 
@@ -765,7 +790,12 @@ describe("StorageApiAsync", () => {
       expect(afterGroupLoad).toEqual(group.core.verified.knownState());
 
       // Then load the map - the group dependency should already be loaded
-      await storage.load(map.id, callback, done);
+      await new Promise<void>((r) => {
+        storage.load(map.id, callback, (found) => {
+          done(found);
+          r();
+        });
+      });
 
       // Should only call callback once for the map since group is already loaded
       expect(callback).toHaveBeenCalledTimes(1);


### PR DESCRIPTION
Loading 1k tasks.

Before:
<img width="955" height="197" alt="Screenshot 2025-09-17 at 18 34 20" src="https://github.com/user-attachments/assets/061627fc-6dd5-41dd-aa77-5e7fbefe3990" />

After:
<img width="575" height="121" alt="Screenshot 2025-09-17 at 18 33 47" src="https://github.com/user-attachments/assets/139c8b37-52d2-4e54-8a6b-30e28367ca95" />
