### PR TITLE
Better Auth: logout from Jazz when Better Auth session is not valid

### DIFF
--- a/.changeset/many-geckos-wait.md
+++ b/.changeset/many-geckos-wait.md
@@ -1,0 +1,5 @@
+---
+"jazz-tools": patch
+---
+
+fix: keep sync between Better Auth's session and Jazz's

--- a/packages/jazz-tools/src/better-auth/auth/client.ts
+++ b/packages/jazz-tools/src/better-auth/auth/client.ts
@@ -122,9 +122,10 @@ export const jazzPluginClient = () => {
             if (context.request.url.toString().includes("/get-session")) {
               if (context.data === null) {
                 if (authSecretStorage.isAuthenticated === true) {
-                  console.warn(
-                    "Jazz is authenticated, but the session is null",
+                  console.info(
+                    "Jazz is authenticated, but the session is null. Logging out",
                   );
+                  await jazzContext.logOut();
                 }
                 return;
               }

--- a/packages/jazz-tools/src/better-auth/auth/tests/client.test.ts
+++ b/packages/jazz-tools/src/better-auth/auth/tests/client.test.ts
@@ -336,6 +336,28 @@ describe("Better-Auth client plugin", () => {
     );
   });
 
+  it("should log out from Jazz when the session is null", async () => {
+    const credentials = await authSecretStorage.get();
+    assert(credentials, "Jazz credentials are not available");
+
+    await jazzContextManager.authenticate({
+      ...credentials,
+      provider: "better-auth",
+    });
+    await authSecretStorage.set({
+      ...credentials,
+      provider: "better-auth",
+    });
+
+    expect(authSecretStorage.isAuthenticated).toBe(true);
+
+    customFetchImpl.mockResolvedValue(new Response(JSON.stringify(null)));
+
+    await authClient.getSession();
+
+    expect(authSecretStorage.isAuthenticated).toBe(false);
+  });
+
   describe("Race condition handling", () => {
     it("should handle multiple concurrent get-session calls without errors", async () => {
       const credentials = await authSecretStorage.get();


### PR DESCRIPTION
# Description
Initially, we designed to keep Jazz authenticated when Better Auth's sessions failed, in order to provide an offline-first approach against an online service.

This behaviour led us to two issues:
1. An unauthenticated user can't log out or delete the account from Better Auth, resulting in a UX problem
2. The BA's feature to revoke a session is not working as expected

In addition, the client plugin listens only to successful API calls. In offline contexts, it will never trigger the plugin's hook, causing no unwanted logouts.

In this PR, we call the Jazz.logout function if Better Auth's getSession returns null (unauthenticated user).

## Tests

- [x] Tests have been added and/or updated

## Checklist

- [ ] I've updated the part of the docs that are affected the PR changes
- [x] I've generated a changeset, if a version bump is required
- [ ] I've updated the jsDoc comments to the public APIs I've modified, or added them when missing