### PR TITLE
fix: required CoMap field refs incorrectly marked as optional when field is not loaded

### DIFF
--- a/.changeset/few-pumpkins-protect.md
+++ b/.changeset/few-pumpkins-protect.md
@@ -1,0 +1,5 @@
+---
+"jazz-tools": patch
+---
+
+Fix refs in partially loaded CoMaps being incorrectly marked as optional

--- a/packages/jazz-tools/src/tools/coValues/coMap.ts
+++ b/packages/jazz-tools/src/tools/coValues/coMap.ts
@@ -34,6 +34,7 @@ import {
   CoValueBase,
   CoValueJazzApi,
   ItemsSym,
+  NotNull,
   Ref,
   RegisteredSchemas,
   SchemaInit,
@@ -760,11 +761,10 @@ class CoMapJazzApi<M extends CoMap> extends CoValueJazzApi<M> {
         ? Key
         : never]?: RefIfCoValue<M[Key]>;
     } & {
-      [Key in CoKeys<M> as M[Key] extends undefined
-        ? never
-        : M[Key] extends CoValue
-          ? Key
-          : never]: RefIfCoValue<M[Key]>;
+      // Non-loaded CoValue refs (i.e. refs with type CoValue | null) are still required refs
+      [Key in CoKeys<M> as NotNull<M[Key]> extends CoValue
+        ? Key
+        : never]: RefIfCoValue<M[Key]>;
     }
   > {
     return makeRefs<CoKeys<this>>(

--- a/packages/jazz-tools/src/tools/tests/coMap.test.ts
+++ b/packages/jazz-tools/src/tools/tests/coMap.test.ts
@@ -1207,7 +1207,7 @@ describe("CoMap resolution", async () => {
 
     expect(loadedPerson.$jazz.refs.dog.id).toBe(person.dog.$jazz.id);
 
-    const dog = await loadedPerson.$jazz.refs.dog?.load();
+    const dog = await loadedPerson.$jazz.refs.dog.load();
 
     assert(dog);
 

--- a/packages/jazz-tools/src/tools/tests/coMap.test.ts
+++ b/packages/jazz-tools/src/tools/tests/coMap.test.ts
@@ -1150,6 +1150,30 @@ describe("CoMap resolution", async () => {
     });
   });
 
+  test("obtaining coMap refs", async () => {
+    const Dog = co.map({
+      name: z.string().optional(),
+      breed: z.string(),
+      owner: co.plainText(),
+      get parent() {
+        return co.optional(Dog);
+      },
+    });
+
+    const dog = Dog.create({
+      name: "Rex",
+      breed: "Labrador",
+      owner: "John",
+      parent: { name: "Fido", breed: "Labrador", owner: "Jane" },
+    });
+
+    const refs = dog.$jazz.refs;
+
+    expect(Object.keys(refs)).toEqual(["owner", "parent"]);
+    expect(refs.owner.id).toEqual(dog.owner.$jazz.id);
+    expect(refs.parent?.id).toEqual(dog.parent!.$jazz.id);
+  });
+
   test("accessing the value refs", async () => {
     const Dog = co.map({
       name: z.string(),
@@ -1181,7 +1205,7 @@ describe("CoMap resolution", async () => {
 
     assert(loadedPerson);
 
-    expect(loadedPerson.$jazz.refs.dog?.id).toBe(person.dog!.$jazz.id);
+    expect(loadedPerson.$jazz.refs.dog.id).toBe(person.dog.$jazz.id);
 
     const dog = await loadedPerson.$jazz.refs.dog?.load();
 


### PR DESCRIPTION
# Description

When a required CoMap field was not loaded, its ref was incorrectly marked as optional at the type-level, even though the field was actually required.

Thanks for finding the issue @nipsuli!

## Tests

- [x] Tests have been added and/or updated

## Checklist

- [ ] I've updated the part of the docs that are affected the PR changes
- [x] I've generated a changeset, if a version bump is required
- [ ] I've updated the jsDoc comments to the public APIs I've modified, or added them when missing