### PR TITLE
fix: batch remote updates and wait for streaming before migrations

### DIFF
--- a/.changeset/big-files-try.md
+++ b/.changeset/big-files-try.md
@@ -1,0 +1,5 @@
+---
+"cojson": patch
+---
+
+Add batching on per-coValue updates when the update doesn't come from a local change

--- a/.changeset/fluffy-singers-hammer.md
+++ b/.changeset/fluffy-singers-hammer.md
@@ -1,0 +1,5 @@
+---
+"jazz-tools": patch
+---
+
+Bugfix: wait for full streaming before triggering migrations on comap

--- a/packages/cojson/src/coValueCore/coValueCore.ts
+++ b/packages/cojson/src/coValueCore/coValueCore.ts
@@ -536,7 +536,7 @@ export class CoValueCore {
     });
   }
 
-  updateCurrentContent() {
+  private updateCurrentContent() {
     if (
       this._cachedContent &&
       "processNewTransactions" in this._cachedContent &&
@@ -550,8 +550,9 @@ export class CoValueCore {
     this._cachedDependentOn = undefined;
   }
 
-  #batching = false;
+  #isNotificationScheduled = false;
   #batchedUpdates = false;
+
   private scheduleNotifyUpdate() {
     if (this.listeners.size === 0) {
       return;
@@ -559,11 +560,11 @@ export class CoValueCore {
 
     this.#batchedUpdates = true;
 
-    if (!this.#batching) {
-      this.#batching = true;
+    if (!this.#isNotificationScheduled) {
+      this.#isNotificationScheduled = true;
 
       queueMicrotask(() => {
-        this.#batching = false;
+        this.#isNotificationScheduled = false;
 
         // Check if an immediate update has been notified
         if (this.#batchedUpdates) {
@@ -674,7 +675,7 @@ export class CoValueCore {
     this.updateCurrentContent();
 
     // force immediate notification because local updates may come from the UI
-    // where we need syncronous updates
+    // where we need synchronous updates
     this.notifyUpdate();
     this.node.syncManager.syncLocalTransaction(
       this.verified,

--- a/packages/cojson/src/coValueCore/coValueCore.ts
+++ b/packages/cojson/src/coValueCore/coValueCore.ts
@@ -277,7 +277,7 @@ export class CoValueCore {
     const previousState = this.loadingState;
     this.peers.set(peerId, { type: "unavailable" });
     this.updateCounter(previousState);
-    this.notifyUpdate("immediate");
+    this.scheduleNotifyUpdate();
   }
 
   missingDependencies = new Set<RawCoID>();
@@ -323,7 +323,7 @@ export class CoValueCore {
         }
 
         if (this.isAvailable()) {
-          this.notifyUpdate("immediate");
+          this.scheduleNotifyUpdate();
         }
       });
 
@@ -360,7 +360,7 @@ export class CoValueCore {
     this.peers.set(fromPeerId, { type: "available" });
 
     this.updateCounter(previousState);
-    this.notifyUpdate("immediate");
+    this.scheduleNotifyUpdate();
 
     return true;
   }
@@ -374,21 +374,21 @@ export class CoValueCore {
       forceOverwrite,
     });
     this.updateCounter(previousState);
-    this.notifyUpdate("immediate");
+    this.scheduleNotifyUpdate();
   }
 
   markErrored(peerId: PeerID, error: TryAddTransactionsError) {
     const previousState = this.loadingState;
     this.peers.set(peerId, { type: "errored", error });
     this.updateCounter(previousState);
-    this.notifyUpdate("immediate");
+    this.scheduleNotifyUpdate();
   }
 
   markPending(peerId: PeerID) {
     const previousState = this.loadingState;
     this.peers.set(peerId, { type: "pending" });
     this.updateCounter(previousState);
-    this.notifyUpdate("immediate");
+    this.scheduleNotifyUpdate();
   }
 
   internalShamefullyCloneVerifiedStateFrom(
@@ -431,7 +431,7 @@ export class CoValueCore {
         this.groupInvalidationSubscription = entry.subscribe((_groupUpdate) => {
           // When the group is updated, we need to reset the cached content because the transactions validity might have changed
           this.internalShamefullyResetCachedContent();
-          this.notifyUpdate("immediate");
+          this.scheduleNotifyUpdate();
         }, false);
       } else {
         logger.error("CoValueCore: Owner group not available", {
@@ -528,17 +528,15 @@ export class CoValueCore {
       );
 
       if (result.isOk()) {
-        this.updateContentAndNotifyUpdate("immediate");
+        this.updateCurrentContent();
+        this.scheduleNotifyUpdate();
       }
 
       return result;
     });
   }
 
-  deferredUpdates = 0;
-  nextDeferredNotify: Promise<void> | undefined;
-
-  updateContentAndNotifyUpdate(notifyMode: "immediate" | "deferred") {
+  updateCurrentContent() {
     if (
       this._cachedContent &&
       "processNewTransactions" in this._cachedContent &&
@@ -550,47 +548,46 @@ export class CoValueCore {
     }
 
     this._cachedDependentOn = undefined;
-
-    this.notifyUpdate(notifyMode);
   }
 
-  notifyUpdate(notifyMode: "immediate" | "deferred") {
+  #batching = false;
+  #batchedUpdates = false;
+  private scheduleNotifyUpdate() {
     if (this.listeners.size === 0) {
       return;
     }
 
-    if (notifyMode === "immediate") {
-      for (const listener of this.listeners) {
-        try {
-          listener(this, () => {
-            this.listeners.delete(listener);
-          });
-        } catch (e) {
-          logger.error("Error in listener for coValue " + this.id, { err: e });
+    this.#batchedUpdates = true;
+
+    if (!this.#batching) {
+      this.#batching = true;
+
+      queueMicrotask(() => {
+        this.#batching = false;
+
+        // Check if an immediate update has been notified
+        if (this.#batchedUpdates) {
+          this.notifyUpdate();
         }
-      }
-    } else {
-      if (!this.nextDeferredNotify) {
-        this.nextDeferredNotify = new Promise((resolve) => {
-          setTimeout(() => {
-            this.nextDeferredNotify = undefined;
-            this.deferredUpdates = 0;
-            for (const listener of this.listeners) {
-              try {
-                listener(this, () => {
-                  this.listeners.delete(listener);
-                });
-              } catch (e) {
-                logger.error("Error in listener for coValue " + this.id, {
-                  err: e,
-                });
-              }
-            }
-            resolve();
-          }, 0);
+      });
+    }
+  }
+
+  private notifyUpdate() {
+    if (this.listeners.size === 0) {
+      return;
+    }
+
+    this.#batchedUpdates = false;
+
+    for (const listener of this.listeners) {
+      try {
+        listener(this, () => {
+          this.listeners.delete(listener);
         });
+      } catch (e) {
+        logger.error("Error in listener for coValue " + this.id, { err: e });
       }
-      this.deferredUpdates++;
     }
   }
 
@@ -674,7 +671,11 @@ export class CoValueCore {
     const session = this.verified.sessions.get(sessionID);
     const txIdx = session ? session.transactions.length - 1 : 0;
 
-    this.updateContentAndNotifyUpdate("immediate");
+    this.updateCurrentContent();
+
+    // force immediate notification because local updates may come from the UI
+    // where we need syncronous updates
+    this.notifyUpdate();
     this.node.syncManager.syncLocalTransaction(
       this.verified,
       transaction,

--- a/packages/cojson/src/tests/coValueCore.test.ts
+++ b/packages/cojson/src/tests/coValueCore.test.ts
@@ -21,6 +21,7 @@ import {
   randomAgentAndSessionID,
   setupTestNode,
   tearDownTestMetricReader,
+  waitFor,
 } from "./testUtils.js";
 import { CO_VALUE_PRIORITY } from "../priority.js";
 import { setMaxTxSizeBytes } from "../config.js";
@@ -189,7 +190,9 @@ test("New transactions in a group correctly update owned values, including subsc
   expect(group.get(agent.id)).toBe("revoked");
   dateNowMock.mockReset();
 
-  expect(listener).toHaveBeenCalledTimes(2);
+  // Group invalidation updates are async
+  await waitFor(() => expect(listener).toHaveBeenCalledTimes(2));
+
   expect(listener).toHaveBeenLastCalledWith(undefined);
   expect(map.core.getValidSortedTransactions().length).toBe(0);
 });

--- a/packages/jazz-tools/src/tools/subscribe/SubscriptionScope.ts
+++ b/packages/jazz-tools/src/tools/subscribe/SubscriptionScope.ts
@@ -79,7 +79,11 @@ export class SubscriptionScope<D extends CoValue> {
         // - Run the migration only once
         // - Skip all the updates until the migration is done
         // - Trigger handleUpdate only with the final value
-        if (!this.migrated && value !== "unavailable") {
+        if (
+          !this.migrated &&
+          value !== "unavailable" &&
+          !value.core.verified.isStreaming()
+        ) {
           if (this.migrating) {
             return;
           }

--- a/packages/jazz-tools/src/tools/tests/subscribe.test.ts
+++ b/packages/jazz-tools/src/tools/tests/subscribe.test.ts
@@ -559,10 +559,7 @@ describe("subscribeToCoValue", () => {
     assert(result);
 
     expect(result[0]?.value).toBe("1");
-
-    // expect(updateFn).toHaveBeenCalledTimes(1);
-    // TODO: Getting an extra update here due to https://github.com/garden-co/jazz/issues/2117
-    expect(updateFn).toHaveBeenCalledTimes(2);
+    expect(updateFn).toHaveBeenCalledTimes(1);
   });
 
   it("should handle undefined values in lists with required refs", async () => {


### PR DESCRIPTION
Some users reported that their migrations where sometimes running on empty covalues.

I haven't been able to reproduce the issue, but my guess is that it could happen for two reasons:
1. The value is large, and we don't wait for full download before triggering the migration
2. https://github.com/garden-co/jazz/issues/2117

It's more likely to be 2, but fixing 1 as well.

This PR also brings a small improvement on subscriptions, and prepares the ground for batching multi-value updates in the same subscription.

Fixes #2117
