### PR TITLE
feat(jazz-tools): CoVector properly extends Float32Array w/o Proxy

### DIFF
--- a/packages/jazz-tools/src/tools/coValues/coVector.ts
+++ b/packages/jazz-tools/src/tools/coValues/coVector.ts
@@ -281,41 +281,6 @@ export class CoVector extends Float32Array implements CoValue {
     return subscribeToCoValueWithoutMe<V, R>(this, id, options, listener);
   }
 
-  // Vector operations
-  /**
-   * Calculate the magnitude of this vector.
-   */
-  magnitude(): number {
-    return VectorCalculation.magnitude(this);
-  }
-
-  /**
-   * Normalize this vector.
-   * @returns A new instance of a normalized vector.
-   */
-  normalize(): Float32Array {
-    return VectorCalculation.normalize(this);
-  }
-
-  /**
-   * Calculate the dot product of this vector and another vector.
-   */
-  dotProduct(otherVector: CoVector | Float32Array): number {
-    return VectorCalculation.dotProduct(this, otherVector);
-  }
-
-  /**
-   * Calculate the cosine similarity between this vector and another vector.
-   *
-   * @returns A value between `-1` and `1`:
-   * - `1` means the vectors are identical
-   * - `0` means the vectors are orthogonal (i.e. no similarity)
-   * - `-1` means the vectors are opposite direction (perfectly dissimilar)
-   */
-  cosineSimilarity(otherVector: CoVector | Float32Array): number {
-    return VectorCalculation.cosineSimilarity(this, otherVector);
-  }
-
   // CoVector mutation method overrides, as CoVectors aren't meant to be mutated
   /**
    * Calling `copyWithin` on a CoVector is forbidden. CoVectors are immutable.
@@ -384,6 +349,41 @@ export class CoVectorJazzApi<V extends CoVector> extends CoValueJazzApi<V> {
    */
   waitForSync(options?: { timeout?: number }) {
     return this.raw.core.waitForSync(options);
+  }
+
+  // Vector operations
+  /**
+   * Calculate the magnitude of this vector.
+   */
+  magnitude(): number {
+    return VectorCalculation.magnitude(this.coVector);
+  }
+
+  /**
+   * Normalize this vector.
+   * @returns A new instance of a normalized vector.
+   */
+  normalize(): Float32Array {
+    return VectorCalculation.normalize(this.coVector);
+  }
+
+  /**
+   * Calculate the dot product of this vector and another vector.
+   */
+  dotProduct(otherVector: CoVector | Float32Array): number {
+    return VectorCalculation.dotProduct(this.coVector, otherVector);
+  }
+
+  /**
+   * Calculate the cosine similarity between this vector and another vector.
+   *
+   * @returns A value between `-1` and `1`:
+   * - `1` means the vectors are identical
+   * - `0` means the vectors are orthogonal (i.e. no similarity)
+   * - `-1` means the vectors are opposite direction (perfectly dissimilar)
+   */
+  cosineSimilarity(otherVector: CoVector | Float32Array): number {
+    return VectorCalculation.cosineSimilarity(this.coVector, otherVector);
   }
 }
 

--- a/packages/jazz-tools/src/tools/coValues/coVector.ts
+++ b/packages/jazz-tools/src/tools/coValues/coVector.ts
@@ -611,14 +611,6 @@ export class CoVectorJazzApi<V extends CoVector> extends CoValueJazzApi<V> {
     super(coVector);
   }
 
-  /**
-   * The ID of this `CoVector`
-   * @category Content
-   */
-  get id(): ID<V> {
-    return this.raw.id;
-  }
-
   get owner(): Group {
     return getCoValueOwner(this.coVector);
   }

