### PR TITLE
fix: update CoValue _subscriptionScope when using getSubscriptionScope

### DIFF
--- a/.changeset/cuddly-vans-dream.md
+++ b/.changeset/cuddly-vans-dream.md
@@ -1,0 +1,5 @@
+---
+"jazz-tools": patch
+---
+
+Ensure subscription scope is cached for each CoValue

--- a/packages/jazz-tools/src/tools/subscribe/index.ts
+++ b/packages/jazz-tools/src/tools/subscribe/index.ts
@@ -18,7 +18,7 @@ export function getSubscriptionScope<D extends CoValue>(value: D) {
   });
 
   Object.defineProperty(value.$jazz, "_subscriptionScope", {
-    value: subscriptionScope,
+    value: newSubscriptionScope,
     writable: false,
     enumerable: false,
     configurable: false,

--- a/packages/jazz-tools/src/tools/tests/subscribe.test.ts
+++ b/packages/jazz-tools/src/tools/tests/subscribe.test.ts
@@ -20,6 +20,7 @@ import {
   setupJazzTestSync,
 } from "../testing.js";
 import { setupAccount, waitFor } from "./utils.js";
+import { getSubscriptionScope } from "../subscribe/index.js";
 
 cojsonInternals.setCoValueLoadingRetryDelay(300);
 
@@ -1276,5 +1277,45 @@ describe("subscribeToCoValue", () => {
     expect(updateFn).toHaveBeenCalledTimes(1);
     expect(result.data.length).toBe(chunks + 1);
     expect(result.data[chunks]).toBe("new entry");
+  });
+});
+
+describe("getSubscriptionScope", () => {
+  const Person = co.map({
+    name: z.string(),
+  });
+  let person: co.output<typeof Person>;
+
+  beforeEach(async () => {
+    await createJazzTestAccount({
+      isCurrentActiveAccount: true,
+      creationProps: { name: "Hermes Puggington" },
+    });
+
+    person = Person.create({ name: "John" });
+  });
+
+  describe("when the coValue doesn't have a subscription scope", () => {
+    it("creates a new subscription scope", () => {
+      expect(person.$jazz._subscriptionScope).toBeUndefined();
+      const subscriptionScope = getSubscriptionScope(person);
+      expect(subscriptionScope).toBeDefined();
+    });
+
+    it("updates the subscription scope in the coValue", () => {
+      const subscriptionScope = getSubscriptionScope(person);
+      expect(person.$jazz._subscriptionScope).toBeDefined();
+      expect(person.$jazz._subscriptionScope).toBe(subscriptionScope);
+    });
+  });
+
+  describe("when the coValue already has a subscription scope", () => {
+    it("returns that subscription scope", async () => {
+      const loadedPerson = await Person.load(person.$jazz.id);
+      assert(loadedPerson);
+      const subscriptionScope = loadedPerson.$jazz._subscriptionScope;
+      expect(subscriptionScope).toBeDefined();
+      expect(getSubscriptionScope(loadedPerson)).toBe(subscriptionScope);
+    });
   });
 });


### PR DESCRIPTION
# Description

We had a small bug in `getSubscriptionScope` that led us to not cache created Subscription Scopes. Don't think it was causing any issues, but caching them prevents generating multiple subscription scopes for the same CoValue.

## Tests

- [x] Tests have been added and/or updated

## Checklist

- [ ] I've updated the part of the docs that are affected the PR changes
- [x] I've generated a changeset, if a version bump is required
- [ ] I've updated the jsDoc comments to the public APIs I've modified, or added them when missing