### PR TITLE
docs: warning on better-auth package

### DIFF
--- a/homepage/homepage/content/docs/authentication/better-auth.mdx
+++ b/homepage/homepage/content/docs/authentication/better-auth.mdx
@@ -162,6 +162,11 @@ export function App() {
 ```
 </CodeGroup>
 
+<Alert variant="warning" className="mt-4" title="Important">
+  The AuthProvider component uses the `better-auth/client` package, not `better-auth/react`.
+  To verify the authentication state in your app, see <a href="#authentication-states">Authentication states</a>.
+</Alert>
+
 </ContentByFramework>
 
 <ContentByFramework framework={["vanilla", "svelte"]}>


### PR DESCRIPTION
# Description

Today, already two community requests have been about the correct usage of the better-auth package.  A simple warning box to enforce reading the _Authentication States_ chapter may be helpful. 