--- a/packages/jazz-tools/src/tools/coValues/coVector.ts
+++ b/packages/jazz-tools/src/tools/coValues/coVector.ts
@@ -1,0 +1,696 @@
+import type { RawBinaryCoStream } from "cojson";
+import { cojsonInternals } from "cojson";
+import {
+  AnonymousJazzAgent,
+  CoValue,
+  CoValueClass,
+  getCoValueOwner,
+  Group,
+  ID,
+  RefsToResolve,
+  Resolved,
+  SubscribeListenerOptions,
+  SubscribeRestArgs,
+  TypeSym,
+} from "../internal.js";
+import {
+  Account,
+  CoValueJazzApi,
+  inspect,
+  loadCoValueWithoutMe,
+  parseCoValueCreateOptions,
+  parseSubscribeRestArgs,
+  subscribeToCoValueWithoutMe,
+  subscribeToExistingCoValue,
+} from "../internal.js";
+
+/**
+ * CoVectors are collaborative storages of vectors (floating point arrays).
+ *
+ * @category CoValues
+ */
+export class CoVector extends Float32Array implements CoValue {
+  declare $jazz: CoVectorJazzApi<this>;
+
+  /** @category Type Helpers */
+  declare [TypeSym]: "BinaryCoStream";
+
+  static get [Symbol.species]() {
+    return Float32Array;
+  }
+
+  static requiredDimensionsCount: number | undefined = undefined;
+  declare _loadedVector: Float32Array | null;
+
+  constructor(
+    options:
+      | {
+          owner: Account | Group;
+        }
+      | {
+          fromRaw: RawBinaryCoStream;
+        },
+  ) {
+    super();
+
+    const proxy = new Proxy(this, CoVectorProxyHandler as ProxyHandler<this>);
+
+    let raw: RawBinaryCoStream;
+
+    if ("fromRaw" in options) {
+      raw = options.fromRaw;
+    } else {
+      const rawOwner = options.owner.$jazz.raw;
+      raw = rawOwner.createBinaryStream();
+    }
+
+    Object.defineProperties(this, {
+      [TypeSym]: { value: "BinaryCoStream", enumerable: false },
+      $jazz: {
+        value: new CoVectorJazzApi(proxy, raw),
+        enumerable: false,
+      },
+      _loadedVector: { value: null, enumerable: false, writable: true },
+    });
+
+    return proxy;
+  }
+
+  /** @category Internals */
+  static fromRaw<V extends CoVector>(
+    this: CoValueClass<V> & typeof CoVector,
+    raw: RawBinaryCoStream,
+  ) {
+    return new this({ fromRaw: raw });
+  }
+
+  /**
+   * Create a new `CoVector` instance with the given vector.
+   *
+   * @category Creation
+   * @deprecated Use `co.vector(...).create` instead.
+   */
+  static create<S extends CoVector>(
+    this: CoValueClass<S> & { requiredDimensionsCount: number | undefined },
+    vector: number[] | Float32Array,
+    options?: { owner?: Account | Group } | Account | Group,
+  ) {
+    const vectorAsFloat32Array =
+      vector instanceof Float32Array ? vector : new Float32Array(vector);
+
+    const givenVectorDimensions =
+      vectorAsFloat32Array.byteLength / vectorAsFloat32Array.BYTES_PER_ELEMENT;
+
+    if (
+      this.requiredDimensionsCount !== undefined &&
+      givenVectorDimensions !== this.requiredDimensionsCount
+    ) {
+      throw new Error(
+        `Vector dimension mismatch! Expected ${this.requiredDimensionsCount} dimensions, got ${
+          givenVectorDimensions
+        }`,
+      );
+    }
+
+    const coVector = new this(parseCoValueCreateOptions(options));
+    coVector._loadedVector = vectorAsFloat32Array;
+
+    const byteArray = CoVector.toByteArray(vectorAsFloat32Array);
+
+    coVector.$jazz.raw.startBinaryStream({
+      mimeType: "application/vector+octet-stream",
+      totalSizeBytes: byteArray.byteLength,
+    });
+
+    const chunkSize =
+      cojsonInternals.TRANSACTION_CONFIG.MAX_RECOMMENDED_TX_SIZE;
+
+    // Although most embedding vectors are small
+    // (3072-dimensional vector is only 12,288 bytes),
+    // we should still chunk the data to avoid transaction size limits
+    for (let idx = 0; idx < byteArray.length; idx += chunkSize) {
+      coVector.$jazz.raw.pushBinaryStreamChunk(
+        byteArray.slice(idx, idx + chunkSize),
+      );
+    }
+    coVector.$jazz.raw.endBinaryStream();
+
+    return coVector;
+  }
+
+  static toByteArray(vector: Float32Array): Uint8Array {
+    // zero copy view of the vector bytes
+    return new Uint8Array(vector.buffer, vector.byteOffset, vector.byteLength);
+  }
+
+  static fromByteArray(bytesChunks: Uint8Array[]): Float32Array {
+    const total = bytesChunks.reduce((acc, c) => acc + c.byteLength, 0);
+
+    if (total % 4 !== 0)
+      throw new Error("[INTERNAL] Total byte length must be multiple of 4");
+
+    const u8 = new Uint8Array(total);
+    let off = 0;
+
+    for (const c of bytesChunks) {
+      u8.set(c, off);
+      off += c.byteLength;
+    }
+
+    return new Float32Array(u8.buffer, u8.byteOffset, total / 4);
+  }
+
+  get requiredDimensionsCount(): number | undefined {
+    return (this.constructor as typeof CoVector).requiredDimensionsCount;
+  }
+
+  get vector(): Float32Array {
+    if (this._loadedVector !== null) {
+      return this._loadedVector;
+    }
+
+    const chunks = this.$jazz.raw.getBinaryChunks();
+
+    if (!chunks) {
+      // This should never happen
+      throw new Error(`CoVector '${this.$jazz.raw.id}' is not loaded`);
+    }
+
+    const vector = CoVector.fromByteArray(chunks.chunks);
+
+    if (
+      this.requiredDimensionsCount !== undefined &&
+      vector.length !== this.requiredDimensionsCount
+    ) {
+      throw new Error(
+        `Vector dimension mismatch! CoVector '${this.$jazz.raw.id}' loaded with ${vector.length} dimensions, but the schema requires ${this.requiredDimensionsCount} dimensions`,
+      );
+    }
+
+    this._loadedVector = vector;
+
+    return vector;
+  }
+
+  /**
+   * Get a JSON representation of the `CoVector`
+   * @category Content
+   */
+  toJSON(): Array<number> {
+    return Array.from(this.vector);
+  }
+
+  valueOf() {
+    return this.vector as this;
+  }
+
+  /** @internal */
+  [inspect]() {
+    return this.toJSON();
+  }
+
+  [Symbol.toPrimitive]() {
+    return this.vector;
+  }
+
+  /**
+   * Load a `CoVector`
+   *
+   * @category Subscription & Loading
+   * @deprecated Use `co.vector(...).load` instead.
+   */
+  static async load<C extends CoVector>(
+    this: CoValueClass<C>,
+    id: ID<C>,
+    options?: {
+      loadAs?: Account | AnonymousJazzAgent;
+    },
+  ): Promise<CoVector | null> {
+    const coVector = await loadCoValueWithoutMe(this, id, options);
+
+    /**
+     * We are only interested in the entire vector. Since most vectors are small (<15kB),
+     * we can wait for the stream to be complete before returning the vector
+     */
+    if (!coVector?.$jazz.raw.isBinaryStreamEnded()) {
+      return new Promise<CoVector>((resolve) => {
+        subscribeToCoValueWithoutMe(
+          this,
+          id,
+          options || {},
+          (value, unsubscribe) => {
+            if (value.$jazz.raw.isBinaryStreamEnded()) {
+              unsubscribe();
+              resolve(value);
+            }
+          },
+        );
+      });
+    }
+
+    return coVector;
+  }
+
+  /**
+   * Subscribe to a `CoVector`, when you have an ID but don't have a `CoVector` instance yet
+   * @category Subscription & Loading
+   * @deprecated Use `co.vector(...).subscribe` instead.
+   */
+  static subscribe<V extends CoVector, const R extends RefsToResolve<V>>(
+    this: CoValueClass<V>,
+    id: ID<V>,
+    listener: (value: Resolved<V, R>, unsubscribe: () => void) => void,
+  ): () => void;
+  static subscribe<V extends CoVector, const R extends RefsToResolve<V>>(
+    this: CoValueClass<V>,
+    id: ID<V>,
+    options: SubscribeListenerOptions<V, R>,
+    listener: (value: Resolved<V, R>, unsubscribe: () => void) => void,
+  ): () => void;
+  static subscribe<V extends CoVector, const R extends RefsToResolve<V>>(
+    this: CoValueClass<V>,
+    id: ID<V>,
+    ...args: SubscribeRestArgs<V, R>
+  ): () => void {
+    const { options, listener } = parseSubscribeRestArgs(args);
+    return subscribeToCoValueWithoutMe<V, R>(this, id, options, listener);
+  }
+
+  // Vector operations
+  /**
+   * Calculate the magnitude of a vector.
+   */
+  static magnitude(vector: Float32Array | CoVector): number {
+    return Math.sqrt(vector.reduce((s, x) => s + x * x, 0));
+  }
+
+  /**
+   * Calculate the magnitude of this vector.
+   */
+  magnitude(): number {
+    return CoVector.magnitude(this.vector);
+  }
+
+  /**
+   * Normalize a vector.
+   * @returns A new instance of a normalized vector.
+   */
+  static normalize(vector: Float32Array | CoVector): Float32Array {
+    const mag = CoVector.magnitude(vector);
+
+    if (mag === 0) {
+      return new Float32Array(vector.length).fill(0);
+    }
+
+    return vector.map((v) => v / mag);
+  }
+
+  /**
+   * Normalize this vector.
+   * @returns A new instance of a normalized vector.
+   */
+  normalize(): Float32Array {
+    return CoVector.normalize(this.vector);
+  }
+
+  /**
+   * Calculate the dot product of two vectors.
+   */
+  static dotProduct(
+    vectorA: Float32Array | CoVector,
+    vectorB: Float32Array | CoVector,
+  ): number {
+    if (vectorA.length !== vectorB.length) {
+      throw new Error(
+        `Vector dimensions don't match: ${vectorA.length} vs ${vectorB.length}`,
+      );
+    }
+
+    // @ts-expect-error vectorB[i] is not undefined because of the previous check
+    return vectorA.reduce((sum, a, i) => sum + a * vectorB[i], 0);
+  }
+
+  /**
+   * Calculate the dot product of this vector and another vector.
+   */
+  dotProduct(otherVector: CoVector | Float32Array): number {
+    return CoVector.dotProduct(this.vector, otherVector);
+  }
+
+  /**
+   * Calculate the cosine similarity between two vectors.
+   *
+   * @returns A value between `-1` and `1`:
+   * - `1` means the vectors are identical
+   * - `0` means the vectors are orthogonal (i.e. no similarity)
+   * - `-1` means the vectors are opposite direction (perfectly dissimilar)
+   */
+  static cosineSimilarity(
+    vectorA: CoVector | Float32Array,
+    vectorB: CoVector | Float32Array,
+  ): number {
+    const magnitudeA = CoVector.magnitude(vectorA);
+    const magnitudeB = CoVector.magnitude(vectorB);
+
+    if (magnitudeA === 0 || magnitudeB === 0) {
+      return 0;
+    }
+
+    const dotProductAB = CoVector.dotProduct(vectorA, vectorB);
+    return dotProductAB / (magnitudeA * magnitudeB);
+  }
+
+  /**
+   * Calculate the cosine similarity between this vector and another vector.
+   *
+   * @returns A value between `-1` and `1`:
+   * - `1` means the vectors are identical
+   * - `0` means the vectors are orthogonal (i.e. no similarity)
+   * - `-1` means the vectors are opposite direction (perfectly dissimilar)
+   */
+  cosineSimilarity(otherVector: CoVector | Float32Array): number {
+    return CoVector.cosineSimilarity(this.vector, otherVector);
+  }
+
+  /**
+   * Check if this vector is equal to another vector.
+   */
+  equals(otherVector: CoVector | Float32Array): boolean {
+    return this.vector.every((value, index) => value === otherVector[index]);
+  }
+
+  // CoVector instance properties
+  get length(): number {
+    return this.vector.length;
+  }
+  get buffer(): ArrayBuffer {
+    return this.vector.buffer as ArrayBuffer;
+  }
+  get byteOffset(): number {
+    return this.vector.byteOffset;
+  }
+  get byteLength(): number {
+    return this.vector.byteLength;
+  }
+  [Symbol.iterator](): ArrayIterator<number> {
+    return this.vector[Symbol.iterator]();
+  }
+
+  // CoVector getters & Float32Array-like allowed methods
+  override at(index: number): number | undefined {
+    return this.vector.at(index);
+  }
+
+  override entries() {
+    return this.vector.entries();
+  }
+
+  override every(
+    predicate: (value: number, index: number, array: this) => unknown,
+    thisArg?: any,
+  ): boolean {
+    return this.vector.every(predicate as any, thisArg);
+  }
+
+  override filter(
+    predicate: (value: number, index: number, array: this) => boolean,
+    thisArg?: any,
+  ) {
+    return this.vector.filter(predicate as any, thisArg);
+  }
+
+  override find(
+    predicate: (value: number, index: number, array: this) => boolean,
+    thisArg?: any,
+  ): number | undefined {
+    return this.vector.find(predicate as any, thisArg);
+  }
+
+  override findIndex(
+    predicate: (value: number, index: number, array: this) => boolean,
+    thisArg?: any,
+  ): number {
+    return this.vector.findIndex(predicate as any, thisArg);
+  }
+
+  override findLast(
+    predicate: (value: number, index: number, array: this) => boolean,
+    thisArg?: any,
+  ): number | undefined {
+    return this.vector.findLast(predicate as any, thisArg);
+  }
+
+  override findLastIndex(
+    predicate: (value: number, index: number, array: this) => boolean,
+    thisArg?: any,
+  ): number {
+    return this.vector.findLastIndex(predicate as any, thisArg);
+  }
+
+  override forEach(
+    callbackFn: (value: number, index: number, array: this) => void,
+    thisArg?: any,
+  ): void {
+    return this.vector.forEach(callbackFn as any, thisArg);
+  }
+
+  override includes(value: number): boolean {
+    return this.vector.includes(value);
+  }
+
+  override indexOf(value: number): number {
+    return this.vector.indexOf(value);
+  }
+
+  override join(value?: string): string {
+    return this.vector.join(value);
+  }
+
+  override keys(): ArrayIterator<number> {
+    return this.vector.keys();
+  }
+
+  override lastIndexOf(value: number): number {
+    return this.vector.lastIndexOf(value);
+  }
+
+  override map(
+    callbackfn: (value: number, index: number, array: this) => number,
+    thisArg?: any,
+  ) {
+    return this.vector.map(callbackfn as any, thisArg);
+  }
+
+  reduce(
+    callbackfn: (
+      previousValue: number,
+      currentValue: number,
+      currentIndex: number,
+      array: this,
+    ) => number,
+    initialValue?: number,
+  ): number {
+    return (this.vector as any).reduce(
+      callbackfn as any,
+      initialValue as any,
+    ) as number;
+  }
+
+  reduceRight(
+    callbackfn: (
+      previousValue: number,
+      currentValue: number,
+      currentIndex: number,
+      array: this,
+    ) => number,
+    initialValue?: number,
+  ): number {
+    return (this.vector as any).reduceRight(
+      callbackfn as any,
+      initialValue as any,
+    ) as number;
+  }
+
+  override slice(start?: number, end?: number) {
+    return this.vector.slice(start, end);
+  }
+
+  override some(
+    predicate: (value: number, index: number, array: this) => unknown,
+    thisArg?: any,
+  ): boolean {
+    return this.vector.some(predicate as any, thisArg);
+  }
+
+  override toLocaleString(
+    locales?: string | string[],
+    options?: Intl.NumberFormatOptions,
+  ): string {
+    if (locales === undefined) {
+      return this.vector.toLocaleString();
+    }
+    return this.vector.toLocaleString(locales, options);
+  }
+
+  override toReversed() {
+    return this.vector.toReversed();
+  }
+
+  override toSorted(compareFn?: (a: number, b: number) => number) {
+    return this.vector.toSorted(compareFn);
+  }
+
+  override toString(): string {
+    return this.vector.toString();
+  }
+
+  override values(): ArrayIterator<number> {
+    return this.vector.values();
+  }
+
+  // CoVector setters & mutators overrides, as CoVectors aren't meant to be mutated
+  /**
+   * Calling `copyWithin` on a CoVector is forbidden. CoVectors are immutable.
+   * @deprecated If you want to change the vector, replace the former instance of CoVector with a new one.
+   */
+  override copyWithin(target: number, start: number, end?: number): never {
+    throw new Error("Cannot mutate a CoVector using `copyWithin`");
+  }
+  /**
+   * Calling `fill` on a CoVector is forbidden. CoVectors are immutable.
+   * @deprecated If you want to change the vector, replace the former instance of CoVector with a new one.
+   */
+  override fill(value: number, start?: number, end?: number): never {
+    throw new Error("Cannot mutate a CoVector using `fill`");
+  }
+  /**
+   * Calling `reverse` on a CoVector is forbidden. CoVectors are immutable.
+   * @deprecated If you want to change the vector, replace the former instance of CoVector with a new one.
+   */
+  override reverse(): never {
+    throw new Error("Cannot mutate a CoVector using `reverse`");
+  }
+  /**
+   * Calling `set` on a CoVector is forbidden. CoVectors are immutable.
+   * @deprecated If you want to change the vector, replace the former instance of CoVector with a new one.
+   */
+  override set(array: ArrayLike<number>, offset?: number): never {
+    throw new Error("Cannot mutate a CoVector using `set`");
+  }
+  /**
+   * Calling `sort` on a CoVector is forbidden. CoVectors are immutable.
+   * @deprecated If you want to change the vector, replace the former instance of CoVector with a new one.
+   */
+  override sort(compareFn?: (a: number, b: number) => number): never {
+    throw new Error("Cannot mutate a CoVector using `sort`");
+  }
+  /**
+   * Calling `subarray` on a CoVector is forbidden. CoVectors are immutable.
+   * @deprecated If you want to change the vector, replace the former instance of CoVector with a new one.
+   */
+  override subarray(begin?: number, end?: number): never {
+    throw new Error("Cannot mutate a CoVector using `subarray`");
+  }
+  /**
+   * Calling `with` on a CoVector is forbidden. CoVectors are immutable.
+   * @deprecated If you want to change the vector, replace the former instance of CoVector with a new one.
+   */
+  override with(index: number, value: number): never {
+    throw new Error("Cannot mutate a CoVector using `with`");
+  }
+}
+
+export class CoVectorJazzApi<V extends CoVector> extends CoValueJazzApi<V> {
+  constructor(
+    private coVector: V,
+    public raw: RawBinaryCoStream,
+  ) {
+    super(coVector);
+  }
+
+  /**
+   * The ID of this `CoVector`
+   * @category Content
+   */
+  get id(): ID<V> {
+    return this.raw.id;
+  }
+
+  get owner(): Group {
+    return getCoValueOwner(this.coVector);
+  }
+
+  /**
+   * An instance method to subscribe to an existing `CoVector`
+   * @category Subscription & Loading
+   */
+  subscribe<B extends CoVector>(
+    this: CoVectorJazzApi<B>,
+    listener: (value: Resolved<B, true>) => void,
+  ): () => void {
+    return subscribeToExistingCoValue(this.coVector, {}, listener);
+  }
+
+  /**
+   * Wait for the `CoVector` to be uploaded to the other peers.
+   *
+   * @category Subscription & Loading
+   */
+  waitForSync(options?: { timeout?: number }) {
+    return this.raw.core.waitForSync(options);
+  }
+}
+
+const CoVectorProxyHandler: ProxyHandler<CoVector> = {
+  get(target, key, receiver) {
+    if (typeof key === "string" && !isNaN(+key)) {
+      return target.at(Number(key));
+    } else {
+      return Reflect.get(target, key, receiver);
+    }
+  },
+  set(target, key, value, receiver) {
+    if (typeof key === "string" && !isNaN(+key)) {
+      throw new Error("Cannot mutate a CoVector.");
+    } else {
+      return Reflect.set(target, key, value, receiver);
+    }
+  },
+  has(target, key) {
+    if (typeof key === "string" && !isNaN(+key)) {
+      const length = target.length;
+      return Number(key) >= 0 && Number(key) < length;
+    } else {
+      return Reflect.has(target, key);
+    }
+  },
+  ownKeys(target) {
+    const keys = Reflect.ownKeys(target);
+
+    const data = target.vector;
+    if (data) {
+      // Add numeric indices for all entries in the vector
+      const indexKeys = Array.from({ length: data.length }, (_, i) =>
+        String(i),
+      );
+      keys.push(...indexKeys);
+    }
+
+    return keys;
+  },
+  getOwnPropertyDescriptor(target, key) {
+    if (typeof key === "string" && !isNaN(+key)) {
+      const i = +key;
+      if (i >= 0 && i < target.length) {
+        return {
+          value: target.vector[i],
+          enumerable: true,
+          configurable: true,
+          writable: false, // CoVectors are immutable
+        };
+      }
+    } else if (key in target) {
+      return Reflect.getOwnPropertyDescriptor(target, key);
+    }
+  },
+};

--- a/packages/jazz-tools/src/tools/coValues/coVector.ts
+++ b/packages/jazz-tools/src/tools/coValues/coVector.ts
@@ -127,8 +127,7 @@ export class CoVector extends Float32Array implements CoValue {
     }
 
     const coVector = new this(parseCoValueCreateOptions(options));
