### PR TITLE
feat: add `unstable_branch` option to useAccountWithSelector

### DIFF
--- a/.changeset/hungry-bulldogs-decide.md
+++ b/.changeset/hungry-bulldogs-decide.md
@@ -1,0 +1,5 @@
+---
+"jazz-tools": patch
+---
+
+Add `unstable_branch` option to useAccountWithSelector

--- a/packages/jazz-tools/src/react-core/hooks.ts
+++ b/packages/jazz-tools/src/react-core/hooks.ts
@@ -719,6 +719,22 @@ export function useAccountWithSelector<
     select: (account: Loaded<A, R> | undefined | null) => TSelectorReturn;
     /** Equality function to determine if the selected value has changed, defaults to `Object.is` */
     equalityFn?: (a: TSelectorReturn, b: TSelectorReturn) => boolean;
+    /**
+     * Create or load a branch for isolated editing.
+     *
+     * Branching lets you take a snapshot of the current state and start modifying it without affecting the canonical/shared version.
+     * It's a fork of your data graph: the same schema, but with diverging values.
+     *
+     * The checkout of the branch is applied on all the resolved values.
+     *
+     * @param name - A unique name for the branch. This identifies the branch
+     *   and can be used to switch between different branches of the same CoValue.
+     * @param owner - The owner of the branch. Determines who can access and modify
+     *   the branch. If not provided, the branch is owned by the current user.
+     *
+     * For more info see the [branching](https://jazz.tools/docs/react/using-covalues/version-control) documentation.
+     */
+    unstable_branch?: BranchDefinition;
   },
 ): TSelectorReturn {
   const subscription = useAccountSubscription(AccountSchema, options);


### PR DESCRIPTION
# Description

Just noticed `useAccountWithSelector` does not currently support `unstable_branch`, so I added it.

## Tests

- [x] Tests have been added and/or updated

## Checklist

- [ ] I've updated the part of the docs that are affected the PR changes
- [x] I've generated a changeset, if a version bump is required
- [x] I've updated the jsDoc comments to the public APIs I've modified, or added them when missing