### PR TITLE
fix: missing edge-lite script

### DIFF
--- a/.changeset/loud-files-kick.md
+++ b/.changeset/loud-files-kick.md
@@ -1,0 +1,5 @@
+---
+"cojson-core-wasm": patch
+---
+
+Missing `edge-lite.js` script in pkg

--- a/crates/cojson-core-wasm/package.json
+++ b/crates/cojson-core-wasm/package.json
@@ -8,6 +8,7 @@
     "public/cojson_core_wasm.wasm.js",
     "public/cojson_core_wasm.wasm.d.ts",
     "public/cojson_core_wasm.wasm",
+    "edge-lite.js",
     "index.js",
     "index.d.ts"
   ],


### PR DESCRIPTION
This pr fixes the missing of `edge-life.js` file
```
[1]   ✘ [ERROR] Could not resolve "cojson-core-wasm/edge-lite"
[1]
[1]       ../../node_modules/cojson/dist/crypto/WasmCryptoEdge.js:1:27:
[1]         1 │ import { initialize } from "cojson-core-wasm/edge-lite";
[1]           ╵                            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
[1]
[1]     The module "./edge-lite.js" was not found on the file system:
[1]
[1]       ../../node_modules/cojson-core-wasm/package.json:22:17:
[1]         22 │       "default": "./edge-lite.js",
[1]            ╵                  ~~~~~~~~~~~~~~~~
```

## Manual testing instructions

<!-- Add any actions required to manually test the changes -->

## Tests

- [ ] Tests have been added and/or updated
- [ ] Tests have not been updated, because: <!-- Insert reason for not updating tests here -->
- [ ] I need help with writing tests


## Checklist

- [ ] I've updated the part of the docs that are affected the PR changes
- [ ] I've generated a changeset, if a version bump is required
- [ ] I've updated the jsDoc comments to the public APIs I've modified, or added them when missing