-    coVector.set(vectorAsFloat32Array, 0);
-    coVector._isVectorLoaded = true;
+    coVector.setVectorData(vectorAsFloat32Array);
 
     const byteArray = CoVector.toByteArray(vectorAsFloat32Array);
 
@@ -195,10 +194,14 @@ export class CoVector extends Float32Array implements CoValue {
       );
     }
 
-    super.set(vector, 0);
-    this._isVectorLoaded = true;
+    this.setVectorData(vector);
 
     return;
+  }
+
+  private setVectorData(vector: Float32Array): void {
+    super.set(vector, 0);
+    this._isVectorLoaded = true;
   }
 
   /**
@@ -311,6 +314,43 @@ export class CoVector extends Float32Array implements CoValue {
    */
   cosineSimilarity(otherVector: CoVector | Float32Array): number {
     return VectorCalculation.cosineSimilarity(this, otherVector);
+  }
+
+  // CoVector mutation method overrides, as CoVectors aren't meant to be mutated
+  /**
+   * Calling `copyWithin` on a CoVector is forbidden. CoVectors are immutable.
+   * @deprecated If you want to change the vector, replace the former instance of CoVector with a new one.
+   */
+  override copyWithin(target: number, start: number, end?: number): never {
+    throw new Error("Cannot mutate a CoVector using `copyWithin`");
+  }
+  /**
+   * Calling `fill` on a CoVector is forbidden. CoVectors are immutable.
+   * @deprecated If you want to change the vector, replace the former instance of CoVector with a new one.
+   */
+  override fill(value: number, start?: number, end?: number): never {
+    throw new Error("Cannot mutate a CoVector using `fill`");
+  }
+  /**
+   * Calling `reverse` on a CoVector is forbidden. CoVectors are immutable.
+   * @deprecated If you want to change the vector, replace the former instance of CoVector with a new one.
+   */
+  override reverse(): never {
+    throw new Error("Cannot mutate a CoVector using `reverse`");
+  }
+  /**
+   * Calling `set` on a CoVector is forbidden. CoVectors are immutable.
+   * @deprecated If you want to change the vector, replace the former instance of CoVector with a new one.
+  //  */
+  override set(array: ArrayLike<number>, offset?: number): never {
+    throw new Error("Cannot mutate a CoVector using `set`");
+  }
+  /**
+   * Calling `sort` on a CoVector is forbidden. CoVectors are immutable.
+   * @deprecated If you want to change the vector, replace the former instance of CoVector with a new one.
+   */
+  override sort(compareFn?: (a: number, b: number) => number): never {
+    throw new Error("Cannot mutate a CoVector using `sort`");
   }
 }
 

--- a/packages/jazz-tools/src/tools/coValues/coVector.ts
+++ b/packages/jazz-tools/src/tools/coValues/coVector.ts
@@ -39,8 +39,8 @@ export class CoVector extends Float32Array implements CoValue {
     return Float32Array;
   }
 
