### PR TITLE
feat: optimize loading CoLists with lots of elements

### DIFF
--- a/packages/jazz-tools/src/tools/subscribe/index.ts
+++ b/packages/jazz-tools/src/tools/subscribe/index.ts
@@ -42,7 +42,7 @@ export function accessChildByKey<D extends CoValue>(
 ) {
   const subscriptionScope = getSubscriptionScope(parent);
 
-  if (!subscriptionScope.childValues.has(childId)) {
+  if (!subscriptionScope.isSubscribedToId(childId)) {
     subscriptionScope.subscribeToKey(key);
   }
 


### PR DESCRIPTION
# Description

Loading a CoList with 10k elements currently takes 8s on my Macbook M4. A lot of that time is spent on the SubscriptionScope. In particular, checking if updates should be fired while loading all CoList elements takes 2.5s:

<img width="1728" height="743" alt="before" src="https://github.com/user-attachments/assets/7b1a9950-9afc-4c19-b59c-5bf11201bfc2" />

Added a separate counter to keep track of unloaded children, in order to brush off that time  from the load:

<img width="1728" height="553" alt="after" src="https://github.com/user-attachments/assets/591dac76-cc65-4c57-9ba1-e76e15c79ba6" />

_Note:_ the first commit has a different optimization using a counter for keeping track of pending explicitly-loaded children. I'm not a fan of it, but if anyone's interested, feel free to take a look.

## Tests

- [x] Tests have not been updated, because: this is an optimization, it doesn't affect any functionality

## Checklist

- [ ] I've updated the part of the docs that are affected the PR changes
- [ ] I've generated a changeset, if a version bump is required
- [ ] I've updated the jsDoc comments to the public APIs I've modified, or added them when missing