### PR TITLE
fix: keep the subscription off when creating new values

### DIFF
--- a/.changeset/neat-pigs-bake.md
+++ b/.changeset/neat-pigs-bake.md
@@ -1,0 +1,5 @@
+---
+"jazz-tools": patch
+---
+
+Optimized the inactive subscriptions, improving performance of updates on created and loaded values by 2.5x

--- a/packages/jazz-tools/src/tools/subscribe/CoValueCoreSubscription.ts
+++ b/packages/jazz-tools/src/tools/subscribe/CoValueCoreSubscription.ts
@@ -41,6 +41,16 @@ export class CoValueCoreSubscription {
     this.initializeSubscription();
   }
 
+  rehydrate() {
+    if (!this.unsubscribed) {
+      return;
+    }
+
+    this.unsubscribed = false;
+    this.initializeSubscription();
+    this.unsubscribe();
+  }
+
   /**
    * Main entry point for subscription initialization.
    * Determines the subscription strategy based on current availability and branch requirements.

--- a/packages/jazz-tools/src/tools/subscribe/CoValueCoreSubscription.ts
+++ b/packages/jazz-tools/src/tools/subscribe/CoValueCoreSubscription.ts
@@ -41,11 +41,15 @@ export class CoValueCoreSubscription {
     this.initializeSubscription();
   }
 
-  rehydrate() {
+  /**
+   * Rehydrates the subscription by resetting the unsubscribed flag and initializing the subscription again
+   */
+  pullValue() {
     if (!this.unsubscribed) {
       return;
     }
 
+    // Reset the unsubscribed flag so we can initialize the subscription again
     this.unsubscribed = false;
     this.initializeSubscription();
     this.unsubscribe();

--- a/packages/jazz-tools/src/tools/subscribe/SubscriptionScope.ts
+++ b/packages/jazz-tools/src/tools/subscribe/SubscriptionScope.ts
@@ -405,7 +405,7 @@ export class SubscriptionScope<D extends CoValue> {
    */
   pullValue(listener: (value: SubscriptionValue<D, any>) => void) {
     if (!this.closed) {
-      throw new Error("Cannot rehydrate a non-closed subscription scope");
+      throw new Error("Cannot pull a non-closed subscription scope");
     }
 
     if (this.value.type === "loaded") {
@@ -431,7 +431,7 @@ export class SubscriptionScope<D extends CoValue> {
 
   subscribeToId(id: string, descriptor: RefEncoded<any>) {
     if (this.isSubscribedToId(id)) {
-      if (this.closed !== true) {
+      if (!this.closed) {
         return;
       }
 

--- a/packages/jazz-tools/src/tools/subscribe/index.ts
+++ b/packages/jazz-tools/src/tools/subscribe/index.ts
@@ -49,7 +49,7 @@ export function accessChildByKey<D extends CoValue>(
   if (!subscriptionScope.isSubscribedToId(childId)) {
     subscriptionScope.subscribeToKey(key);
   } else if (node && node.closed) {
-    node.rehydrate((value) =>
+    node.pullValue((value) =>
       subscriptionScope.handleChildUpdate(childId, value),
     );
   }

--- a/packages/jazz-tools/src/tools/subscribe/index.ts
+++ b/packages/jazz-tools/src/tools/subscribe/index.ts
@@ -24,6 +24,8 @@ export function getSubscriptionScope<D extends CoValue>(value: D) {
     configurable: false,
   });
 
+  newSubscriptionScope.destroy();
+
   return newSubscriptionScope;
 }
 
@@ -42,8 +44,14 @@ export function accessChildByKey<D extends CoValue>(
 ) {
   const subscriptionScope = getSubscriptionScope(parent);
 
+  const node = subscriptionScope.childNodes.get(childId);
+
   if (!subscriptionScope.isSubscribedToId(childId)) {
     subscriptionScope.subscribeToKey(key);
+  } else if (node && node.closed) {
+    node.rehydrate((value) =>
+      subscriptionScope.handleChildUpdate(childId, value),
+    );
   }
 
   const value = subscriptionScope.childValues.get(childId);


### PR DESCRIPTION
Optimized the inactive subscriptions (anything from .load and .create or unsubscribed subscriptions) to not listen to updates to their childs.

Should fix also a memory leak when autoloading on inactive subscriptions.

Filling 1k tasks list

Before:
<img width="538" height="539" alt="Screenshot 2025-09-22 at 19 22 09" src="https://github.com/user-attachments/assets/456b0908-a3c1-4a96-8564-e263398c81a7" />

After:
<img width="362" height="97" alt="Screenshot 2025-09-22 at 19 17 26" src="https://github.com/user-attachments/assets/007b09d9-18d4-4045-81f3-2d3ab67f25ea" />
 