-  static requiredDimensionsCount: number | undefined = undefined;
-  declare _loadedVector: Float32Array | null;
+  protected static requiredDimensionsCount: number | undefined = undefined;
+  private declare _loadedVector: Float32Array | null;
 
   constructor(
     options:
@@ -91,7 +91,7 @@ export class CoVector extends Float32Array implements CoValue {
    * @deprecated Use `co.vector(...).create` instead.
    */
   static create<S extends CoVector>(
-    this: CoValueClass<S> & { requiredDimensionsCount: number | undefined },
+    this: CoValueClass<S> & typeof CoVector,
     vector: number[] | Float32Array,
     options?: { owner?: Account | Group } | Account | Group,
   ) {
@@ -160,7 +160,7 @@ export class CoVector extends Float32Array implements CoValue {
     return new Float32Array(u8.buffer, u8.byteOffset, total / 4);
   }
 
-  get requiredDimensionsCount(): number | undefined {
+  private get requiredDimensionsCount(): number | undefined {
     return (this.constructor as typeof CoVector).requiredDimensionsCount;
   }
 

--- a/packages/jazz-tools/src/tools/coValues/coVector.ts
+++ b/packages/jazz-tools/src/tools/coValues/coVector.ts
@@ -7,7 +7,6 @@ import {
   getCoValueOwner,
   Group,
   ID,
-  RefsToResolve,
   Resolved,
   SubscribeListenerOptions,
   SubscribeRestArgs,
@@ -29,7 +28,10 @@ import {
  *
  * @category CoValues
  */
-export class CoVector extends Float32Array implements CoValue {
+export class CoVector
+  extends Float32Array
+  implements Readonly<Float32Array>, CoValue
+{
   declare $jazz: CoVectorJazzApi<this>;
 
   /** @category Type Helpers */
@@ -229,7 +231,7 @@ export class CoVector extends Float32Array implements CoValue {
     options?: {
       loadAs?: Account | AnonymousJazzAgent;
     },
-  ): Promise<CoVector | null> {
+  ): Promise<C | null> {
     const coVector = await loadCoValueWithoutMe(this, id, options);
 
     /**
@@ -237,7 +239,7 @@ export class CoVector extends Float32Array implements CoValue {
      * we can wait for the stream to be complete before returning the vector
      */
     if (!coVector?.$jazz.raw.isBinaryStreamEnded()) {
-      return new Promise<CoVector>((resolve) => {
+      return new Promise<C | null>((resolve) => {
         subscribeToCoValueWithoutMe(
           this,
           id,
@@ -261,24 +263,24 @@ export class CoVector extends Float32Array implements CoValue {
    * @category Subscription & Loading
    * @deprecated Use `co.vector(...).subscribe` instead.
    */
-  static subscribe<V extends CoVector, const R extends RefsToResolve<V>>(
+  static subscribe<V extends CoVector>(
     this: CoValueClass<V>,
     id: ID<V>,
-    listener: (value: Resolved<V, R>, unsubscribe: () => void) => void,
+    listener: (value: Resolved<V, true>, unsubscribe: () => void) => void,
   ): () => void;
-  static subscribe<V extends CoVector, const R extends RefsToResolve<V>>(
+  static subscribe<V extends CoVector>(
     this: CoValueClass<V>,
     id: ID<V>,
-    options: SubscribeListenerOptions<V, R>,
-    listener: (value: Resolved<V, R>, unsubscribe: () => void) => void,
+    options: SubscribeListenerOptions<V, true>,
+    listener: (value: Resolved<V, true>, unsubscribe: () => void) => void,
   ): () => void;
-  static subscribe<V extends CoVector, const R extends RefsToResolve<V>>(
+  static subscribe<V extends CoVector>(
     this: CoValueClass<V>,
     id: ID<V>,
-    ...args: SubscribeRestArgs<V, R>
+    ...args: SubscribeRestArgs<V, true>
   ): () => void {
     const { options, listener } = parseSubscribeRestArgs(args);
-    return subscribeToCoValueWithoutMe<V, R>(this, id, options, listener);
+    return subscribeToCoValueWithoutMe<V, true>(this, id, options, listener);
   }
 
   // CoVector mutation method overrides, as CoVectors aren't meant to be mutated

--- a/packages/jazz-tools/src/tools/implementation/zodSchema/coExport.ts
+++ b/packages/jazz-tools/src/tools/implementation/zodSchema/coExport.ts
@@ -7,6 +7,7 @@ export { CoFeedSchema as Feed } from "./schemaTypes/CoFeedSchema.js";
 export { PlainTextSchema as PlainText } from "./schemaTypes/PlainTextSchema.js";
 export { RichTextSchema as RichText } from "./schemaTypes/RichTextSchema.js";
 export { FileStreamSchema as FileStream } from "./schemaTypes/FileStreamSchema.js";
+export { CoVectorSchema as Vector } from "./schemaTypes/CoVectorSchema.js";
 export { CoInput as input } from "./typeConverters/CoFieldSchemaInit.js";
 export {
   AccountSchema as Account,
@@ -23,6 +24,7 @@ export {
   coPlainTextDefiner as plainText,
   coRichTextDefiner as richText,
   coFileStreamDefiner as fileStream,
+  coVectorDefiner as vector,
   coImageDefiner as image,
   coAccountDefiner as account,
   coGroupDefiner as group,

--- a/packages/jazz-tools/src/tools/implementation/zodSchema/runtimeConverters/coValueSchemaTransformation.ts
+++ b/packages/jazz-tools/src/tools/implementation/zodSchema/runtimeConverters/coValueSchemaTransformation.ts
@@ -12,12 +12,14 @@ import {
   CoValueClass,
   FileStream,
   FileStreamSchema,
+  CoVectorSchema,
   PlainTextSchema,
   SchemaUnion,
   enrichAccountSchema,
   enrichCoMapSchema,
   isCoValueClass,
   Group,
+  CoVector,
 } from "../../../internal.js";
 import { coField } from "../../schema.js";
 
@@ -123,6 +125,17 @@ export function hydrateCoreCoValueSchema<S extends AnyCoreCoValueSchema>(
   } else if (schema.builtin === "FileStream") {
     const coValueClass = FileStream;
     return new FileStreamSchema(coValueClass) as CoValueSchemaFromCoreSchema<S>;
+  } else if (schema.builtin === "CoVector") {
+    const dimensions = schema.dimensions;
+
+    const coValueClass = class CoVectorWithDimensions extends CoVector {
+      static requiredDimensionsCount = dimensions;
+    };
+
+    return new CoVectorSchema(
+      dimensions,
+      coValueClass,
+    ) as CoValueSchemaFromCoreSchema<S>;
   } else if (schema.builtin === "CoPlainText") {
     const coValueClass = CoPlainText;
     return new PlainTextSchema(coValueClass) as CoValueSchemaFromCoreSchema<S>;

--- a/packages/jazz-tools/src/tools/implementation/zodSchema/runtimeConverters/coValueSchemaTransformation.ts
+++ b/packages/jazz-tools/src/tools/implementation/zodSchema/runtimeConverters/coValueSchemaTransformation.ts
@@ -129,7 +129,7 @@ export function hydrateCoreCoValueSchema<S extends AnyCoreCoValueSchema>(
     const dimensions = schema.dimensions;
 
     const coValueClass = class CoVectorWithDimensions extends CoVector {
-      static requiredDimensionsCount = dimensions;
+      protected static requiredDimensionsCount = dimensions;
     };
 
     return new CoVectorSchema(

--- a/packages/jazz-tools/src/tools/implementation/zodSchema/schemaTypes/CoVectorSchema.ts
+++ b/packages/jazz-tools/src/tools/implementation/zodSchema/schemaTypes/CoVectorSchema.ts
@@ -1,0 +1,133 @@
+import {
+  Account,
+  AnonymousJazzAgent,
+  CoVector,
+  Group,
+  coOptionalDefiner,
+} from "../../../internal.js";
+import { CoOptionalSchema } from "./CoOptionalSchema.js";
+import { CoreCoValueSchema } from "./CoValueSchema.js";
+
+export interface CoreCoVectorSchema extends CoreCoValueSchema {
+  builtin: "CoVector";
+  dimensions: number;
+}
+
+export function createCoreCoVectorSchema(
+  dimensions: number,
+): CoreCoVectorSchema {
+  return {
+    collaborative: true as const,
+    builtin: "CoVector" as const,
+    dimensions,
+  };
+}
+
+export class CoVectorSchema implements CoreCoVectorSchema {
+  readonly collaborative = true as const;
+  readonly builtin = "CoVector" as const;
+
+  constructor(
+    public dimensions: number,
+    private coValueClass: typeof CoVector,
+  ) {}
+
+  /**
+   * Create a `CoVector` from a given vector.
+   */
+  create(
+    vector: number[] | Float32Array,
+    options?: { owner: Group } | Group,
+  ): CoVector;
+  /**
+   * Create a `CoVector` from a given vector.
+   *
+   * @deprecated Creating CoValues with an Account as owner is deprecated. Use a Group instead.
+   */
+  create(
+    vector: number[] | Float32Array,
+    options?: { owner: Account | Group } | Account | Group,
+  ): CoVector;
+  create(
+    vector: number[] | Float32Array,
+    options?: { owner: Account | Group } | Account | Group,
+  ): CoVector {
+    return this.coValueClass.create(vector, options);
+  }
+
+  /**
+   * Load a `CoVector` with a given ID.
+   */
+  load(
+    id: string,
+    options?: { loadAs: Account | AnonymousJazzAgent },
+  ): Promise<CoVector | null> {
+    return this.coValueClass.load(id, options);
+  }
+
+  /**
+   * Subscribe to a `CoVector`, when you have an ID but don't have a `CoVector` instance yet
+   */
+  subscribe(
+    id: string,
+    options: { loadAs: Account | AnonymousJazzAgent },
+    listener: (value: CoVector, unsubscribe: () => void) => void,
+  ): () => void;
+  subscribe(
+    id: string,
+    listener: (value: CoVector, unsubscribe: () => void) => void,
+  ): () => void;
+  subscribe(...args: [any, ...any[]]) {
+    // @ts-expect-error
+    return this.coValueClass.subscribe(...args);
+  }
+
+  getCoValueClass(): typeof CoVector {
+    return this.coValueClass;
+  }
+
+  optional(): CoOptionalSchema<this> {
+    return coOptionalDefiner(this);
+  }
+
+  // Vector operations
+  /**
+   * Calculate the magnitude of a vector.
+   */
+  magnitude(vector: Float32Array | CoVector): number {
+    return this.coValueClass.magnitude(vector);
+  }
+
+  /**
+   * Normalize a vector.
+   * @returns A new instance of a normalized vector.
+   */
+  normalize(vector: Float32Array | CoVector): Float32Array {
+    return this.coValueClass.normalize(vector);
+  }
+
+  /**
+   * Calculate the dot product of two vectors.
+   */
+  dotProduct(
+    vectorA: Float32Array | CoVector,
+    vectorB: Float32Array | CoVector,
+  ): number {
+    return this.coValueClass.dotProduct(vectorA, vectorB);
+  }
+
+  /**
+   * Calculate the cosine similarity between two vectors.
+   *
+   * @returns A value between `-1` and `1`:
+   * - `1` means the vectors are identical
+   * - `0` means the vectors are orthogonal (i.e. no similarity)
+   * - `-1` means the vectors are opposite direction (perfectly dissimilar)
+   */
+  cosineSimilarity(
+    vectorA: CoVector | Float32Array,
+    vectorB: CoVector | Float32Array,
+  ): number {
+    return this.coValueClass.cosineSimilarity(vectorA, vectorB);
+  }
+}

--- a/packages/jazz-tools/src/tools/implementation/zodSchema/schemaTypes/CoVectorSchema.ts
+++ b/packages/jazz-tools/src/tools/implementation/zodSchema/schemaTypes/CoVectorSchema.ts
@@ -3,6 +3,8 @@ import {
   AnonymousJazzAgent,
   CoVector,
   Group,
+  InstanceOrPrimitiveOfSchema,
+  InstanceOrPrimitiveOfSchemaCoValuesNullable,
   coOptionalDefiner,
 } from "../../../internal.js";
 import { CoOptionalSchema } from "./CoOptionalSchema.js";
@@ -38,7 +40,7 @@ export class CoVectorSchema implements CoreCoVectorSchema {
   create(
     vector: number[] | Float32Array,
     options?: { owner: Group } | Group,
-  ): CoVector;
+  ): CoVectorInstance;
   /**
    * Create a `CoVector` from a given vector.
    *
@@ -47,11 +49,11 @@ export class CoVectorSchema implements CoreCoVectorSchema {
   create(
     vector: number[] | Float32Array,
     options?: { owner: Account | Group } | Account | Group,
-  ): CoVector;
+  ): CoVectorInstance;
   create(
     vector: number[] | Float32Array,
     options?: { owner: Account | Group } | Account | Group,
-  ): CoVector {
+  ): CoVectorInstance {
     return this.coValueClass.create(vector, options);
   }
 
@@ -61,7 +63,7 @@ export class CoVectorSchema implements CoreCoVectorSchema {
   load(
     id: string,
     options?: { loadAs: Account | AnonymousJazzAgent },
-  ): Promise<CoVector | null> {
+  ): Promise<CoVectorInstanceNullable> {
     return this.coValueClass.load(id, options);
   }
 
@@ -71,11 +73,17 @@ export class CoVectorSchema implements CoreCoVectorSchema {
   subscribe(
     id: string,
     options: { loadAs: Account | AnonymousJazzAgent },
-    listener: (value: CoVector, unsubscribe: () => void) => void,
+    listener: (
+      value: CoVectorInstanceNullable,
+      unsubscribe: () => void,
+    ) => void,
   ): () => void;
   subscribe(
     id: string,
-    listener: (value: CoVector, unsubscribe: () => void) => void,
+    listener: (
+      value: CoVectorInstanceNullable,
+      unsubscribe: () => void,
+    ) => void,
   ): () => void;
   subscribe(...args: [any, ...any[]]) {
     // @ts-expect-error
@@ -90,3 +98,8 @@ export class CoVectorSchema implements CoreCoVectorSchema {
     return coOptionalDefiner(this);
   }
 }
+
+export type CoVectorInstance = InstanceOrPrimitiveOfSchema<CoVectorSchema>;
+
+export type CoVectorInstanceNullable =
+  InstanceOrPrimitiveOfSchemaCoValuesNullable<CoVectorSchema>;

--- a/packages/jazz-tools/src/tools/implementation/zodSchema/schemaTypes/CoVectorSchema.ts
+++ b/packages/jazz-tools/src/tools/implementation/zodSchema/schemaTypes/CoVectorSchema.ts
@@ -89,45 +89,4 @@ export class CoVectorSchema implements CoreCoVectorSchema {
   optional(): CoOptionalSchema<this> {
     return coOptionalDefiner(this);
   }
-
-  // Vector operations
-  /**
-   * Calculate the magnitude of a vector.
-   */
-  magnitude(vector: Float32Array | CoVector): number {
-    return this.coValueClass.magnitude(vector);
-  }
-
-  /**
-   * Normalize a vector.
-   * @returns A new instance of a normalized vector.
-   */
-  normalize(vector: Float32Array | CoVector): Float32Array {
-    return this.coValueClass.normalize(vector);
-  }
-
-  /**
-   * Calculate the dot product of two vectors.
-   */
-  dotProduct(
-    vectorA: Float32Array | CoVector,
-    vectorB: Float32Array | CoVector,
-  ): number {
-    return this.coValueClass.dotProduct(vectorA, vectorB);
-  }
-
-  /**
-   * Calculate the cosine similarity between two vectors.
-   *
-   * @returns A value between `-1` and `1`:
-   * - `1` means the vectors are identical
-   * - `0` means the vectors are orthogonal (i.e. no similarity)
-   * - `-1` means the vectors are opposite direction (perfectly dissimilar)
-   */
-  cosineSimilarity(
-    vectorA: CoVector | Float32Array,
-    vectorB: CoVector | Float32Array,
-  ): number {
-    return this.coValueClass.cosineSimilarity(vectorA, vectorB);
-  }
 }

--- a/packages/jazz-tools/src/tools/implementation/zodSchema/typeConverters/InstanceOfSchema.ts
+++ b/packages/jazz-tools/src/tools/implementation/zodSchema/typeConverters/InstanceOfSchema.ts
@@ -7,9 +7,11 @@ import {
   CoMap,
   CoPlainText,
   CoRichText,
+  CoVector,
   CoValueClass,
   CoreAccountSchema,
   CoreCoRecordSchema,
+  CoreCoVectorSchema,
   FileStream,
   Group,
 } from "../../../internal.js";
@@ -63,11 +65,13 @@ export type InstanceOfSchema<S extends CoValueClass | AnyZodOrCoValueSchema> =
                     ? CoRichText
                     : S extends CoreFileStreamSchema
                       ? FileStream
-                      : S extends CoreCoOptionalSchema<infer T>
-                        ? InstanceOrPrimitiveOfSchema<T> | undefined
-                        : S extends CoDiscriminatedUnionSchema<infer Members>
-                          ? InstanceOrPrimitiveOfSchema<Members[number]>
-                          : never
+                      : S extends CoreCoVectorSchema
+                        ? CoVector
+                        : S extends CoreCoOptionalSchema<infer T>
+                          ? InstanceOrPrimitiveOfSchema<T> | undefined
+                          : S extends CoDiscriminatedUnionSchema<infer Members>
+                            ? InstanceOrPrimitiveOfSchema<Members[number]>
+                            : never
     : S extends CoValueClass
       ? InstanceType<S>
       : never;

--- a/packages/jazz-tools/src/tools/implementation/zodSchema/typeConverters/InstanceOfSchema.ts
+++ b/packages/jazz-tools/src/tools/implementation/zodSchema/typeConverters/InstanceOfSchema.ts
@@ -66,7 +66,7 @@ export type InstanceOfSchema<S extends CoValueClass | AnyZodOrCoValueSchema> =
                     : S extends CoreFileStreamSchema
                       ? FileStream
                       : S extends CoreCoVectorSchema
-                        ? CoVector
+                        ? Readonly<CoVector>
                         : S extends CoreCoOptionalSchema<infer T>
                           ? InstanceOrPrimitiveOfSchema<T> | undefined
                           : S extends CoDiscriminatedUnionSchema<infer Members>

--- a/packages/jazz-tools/src/tools/implementation/zodSchema/typeConverters/InstanceOfSchemaCoValuesNullable.ts
+++ b/packages/jazz-tools/src/tools/implementation/zodSchema/typeConverters/InstanceOfSchemaCoValuesNullable.ts
@@ -73,7 +73,7 @@ export type InstanceOfSchemaCoValuesNullable<
                   : S extends CoreFileStreamSchema
                     ? FileStream | null
                     : S extends CoreCoVectorSchema
-                      ? CoVector | null
+                      ? Readonly<CoVector> | null
                       : S extends CoreCoOptionalSchema<infer Inner>
                         ?
                             | InstanceOrPrimitiveOfSchemaCoValuesNullable<Inner>

--- a/packages/jazz-tools/src/tools/implementation/zodSchema/typeConverters/InstanceOfSchemaCoValuesNullable.ts
+++ b/packages/jazz-tools/src/tools/implementation/zodSchema/typeConverters/InstanceOfSchemaCoValuesNullable.ts
@@ -13,6 +13,8 @@ import {
   CoreCoListSchema,
   CoreCoMapSchema,
   CoreCoRecordSchema,
+  CoreCoVectorSchema,
+  CoVector,
   FileStream,
   Group,
 } from "../../../internal.js";
@@ -70,15 +72,19 @@ export type InstanceOfSchemaCoValuesNullable<
                   ? CoRichText | null
                   : S extends CoreFileStreamSchema
                     ? FileStream | null
-                    : S extends CoreCoOptionalSchema<infer Inner>
-                      ?
-                          | InstanceOrPrimitiveOfSchemaCoValuesNullable<Inner>
-                          | undefined
-                      : S extends CoreCoDiscriminatedUnionSchema<infer Members>
-                        ? InstanceOrPrimitiveOfSchemaCoValuesNullable<
-                            Members[number]
-                          >
-                        : never
+                    : S extends CoreCoVectorSchema
+                      ? CoVector | null
+                      : S extends CoreCoOptionalSchema<infer Inner>
+                        ?
+                            | InstanceOrPrimitiveOfSchemaCoValuesNullable<Inner>
+                            | undefined
+                        : S extends CoreCoDiscriminatedUnionSchema<
+                              infer Members
+                            >
+                          ? InstanceOrPrimitiveOfSchemaCoValuesNullable<
+                              Members[number]
+                            >
+                          : never
   : S extends CoValueClass
     ? InstanceType<S> | null
     : never;

--- a/packages/jazz-tools/src/tools/implementation/zodSchema/zodCo.ts
+++ b/packages/jazz-tools/src/tools/implementation/zodSchema/zodCo.ts
@@ -9,6 +9,7 @@ import {
   type CoRecordSchema,
   type DefaultProfileShape,
   type FileStreamSchema,
+  type CoVectorSchema,
   ImageDefinition,
   type PlainTextSchema,
   type Simplify,
@@ -18,6 +19,7 @@ import {
   createCoreCoMapSchema,
   createCoreCoPlainTextSchema,
   createCoreFileStreamSchema,
+  createCoreCoVectorSchema,
   hydrateCoreCoValueSchema,
   isAnyCoValueSchema,
   isCoValueClass,
@@ -190,6 +192,19 @@ export const coFeedDefiner = <T extends AnyZodOrCoValueSchema>(
 
 export const coFileStreamDefiner = (): FileStreamSchema => {
   const coreSchema = createCoreFileStreamSchema();
+  return hydrateCoreCoValueSchema(coreSchema);
+};
+
+export const coVectorDefiner = (dimensions: number): CoVectorSchema => {
+  const isPositiveInteger = Number.isInteger(dimensions) && dimensions > 0;
+
+  if (!isPositiveInteger) {
+    throw new Error(
+      "co.vector() expects the vector dimensions count to be a positive integer",
+    );
+  }
+
+  const coreSchema = createCoreCoVectorSchema(dimensions);
   return hydrateCoreCoValueSchema(coreSchema);
 };
 

--- a/packages/jazz-tools/src/tools/implementation/zodSchema/zodSchema.ts
+++ b/packages/jazz-tools/src/tools/implementation/zodSchema/zodSchema.ts
@@ -34,6 +34,10 @@ import {
   FileStreamSchema,
 } from "./schemaTypes/FileStreamSchema.js";
 import {
+  CoreCoVectorSchema,
+  CoVectorSchema,
+} from "./schemaTypes/CoVectorSchema.js";
+import {
   CorePlainTextSchema,
   PlainTextSchema,
 } from "./schemaTypes/PlainTextSchema.js";
@@ -75,11 +79,15 @@ export type CoValueSchemaFromCoreSchema<S extends CoreCoValueSchema> =
                   ? RichTextSchema
                   : S extends CoreFileStreamSchema
                     ? FileStreamSchema
-                    : S extends CoreCoOptionalSchema<infer Inner>
-                      ? CoOptionalSchema<Inner>
-                      : S extends CoreCoDiscriminatedUnionSchema<infer Members>
-                        ? CoDiscriminatedUnionSchema<Members>
-                        : never;
+                    : S extends CoreCoVectorSchema
+                      ? CoVectorSchema
+                      : S extends CoreCoOptionalSchema<infer Inner>
+                        ? CoOptionalSchema<Inner>
+                        : S extends CoreCoDiscriminatedUnionSchema<
+                              infer Members
+                            >
+                          ? CoDiscriminatedUnionSchema<Members>
+                          : never;
 
 export type CoValueClassFromAnySchema<S extends CoValueClassOrSchema> =
   S extends CoValueClass<any>
@@ -104,7 +112,8 @@ export type AnyCoreCoValueSchema =
   | CoreCoOptionalSchema
   | CorePlainTextSchema
   | CoreRichTextSchema
-  | CoreFileStreamSchema;
+  | CoreFileStreamSchema
+  | CoreCoVectorSchema;
 
 export type AnyZodSchema = z.core.$ZodType;
 

--- a/packages/jazz-tools/src/tools/internal.ts
+++ b/packages/jazz-tools/src/tools/internal.ts
@@ -16,6 +16,7 @@ export * from "./coValues/inbox.js";
 export * from "./coValues/coPlainText.js";
 export * from "./coValues/coRichText.js";
 export * from "./coValues/schemaUnion.js";
+export * from "./coValues/coVector.js";
 
 export type * from "./subscribe/types.js";
 
@@ -43,6 +44,7 @@ export * from "./implementation/zodSchema/schemaTypes/CoListSchema.js";
 export * from "./implementation/zodSchema/schemaTypes/CoFeedSchema.js";
 export * from "./implementation/zodSchema/schemaTypes/AccountSchema.js";
 export * from "./implementation/zodSchema/schemaTypes/FileStreamSchema.js";
+export * from "./implementation/zodSchema/schemaTypes/CoVectorSchema.js";
 export * from "./implementation/zodSchema/schemaTypes/PlainTextSchema.js";
 export * from "./implementation/zodSchema/typeConverters/InstanceOrPrimitiveOfSchema.js";
 export * from "./implementation/zodSchema/typeConverters/InstanceOrPrimitiveOfSchemaCoValuesNullable.js";

--- a/packages/jazz-tools/src/tools/tests/coVector.test-d.ts
+++ b/packages/jazz-tools/src/tools/tests/coVector.test-d.ts
@@ -1,0 +1,33 @@
+import { describe, expectTypeOf, test } from "vitest";
+import { Group, co } from "../exports.js";
+import { CoVectorSchema } from "../internal.js";
+
+describe("CoVector types", () => {
+  test("co.vector() • defines a correct CoVectorSchema", () => {
+    type ExpectedType = CoVectorSchema;
+
+    function matches(value: ExpectedType) {
+      return value;
+    }
+
+    matches(co.vector(384));
+  });
+
+  test("co.vector().create() • creates a CoVector with Float32Array-like typing", () => {
+    const embedding = co.vector(3).create([1, 2, 3]);
+
+    type ExpectedType = Float32Array;
+
+    function matches(value: ExpectedType) {
+      return value;
+    }
+
+    matches(embedding);
+  });
+
+  test("CoVector instance • has the owner property", () => {
+    const embedding = co.vector(3).create([1, 2, 3]);
+
+    expectTypeOf(embedding.$jazz.owner).toEqualTypeOf<Group>();
+  });
+});

--- a/packages/jazz-tools/src/tools/tests/coVector.test-d.ts
+++ b/packages/jazz-tools/src/tools/tests/coVector.test-d.ts
@@ -16,7 +16,7 @@ describe("CoVector types", () => {
   test("co.vector().create() • creates a CoVector with Float32Array-like typing", () => {
     const embedding = co.vector(3).create([1, 2, 3]);
 
-    type ExpectedType = Float32Array;
+    type ExpectedType = Readonly<Float32Array>;
 
     function matches(value: ExpectedType) {
       return value;
@@ -29,5 +29,12 @@ describe("CoVector types", () => {
     const embedding = co.vector(3).create([1, 2, 3]);
 
     expectTypeOf(embedding.$jazz.owner).toEqualTypeOf<Group>();
+  });
+
+  test("setting a value via index access • is a type error", () => {
+    const embedding = co.vector(3).create([1, 2, 3]);
+
+    // @ts-expect-error: assignment to index should be disallowed
+    embedding[0] = 6;
   });
 });

--- a/packages/jazz-tools/src/tools/tests/coVector.test.ts
+++ b/packages/jazz-tools/src/tools/tests/coVector.test.ts
@@ -1,0 +1,928 @@
+import { assert, beforeEach, describe, expect, test, vi } from "vitest";
+import { cojsonInternals, Group, isControlledAccount, z } from "../index.js";
+import {
+  CoVector,
+  CoVectorSchema,
+  ControlledAccount,
+  Loaded,
+  co,
+} from "../internal.js";
+import { createJazzTestAccount, setupJazzTestSync } from "../testing.js";
+import { setupTwoNodes, waitFor } from "./utils.js";
+
+let me: ControlledAccount;
+
+beforeEach(async () => {
+  await setupJazzTestSync();
+  const account = await createJazzTestAccount({
+    isCurrentActiveAccount: true,
+    creationProps: { name: "Hermes Puggington" },
+  });
+  if (!isControlledAccount(account)) {
+    throw new Error("account is not a controlled account");
+  }
+  me = account;
+});
+
+const initNodeAndVector = async (
+  coVectorSchema: CoVectorSchema,
+  vectorInput: number[] | Float32Array = [1, 2, 3],
+) => {
+  const me = await createJazzTestAccount({
+    isCurrentActiveAccount: true,
+  });
+
+  const group = Group.create(me);
+  group.addMember("everyone", "reader");
+
+  const coVector = coVectorSchema.create(vectorInput, {
+    owner: group,
+  });
+
+  return { me, coVector };
+};
+
+const kbToBytes = (kb: number) => kb * 1024;
+const elementsForKb = (kb: number) => kbToBytes(kb) / 4;
+
+describe("Defining a co.vector()", () => {
+  test("given a non-positive dimensions count • throws an error", () => {
+    expect(() => co.vector(-1)).toThrow(
+      "co.vector() expects the vector dimensions count to be a positive integer",
+    );
+    expect(() => co.vector(0)).toThrow(
+      "co.vector() expects the vector dimensions count to be a positive integer",
+    );
+  });
+
+  test("given a non-integer dimensions count • throws an error", () => {
+    expect(() => co.vector(384.5)).toThrow(
+      "co.vector() expects the vector dimensions count to be a positive integer",
+    );
+  });
+
+  test("given a valid dimensions count • creates a CoVector schema", () => {
+    const EmbeddingSchema = co.vector(384);
+    expect(EmbeddingSchema.builtin).toBe("CoVector");
+    expect(EmbeddingSchema.dimensions).toBe(384);
+    expect(EmbeddingSchema.create).toBeDefined();
+  });
+});
+
+describe("Creating a CoVector", async () => {
+  const EmbeddingSchema = co.vector(3);
+  const { me } = await initNodeAndVector(EmbeddingSchema);
+
+  test("given a vector of mismatched dimensions count • throws an error", () => {
+    expect(() => EmbeddingSchema.create([1, 2, 3, 4, 5])).toThrow(
+      "Vector dimension mismatch! Expected 3 dimensions, got 5",
+    );
+  });
+
+  test("given a Array<number> with valid dimensions count • creates a CoVector", () => {
+    const embedding = EmbeddingSchema.create([1, 2, 3]);
+    expect(embedding).toBeInstanceOf(CoVector);
+  });
+
+  test("given a Float32Array with valid dimensions count • creates a CoVector", () => {
+    const embedding = EmbeddingSchema.create(new Float32Array([1, 2, 3]));
+    expect(embedding).toBeInstanceOf(CoVector);
+  });
+
+  test("given Account as owner • creates a CoVector", () => {
+    const embedding = EmbeddingSchema.create([1, 2, 3], me);
+    expect(embedding.$jazz.owner.myRole()).toEqual("admin");
+  });
+
+  test("given Group as owner • creates a CoVector", () => {
+    const group = Group.create(me);
+    const embedding = EmbeddingSchema.create([1, 2, 3], group);
+
+    expect(embedding.$jazz.owner).toEqual(group);
+  });
+});
+
+describe("CoVector structure", async () => {
+  const EmbeddingSchema = co.vector(5);
+  const vector = new Float32Array([1, 2, 3, 4, 5]);
+  const coVector = EmbeddingSchema.create(vector);
+
+  test("CoVector keys can be iterated over just like an Float32Array's", () => {
+    const keys = [];
+
+    for (const key in coVector) {
+      keys.push(key);
+    }
+
+    expect(keys).toEqual(Object.keys(vector));
+    expect(Object.keys(coVector)).toEqual(Object.keys(vector));
+  });
+
+  test("Float32Array can be constructed from a CoVector", () => {
+    expect(new Float32Array(coVector)).toEqual(vector);
+  });
+
+  test("a CoVector is NOT structurally equal to a Float32Array", () => {
+    // Since CoVector is a proxy, it will never pass the equality check with a Float32Array (TypedArray)
+    expect(coVector).not.toEqual(vector);
+    // but
+    expect(coVector.vector).toEqual(vector);
+  });
+});
+
+describe("CoVector methods & properties (Float32Array-like)", async () => {
+  const EmbeddingSchema = co.vector(5);
+
+  const { me, coVector } = await initNodeAndVector(
+    EmbeddingSchema,
+    new Float32Array([1, 2, 3, 4, 5]),
+  );
+
+  // Properties
+  test("has .length", () => {
+    expect(coVector.length).toBe(5);
+  });
+  test("has .buffer", () => {
+    expect(coVector.buffer).toEqual(new Float32Array([1, 2, 3, 4, 5]).buffer);
+  });
+  test("has .byteLength", () => {
+    expect(coVector.byteLength).toBe(20);
+  });
+  test("has .byteOffset", () => {
+    expect(coVector.byteOffset).toBe(0);
+  });
+
+  test("has index access", () => {
+    expect(coVector[0]).toBe(1);
+    expect(coVector[1]).toBe(2);
+    expect(coVector[2]).toBe(3);
+    expect(coVector[3]).toBe(4);
+    expect(coVector[4]).toBe(5);
+  });
+
+  // Methods
+  test("supports .at", () => {
+    expect(coVector.at(0)).toBe(1);
+    expect(coVector.at(1)).toBe(2);
+    expect(coVector.at(2)).toBe(3);
+    expect(coVector.at(3)).toBe(4);
+    expect(coVector.at(4)).toBe(5);
+  });
+
+  test("supports .entries", () => {
+    expect(Array.from(coVector.entries())).toEqual([
+      [0, 1],
+      [1, 2],
+      [2, 3],
+      [3, 4],
+      [4, 5],
+    ]);
+  });
+
+  test("supports .every", () => {
+    expect(coVector.every((item) => item > 0)).toEqual(true);
+    expect(coVector.every((item) => item > 3)).toEqual(false);
+  });
+
+  test("supports .filter", () => {
+    expect(coVector.filter((item) => item > 3)).toEqual(
+      new Float32Array([4, 5]),
+    );
+  });
+
+  test("supports .find", () => {
+    expect(coVector.find((item) => item > 3)).toEqual(4);
+  });
+
+  test("supports .findIndex", () => {
+    expect(coVector.findIndex((item) => item > 3)).toEqual(3);
+  });
+
+  test("supports .findLast", () => {
+    expect(coVector.findLast((item) => item > 3)).toEqual(5);
+  });
+
+  test("supports .findLastIndex", () => {
+    expect(coVector.findLastIndex((item) => item > 3)).toEqual(4);
+  });
+
+  test("supports .forEach", () => {
+    const iterationFn = vi.fn();
+    coVector.forEach(iterationFn);
+
+    expect(iterationFn).toHaveBeenCalledTimes(5);
+
+    const f32 = new Float32Array([1, 2, 3, 4, 5]);
+
+    expect(iterationFn).toHaveBeenCalledWith(1, 0, f32);
+    expect(iterationFn).toHaveBeenCalledWith(2, 1, f32);
+    expect(iterationFn).toHaveBeenCalledWith(3, 2, f32);
+    expect(iterationFn).toHaveBeenCalledWith(4, 3, f32);
+    expect(iterationFn).toHaveBeenCalledWith(5, 4, f32);
+  });
+
+  test("supports .includes", () => {
+    expect(coVector.includes(3)).toBe(true);
+    expect(coVector.includes(6)).toBe(false);
+  });
+
+  test("supports .indexOf", () => {
+    expect(coVector.indexOf(3)).toBe(2);
+    expect(coVector.indexOf(6)).toBe(-1);
+  });
+
+  test("supports .join", () => {
+    expect(coVector.join(":")).toEqual("1:2:3:4:5");
+  });
+
+  test("supports .keys", () => {
+    expect(Array.from(coVector.keys())).toEqual([0, 1, 2, 3, 4]);
+  });
+
+  test("supports .lastIndexOf", () => {
+    const coVector = EmbeddingSchema.create([1, 2, 3, 4, 3]);
+    expect(coVector.lastIndexOf(3)).toBe(4);
+    expect(coVector.lastIndexOf(6)).toBe(-1);
+  });
+
+  test("supports .map", () => {
+    expect(coVector.map((item) => item * 2)).toEqual(
+      new Float32Array([2, 4, 6, 8, 10]),
+    );
+  });
+
+  test("supports .reduce", () => {
+    const reducerFn = vi.fn((acc, item) => acc + item);
+
+    expect(coVector.reduce(reducerFn, 0)).toEqual(15);
+
+    const f32 = new Float32Array([1, 2, 3, 4, 5]);
+
+    expect(reducerFn).toHaveBeenCalledTimes(5);
+    expect(reducerFn).toHaveBeenCalledWith(0, 1, 0, f32);
+    expect(reducerFn).toHaveBeenCalledWith(1, 2, 1, f32);
+    expect(reducerFn).toHaveBeenCalledWith(3, 3, 2, f32);
+    expect(reducerFn).toHaveBeenCalledWith(6, 4, 3, f32);
+    expect(reducerFn).toHaveBeenCalledWith(10, 5, 4, f32);
+  });
+
+  test("supports .reduceRight", () => {
+    const reducerFn = vi.fn((acc, item) => acc + item);
+
+    expect(coVector.reduceRight(reducerFn, 0)).toEqual(15);
+
+    const f32 = new Float32Array([1, 2, 3, 4, 5]);
+
+    expect(reducerFn).toHaveBeenCalledTimes(5);
+    expect(reducerFn).toHaveBeenCalledWith(0, 5, 4, f32);
+    expect(reducerFn).toHaveBeenCalledWith(5, 4, 3, f32);
+    expect(reducerFn).toHaveBeenCalledWith(9, 3, 2, f32);
+    expect(reducerFn).toHaveBeenCalledWith(12, 2, 1, f32);
+    expect(reducerFn).toHaveBeenCalledWith(14, 1, 0, f32);
+  });
+
+  test("supports .slice", () => {
+    expect(coVector.slice()).toEqual(new Float32Array([1, 2, 3, 4, 5]));
+    expect(coVector.slice(2)).toEqual(new Float32Array([3, 4, 5]));
+    expect(coVector.slice(2, 4)).toEqual(new Float32Array([3, 4]));
+  });
+
+  test("supports .some", () => {
+    expect(coVector.some((item) => item > 3)).toBe(true);
+    expect(coVector.some((item) => item > 5)).toBe(false);
+  });
+
+  test("supports .toJSON (JSON.stringify)", () => {
+    expect(JSON.stringify(coVector)).toEqual(`[1,2,3,4,5]`);
+  });
+
+  test("supports .toLocaleString", () => {
+    expect(coVector.toLocaleString()).toEqual("1,2,3,4,5");
+    expect(
+      coVector.toLocaleString("ja-JP", { style: "currency", currency: "JPY" }),
+    ).toEqual("￥1,￥2,￥3,￥4,￥5");
+  });
+
+  test("supports .toReversed", () => {
+    expect(coVector.toReversed()).toEqual(new Float32Array([5, 4, 3, 2, 1]));
+  });
+
+  test("supports .toSorted", () => {
+    const coVector = EmbeddingSchema.create([2, 3, 4, 5, 1]);
+    expect(coVector.toSorted()).toEqual(new Float32Array([1, 2, 3, 4, 5]));
+  });
+
+  test("supports .toString", () => {
+    expect(coVector.toString()).toEqual("1,2,3,4,5");
+  });
+
+  test("supports .values", () => {
+    expect(Array.from(coVector.values())).toEqual([1, 2, 3, 4, 5]);
+  });
+});
+
+describe("CoVector setters & mutators", async () => {
+  const EmbeddingSchema = co.vector(5);
+  const { me, coVector } = await initNodeAndVector(
+    EmbeddingSchema,
+    new Float32Array([1, 2, 3, 4, 5]),
+  );
+
+  const expectedErrorMessage = /Cannot mutate a CoVector/i;
+
+  test("updating value at index • throws an error", () => {
+    expect(() => {
+      coVector[0] = 6;
+    }).toThrow(expectedErrorMessage);
+  });
+  test("calling .copyWithin • throws an error", () => {
+    expect(() => coVector.copyWithin(1, 2)).toThrow(expectedErrorMessage);
+  });
+  test("calling .fill • throws an error", () => {
+    expect(() => coVector.fill(1)).toThrow(expectedErrorMessage);
+  });
+  test("calling .reverse • throws an error", () => {
+    expect(() => coVector.reverse()).toThrow(expectedErrorMessage);
+  });
+  test("calling .set • throws an error", () => {
+    expect(() => coVector.set(new Float32Array([6, 7, 8]))).toThrow(
+      expectedErrorMessage,
+    );
+  });
+  test("calling .sort • throws an error", () => {
+    expect(() => coVector.sort()).toThrow(expectedErrorMessage);
+  });
+  test("calling .subarray • throws an error", () => {
+    expect(() => coVector.subarray()).toThrow(expectedErrorMessage);
+  });
+  test("calling .with • throws an error", () => {
+    expect(() => coVector.with(1, 2)).toThrow(expectedErrorMessage);
+  });
+});
+
+describe("Vector calculations", async () => {
+  const VectorSchema = co.vector(5);
+
+  const vecA = new Float32Array([1, 2, 3, 4, 5]);
+  const vecB = new Float32Array([5, 4, 3, 2, 1]);
+
+  const coVectorA = VectorSchema.create(vecA);
+  const coVectorB = VectorSchema.create(vecB);
+
+  describe("magnitude", () => {
+    const magnitudeApprox: [number, number] = [7.4162, 4];
+
+    test("schema method", () => {
+      expect(VectorSchema.magnitude(vecA)).toBeCloseTo(...magnitudeApprox);
+      expect(VectorSchema.magnitude(coVectorA)).toBeCloseTo(...magnitudeApprox);
+    });
+    test("static method", () => {
+      expect(CoVector.magnitude(vecA)).toBeCloseTo(...magnitudeApprox);
+      expect(CoVector.magnitude(coVectorA)).toBeCloseTo(...magnitudeApprox);
+    });
+    test("instance method", () => {
+      expect(coVectorA.magnitude()).toBeCloseTo(...magnitudeApprox);
+    });
+  });
+
+  describe("normalize", () => {
+    const normalized = new Float32Array([
+      0.1348399668931961, 0.2696799337863922, 0.4045199155807495,
+      0.5393598675727844, 0.6741998791694641,
+    ]);
+
+    test("schema method", () => {
+      expect(VectorSchema.normalize(vecA)).toEqual(normalized);
+      expect(VectorSchema.normalize(coVectorA)).toEqual(normalized);
+    });
+
+    test("static method", () => {
+      expect(CoVector.normalize(vecA)).toEqual(normalized);
+      expect(CoVector.normalize(coVectorA)).toEqual(normalized);
+    });
+
+    test("instance method", () => {
+      expect(coVectorA.normalize()).toEqual(normalized);
+    });
+  });
+
+  describe("dot product", () => {
+    const dotProduct = 35;
+
+    test("schema method", () => {
+      expect(VectorSchema.dotProduct(vecA, vecB)).toBe(dotProduct);
+      expect(VectorSchema.dotProduct(vecA, coVectorB)).toBe(dotProduct);
+      expect(VectorSchema.dotProduct(coVectorA, vecB)).toBe(dotProduct);
+      expect(VectorSchema.dotProduct(coVectorA, coVectorB)).toBe(dotProduct);
+    });
+
+    test("static method", () => {
+      expect(CoVector.dotProduct(vecA, vecB)).toBe(dotProduct);
+      expect(CoVector.dotProduct(vecA, coVectorB)).toBe(dotProduct);
+      expect(CoVector.dotProduct(coVectorA, vecB)).toBe(dotProduct);
+      expect(CoVector.dotProduct(coVectorA, coVectorB)).toBe(dotProduct);
+    });
+
+    test("instance method", () => {
+      expect(coVectorA.dotProduct(vecB)).toBe(dotProduct);
+      expect(coVectorA.dotProduct(coVectorB)).toBe(dotProduct);
+    });
+  });
+
+  describe("cosine similarity", () => {
+    const similarityApprox: [number, number] = [0.6364, 4];
+
+    test("schema method", () => {
+      expect(VectorSchema.cosineSimilarity(vecA, vecB)).toBeCloseTo(
+        ...similarityApprox,
+      );
+      expect(VectorSchema.cosineSimilarity(vecA, coVectorB)).toBeCloseTo(
+        ...similarityApprox,
+      );
+      expect(VectorSchema.cosineSimilarity(coVectorA, vecB)).toBeCloseTo(
+        ...similarityApprox,
+      );
+      expect(VectorSchema.cosineSimilarity(coVectorA, coVectorB)).toBeCloseTo(
+        ...similarityApprox,
+      );
+    });
+
+    test("static method", () => {
+      expect(CoVector.cosineSimilarity(vecA, vecB)).toBeCloseTo(
+        ...similarityApprox,
+      );
+      expect(CoVector.cosineSimilarity(vecA, coVectorB)).toBeCloseTo(
+        ...similarityApprox,
+      );
+      expect(CoVector.cosineSimilarity(coVectorA, vecB)).toBeCloseTo(
+        ...similarityApprox,
+      );
+      expect(CoVector.cosineSimilarity(coVectorA, coVectorB)).toBeCloseTo(
+        ...similarityApprox,
+      );
+    });
+
+    test("instance method", () => {
+      expect(coVectorA.cosineSimilarity(vecB)).toBeCloseTo(...similarityApprox);
+      expect(coVectorA.cosineSimilarity(coVectorB)).toBeCloseTo(
+        ...similarityApprox,
+      );
+    });
+  });
+
+  test("equals", () => {
+    expect(coVectorA.equals(vecA)).toBe(true);
+    expect(coVectorA.equals(coVectorA)).toBe(true);
+    expect(coVectorA.equals(vecB)).toBe(false);
+  });
+});
+
+describe("CoVector loading & availability", async () => {
+  const EmbeddingSchema = co.vector(3);
+
+  test("when .waitForSync is called • the entire vector is uploaded", async () => {
+    const { clientNode, serverNode, clientAccount } = await setupTwoNodes();
+
+    const embedding = EmbeddingSchema.create([1, 2, 3], {
+      owner: clientAccount,
+    });
+    await embedding.$jazz.waitForSync({ timeout: 1000 });
+
+    // Killing the client node so the serverNode can't load the vector from it
+    clientNode.gracefulShutdown();
+
+    const loadedEmbedding = await serverNode.load(embedding.$jazz.raw.id);
+
+    expect(loadedEmbedding).not.toBe("unavailable");
+
+    if (loadedEmbedding !== "unavailable") {
+      // check that the data was uploaded (3 transactions for smaller vectors: start, data, end)
+      expect(loadedEmbedding?.core?.verifiedTransactions.length).toBe(3);
+    }
+  });
+
+  test("when .waitForSync is called on 1024 kB vector • the entire vector is uploaded", async () => {
+    const { clientNode, serverNode, clientAccount } = await setupTwoNodes();
+
+    const kB = 1024;
+
+    const EmbeddingSchema = co.vector(elementsForKb(kB));
+    const embedding = EmbeddingSchema.create(
+      new Float32Array(elementsForKb(kB)).fill(0.5),
+      { owner: clientAccount },
+    );
+    await embedding.$jazz.waitForSync({ timeout: 1000 });
+
+    // Killing the client node so the serverNode can't load the vector from it
+    clientNode.gracefulShutdown();
+
+    const loadedEmbedding = await serverNode.load(embedding.$jazz.raw.id);
+
+    expect(loadedEmbedding).not.toBe("unavailable");
+
+    // check that the data was uploaded
+    if (loadedEmbedding !== "unavailable") {
+      const expectedTransactionsCount = Math.ceil(
+        kbToBytes(kB) /
+          cojsonInternals.TRANSACTION_CONFIG.MAX_RECOMMENDED_TX_SIZE,
+      );
+      expect(loadedEmbedding?.core?.verifiedTransactions.length).toBe(
+        expectedTransactionsCount + 2, // +2 for the start and end transactions
+      );
+    }
+  });
+
+  test("when calling .load from different account • syncs across peers", async () => {
+    const { coVector } = await initNodeAndVector(
+      EmbeddingSchema,
+      new Float32Array([9, 8, 7]),
+    );
+
+    const alice = await createJazzTestAccount();
+
+    const loadedVector = await EmbeddingSchema.load(coVector.$jazz.id, {
+      loadAs: alice,
+    });
+
+    assert(loadedVector);
+    expect(loadedVector.length).toBe(3);
+    expect(loadedVector[0]).toBe(9);
+    expect(loadedVector[1]).toBe(8);
+    expect(loadedVector[2]).toBe(7);
+
+    // Check that the cores are not the same...
+    expect(loadedVector.$jazz.raw.core).not.toEqual(coVector.$jazz.raw.core);
+
+    // ...but the known states are the same
+    expect(loadedVector.$jazz.raw.core.knownState()).toEqual(
+      coVector.$jazz.raw.core.knownState(),
+    );
+    expect(loadedVector.$jazz.raw.core.verifiedTransactions.length).toBe(
+      coVector.$jazz.raw.core.verifiedTransactions.length,
+    );
+  });
+
+  test("when calling .load on a 1024 kB vector from different account • syncs across peers", async () => {
+    const kb = 1024;
+
+    const EmbeddingSchema = co.vector(elementsForKb(kb));
+    const { coVector } = await initNodeAndVector(
+      EmbeddingSchema,
+      new Float32Array(elementsForKb(kb)).fill(0.5),
+    );
+
+    const alice = await createJazzTestAccount();
+
+    const loadedVector = await EmbeddingSchema.load(coVector.$jazz.id, {
+      loadAs: alice,
+    });
+
+    assert(loadedVector);
+    expect(loadedVector).toBeInstanceOf(CoVector);
+    expect(loadedVector.length).toBe(elementsForKb(kb));
+    expect(loadedVector.every((item) => item === 0.5)).toBe(true);
+
+    // Check that the cores are not the same...
+    expect(loadedVector.$jazz.raw.core).not.toEqual(coVector.$jazz.raw.core);
+
+    // ...but the known states are the same
+    expect(loadedVector.$jazz.raw.core.knownState()).toEqual(
+      coVector.$jazz.raw.core.knownState(),
+    );
+    expect(loadedVector.$jazz.raw.core.verifiedTransactions.length).toBe(
+      coVector.$jazz.raw.core.verifiedTransactions.length,
+    );
+  });
+});
+
+describe("CoVector in subscription", async () => {
+  const EmbeddingSchema = co.vector(3);
+  const DocsChunk = co.map({
+    content: z.string(),
+    embedding: EmbeddingSchema,
+  });
+  const Docs = co.list(DocsChunk);
+
+  describe("standalone CoVector", async () => {
+    test("subscribing to locally available CoVector • sends update holding the CoVector", async () => {
+      const embedding = EmbeddingSchema.create(new Float32Array([10, 20, 30]));
+
+      const updates: Loaded<typeof EmbeddingSchema>[] = [];
+      const updatesCallback = vi.fn((embedding) => updates.push(embedding));
+
+      EmbeddingSchema.subscribe(
+        embedding.$jazz.id,
+        { loadAs: me },
+        updatesCallback,
+      );
+
+      expect(updatesCallback).not.toHaveBeenCalled();
+
+      await waitFor(() => expect(updatesCallback).toHaveBeenCalled());
+
+      expect(updatesCallback).toHaveBeenCalledTimes(1);
+
+      expect(updates[0]).toBeInstanceOf(CoVector);
+      expect(updates[0]?.toString()).toEqual("10,20,30");
+    });
+
+    test("subscribing to remotely available CoVector • sends update holding the CoVector", async () => {
+      const group = Group.create();
+      group.addMember("everyone", "writer");
+
+      const embedding = EmbeddingSchema.create(
+        new Float32Array([10, 20, 30]),
+        group,
+      );
+
+      const userB = await createJazzTestAccount();
+
+      const updates: Loaded<typeof EmbeddingSchema>[] = [];
+      const updatesCallback = vi.fn((embedding) => updates.push(embedding));
+
+      EmbeddingSchema.subscribe(
+        embedding.$jazz.id,
+        { loadAs: userB },
+        updatesCallback,
+      );
+
+      expect(updatesCallback).not.toHaveBeenCalled();
+
+      await waitFor(() => expect(updatesCallback).toHaveBeenCalled());
+
+      expect(updatesCallback).toHaveBeenCalledTimes(1);
+
+      expect(updates[0]).toBeInstanceOf(CoVector);
+      expect(updates[0]?.toString()).toEqual("10,20,30");
+    });
+  });
+
+  describe("CoVector in CoList[CoMap]", async () => {
+    describe("locally available list", async () => {
+      test("subscribing with deep resolve • sends update holding the CoVectors", async () => {
+        const docs = Docs.create([
+          DocsChunk.create({
+            content: "Call GET to retrieve document",
+            embedding: EmbeddingSchema.create(new Float32Array([1, 2, 3])),
+          }),
+          DocsChunk.create({
+            content: "Call POST to create a new document",
+            embedding: EmbeddingSchema.create(new Float32Array([4, 5, 6])),
+          }),
+        ]);
+
+        const updates: Loaded<typeof Docs, { $each: true }>[] = [];
+        const updatesCallback = vi.fn((docs) => updates.push(docs));
+
+        Docs.subscribe(
+          docs.$jazz.id,
+          { resolve: { $each: true } },
+          updatesCallback,
+        );
+
+        expect(updatesCallback).not.toHaveBeenCalled();
+
+        await waitFor(() => expect(updatesCallback).toHaveBeenCalled());
+
+        expect(updatesCallback).toHaveBeenCalledTimes(1);
+
+        expect(updates[0]?.[0]?.content).toEqual(
+          "Call GET to retrieve document",
+        );
+        expect(updates[0]?.[1]?.content).toEqual(
+          "Call POST to create a new document",
+        );
+        expect(updates[0]?.[0]?.embedding?.toString()).toBe("1,2,3");
+        expect(updates[0]?.[1]?.embedding?.toString()).toBe("4,5,6");
+
+        // Update the second document's embedding
+        docs[1]!.$jazz.set(
+          "embedding",
+          EmbeddingSchema.create(new Float32Array([7, 8, 9])),
+        );
+
+        await waitFor(() => expect(updatesCallback).toHaveBeenCalledTimes(2));
+
+        expect(updates[1]?.[0]?.embedding?.toString()).toBe("1,2,3");
+        expect(updates[1]?.[1]?.embedding?.toString()).toBe("7,8,9");
+
+        expect(updatesCallback).toHaveBeenCalledTimes(2);
+      });
+
+      test("subscribing with autoload • sends update holding the CoVectors", async () => {
+        const docs = Docs.create([
+          DocsChunk.create({
+            content: "Call GET to retrieve document",
+            embedding: EmbeddingSchema.create(new Float32Array([1, 2, 3])),
+          }),
+          DocsChunk.create({
+            content: "Call POST to create a new document",
+            embedding: EmbeddingSchema.create(new Float32Array([4, 5, 6])),
+          }),
+        ]);
+
+        const updates: Loaded<typeof Docs>[] = [];
+        const updatesCallback = vi.fn((docs) => updates.push(docs));
+
+        Docs.subscribe(docs.$jazz.id, {}, updatesCallback);
+
+        expect(updatesCallback).not.toHaveBeenCalled();
+
+        await waitFor(() => expect(updatesCallback).toHaveBeenCalled());
+
+        expect(updatesCallback).toHaveBeenCalledTimes(1);
+
+        expect(updates[0]?.[0]?.content).toEqual(
+          "Call GET to retrieve document",
+        );
+        expect(updates[0]?.[1]?.content).toEqual(
+          "Call POST to create a new document",
+        );
+        expect(updates[0]?.[0]?.embedding?.toString()).toBe("1,2,3");
+        expect(updates[0]?.[1]?.embedding?.toString()).toBe("4,5,6");
+
+        // Update the second document's embedding
+        docs[1]!.$jazz.set(
+          "embedding",
+          EmbeddingSchema.create(new Float32Array([7, 8, 9])),
+        );
+
+        await waitFor(() => expect(updatesCallback).toHaveBeenCalledTimes(2));
+
+        expect(updates[1]?.[0]?.embedding?.toString()).toBe("1,2,3");
+        expect(updates[1]?.[1]?.embedding?.toString()).toBe("7,8,9");
+
+        expect(updatesCallback).toHaveBeenCalledTimes(2);
+      });
+    });
+
+    describe("remotely available list", async () => {
+      test("subscribing with deep resolve • sends update holding the CoVectors", async () => {
+        const group = Group.create({ owner: me });
+        group.addMember("everyone", "writer");
+
+        const docs = Docs.create(
+          [
+            DocsChunk.create(
+              {
+                content: "Call GET to retrieve document",
+                embedding: EmbeddingSchema.create(
+                  new Float32Array([1, 2, 3]),
+                  group,
+                ),
+              },
+              group,
+            ),
+            DocsChunk.create(
+              {
+                content: "Call POST to create a new document",
+                embedding: EmbeddingSchema.create(
+                  new Float32Array([4, 5, 6]),
+                  group,
+                ),
+              },
+              group,
+            ),
+          ],
+          group,
+        );
+
+        const userB = await createJazzTestAccount();
+
+        const updates: Loaded<typeof Docs, { $each: true }>[] = [];
+        const updatesCallback = vi.fn((docs) => updates.push(docs));
+
+        Docs.subscribe(
+          docs.$jazz.id,
+          {
+            resolve: { $each: true },
+            loadAs: userB,
+          },
+          updatesCallback,
+        );
+
+        expect(updatesCallback).not.toHaveBeenCalled();
+
+        await waitFor(() => expect(updatesCallback).toHaveBeenCalled());
+
+        expect(updatesCallback).toHaveBeenCalledTimes(1);
+
+        await waitFor(() => {
+          expect(updates[0]?.[0]?.embedding?.toString()).toBe("1,2,3");
+          expect(updates[0]?.[1]?.embedding?.toString()).toBe("4,5,6");
+        });
+
+        // Update the second document's embedding
+        docs[1]!.$jazz.set(
+          "embedding",
+          EmbeddingSchema.create(new Float32Array([7, 8, 9]), group),
+        );
+
+        await waitFor(() => expect(updatesCallback).toHaveBeenCalledTimes(5));
+
+        expect(updates[1]?.[0]?.embedding?.toString()).toBe("1,2,3");
+        expect(updates[1]?.[1]?.embedding?.toString()).toBe("7,8,9");
+
+        expect(updatesCallback).toHaveBeenCalledTimes(5);
+      });
+
+      test("subscribing with autoload • sends update holding the CoVectors", async () => {
+        const group = Group.create({ owner: me });
+        group.addMember("everyone", "writer");
+
+        const docs = Docs.create(
+          [
+            DocsChunk.create(
+              {
+                content: "Call GET to retrieve document",
+                embedding: EmbeddingSchema.create(
+                  new Float32Array([1, 2, 3]),
+                  group,
+                ),
+              },
+              group,
+            ),
+            DocsChunk.create(
+              {
+                content: "Call POST to create a new document",
+                embedding: EmbeddingSchema.create(
+                  new Float32Array([4, 5, 6]),
+                  group,
+                ),
+              },
+              group,
+            ),
+          ],
+          group,
+        );
+
+        const userB = await createJazzTestAccount();
+
+        const updates: Loaded<typeof Docs>[] = [];
+        const updatesCallback = vi.fn((docs) => updates.push(docs));
+
+        Docs.subscribe(
+          docs.$jazz.id,
+          {
+            loadAs: userB,
+          },
+          updatesCallback,
+        );
+
+        expect(updatesCallback).not.toHaveBeenCalled();
+
+        await waitFor(() => expect(updatesCallback).toHaveBeenCalled());
+
+        await waitFor(() => {
+          expect(updates[0]?.[0]?.embedding?.toString()).toBe("1,2,3");
+          expect(updates[0]?.[1]?.embedding?.toString()).toBe("4,5,6");
+        });
+
+        // Update the second document's embedding
+        docs[1]!.$jazz.set(
+          "embedding",
+          EmbeddingSchema.create(new Float32Array([7, 8, 9]), group),
+        );
+
+        await waitFor(() => expect(updatesCallback).toHaveBeenCalledTimes(7));
+
+        expect(updates[1]?.[0]?.embedding?.toString()).toBe("1,2,3");
+        expect(updates[1]?.[1]?.embedding?.toString()).toBe("7,8,9");
+
+        expect(updatesCallback).toHaveBeenCalledTimes(7);
+      });
+    });
+  });
+});
+
+describe("CoVector dimension mismatch after loading", async () => {
+  test("accessing CoVector loaded with an incompatible schema • throws an error", async () => {
+    const { coVector } = await initNodeAndVector(
+      co.vector(3),
+      new Float32Array([1, 2, 3]),
+    );
+
+    const loadedVector = await co.vector(9).load(coVector.$jazz.id);
+    expect(loadedVector).toBeInstanceOf(CoVector);
+    expect(() => loadedVector?.vector).toThrow(/Vector dimension mismatch/);
+  });
+
+  test("accessing CoVector from subscription, loaded with an incompatible schema • throws an error", async () => {
+    const EmbeddingSchema = co.vector(3);
+
+    const { coVector } = await initNodeAndVector(
+      EmbeddingSchema,
+      new Float32Array([1, 2, 3]),
+    );
+
+    const updates: Loaded<typeof EmbeddingSchema>[] = [];
+    const updatesCallback = vi.fn((embedding) => updates.push(embedding));
+
+    co.vector(5).subscribe(coVector.$jazz.id, updatesCallback);
+
+    await waitFor(() => expect(updatesCallback).toHaveBeenCalled());
+
+    expect(updates[0]).toBeInstanceOf(CoVector);
+    expect(() => updates[0]?.vector).toThrow(/Vector dimension mismatch/);
+  });
+});

--- a/packages/jazz-tools/src/tools/tests/coVector.test.ts
+++ b/packages/jazz-tools/src/tools/tests/coVector.test.ts
@@ -385,7 +385,7 @@ describe("CoVector mutation methods", async () => {
   });
 });
 
-describe("Vector calculations", async () => {
+describe("Vector calculations on .$jazz", async () => {
   const VectorSchema = co.vector(5);
 
   const vecA = new Float32Array([1, 2, 3, 4, 5]);
@@ -397,8 +397,8 @@ describe("Vector calculations", async () => {
   describe("magnitude", () => {
     const magnitudeApprox: [number, number] = [7.4162, 4];
 
-    test("instance method", () => {
-      expect(coVectorA.magnitude()).toBeCloseTo(...magnitudeApprox);
+    test("returns the magnitude of the vector", () => {
+      expect(coVectorA.$jazz.magnitude()).toBeCloseTo(...magnitudeApprox);
     });
   });
 
@@ -408,26 +408,28 @@ describe("Vector calculations", async () => {
       0.5393598675727844, 0.6741998791694641,
     ]);
 
-    test("instance method", () => {
-      expect(coVectorA.normalize()).toEqual(normalized);
+    test("returns the normalized vector", () => {
+      expect(coVectorA.$jazz.normalize()).toEqual(normalized);
     });
   });
 
   describe("dot product", () => {
     const dotProduct = 35;
 
-    test("instance method", () => {
-      expect(coVectorA.dotProduct(vecB)).toBe(dotProduct);
-      expect(coVectorA.dotProduct(coVectorB)).toBe(dotProduct);
+    test("returns the dot product of the 2 vectors", () => {
+      expect(coVectorA.$jazz.dotProduct(vecB)).toBe(dotProduct);
+      expect(coVectorA.$jazz.dotProduct(coVectorB)).toBe(dotProduct);
     });
   });
 
   describe("cosine similarity", () => {
     const similarityApprox: [number, number] = [0.6364, 4];
 
-    test("instance method", () => {
-      expect(coVectorA.cosineSimilarity(vecB)).toBeCloseTo(...similarityApprox);
-      expect(coVectorA.cosineSimilarity(coVectorB)).toBeCloseTo(
+    test("returns the cosine similarity of the 2 vectors", () => {
+      expect(coVectorA.$jazz.cosineSimilarity(vecB)).toBeCloseTo(
+        ...similarityApprox,
+      );
+      expect(coVectorA.$jazz.cosineSimilarity(coVectorB)).toBeCloseTo(
         ...similarityApprox,
       );
     });

--- a/packages/jazz-tools/src/tools/tests/coVector.test.ts
+++ b/packages/jazz-tools/src/tools/tests/coVector.test.ts
@@ -318,6 +318,12 @@ describe("CoVector reader methods & properties (Float32Array-like)", async () =>
     expect(coVector.some((item) => item > 5)).toBe(false);
   });
 
+  test("supports .subarray", () => {
+    expect(coVector.subarray().toString()).toEqual("1,2,3,4,5");
+    expect(coVector.subarray(2).toString()).toEqual("3,4,5");
+    expect(coVector.subarray(2, 4).toString()).toEqual("3,4");
+  });
+
   test("supports .toJSON (JSON.stringify)", () => {
     expect(JSON.stringify(coVector)).toEqual(`[1,2,3,4,5]`);
   });
@@ -345,65 +351,37 @@ describe("CoVector reader methods & properties (Float32Array-like)", async () =>
   test("supports .values", () => {
     expect(Array.from(coVector.values())).toEqual([1, 2, 3, 4, 5]);
   });
-});
-
-describe("CoVector setters & mutators (Float32Array-like)", async () => {
-  const EmbeddingSchema = co.vector(5);
-
-  test("supports updating value at index", () => {
-    const coVector = EmbeddingSchema.create([1, 2, 3, 4, 5]);
-    coVector[0] = 6;
-    expect(coVector.toString()).toEqual("6,2,3,4,5");
-  });
-
-  test("supports .copyWithin", () => {
-    const coVector = EmbeddingSchema.create([1, 2, 3, 4, 5]);
-    coVector.copyWithin(3, 0, 2);
-    expect(coVector.toString()).toEqual("1,2,3,1,2");
-  });
-
-  test("supports .fill", () => {
-    const coVector = EmbeddingSchema.create([1, 2, 3, 4, 5]);
-    coVector.fill(6);
-    expect(coVector.toString()).toEqual("6,6,6,6,6");
-
-    const coVector2 = EmbeddingSchema.create([1, 2, 3, 4, 5]);
-    coVector2.fill(6, 2);
-    expect(coVector2.toString()).toEqual("1,2,6,6,6");
-  });
-
-  test("supports .reverse", () => {
-    const coVector = EmbeddingSchema.create([1, 2, 3, 4, 5]);
-    coVector.reverse();
-    expect(coVector.toString()).toEqual("5,4,3,2,1");
-  });
-
-  test("supports .set", () => {
-    const coVector = EmbeddingSchema.create([1, 2, 3, 4, 5]);
-    coVector.set(new Float32Array([6, 7, 8]));
-    expect(coVector.toString()).toEqual("6,7,8,4,5");
-  });
-
-  test("supports .sort", () => {
-    const coVector = EmbeddingSchema.create([3, 1, 2, 5, 4]);
-    coVector.sort();
-    expect(coVector.toString()).toEqual("1,2,3,4,5");
-  });
-
-  test("supports .subarray", () => {
-    const coVector = EmbeddingSchema.create([1, 2, 3, 4, 5]);
-    expect(coVector.subarray().toString()).toEqual("1,2,3,4,5");
-
-    const coVector2 = EmbeddingSchema.create([1, 2, 3, 4, 5]);
-    expect(coVector2.subarray(2).toString()).toEqual("3,4,5");
-
-    const coVector3 = EmbeddingSchema.create([1, 2, 3, 4, 5]);
-    expect(coVector3.subarray(2, 4).toString()).toEqual("3,4");
-  });
 
   test("supports .with", () => {
-    const coVector = EmbeddingSchema.create([1, 2, 3, 4, 5]);
     expect(coVector.with(4, 2).toString()).toEqual("1,2,3,4,2");
+  });
+});
+
+describe("CoVector mutation methods", async () => {
+  const EmbeddingSchema = co.vector(5);
+  const { coVector } = await initNodeAndVector(
+    EmbeddingSchema,
+    new Float32Array([1, 2, 3, 4, 5]),
+  );
+
+  const expectedErrorMessage = /Cannot mutate a CoVector/i;
+
+  test("calling .copyWithin • throws an error", () => {
+    expect(() => coVector.copyWithin(1, 2)).toThrow(expectedErrorMessage);
+  });
+  test("calling .fill • throws an error", () => {
+    expect(() => coVector.fill(1)).toThrow(expectedErrorMessage);
+  });
+  test("calling .reverse • throws an error", () => {
+    expect(() => coVector.reverse()).toThrow(expectedErrorMessage);
+  });
+  test("calling .set • throws an error", () => {
+    expect(() => coVector.set(new Float32Array([6, 7, 8]))).toThrow(
+      expectedErrorMessage,
+    );
+  });
+  test("calling .sort • throws an error", () => {
+    expect(() => coVector.sort()).toThrow(expectedErrorMessage);
   });
 });
 

--- a/packages/jazz-tools/src/tools/tests/coVector.test.ts
+++ b/packages/jazz-tools/src/tools/tests/coVector.test.ts
@@ -82,11 +82,17 @@ describe("Creating a CoVector", async () => {
   test("given a Array<number> with valid dimensions count • creates a CoVector", () => {
     const embedding = EmbeddingSchema.create([1, 2, 3]);
     expect(embedding).toBeInstanceOf(CoVector);
+    expect(embedding[0]).toBe(1);
+    expect(embedding[1]).toBe(2);
+    expect(embedding[2]).toBe(3);
   });
 
   test("given a Float32Array with valid dimensions count • creates a CoVector", () => {
     const embedding = EmbeddingSchema.create(new Float32Array([1, 2, 3]));
     expect(embedding).toBeInstanceOf(CoVector);
+    expect(embedding[0]).toBe(1);
+    expect(embedding[1]).toBe(2);
+    expect(embedding[2]).toBe(3);
   });
 
   test("given Account as owner • creates a CoVector", () => {

--- a/packages/jazz-tools/src/tools/tests/coVector.test.ts
+++ b/packages/jazz-tools/src/tools/tests/coVector.test.ts
@@ -79,6 +79,12 @@ describe("Creating a CoVector", async () => {
     );
   });
 
+  test("directly instantiating CoVector.create • throws an error", () => {
+    expect(() => CoVector.create([1, 2, 3])).toThrow(
+      "Instantiating CoVector without a dimensions count is not allowed. Use co.vector(...).create() instead.",
+    );
+  });
+
   test("given a Array<number> with valid dimensions count • creates a CoVector", () => {
     const embedding = EmbeddingSchema.create([1, 2, 3]);
     expect(embedding).toBeInstanceOf(CoVector);


### PR DESCRIPTION
# Description
Based on the comments [[1](https://github.com/garden-co/jazz/pull/2936#discussion_r2362764967)] [[2](https://github.com/garden-co/jazz/pull/2936#pullrequestreview-3244763956)] in the former related PR I explored the **`CoVector` that could be made without proxy**.

Because we know the expected vector length at construction (from the schema definer), we can `super()` call `Float32Array` properly with that expected length, then populate its data on load (this is important because TypedArrays cannot be resized like regular Arrays after init).

This allows CoVector to properly extend Float32Array with _all of its native behaviors, without a proxy and overrides_.

With 1 caveat: **losing the proxy it makes the CoVector instance locally mutable**. Although we could override the mutation methods, one could still mutate the contents via index access (ie `vec[6] = 4.5`) so I wouldn't go there.

## Questions

1. Is this better than the base branch implementation? ref #2936
2. Given the future plans as outlined in [[3](https://github.com/garden-co/jazz/pull/2936#issuecomment-3313678937)], should we remove the vector calculations from the CoVector altogether; or move inside `vec.$jazz`?

## Tests

- [x] Tests have been added and/or updated
- [ ] Tests have not been updated, because: <!-- Insert reason for not updating tests here -->
- [ ] I need help with writing tests


## Checklist

- [ ] I've updated the part of the docs that are affected the PR changes
- [ ] I've generated a changeset, if a version bump is required
- [x] I've updated the jsDoc comments to the public APIs I've modified, or added them when missing