### PR TITLE
feat: simplify bench code to focus on cojson

### DIFF
--- a/bench/colist.load.bench.ts
+++ b/bench/colist.load.bench.ts
@@ -1,90 +1,121 @@
 import { describe, bench } from "vitest";
-import * as tools from "jazz-tools";
-import * as toolsLatest from "jazz-tools-latest";
+
+import * as cojson from "cojson";
+import * as cojsonFromNpm from "cojson-latest";
 import { WasmCrypto } from "cojson/crypto/WasmCrypto";
 import { WasmCrypto as WasmCryptoLatest } from "cojson-latest/crypto/WasmCrypto";
 import { PureJSCrypto } from "cojson/crypto/PureJSCrypto";
 import { PureJSCrypto as PureJSCryptoLatest } from "cojson-latest/crypto/PureJSCrypto";
 
-// Define the schemas based on the provided Message schema
-async function createSchema(
-  { co, Group, z, createJazzContextForNewAccount }: typeof tools,
-  WasmCrypto: typeof WasmCryptoLatest,
-) {
-  const List = co.list(z.string());
-
-  const ctx = await createJazzContextForNewAccount({
-    creationProps: {
-      name: "Test Account",
-    },
-    peersToLoadFrom: [],
-    crypto: await WasmCrypto.create(),
-  });
-
-  return {
-    List,
-    Group,
-    account: ctx.account,
-  };
-}
-
 const PUREJS = false;
 
+const crypto = PUREJS ? await PureJSCrypto.create() : await WasmCrypto.create();
+const cryptoFromNpm = PUREJS
+  ? await PureJSCryptoLatest.create()
+  : await WasmCryptoLatest.create();
+
+const NUM_ITEMS = 1000;
+
+function generateFixtures(module: typeof cojson, crypto: any) {
+  const account = module.LocalNode.internalCreateAccount({
+    crypto,
+  });
+
+  const group = account.core.node.createGroup();
+  const list = group.createList();
+
+  for (let i = 0; i <= NUM_ITEMS; i++) {
+    list.append("A");
+  }
+
+  for (let i = NUM_ITEMS; i > 0; i--) {
+    if (i % 3 === 0) {
+      list.delete(i);
+    } else if (i % 3 === 1) {
+      list.replace(i, "B");
+    }
+  }
+
+  return list;
+}
+
+const list = generateFixtures(cojson, crypto);
 // @ts-expect-error
-const schema = await createSchema(tools, PUREJS ? PureJSCrypto : WasmCrypto);
-const schemaLatest = await createSchema(
-  toolsLatest as any,
-  // @ts-expect-error
-  PUREJS ? PureJSCryptoLatest : WasmCryptoLatest,
-);
+const listFromNpm = generateFixtures(cojsonFromNpm, cryptoFromNpm);
 
-const list = schema.List.create(
-  [],
-  schema.Group.create(schema.account).makePublic(),
-);
+const content = list.core.verified?.newContentSince(undefined) ?? [];
+const contentFromNpm =
+  listFromNpm.core.verified?.newContentSince(undefined) ?? [];
 
-for (let i = 0; i < 1000; i++) {
-  list.$jazz.push("A");
-}
+describe("list import", () => {
+  function importList(list: any, content: any) {
+    list.core.node.getCoValue(list.id).unmount();
+    for (const msg of content) {
+      list.core.node.syncManager.handleNewContent(msg, "storage");
+    }
+  }
 
-for (let i = 0; i < 100; i++) {
-  const index = Math.floor(Math.random() * list.length);
-  list.$jazz.set(index, "B");
-}
-
-list.$jazz.remove(() => Math.random() < 0.3);
-
-const content = await tools.exportCoValue(schema.List, list.$jazz.id, {
-  loadAs: schema.account,
-});
-tools.importContentPieces(content ?? [], schema.account as any);
-toolsLatest.importContentPieces(content ?? [], schemaLatest.account as any);
-
-describe("list loading", () => {
   bench(
     "current version",
     () => {
-      const node = schema.account.$jazz.localNode;
+      importList(list, content);
+    },
+    { iterations: 500 },
+  );
 
-      const coValue = node.expectCoValueLoaded(list.$jazz.id as any);
+  bench(
+    "Jazz 0.18.18",
+    () => {
+      importList(listFromNpm, contentFromNpm);
+    },
+    { iterations: 500 },
+  );
+});
 
-      coValue.getCurrentContent();
-      // @ts-expect-error
-      coValue._cachedContent = undefined;
+describe("list import + content load", () => {
+  function loadList(list: any, content: any) {
+    list.core.node.getCoValue(list.id).unmount();
+    for (const msg of content) {
+      list.core.node.syncManager.handleNewContent(msg, "storage");
+    }
+    const coValue = list.core.node.getCoValue(list.id);
+    coValue.getCurrentContent();
+  }
+
+  bench(
+    "current version",
+    () => {
+      loadList(list, content);
+    },
+    { iterations: 500 },
+  );
+
+  bench(
+    "Jazz 0.18.18",
+    () => {
+      loadList(listFromNpm, contentFromNpm);
+    },
+    { iterations: 500 },
+  );
+});
+
+describe("list updating", () => {
+  const list = generateFixtures(cojson, crypto);
+  // @ts-expect-error
+  const listFromNpm = generateFixtures(cojsonFromNpm, cryptoFromNpm);
+
+  bench(
+    "current version",
+    () => {
+      list.append("A");
     },
     { iterations: 5000 },
   );
 
   bench(
-    "Jazz 0.18.5",
+    "Jazz 0.18.18",
     () => {
-      const node = schemaLatest.account.$jazz.localNode;
-
-      const coValue = node.expectCoValueLoaded(list.$jazz.id as any);
-
-      coValue.getCurrentContent();
-      // @ts-expect-error
-      coValue._cachedContent = undefined;
+      listFromNpm.append("A");
     },
     { iterations: 5000 },
   );

--- a/bench/comap.create.bench.ts
+++ b/bench/comap.create.bench.ts
@@ -1,178 +1,115 @@
 import { describe, bench } from "vitest";
-import * as tools from "jazz-tools";
-import * as toolsLatest from "jazz-tools-latest";
+
+import * as cojson from "cojson";
+import * as cojsonFromNpm from "cojson-latest";
 import { WasmCrypto } from "cojson/crypto/WasmCrypto";
 import { WasmCrypto as WasmCryptoLatest } from "cojson-latest/crypto/WasmCrypto";
 import { PureJSCrypto } from "cojson/crypto/PureJSCrypto";
 import { PureJSCrypto as PureJSCryptoLatest } from "cojson-latest/crypto/PureJSCrypto";
 
-const sampleReactions = ["👍", "❤️", "😄", "🎉"];
-const sampleHiddenIn = ["user1", "user2", "user3"];
-
-// Define the schemas based on the provided Message schema
-async function createSchema(
-  tools: typeof toolsLatest,
-  WasmCrypto: typeof WasmCryptoLatest,
-) {
-  const Embed = tools.co.map({
-    url: tools.z.string(),
-    title: tools.z.string().optional(),
-    description: tools.z.string().optional(),
-    image: tools.z.string().optional(),
-  });
-
-  const Message = tools.co.map({
-    content: tools.z.string(),
-    createdAt: tools.z.date(),
-    updatedAt: tools.z.date(),
-    hiddenIn: tools.co.list(tools.z.string()),
-    replyTo: tools.z.string().optional(),
-    reactions: tools.co.list(tools.z.string()),
-    softDeleted: tools.z.boolean().optional(),
-    embeds: tools.co.optional(tools.co.list(Embed)),
-    author: tools.z.string().optional(),
-    threadId: tools.z.string().optional(),
-  });
-
-  const ctx = await tools.createJazzContextForNewAccount({
-    creationProps: {
-      name: "Test Account",
-    },
-    peersToLoadFrom: [],
-    crypto: await WasmCrypto.create(),
-  });
-
-  return {
-    Message,
-    sampleReactions,
-    sampleHiddenIn,
-    Group: tools.Group,
-    account: ctx.account,
-  };
-}
-
 const PUREJS = false;
 
+const crypto = PUREJS ? await PureJSCrypto.create() : await WasmCrypto.create();
+const cryptoFromNpm = PUREJS
+  ? await PureJSCryptoLatest.create()
+  : await WasmCryptoLatest.create();
+
+const NUM_KEYS = 10;
+const NUM_UPDATES = 100;
+
+function generateFixtures(module: typeof cojson, crypto: any) {
+  const account = module.LocalNode.internalCreateAccount({
+    crypto,
+  });
+
+  const group = account.core.node.createGroup();
+  const map = group.createMap();
+
+  for (let i = 0; i <= NUM_KEYS; i++) {
+    for (let j = 0; j <= NUM_UPDATES; j++) {
+      map.set(i.toString(), j.toString(), "private");
+    }
+  }
+
+  return map;
+}
+
+const map = generateFixtures(cojson, crypto);
 // @ts-expect-error
-const schema = await createSchema(tools, PUREJS ? PureJSCrypto : WasmCrypto);
-const schemaLatest = await createSchema(
-  toolsLatest,
+const mapFromNpm = generateFixtures(cojsonFromNpm, cryptoFromNpm);
+
+const content = map.core.verified?.newContentSince(undefined) ?? [];
+const contentFromNpm =
+  mapFromNpm.core.verified?.newContentSince(undefined) ?? [];
+
+describe("map import", () => {
+  function importMap(map: any, content: any) {
+    map.core.node.getCoValue(map.id).unmount();
+    for (const msg of content) {
+      map.core.node.syncManager.handleNewContent(msg, "storage");
+    }
+  }
+
+  bench(
+    "current version",
+    () => {
+      importMap(map, content);
+    },
+    { iterations: 500 },
+  );
+
+  bench(
+    "Jazz 0.18.18",
+    () => {
+      importMap(mapFromNpm, contentFromNpm);
+    },
+    { iterations: 500 },
+  );
+});
+
+describe("list import + content load", () => {
+  function loadMap(map: any, content: any) {
+    map.core.node.getCoValue(map.id).unmount();
+    for (const msg of content) {
+      map.core.node.syncManager.handleNewContent(msg, "storage");
+    }
+    const coValue = map.core.node.getCoValue(map.id);
+    coValue.getCurrentContent();
+  }
+
+  bench(
+    "current version",
+    () => {
+      loadMap(map, content);
+    },
+    { iterations: 500 },
+  );
+
+  bench(
+    "Jazz 0.18.18",
+    () => {
+      loadMap(mapFromNpm, contentFromNpm);
+    },
+    { iterations: 500 },
+  );
+});
+
+describe("map updating", () => {
+  const map = generateFixtures(cojson, crypto);
   // @ts-expect-error
-  PUREJS ? PureJSCryptoLatest : WasmCryptoLatest,
-);
-
-const message = schema.Message.create(
-  {
-    content: "A".repeat(1024),
-    createdAt: new Date(),
-    updatedAt: new Date(),
-    hiddenIn: sampleHiddenIn,
-    reactions: sampleReactions,
-    author: "user123",
-  },
-  schema.Group.create(schema.account).makePublic(),
-);
-
-const content = await tools.exportCoValue(
-  schema.Message,
-  message.$jazz.raw.id,
-  {
-    // @ts-expect-error
-    loadAs: schema.account,
-  },
-);
-tools.importContentPieces(content ?? [], schema.account as any);
-toolsLatest.importContentPieces(content ?? [], schemaLatest.account);
-schema.account.$jazz.localNode.internalDeleteCoValue(message.$jazz.raw.id);
-schemaLatest.account.$jazz.localNode.internalDeleteCoValue(
-  message.$jazz.raw.id,
-);
-
-describe("Message.create", () => {
+  const mapFromNpm = generateFixtures(cojsonFromNpm, cryptoFromNpm);
   bench(
     "current version",
     () => {
-      schema.Message.create(
-        {
-          content: "A".repeat(1024),
-          createdAt: new Date(),
-          updatedAt: new Date(),
-          hiddenIn: sampleHiddenIn,
-          reactions: sampleReactions,
-          author: "user123",
-        },
-        schema.Group.create(schema.account),
-      );
-    },
-    { iterations: 1000 },
-  );
-
-  bench(
-    "Jazz 0.18.5",
-    () => {
-      schemaLatest.Message.create(
-        {
-          content: "A".repeat(1024),
-          createdAt: new Date(),
-          updatedAt: new Date(),
-          hiddenIn: sampleHiddenIn,
-          reactions: sampleReactions,
-          author: "user123",
-        },
-        schemaLatest.Group.create(schemaLatest.account),
-      );
-    },
-    { iterations: 1000 },
-  );
-});
-
-describe("Message import", () => {
-  bench(
-    "current version",
-    () => {
-      tools.importContentPieces(content ?? [], schema.account as any);
-      schema.account.$jazz.localNode.internalDeleteCoValue(
-        message.$jazz.raw.id,
-      );
+      map.set("A", Math.random().toString(), "private");
     },
     { iterations: 5000 },
   );
 
   bench(
-    "Jazz 0.18.5",
+    "Jazz 0.18.18",
     () => {
-      toolsLatest.importContentPieces(content ?? [], schemaLatest.account);
-      schemaLatest.account.$jazz.localNode.internalDeleteCoValue(
-        message.$jazz.raw.id,
-      );
-    },
-    { iterations: 5000 },
-  );
-});
-
-describe("import+ decrypt", () => {
-  bench(
-    "current version",
-    () => {
-      tools.importContentPieces(content ?? [], schema.account as any);
-
-      const node = schema.account.$jazz.localNode;
-
-      node.expectCoValueLoaded(message.$jazz.raw.id).getCurrentContent();
-      node.internalDeleteCoValue(message.$jazz.raw.id);
-    },
-    { iterations: 5000 },
-  );
-
-  bench(
-    "Jazz 0.18.5",
-    () => {
-      toolsLatest.importContentPieces(content ?? [], schemaLatest.account);
-
-      const node = schemaLatest.account.$jazz.localNode;
-
-      node.expectCoValueLoaded(message.$jazz.raw.id).getCurrentContent();
-      node.internalDeleteCoValue(message.$jazz.raw.id);
+      mapFromNpm.set("A", Math.random().toString(), "private");
     },
     { iterations: 5000 },
   );

--- a/bench/package.json
+++ b/bench/package.json
@@ -4,9 +4,7 @@
   "type": "module",
   "dependencies": {
     "cojson": "workspace:*",
-    "jazz-tools": "workspace:*",
-    "cojson-latest": "npm:cojson@0.18.5",
-    "jazz-tools-latest": "npm:jazz-tools@0.18.5"
+    "cojson-latest": "npm:cojson@0.18.18"
   },
   "scripts": {
     "bench": "vitest bench"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -143,14 +143,8 @@ importers:
         specifier: workspace:*
         version: link:../packages/cojson
       cojson-latest:
-        specifier: npm:cojson@0.18.5
-        version: cojson@0.18.5
-      jazz-tools:
-        specifier: workspace:*
-        version: link:../packages/jazz-tools
-      jazz-tools-latest:
-        specifier: npm:jazz-tools@0.18.5
-        version: jazz-tools@0.18.5(a288373a09e7d4e00d8a579fc436cdcc)
+        specifier: npm:cojson@0.18.18
+        version: cojson@0.18.18
 
   crates/cojson-core-wasm:
     devDependencies:
@@ -9218,17 +9212,11 @@ packages:
   code-block-writer@13.0.3:
     resolution: {integrity: sha512-Oofo0pq3IKnsFtuHqSF7TqBfr71aeyZDVJ0HpmqB7FBM2qEigL0iPONSCZSO9pE9dZTAxANe5XHG9Uy0YMv8cg==}
 
-  cojson-core-wasm@0.18.5:
-    resolution: {integrity: sha512-u/xL4D2VTBADxgw4w2mG1pyNGS2WHKiPSM4rQcM324VmKmdEdhsz1+149s8fn2Rw+CJ7K8FA1DjOl+dNNFueTg==}
+  cojson-core-wasm@0.18.18:
+    resolution: {integrity: sha512-NEmct2zo0H1k6FYEVw+Fw4Ec8LjDoCVRRRu00pqM1vS2807+EZr+fFrqoBBZvx1uejcDikZ4JKBKnLFW3oS7wA==}
 
-  cojson-storage-indexeddb@0.18.5:
-    resolution: {integrity: sha512-afr5mXyjdHUHZfkQ8osnhJJi6MmfPR9tQIT85X/2ZDkEZzcpAIb3dqS7pSIZ05ITTtPNu28yDyU+P7JxxPXihA==}
-
-  cojson-transport-ws@0.18.5:
-    resolution: {integrity: sha512-2NyezyvUjMdmn3c9hzULwxMHtA8iyMrfz5cxkQjuWkNxD5Mje2YN0XXiYa7I6QrkHxydn1e9weFXQunp6TO1QQ==}
-
-  cojson@0.18.5:
-    resolution: {integrity: sha512-UY3o25htwGmTMHNTVuGzYjLYfP4M6lGgY2lb4k0xQdTMtYE0xUlU8CnV7xtbpPMrGUsNvFEDWxygaNXOIN2XCA==}
+  cojson@0.18.18:
+    resolution: {integrity: sha512-/IdwMOefFmGd6Nhqrs+nssB1kK3LVl9GWoGcIuNB7GDXI/gF76dTv/VGF6aHDBrBR/E8PshQHXGji162XzNEKw==}
 
   collect-v8-coverage@1.0.2:
     resolution: {integrity: sha512-lHl4d5/ONEbLlJvaJNtsF/Lz+WvB07u2ycqTYbdrq7UypDXailES4valYb2eWiJFxZlVmpGekfqoxQhzyFdT4Q==}
@@ -11246,59 +11234,6 @@ packages:
     resolution: {integrity: sha512-wpHYzhxiVQL+IV05BLE2Xn34zW1S223hvjtqk0+gsPrwd/8JNLXJgZZM/iPFsYc1xyphF+6M6EvdE5E9MBGkDA==}
     engines: {node: '>=10'}
     hasBin: true
-
-  jazz-tools@0.18.5:
-    resolution: {integrity: sha512-iAwS2yn1Ur54zpk+rrgnwE39ZswIh0dt26uioT8WZPDW60JrvCQhJl9ycN8CrY7LF4FTrEpQF9E45b1lQOZAHw==}
-    peerDependencies:
-      '@bam.tech/react-native-image-resizer': '*'
-      '@op-engineering/op-sqlite': '*'
-      '@react-native-community/netinfo': '*'
-      better-auth: ^1.3.0
-      expo-file-system: '*'
-      expo-secure-store: '*'
-      expo-sqlite: '*'
-      react: 19.1.0
-      react-dom: 19.1.0
-      react-native: '*'
-      react-native-fast-encoder: ^0.2.0
-      react-native-mmkv: ^3.3.0
-      react-native-nitro-modules: ^0.26.4
-      react-native-quick-crypto: ^1.0.0-beta.18
-      sharp: ^0.33.5
-      svelte: ^5.0.0
-    peerDependenciesMeta:
-      '@bam.tech/react-native-image-resizer':
-        optional: true
-      '@op-engineering/op-sqlite':
-        optional: true
-      '@react-native-community/netinfo':
-        optional: true
-      better-auth:
-        optional: true
-      expo-file-system:
-        optional: true
-      expo-secure-store:
-        optional: true
-      expo-sqlite:
-        optional: true
-      react:
-        optional: true
-      react-dom:
-        optional: true
-      react-native:
-        optional: true
-      react-native-fast-encoder:
-        optional: true
-      react-native-mmkv:
-        optional: true
-      react-native-nitro-modules:
-        optional: true
-      react-native-quick-crypto:
-        optional: true
-      sharp:
-        optional: true
-      svelte:
-        optional: true
 
   jest-changed-files@29.7.0:
     resolution: {integrity: sha512-fEArFiwf1BpQ+4bXSprcDc3/x4HSzL4al2tozwVpDFpsxALjLYdyiIK4e5Vz66GQJIbXJ82+35PtysofptNX2w==}
@@ -18176,12 +18111,6 @@ snapshots:
       react: 19.1.0
       react-native: 0.81.0(@babel/core@7.27.1)(@react-native-community/cli@19.0.0(typescript@5.9.2))(@react-native/metro-config@0.81.0(@babel/core@7.27.1))(@types/react@19.1.0)(react@19.1.0)
 
-  '@bam.tech/react-native-image-resizer@3.0.11(react-native@0.81.0(@babel/core@7.28.3)(@react-native-community/cli@19.0.0(typescript@5.9.2))(@react-native/metro-config@0.81.0(@babel/core@7.28.3))(@types/react@19.1.0)(react@19.1.0))(react@19.1.0)':
-    dependencies:
-      react: 19.1.0
-      react-native: 0.81.0(@babel/core@7.28.3)(@react-native-community/cli@19.0.0(typescript@5.9.2))(@react-native/metro-config@0.81.0(@babel/core@7.28.3))(@types/react@19.1.0)(react@19.1.0)
-    optional: true
-
   '@base-ui-components/react@1.0.0-beta.1(@types/react@19.1.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
     dependencies:
       '@babel/runtime': 7.27.6
@@ -18658,15 +18587,6 @@ snapshots:
       - react
       - react-native
 
-  '@craftzdog/react-native-buffer@6.1.0(react-native@0.81.0(@babel/core@7.28.3)(@react-native-community/cli@19.0.0(typescript@5.9.2))(@react-native/metro-config@0.81.0(@babel/core@7.28.3))(@types/react@19.1.0)(react@19.1.0))(react@19.1.0)':
-    dependencies:
-      ieee754: 1.2.1
-      react-native-quick-base64: 2.2.0(react-native@0.81.0(@babel/core@7.28.3)(@react-native-community/cli@19.0.0(typescript@5.9.2))(@react-native/metro-config@0.81.0(@babel/core@7.28.3))(@types/react@19.1.0)(react@19.1.0))(react@19.1.0)
-    transitivePeerDependencies:
-      - react
-      - react-native
-    optional: true
-
   '@cspotcode/source-map-support@0.8.1':
     dependencies:
       '@jridgewell/trace-mapping': 0.3.9
@@ -19113,82 +19033,6 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  '@expo/cli@0.26.0(expo@54.0.0-preview.4(@babel/core@7.28.3)(graphql@16.11.0)(react-native@0.81.0(@babel/core@7.28.3)(@react-native-community/cli@19.0.0(typescript@5.9.2))(@react-native/metro-config@0.81.0(@babel/core@7.28.3))(@types/react@19.1.0)(react@19.1.0))(react@19.1.0))(graphql@16.11.0)(react-native@0.81.0(@babel/core@7.28.3)(@react-native-community/cli@19.0.0(typescript@5.9.2))(@react-native/metro-config@0.81.0(@babel/core@7.28.3))(@types/react@19.1.0)(react@19.1.0))':
-    dependencies:
-      '@0no-co/graphql.web': 1.0.12(graphql@16.11.0)
-      '@babel/runtime': 7.28.3
-      '@expo/code-signing-certificates': 0.0.5
-      '@expo/config': 12.0.3
-      '@expo/config-plugins': 11.0.3
-      '@expo/devcert': 1.1.4
-      '@expo/env': 2.0.2
-      '@expo/image-utils': 0.8.2
-      '@expo/json-file': 10.0.2
-      '@expo/metro': 0.1.1
-      '@expo/metro-config': 0.21.3(expo@54.0.0-preview.4(@babel/core@7.28.3)(graphql@16.11.0)(react-native@0.81.0(@babel/core@7.28.3)(@react-native-community/cli@19.0.0(typescript@5.9.2))(@react-native/metro-config@0.81.0(@babel/core@7.28.3))(@types/react@19.1.0)(react@19.1.0))(react@19.1.0))
-      '@expo/osascript': 2.3.2
-      '@expo/package-manager': 1.9.2
-      '@expo/plist': 0.4.2
-      '@expo/prebuild-config': 10.0.3(expo@54.0.0-preview.4(@babel/core@7.28.3)(graphql@16.11.0)(react-native@0.81.0(@babel/core@7.28.3)(@react-native-community/cli@19.0.0(typescript@5.9.2))(@react-native/metro-config@0.81.0(@babel/core@7.28.3))(@types/react@19.1.0)(react@19.1.0))(react@19.1.0))
-      '@expo/schema-utils': 0.1.2
-      '@expo/server': 0.7.2
-      '@expo/spawn-async': 1.7.2
-      '@expo/ws-tunnel': 1.0.6
-      '@expo/xcpretty': 4.3.2
-      '@react-native/dev-middleware': 0.80.1
-      '@urql/core': 5.1.0(graphql@16.11.0)
-      '@urql/exchange-retry': 1.3.0(@urql/core@5.1.0(graphql@16.11.0))
-      accepts: 1.3.8
-      arg: 5.0.2
-      better-opn: 3.0.2
-      bplist-creator: 0.1.0
-      bplist-parser: 0.3.2
-      chalk: 4.1.2
-      ci-info: 3.9.0
-      compression: 1.7.5
-      connect: 3.7.0
-      debug: 4.4.1
-      env-editor: 0.4.2
-      expo: 54.0.0-preview.4(@babel/core@7.28.3)(graphql@16.11.0)(react-native@0.81.0(@babel/core@7.28.3)(@react-native-community/cli@19.0.0(typescript@5.9.2))(@react-native/metro-config@0.81.0(@babel/core@7.28.3))(@types/react@19.1.0)(react@19.1.0))(react@19.1.0)
-      freeport-async: 2.0.0
-      getenv: 2.0.0
-      glob: 10.4.5
-      lan-network: 0.1.7
-      minimatch: 9.0.5
-      node-forge: 1.3.1
-      npm-package-arg: 11.0.3
-      ora: 3.4.0
-      picomatch: 3.0.1
-      pretty-bytes: 5.6.0
-      pretty-format: 29.7.0
-      progress: 2.0.3
-      prompts: 2.4.2
-      qrcode-terminal: 0.11.0
-      require-from-string: 2.0.2
-      requireg: 0.2.2
-      resolve: 1.22.10
-      resolve-from: 5.0.0
-      resolve.exports: 2.0.3
-      semver: 7.7.2
-      send: 0.19.1
-      slugify: 1.6.6
-      source-map-support: 0.5.21
-      stacktrace-parser: 0.1.10
-      structured-headers: 0.4.1
-      tar: 7.4.3
-      terminal-link: 2.1.1
-      undici: 6.21.0
-      wrap-ansi: 7.0.0
-      ws: 8.18.2
-    optionalDependencies:
-      react-native: 0.81.0(@babel/core@7.28.3)(@react-native-community/cli@19.0.0(typescript@5.9.2))(@react-native/metro-config@0.81.0(@babel/core@7.28.3))(@types/react@19.1.0)(react@19.1.0)
-    transitivePeerDependencies:
-      - bufferutil
-      - graphql
-      - supports-color
-      - utf-8-validate
-    optional: true
-
   '@expo/code-signing-certificates@0.0.5':
     dependencies:
       node-forge: 1.3.1
@@ -19302,14 +19146,6 @@ snapshots:
     optionalDependencies:
       react: 19.1.0
       react-native: 0.81.0(@babel/core@7.27.1)(@react-native-community/cli@19.0.0(typescript@5.9.2))(@react-native/metro-config@0.81.0(@babel/core@7.27.1))(@types/react@19.1.0)(react@19.1.0)
-
-  '@expo/devtools@0.1.2(react-native@0.81.0(@babel/core@7.28.3)(@react-native-community/cli@19.0.0(typescript@5.9.2))(@react-native/metro-config@0.81.0(@babel/core@7.28.3))(@types/react@19.1.0)(react@19.1.0))(react@19.1.0)':
-    dependencies:
-      chalk: 4.1.2
-    optionalDependencies:
-      react: 19.1.0
-      react-native: 0.81.0(@babel/core@7.28.3)(@react-native-community/cli@19.0.0(typescript@5.9.2))(@react-native/metro-config@0.81.0(@babel/core@7.28.3))(@types/react@19.1.0)(react@19.1.0)
-    optional: true
 
   '@expo/env@0.4.2':
     dependencies:
@@ -19437,37 +19273,6 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  '@expo/metro-config@0.21.3(expo@54.0.0-preview.4(@babel/core@7.28.3)(graphql@16.11.0)(react-native@0.81.0(@babel/core@7.28.3)(@react-native-community/cli@19.0.0(typescript@5.9.2))(@react-native/metro-config@0.81.0(@babel/core@7.28.3))(@types/react@19.1.0)(react@19.1.0))(react@19.1.0))':
-    dependencies:
-      '@babel/code-frame': 7.27.1
-      '@babel/core': 7.28.3
-      '@babel/generator': 7.28.3
-      '@expo/config': 12.0.3
-      '@expo/env': 2.0.2
-      '@expo/json-file': 10.0.2
-      '@expo/metro': 0.1.1
-      '@expo/spawn-async': 1.7.2
-      browserslist: 4.25.3
-      chalk: 4.1.2
-      debug: 4.4.1
-      dotenv: 16.4.7
-      dotenv-expand: 11.0.7
-      getenv: 2.0.0
-      glob: 10.4.5
-      hermes-parser: 0.29.1
-      jsc-safe-url: 0.2.4
-      lightningcss: 1.27.0
-      minimatch: 9.0.5
-      postcss: 8.4.49
-      resolve-from: 5.0.0
-    optionalDependencies:
-      expo: 54.0.0-preview.4(@babel/core@7.28.3)(graphql@16.11.0)(react-native@0.81.0(@babel/core@7.28.3)(@react-native-community/cli@19.0.0(typescript@5.9.2))(@react-native/metro-config@0.81.0(@babel/core@7.28.3))(@types/react@19.1.0)(react@19.1.0))(react@19.1.0)
-    transitivePeerDependencies:
-      - bufferutil
-      - supports-color
-      - utf-8-validate
-    optional: true
-
   '@expo/metro@0.1.1':
     dependencies:
       metro: 0.83.1
@@ -19545,23 +19350,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@expo/prebuild-config@10.0.3(expo@54.0.0-preview.4(@babel/core@7.28.3)(graphql@16.11.0)(react-native@0.81.0(@babel/core@7.28.3)(@react-native-community/cli@19.0.0(typescript@5.9.2))(@react-native/metro-config@0.81.0(@babel/core@7.28.3))(@types/react@19.1.0)(react@19.1.0))(react@19.1.0))':
-    dependencies:
-      '@expo/config': 12.0.3
-      '@expo/config-plugins': 11.0.3
-      '@expo/config-types': 54.0.3
-      '@expo/image-utils': 0.8.2
-      '@expo/json-file': 10.0.2
-      '@react-native/normalize-colors': 0.81.0
-      debug: 4.4.1
-      expo: 54.0.0-preview.4(@babel/core@7.28.3)(graphql@16.11.0)(react-native@0.81.0(@babel/core@7.28.3)(@react-native-community/cli@19.0.0(typescript@5.9.2))(@react-native/metro-config@0.81.0(@babel/core@7.28.3))(@types/react@19.1.0)(react@19.1.0))(react@19.1.0)
-      resolve-from: 5.0.0
-      semver: 7.7.2
-      xml2js: 0.6.0
-    transitivePeerDependencies:
-      - supports-color
-    optional: true
-
   '@expo/schema-utils@0.1.2': {}
 
   '@expo/sdk-runtime-versions@1.0.0': {}
@@ -19588,13 +19376,6 @@ snapshots:
       expo-font: 14.0.2(expo@54.0.0-preview.4(@babel/core@7.28.3)(graphql@16.11.0)(react-native@0.80.0(@babel/core@7.28.3)(@react-native-community/cli@19.0.0(typescript@5.6.2))(@types/react@19.1.0)(react@19.1.0))(react@19.1.0))(react-native@0.80.0(@babel/core@7.28.3)(@react-native-community/cli@19.0.0(typescript@5.6.2))(@types/react@19.1.0)(react@19.1.0))(react@19.1.0)
       react: 19.1.0
       react-native: 0.80.0(@babel/core@7.28.3)(@react-native-community/cli@19.0.0(typescript@5.6.2))(@types/react@19.1.0)(react@19.1.0)
-
-  '@expo/vector-icons@14.1.0(expo-font@14.0.2(expo@54.0.0-preview.4(@babel/core@7.28.3)(graphql@16.11.0)(react-native@0.81.0(@babel/core@7.28.3)(@react-native-community/cli@19.0.0(typescript@5.9.2))(@react-native/metro-config@0.81.0(@babel/core@7.28.3))(@types/react@19.1.0)(react@19.1.0))(react@19.1.0))(react-native@0.81.0(@babel/core@7.28.3)(@react-native-community/cli@19.0.0(typescript@5.9.2))(@react-native/metro-config@0.81.0(@babel/core@7.28.3))(@types/react@19.1.0)(react@19.1.0))(react@19.1.0))(react-native@0.81.0(@babel/core@7.28.3)(@react-native-community/cli@19.0.0(typescript@5.9.2))(@react-native/metro-config@0.81.0(@babel/core@7.28.3))(@types/react@19.1.0)(react@19.1.0))(react@19.1.0)':
-    dependencies:
-      expo-font: 14.0.2(expo@54.0.0-preview.4(@babel/core@7.28.3)(graphql@16.11.0)(react-native@0.81.0(@babel/core@7.28.3)(@react-native-community/cli@19.0.0(typescript@5.9.2))(@react-native/metro-config@0.81.0(@babel/core@7.28.3))(@types/react@19.1.0)(react@19.1.0))(react@19.1.0))(react-native@0.81.0(@babel/core@7.28.3)(@react-native-community/cli@19.0.0(typescript@5.9.2))(@react-native/metro-config@0.81.0(@babel/core@7.28.3))(@types/react@19.1.0)(react@19.1.0))(react@19.1.0)
-      react: 19.1.0
-      react-native: 0.81.0(@babel/core@7.28.3)(@react-native-community/cli@19.0.0(typescript@5.9.2))(@react-native/metro-config@0.81.0(@babel/core@7.28.3))(@types/react@19.1.0)(react@19.1.0)
-    optional: true
 
   '@expo/ws-tunnel@1.0.6': {}
 
@@ -20605,12 +20386,6 @@ snapshots:
       react: 19.1.0
       react-native: 0.81.0(@babel/core@7.27.1)(@react-native-community/cli@19.0.0(typescript@5.6.2))(@react-native/metro-config@0.81.0(@babel/core@7.27.1))(@types/react@19.1.0)(react@19.1.0)
 
-  '@op-engineering/op-sqlite@14.1.4(react-native@0.81.0(@babel/core@7.28.3)(@react-native-community/cli@19.0.0(typescript@5.9.2))(@react-native/metro-config@0.81.0(@babel/core@7.28.3))(@types/react@19.1.0)(react@19.1.0))(react@19.1.0)':
-    dependencies:
-      react: 19.1.0
-      react-native: 0.81.0(@babel/core@7.28.3)(@react-native-community/cli@19.0.0(typescript@5.9.2))(@react-native/metro-config@0.81.0(@babel/core@7.28.3))(@types/react@19.1.0)(react@19.1.0)
-    optional: true
-
   '@open-draft/deferred-promise@2.2.0': {}
 
   '@open-draft/logger@0.3.0':
@@ -21619,11 +21394,6 @@ snapshots:
     dependencies:
       react-native: 0.81.0(@babel/core@7.27.1)(@react-native-community/cli@19.0.0(typescript@5.9.2))(@react-native/metro-config@0.81.0(@babel/core@7.27.1))(@types/react@19.1.0)(react@19.1.0)
 
-  '@react-native-community/netinfo@11.4.1(react-native@0.81.0(@babel/core@7.28.3)(@react-native-community/cli@19.0.0(typescript@5.9.2))(@react-native/metro-config@0.81.0(@babel/core@7.28.3))(@types/react@19.1.0)(react@19.1.0))':
-    dependencies:
-      react-native: 0.81.0(@babel/core@7.28.3)(@react-native-community/cli@19.0.0(typescript@5.9.2))(@react-native/metro-config@0.81.0(@babel/core@7.28.3))(@types/react@19.1.0)(react@19.1.0)
-    optional: true
-
   '@react-native/assets-registry@0.80.0': {}
 
   '@react-native/assets-registry@0.81.0': {}
@@ -21822,24 +21592,6 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  '@react-native/community-cli-plugin@0.81.0(@react-native-community/cli@19.0.0(typescript@5.9.2))(@react-native/metro-config@0.81.0(@babel/core@7.28.3))':
-    dependencies:
-      '@react-native/dev-middleware': 0.81.0
-      '@react-native/metro-config': 0.81.0(@babel/core@7.28.3)
-      debug: 4.4.1
-      invariant: 2.2.4
-      metro: 0.83.1
-      metro-config: 0.83.1
-      metro-core: 0.83.1
-      semver: 7.7.2
-    optionalDependencies:
-      '@react-native-community/cli': 19.0.0(typescript@5.9.2)
-    transitivePeerDependencies:
-      - bufferutil
-      - supports-color
-      - utf-8-validate
-    optional: true
-
   '@react-native/debugger-frontend@0.80.0': {}
 
   '@react-native/debugger-frontend@0.80.1': {}
@@ -21940,16 +21692,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@react-native/metro-babel-transformer@0.81.0(@babel/core@7.28.3)':
-    dependencies:
-      '@babel/core': 7.28.3
-      '@react-native/babel-preset': 0.81.0(@babel/core@7.28.3)
-      hermes-parser: 0.29.1
-      nullthrows: 1.1.1
-    transitivePeerDependencies:
-      - supports-color
-    optional: true
-
   '@react-native/metro-config@0.81.0(@babel/core@7.27.1)':
     dependencies:
       '@react-native/js-polyfills': 0.81.0
@@ -21961,19 +21703,6 @@ snapshots:
       - bufferutil
       - supports-color
       - utf-8-validate
-
-  '@react-native/metro-config@0.81.0(@babel/core@7.28.3)':
-    dependencies:
-      '@react-native/js-polyfills': 0.81.0
-      '@react-native/metro-babel-transformer': 0.81.0(@babel/core@7.28.3)
-      metro-config: 0.83.1
-      metro-runtime: 0.83.1
-    transitivePeerDependencies:
-      - '@babel/core'
-      - bufferutil
-      - supports-color
-      - utf-8-validate
-    optional: true
 
   '@react-native/normalize-colors@0.80.0': {}
 
@@ -22007,16 +21736,6 @@ snapshots:
       react-native: 0.81.0(@babel/core@7.27.1)(@react-native-community/cli@19.0.0(typescript@5.9.2))(@react-native/metro-config@0.81.0(@babel/core@7.27.1))(@types/react@19.1.0)(react@19.1.0)
     optionalDependencies:
       '@types/react': 19.1.0
-
-  '@react-native/virtualized-lists@0.81.0(@types/react@19.1.0)(react-native@0.81.0(@babel/core@7.28.3)(@react-native-community/cli@19.0.0(typescript@5.9.2))(@react-native/metro-config@0.81.0(@babel/core@7.28.3))(@types/react@19.1.0)(react@19.1.0))(react@19.1.0)':
-    dependencies:
-      invariant: 2.2.4
-      nullthrows: 1.1.1
-      react: 19.1.0
-      react-native: 0.81.0(@babel/core@7.28.3)(@react-native-community/cli@19.0.0(typescript@5.9.2))(@react-native/metro-config@0.81.0(@babel/core@7.28.3))(@types/react@19.1.0)(react@19.1.0)
-    optionalDependencies:
-      '@types/react': 19.1.0
-    optional: true
 
   '@react-navigation/core@7.12.1(react@19.1.0)':
     dependencies:
@@ -24633,38 +24352,6 @@ snapshots:
       - '@babel/core'
       - supports-color
 
-  babel-preset-expo@14.0.2(@babel/core@7.28.3)(expo@54.0.0-preview.4(@babel/core@7.28.3)(graphql@16.11.0)(react-native@0.81.0(@babel/core@7.28.3)(@react-native-community/cli@19.0.0(typescript@5.9.2))(@react-native/metro-config@0.81.0(@babel/core@7.28.3))(@types/react@19.1.0)(react@19.1.0))(react@19.1.0))(react-refresh@0.14.2):
-    dependencies:
-      '@babel/helper-module-imports': 7.27.1
-      '@babel/plugin-proposal-decorators': 7.25.9(@babel/core@7.28.3)
-      '@babel/plugin-proposal-export-default-from': 7.25.9(@babel/core@7.28.3)
-      '@babel/plugin-syntax-export-default-from': 7.25.9(@babel/core@7.28.3)
-      '@babel/plugin-transform-class-static-block': 7.28.3(@babel/core@7.28.3)
-      '@babel/plugin-transform-export-namespace-from': 7.27.1(@babel/core@7.28.3)
-      '@babel/plugin-transform-flow-strip-types': 7.25.9(@babel/core@7.28.3)
-      '@babel/plugin-transform-modules-commonjs': 7.27.1(@babel/core@7.28.3)
-      '@babel/plugin-transform-object-rest-spread': 7.28.0(@babel/core@7.28.3)
-      '@babel/plugin-transform-parameters': 7.27.7(@babel/core@7.28.3)
-      '@babel/plugin-transform-private-methods': 7.27.1(@babel/core@7.28.3)
-      '@babel/plugin-transform-private-property-in-object': 7.27.1(@babel/core@7.28.3)
-      '@babel/plugin-transform-runtime': 7.25.9(@babel/core@7.28.3)
-      '@babel/preset-react': 7.26.3(@babel/core@7.28.3)
-      '@babel/preset-typescript': 7.27.1(@babel/core@7.28.3)
-      '@react-native/babel-preset': 0.81.0(@babel/core@7.28.3)
-      babel-plugin-react-compiler: 19.1.0-rc.2
-      babel-plugin-react-native-web: 0.21.1
-      babel-plugin-syntax-hermes-parser: 0.25.1
-      babel-plugin-transform-flow-enums: 0.0.2(@babel/core@7.28.3)
-      debug: 4.4.1
-      react-refresh: 0.14.2
-      resolve-from: 5.0.0
-    optionalDependencies:
-      expo: 54.0.0-preview.4(@babel/core@7.28.3)(graphql@16.11.0)(react-native@0.81.0(@babel/core@7.28.3)(@react-native-community/cli@19.0.0(typescript@5.9.2))(@react-native/metro-config@0.81.0(@babel/core@7.28.3))(@types/react@19.1.0)(react@19.1.0))(react@19.1.0)
-    transitivePeerDependencies:
-      - '@babel/core'
-      - supports-color
-    optional: true
-
   babel-preset-jest@29.6.3(@babel/core@7.27.1):
     dependencies:
       '@babel/core': 7.27.1
@@ -25132,25 +24819,16 @@ snapshots:
 
   code-block-writer@13.0.3: {}
 
-  cojson-core-wasm@0.18.5: {}
+  cojson-core-wasm@0.18.18: {}
 
-  cojson-storage-indexeddb@0.18.5:
-    dependencies:
-      cojson: 0.18.5
-
-  cojson-transport-ws@0.18.5:
-    dependencies:
-      '@opentelemetry/api': 1.9.0
-      cojson: 0.18.5
-
-  cojson@0.18.5:
+  cojson@0.18.18:
     dependencies:
       '@noble/ciphers': 1.3.0
       '@noble/curves': 1.9.1
       '@noble/hashes': 1.8.0
       '@opentelemetry/api': 1.9.0
       '@scure/base': 1.2.1
-      cojson-core-wasm: 0.18.5
+      cojson-core-wasm: 0.18.18
       neverthrow: 7.2.0
       unicode-segmenter: 0.12.0
 
@@ -26245,17 +25923,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  expo-asset@12.0.2(expo@54.0.0-preview.4(@babel/core@7.28.3)(graphql@16.11.0)(react-native@0.81.0(@babel/core@7.28.3)(@react-native-community/cli@19.0.0(typescript@5.9.2))(@react-native/metro-config@0.81.0(@babel/core@7.28.3))(@types/react@19.1.0)(react@19.1.0))(react@19.1.0))(react-native@0.81.0(@babel/core@7.28.3)(@react-native-community/cli@19.0.0(typescript@5.9.2))(@react-native/metro-config@0.81.0(@babel/core@7.28.3))(@types/react@19.1.0)(react@19.1.0))(react@19.1.0):
-    dependencies:
-      '@expo/image-utils': 0.8.2
-      expo: 54.0.0-preview.4(@babel/core@7.28.3)(graphql@16.11.0)(react-native@0.81.0(@babel/core@7.28.3)(@react-native-community/cli@19.0.0(typescript@5.9.2))(@react-native/metro-config@0.81.0(@babel/core@7.28.3))(@types/react@19.1.0)(react@19.1.0))(react@19.1.0)
-      expo-constants: 18.0.2(expo@54.0.0-preview.4(@babel/core@7.28.3)(graphql@16.11.0)(react-native@0.81.0(@babel/core@7.28.3)(@react-native-community/cli@19.0.0(typescript@5.9.2))(@react-native/metro-config@0.81.0(@babel/core@7.28.3))(@types/react@19.1.0)(react@19.1.0))(react@19.1.0))(react-native@0.81.0(@babel/core@7.28.3)(@react-native-community/cli@19.0.0(typescript@5.9.2))(@react-native/metro-config@0.81.0(@babel/core@7.28.3))(@types/react@19.1.0)(react@19.1.0))
-      react: 19.1.0
-      react-native: 0.81.0(@babel/core@7.28.3)(@react-native-community/cli@19.0.0(typescript@5.9.2))(@react-native/metro-config@0.81.0(@babel/core@7.28.3))(@types/react@19.1.0)(react@19.1.0)
-    transitivePeerDependencies:
-      - supports-color
-    optional: true
-
   expo-auth-session@6.0.1(expo@54.0.0-preview.4(@babel/core@7.27.1)(graphql@16.11.0)(react-native@0.81.0(@babel/core@7.27.1)(@react-native-community/cli@19.0.0(typescript@5.9.2))(@react-native/metro-config@0.81.0(@babel/core@7.27.1))(@types/react@19.1.0)(react@19.1.0))(react@19.1.0))(react-native@0.81.0(@babel/core@7.27.1)(@react-native-community/cli@19.0.0(typescript@5.9.2))(@react-native/metro-config@0.81.0(@babel/core@7.27.1))(@types/react@19.1.0)(react@19.1.0))(react@19.1.0):
     dependencies:
       expo-application: 6.0.2(expo@54.0.0-preview.4(@babel/core@7.27.1)(graphql@16.11.0)(react-native@0.81.0(@babel/core@7.27.1)(@react-native-community/cli@19.0.0(typescript@5.9.2))(@react-native/metro-config@0.81.0(@babel/core@7.27.1))(@types/react@19.1.0)(react@19.1.0))(react@19.1.0))
@@ -26303,16 +25970,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  expo-constants@18.0.2(expo@54.0.0-preview.4(@babel/core@7.28.3)(graphql@16.11.0)(react-native@0.81.0(@babel/core@7.28.3)(@react-native-community/cli@19.0.0(typescript@5.9.2))(@react-native/metro-config@0.81.0(@babel/core@7.28.3))(@types/react@19.1.0)(react@19.1.0))(react@19.1.0))(react-native@0.81.0(@babel/core@7.28.3)(@react-native-community/cli@19.0.0(typescript@5.9.2))(@react-native/metro-config@0.81.0(@babel/core@7.28.3))(@types/react@19.1.0)(react@19.1.0)):
-    dependencies:
-      '@expo/config': 12.0.3
-      '@expo/env': 2.0.2
-      expo: 54.0.0-preview.4(@babel/core@7.28.3)(graphql@16.11.0)(react-native@0.81.0(@babel/core@7.28.3)(@react-native-community/cli@19.0.0(typescript@5.9.2))(@react-native/metro-config@0.81.0(@babel/core@7.28.3))(@types/react@19.1.0)(react@19.1.0))(react@19.1.0)
-      react-native: 0.81.0(@babel/core@7.28.3)(@react-native-community/cli@19.0.0(typescript@5.9.2))(@react-native/metro-config@0.81.0(@babel/core@7.28.3))(@types/react@19.1.0)(react@19.1.0)
-    transitivePeerDependencies:
-      - supports-color
-    optional: true
-
   expo-crypto@14.0.2(expo@54.0.0-preview.4(@babel/core@7.27.1)(graphql@16.11.0)(react-native@0.81.0(@babel/core@7.27.1)(@react-native-community/cli@19.0.0(typescript@5.9.2))(@react-native/metro-config@0.81.0(@babel/core@7.27.1))(@types/react@19.1.0)(react@19.1.0))(react@19.1.0)):
     dependencies:
       base64-js: 1.5.1
@@ -26328,12 +25985,6 @@ snapshots:
       expo: 54.0.0-preview.4(@babel/core@7.28.3)(graphql@16.11.0)(react-native@0.80.0(@babel/core@7.28.3)(@react-native-community/cli@19.0.0(typescript@5.6.2))(@types/react@19.1.0)(react@19.1.0))(react@19.1.0)
       react-native: 0.80.0(@babel/core@7.28.3)(@react-native-community/cli@19.0.0(typescript@5.6.2))(@types/react@19.1.0)(react@19.1.0)
 
-  expo-file-system@18.1.10(expo@54.0.0-preview.4(@babel/core@7.28.3)(graphql@16.11.0)(react-native@0.81.0(@babel/core@7.28.3)(@react-native-community/cli@19.0.0(typescript@5.9.2))(@react-native/metro-config@0.81.0(@babel/core@7.28.3))(@types/react@19.1.0)(react@19.1.0))(react@19.1.0))(react-native@0.81.0(@babel/core@7.28.3)(@react-native-community/cli@19.0.0(typescript@5.9.2))(@react-native/metro-config@0.81.0(@babel/core@7.28.3))(@types/react@19.1.0)(react@19.1.0)):
-    dependencies:
-      expo: 54.0.0-preview.4(@babel/core@7.28.3)(graphql@16.11.0)(react-native@0.81.0(@babel/core@7.28.3)(@react-native-community/cli@19.0.0(typescript@5.9.2))(@react-native/metro-config@0.81.0(@babel/core@7.28.3))(@types/react@19.1.0)(react@19.1.0))(react@19.1.0)
-      react-native: 0.81.0(@babel/core@7.28.3)(@react-native-community/cli@19.0.0(typescript@5.9.2))(@react-native/metro-config@0.81.0(@babel/core@7.28.3))(@types/react@19.1.0)(react@19.1.0)
-    optional: true
-
   expo-font@14.0.2(expo@54.0.0-preview.4(@babel/core@7.27.1)(graphql@16.11.0)(react-native@0.81.0(@babel/core@7.27.1)(@react-native-community/cli@19.0.0(typescript@5.9.2))(@react-native/metro-config@0.81.0(@babel/core@7.27.1))(@types/react@19.1.0)(react@19.1.0))(react@19.1.0))(react-native@0.81.0(@babel/core@7.27.1)(@react-native-community/cli@19.0.0(typescript@5.9.2))(@react-native/metro-config@0.81.0(@babel/core@7.27.1))(@types/react@19.1.0)(react@19.1.0))(react@19.1.0):
     dependencies:
       expo: 54.0.0-preview.4(@babel/core@7.27.1)(graphql@16.11.0)(react-native@0.81.0(@babel/core@7.27.1)(@react-native-community/cli@19.0.0(typescript@5.9.2))(@react-native/metro-config@0.81.0(@babel/core@7.27.1))(@types/react@19.1.0)(react@19.1.0))(react@19.1.0)
@@ -26348,14 +25999,6 @@ snapshots:
       react: 19.1.0
       react-native: 0.80.0(@babel/core@7.28.3)(@react-native-community/cli@19.0.0(typescript@5.6.2))(@types/react@19.1.0)(react@19.1.0)
 
-  expo-font@14.0.2(expo@54.0.0-preview.4(@babel/core@7.28.3)(graphql@16.11.0)(react-native@0.81.0(@babel/core@7.28.3)(@react-native-community/cli@19.0.0(typescript@5.9.2))(@react-native/metro-config@0.81.0(@babel/core@7.28.3))(@types/react@19.1.0)(react@19.1.0))(react@19.1.0))(react-native@0.81.0(@babel/core@7.28.3)(@react-native-community/cli@19.0.0(typescript@5.9.2))(@react-native/metro-config@0.81.0(@babel/core@7.28.3))(@types/react@19.1.0)(react@19.1.0))(react@19.1.0):
-    dependencies:
-      expo: 54.0.0-preview.4(@babel/core@7.28.3)(graphql@16.11.0)(react-native@0.81.0(@babel/core@7.28.3)(@react-native-community/cli@19.0.0(typescript@5.9.2))(@react-native/metro-config@0.81.0(@babel/core@7.28.3))(@types/react@19.1.0)(react@19.1.0))(react@19.1.0)
-      fontfaceobserver: 2.3.0
-      react: 19.1.0
-      react-native: 0.81.0(@babel/core@7.28.3)(@react-native-community/cli@19.0.0(typescript@5.9.2))(@react-native/metro-config@0.81.0(@babel/core@7.28.3))(@types/react@19.1.0)(react@19.1.0)
-    optional: true
-
   expo-keep-awake@15.0.2(expo@54.0.0-preview.4(@babel/core@7.27.1)(graphql@16.11.0)(react-native@0.81.0(@babel/core@7.27.1)(@react-native-community/cli@19.0.0(typescript@5.9.2))(@react-native/metro-config@0.81.0(@babel/core@7.27.1))(@types/react@19.1.0)(react@19.1.0))(react@19.1.0))(react@19.1.0):
     dependencies:
       expo: 54.0.0-preview.4(@babel/core@7.27.1)(graphql@16.11.0)(react-native@0.81.0(@babel/core@7.27.1)(@react-native-community/cli@19.0.0(typescript@5.9.2))(@react-native/metro-config@0.81.0(@babel/core@7.27.1))(@types/react@19.1.0)(react@19.1.0))(react@19.1.0)
@@ -26365,12 +26008,6 @@ snapshots:
     dependencies:
       expo: 54.0.0-preview.4(@babel/core@7.28.3)(graphql@16.11.0)(react-native@0.80.0(@babel/core@7.28.3)(@react-native-community/cli@19.0.0(typescript@5.6.2))(@types/react@19.1.0)(react@19.1.0))(react@19.1.0)
       react: 19.1.0
-
-  expo-keep-awake@15.0.2(expo@54.0.0-preview.4(@babel/core@7.28.3)(graphql@16.11.0)(react-native@0.81.0(@babel/core@7.28.3)(@react-native-community/cli@19.0.0(typescript@5.9.2))(@react-native/metro-config@0.81.0(@babel/core@7.28.3))(@types/react@19.1.0)(react@19.1.0))(react@19.1.0))(react@19.1.0):
-    dependencies:
-      expo: 54.0.0-preview.4(@babel/core@7.28.3)(graphql@16.11.0)(react-native@0.81.0(@babel/core@7.28.3)(@react-native-community/cli@19.0.0(typescript@5.9.2))(@react-native/metro-config@0.81.0(@babel/core@7.28.3))(@types/react@19.1.0)(react@19.1.0))(react@19.1.0)
-      react: 19.1.0
-    optional: true
 
   expo-linking@7.0.5(expo@54.0.0-preview.4(@babel/core@7.27.1)(graphql@16.11.0)(react-native@0.81.0(@babel/core@7.27.1)(@react-native-community/cli@19.0.0(typescript@5.9.2))(@react-native/metro-config@0.81.0(@babel/core@7.27.1))(@types/react@19.1.0)(react@19.1.0))(react@19.1.0))(react-native@0.81.0(@babel/core@7.27.1)(@react-native-community/cli@19.0.0(typescript@5.9.2))(@react-native/metro-config@0.81.0(@babel/core@7.27.1))(@types/react@19.1.0)(react@19.1.0))(react@19.1.0):
     dependencies:
@@ -26414,13 +26051,6 @@ snapshots:
       react: 19.1.0
       react-native: 0.81.0(@babel/core@7.27.1)(@react-native-community/cli@19.0.0(typescript@5.9.2))(@react-native/metro-config@0.81.0(@babel/core@7.27.1))(@types/react@19.1.0)(react@19.1.0)
 
-  expo-modules-core@3.0.4(react-native@0.81.0(@babel/core@7.28.3)(@react-native-community/cli@19.0.0(typescript@5.9.2))(@react-native/metro-config@0.81.0(@babel/core@7.28.3))(@types/react@19.1.0)(react@19.1.0))(react@19.1.0):
-    dependencies:
-      invariant: 2.2.4
-      react: 19.1.0
-      react-native: 0.81.0(@babel/core@7.28.3)(@react-native-community/cli@19.0.0(typescript@5.9.2))(@react-native/metro-config@0.81.0(@babel/core@7.28.3))(@types/react@19.1.0)(react@19.1.0)
-    optional: true
-
   expo-secure-store@14.2.3(expo@54.0.0-preview.4(@babel/core@7.28.3)(graphql@16.11.0)(react-native@0.80.0(@babel/core@7.28.3)(@react-native-community/cli@19.0.0(typescript@5.6.2))(@types/react@19.1.0)(react@19.1.0))(react@19.1.0)):
     dependencies:
       expo: 54.0.0-preview.4(@babel/core@7.28.3)(graphql@16.11.0)(react-native@0.80.0(@babel/core@7.28.3)(@react-native-community/cli@19.0.0(typescript@5.6.2))(@types/react@19.1.0)(react@19.1.0))(react@19.1.0)
@@ -26428,11 +26058,6 @@ snapshots:
   expo-secure-store@15.0.2(expo@54.0.0-preview.4(@babel/core@7.27.1)(graphql@16.11.0)(react-native@0.81.0(@babel/core@7.27.1)(@react-native-community/cli@19.0.0(typescript@5.9.2))(@react-native/metro-config@0.81.0(@babel/core@7.27.1))(@types/react@19.1.0)(react@19.1.0))(react@19.1.0)):
     dependencies:
       expo: 54.0.0-preview.4(@babel/core@7.27.1)(graphql@16.11.0)(react-native@0.81.0(@babel/core@7.27.1)(@react-native-community/cli@19.0.0(typescript@5.9.2))(@react-native/metro-config@0.81.0(@babel/core@7.27.1))(@types/react@19.1.0)(react@19.1.0))(react@19.1.0)
-
-  expo-secure-store@15.0.2(expo@54.0.0-preview.4(@babel/core@7.28.3)(graphql@16.11.0)(react-native@0.81.0(@babel/core@7.28.3)(@react-native-community/cli@19.0.0(typescript@5.9.2))(@react-native/metro-config@0.81.0(@babel/core@7.28.3))(@types/react@19.1.0)(react@19.1.0))(react@19.1.0)):
-    dependencies:
-      expo: 54.0.0-preview.4(@babel/core@7.28.3)(graphql@16.11.0)(react-native@0.81.0(@babel/core@7.28.3)(@react-native-community/cli@19.0.0(typescript@5.9.2))(@react-native/metro-config@0.81.0(@babel/core@7.28.3))(@types/react@19.1.0)(react@19.1.0))(react@19.1.0)
-    optional: true
 
   expo-sqlite@16.0.3(expo@54.0.0-preview.4(@babel/core@7.27.1)(graphql@16.11.0)(react-native@0.81.0(@babel/core@7.27.1)(@react-native-community/cli@19.0.0(typescript@5.9.2))(@react-native/metro-config@0.81.0(@babel/core@7.27.1))(@types/react@19.1.0)(react@19.1.0))(react@19.1.0))(react-native@0.81.0(@babel/core@7.27.1)(@react-native-community/cli@19.0.0(typescript@5.9.2))(@react-native/metro-config@0.81.0(@babel/core@7.27.1))(@types/react@19.1.0)(react@19.1.0))(react@19.1.0):
     dependencies:
@@ -26447,14 +26072,6 @@ snapshots:
       expo: 54.0.0-preview.4(@babel/core@7.28.3)(graphql@16.11.0)(react-native@0.80.0(@babel/core@7.28.3)(@react-native-community/cli@19.0.0(typescript@5.6.2))(@types/react@19.1.0)(react@19.1.0))(react@19.1.0)
       react: 19.1.0
       react-native: 0.80.0(@babel/core@7.28.3)(@react-native-community/cli@19.0.0(typescript@5.6.2))(@types/react@19.1.0)(react@19.1.0)
-
-  expo-sqlite@16.0.3(expo@54.0.0-preview.4(@babel/core@7.28.3)(graphql@16.11.0)(react-native@0.81.0(@babel/core@7.28.3)(@react-native-community/cli@19.0.0(typescript@5.9.2))(@react-native/metro-config@0.81.0(@babel/core@7.28.3))(@types/react@19.1.0)(react@19.1.0))(react@19.1.0))(react-native@0.81.0(@babel/core@7.28.3)(@react-native-community/cli@19.0.0(typescript@5.9.2))(@react-native/metro-config@0.81.0(@babel/core@7.28.3))(@types/react@19.1.0)(react@19.1.0))(react@19.1.0):
-    dependencies:
-      await-lock: 2.2.2
-      expo: 54.0.0-preview.4(@babel/core@7.28.3)(graphql@16.11.0)(react-native@0.81.0(@babel/core@7.28.3)(@react-native-community/cli@19.0.0(typescript@5.9.2))(@react-native/metro-config@0.81.0(@babel/core@7.28.3))(@types/react@19.1.0)(react@19.1.0))(react@19.1.0)
-      react: 19.1.0
-      react-native: 0.81.0(@babel/core@7.28.3)(@react-native-community/cli@19.0.0(typescript@5.9.2))(@react-native/metro-config@0.81.0(@babel/core@7.28.3))(@types/react@19.1.0)(react@19.1.0)
-    optional: true
 
   expo-web-browser@14.0.2(expo@54.0.0-preview.4(@babel/core@7.27.1)(graphql@16.11.0)(react-native@0.81.0(@babel/core@7.27.1)(@react-native-community/cli@19.0.0(typescript@5.9.2))(@react-native/metro-config@0.81.0(@babel/core@7.27.1))(@types/react@19.1.0)(react@19.1.0))(react@19.1.0))(react-native@0.81.0(@babel/core@7.27.1)(@react-native-community/cli@19.0.0(typescript@5.9.2))(@react-native/metro-config@0.81.0(@babel/core@7.27.1))(@types/react@19.1.0)(react@19.1.0)):
     dependencies:
@@ -26527,38 +26144,6 @@ snapshots:
       - graphql
       - supports-color
       - utf-8-validate
-
-  expo@54.0.0-preview.4(@babel/core@7.28.3)(graphql@16.11.0)(react-native@0.81.0(@babel/core@7.28.3)(@react-native-community/cli@19.0.0(typescript@5.9.2))(@react-native/metro-config@0.81.0(@babel/core@7.28.3))(@types/react@19.1.0)(react@19.1.0))(react@19.1.0):
-    dependencies:
-      '@babel/runtime': 7.28.3
-      '@expo/cli': 0.26.0(expo@54.0.0-preview.4(@babel/core@7.28.3)(graphql@16.11.0)(react-native@0.81.0(@babel/core@7.28.3)(@react-native-community/cli@19.0.0(typescript@5.9.2))(@react-native/metro-config@0.81.0(@babel/core@7.28.3))(@types/react@19.1.0)(react@19.1.0))(react@19.1.0))(graphql@16.11.0)(react-native@0.81.0(@babel/core@7.28.3)(@react-native-community/cli@19.0.0(typescript@5.9.2))(@react-native/metro-config@0.81.0(@babel/core@7.28.3))(@types/react@19.1.0)(react@19.1.0))
-      '@expo/config': 12.0.3
-      '@expo/config-plugins': 11.0.3
-      '@expo/devtools': 0.1.2(react-native@0.81.0(@babel/core@7.28.3)(@react-native-community/cli@19.0.0(typescript@5.9.2))(@react-native/metro-config@0.81.0(@babel/core@7.28.3))(@types/react@19.1.0)(react@19.1.0))(react@19.1.0)
-      '@expo/fingerprint': 0.14.2
-      '@expo/metro': 0.1.1
-      '@expo/metro-config': 0.21.3(expo@54.0.0-preview.4(@babel/core@7.28.3)(graphql@16.11.0)(react-native@0.81.0(@babel/core@7.28.3)(@react-native-community/cli@19.0.0(typescript@5.9.2))(@react-native/metro-config@0.81.0(@babel/core@7.28.3))(@types/react@19.1.0)(react@19.1.0))(react@19.1.0))
-      '@expo/vector-icons': 14.1.0(expo-font@14.0.2(expo@54.0.0-preview.4(@babel/core@7.28.3)(graphql@16.11.0)(react-native@0.81.0(@babel/core@7.28.3)(@react-native-community/cli@19.0.0(typescript@5.9.2))(@react-native/metro-config@0.81.0(@babel/core@7.28.3))(@types/react@19.1.0)(react@19.1.0))(react@19.1.0))(react-native@0.81.0(@babel/core@7.28.3)(@react-native-community/cli@19.0.0(typescript@5.9.2))(@react-native/metro-config@0.81.0(@babel/core@7.28.3))(@types/react@19.1.0)(react@19.1.0))(react@19.1.0))(react-native@0.81.0(@babel/core@7.28.3)(@react-native-community/cli@19.0.0(typescript@5.9.2))(@react-native/metro-config@0.81.0(@babel/core@7.28.3))(@types/react@19.1.0)(react@19.1.0))(react@19.1.0)
-      babel-preset-expo: 14.0.2(@babel/core@7.28.3)(expo@54.0.0-preview.4(@babel/core@7.28.3)(graphql@16.11.0)(react-native@0.81.0(@babel/core@7.28.3)(@react-native-community/cli@19.0.0(typescript@5.9.2))(@react-native/metro-config@0.81.0(@babel/core@7.28.3))(@types/react@19.1.0)(react@19.1.0))(react@19.1.0))(react-refresh@0.14.2)
-      expo-asset: 12.0.2(expo@54.0.0-preview.4(@babel/core@7.28.3)(graphql@16.11.0)(react-native@0.81.0(@babel/core@7.28.3)(@react-native-community/cli@19.0.0(typescript@5.9.2))(@react-native/metro-config@0.81.0(@babel/core@7.28.3))(@types/react@19.1.0)(react@19.1.0))(react@19.1.0))(react-native@0.81.0(@babel/core@7.28.3)(@react-native-community/cli@19.0.0(typescript@5.9.2))(@react-native/metro-config@0.81.0(@babel/core@7.28.3))(@types/react@19.1.0)(react@19.1.0))(react@19.1.0)
-      expo-constants: 18.0.2(expo@54.0.0-preview.4(@babel/core@7.28.3)(graphql@16.11.0)(react-native@0.81.0(@babel/core@7.28.3)(@react-native-community/cli@19.0.0(typescript@5.9.2))(@react-native/metro-config@0.81.0(@babel/core@7.28.3))(@types/react@19.1.0)(react@19.1.0))(react@19.1.0))(react-native@0.81.0(@babel/core@7.28.3)(@react-native-community/cli@19.0.0(typescript@5.9.2))(@react-native/metro-config@0.81.0(@babel/core@7.28.3))(@types/react@19.1.0)(react@19.1.0))
-      expo-font: 14.0.2(expo@54.0.0-preview.4(@babel/core@7.28.3)(graphql@16.11.0)(react-native@0.81.0(@babel/core@7.28.3)(@react-native-community/cli@19.0.0(typescript@5.9.2))(@react-native/metro-config@0.81.0(@babel/core@7.28.3))(@types/react@19.1.0)(react@19.1.0))(react@19.1.0))(react-native@0.81.0(@babel/core@7.28.3)(@react-native-community/cli@19.0.0(typescript@5.9.2))(@react-native/metro-config@0.81.0(@babel/core@7.28.3))(@types/react@19.1.0)(react@19.1.0))(react@19.1.0)
-      expo-keep-awake: 15.0.2(expo@54.0.0-preview.4(@babel/core@7.28.3)(graphql@16.11.0)(react-native@0.81.0(@babel/core@7.28.3)(@react-native-community/cli@19.0.0(typescript@5.9.2))(@react-native/metro-config@0.81.0(@babel/core@7.28.3))(@types/react@19.1.0)(react@19.1.0))(react@19.1.0))(react@19.1.0)
-      expo-modules-autolinking: 3.0.2
-      expo-modules-core: 3.0.4(react-native@0.81.0(@babel/core@7.28.3)(@react-native-community/cli@19.0.0(typescript@5.9.2))(@react-native/metro-config@0.81.0(@babel/core@7.28.3))(@types/react@19.1.0)(react@19.1.0))(react@19.1.0)
-      pretty-format: 29.7.0
-      react: 19.1.0
-      react-native: 0.81.0(@babel/core@7.28.3)(@react-native-community/cli@19.0.0(typescript@5.9.2))(@react-native/metro-config@0.81.0(@babel/core@7.28.3))(@types/react@19.1.0)(react@19.1.0)
-      react-refresh: 0.14.2
-      whatwg-url-without-unicode: 8.0.0-3
-    transitivePeerDependencies:
-      - '@babel/core'
-      - bufferutil
-      - expo-router
-      - graphql
-      - supports-color
-      - utf-8-validate
-    optional: true
 
   exponential-backoff@3.1.1: {}
 
@@ -27557,46 +27142,6 @@ snapshots:
       async: 3.2.6
       filelist: 1.0.4
       picocolors: 1.1.1
-
-  jazz-tools@0.18.5(a288373a09e7d4e00d8a579fc436cdcc):
-    dependencies:
-      '@manuscripts/prosemirror-recreate-steps': 0.1.4
-      '@scure/base': 1.2.1
-      '@scure/bip39': 1.5.0
-      '@tiptap/core': 2.12.0(@tiptap/pm@2.12.0)
-      clsx: 2.1.1
-      cojson: 0.18.5
-      cojson-storage-indexeddb: 0.18.5
-      cojson-transport-ws: 0.18.5
-      fast-myers-diff: 3.2.0
-      goober: 2.1.16(csstype@3.1.3)
-      prosemirror-example-setup: 1.2.3
-      prosemirror-menu: 1.2.5
-      prosemirror-model: 1.25.1
-      prosemirror-schema-basic: 1.2.4
-      prosemirror-state: 1.4.3
-      prosemirror-transform: 1.10.4
-      zod: 3.25.76
-    optionalDependencies:
-      '@bam.tech/react-native-image-resizer': 3.0.11(react-native@0.81.0(@babel/core@7.28.3)(@react-native-community/cli@19.0.0(typescript@5.9.2))(@react-native/metro-config@0.81.0(@babel/core@7.28.3))(@types/react@19.1.0)(react@19.1.0))(react@19.1.0)
-      '@op-engineering/op-sqlite': 14.1.4(react-native@0.81.0(@babel/core@7.28.3)(@react-native-community/cli@19.0.0(typescript@5.9.2))(@react-native/metro-config@0.81.0(@babel/core@7.28.3))(@types/react@19.1.0)(react@19.1.0))(react@19.1.0)
-      '@react-native-community/netinfo': 11.4.1(react-native@0.81.0(@babel/core@7.28.3)(@react-native-community/cli@19.0.0(typescript@5.9.2))(@react-native/metro-config@0.81.0(@babel/core@7.28.3))(@types/react@19.1.0)(react@19.1.0))
-      better-auth: 1.3.6(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(zod@4.0.15)
-      expo-file-system: 18.1.10(expo@54.0.0-preview.4(@babel/core@7.28.3)(graphql@16.11.0)(react-native@0.81.0(@babel/core@7.28.3)(@react-native-community/cli@19.0.0(typescript@5.9.2))(@react-native/metro-config@0.81.0(@babel/core@7.28.3))(@types/react@19.1.0)(react@19.1.0))(react@19.1.0))(react-native@0.81.0(@babel/core@7.28.3)(@react-native-community/cli@19.0.0(typescript@5.9.2))(@react-native/metro-config@0.81.0(@babel/core@7.28.3))(@types/react@19.1.0)(react@19.1.0))
-      expo-secure-store: 15.0.2(expo@54.0.0-preview.4(@babel/core@7.28.3)(graphql@16.11.0)(react-native@0.81.0(@babel/core@7.28.3)(@react-native-community/cli@19.0.0(typescript@5.9.2))(@react-native/metro-config@0.81.0(@babel/core@7.28.3))(@types/react@19.1.0)(react@19.1.0))(react@19.1.0))
-      expo-sqlite: 16.0.3(expo@54.0.0-preview.4(@babel/core@7.28.3)(graphql@16.11.0)(react-native@0.81.0(@babel/core@7.28.3)(@react-native-community/cli@19.0.0(typescript@5.9.2))(@react-native/metro-config@0.81.0(@babel/core@7.28.3))(@types/react@19.1.0)(react@19.1.0))(react@19.1.0))(react-native@0.81.0(@babel/core@7.28.3)(@react-native-community/cli@19.0.0(typescript@5.9.2))(@react-native/metro-config@0.81.0(@babel/core@7.28.3))(@types/react@19.1.0)(react@19.1.0))(react@19.1.0)
-      react: 19.1.0
-      react-dom: 19.1.0(react@19.1.0)
-      react-native: 0.81.0(@babel/core@7.28.3)(@react-native-community/cli@19.0.0(typescript@5.9.2))(@react-native/metro-config@0.81.0(@babel/core@7.28.3))(@types/react@19.1.0)(react@19.1.0)
-      react-native-fast-encoder: 0.2.0(react-native@0.81.0(@babel/core@7.28.3)(@react-native-community/cli@19.0.0(typescript@5.9.2))(@react-native/metro-config@0.81.0(@babel/core@7.28.3))(@types/react@19.1.0)(react@19.1.0))(react@19.1.0)
-      react-native-mmkv: 3.3.0(react-native@0.81.0(@babel/core@7.28.3)(@react-native-community/cli@19.0.0(typescript@5.9.2))(@react-native/metro-config@0.81.0(@babel/core@7.28.3))(@types/react@19.1.0)(react@19.1.0))(react@19.1.0)
-      react-native-nitro-modules: 0.26.4(react-native@0.81.0(@babel/core@7.28.3)(@react-native-community/cli@19.0.0(typescript@5.9.2))(@react-native/metro-config@0.81.0(@babel/core@7.28.3))(@types/react@19.1.0)(react@19.1.0))(react@19.1.0)
-      react-native-quick-crypto: 1.0.0-beta.20(expo@54.0.0-preview.4(@babel/core@7.28.3)(graphql@16.11.0)(react-native@0.81.0(@babel/core@7.28.3)(@react-native-community/cli@19.0.0(typescript@5.9.2))(@react-native/metro-config@0.81.0(@babel/core@7.28.3))(@types/react@19.1.0)(react@19.1.0))(react@19.1.0))(react-native-nitro-modules@0.26.4(react-native@0.81.0(@babel/core@7.28.3)(@react-native-community/cli@19.0.0(typescript@5.9.2))(@react-native/metro-config@0.81.0(@babel/core@7.28.3))(@types/react@19.1.0)(react@19.1.0))(react@19.1.0))(react-native@0.81.0(@babel/core@7.28.3)(@react-native-community/cli@19.0.0(typescript@5.9.2))(@react-native/metro-config@0.81.0(@babel/core@7.28.3))(@types/react@19.1.0)(react@19.1.0))(react@19.1.0)
-      sharp: 0.33.5
-      svelte: 5.38.2
-    transitivePeerDependencies:
-      - '@tiptap/pm'
-      - csstype
 
   jest-changed-files@29.7.0:
     dependencies:
@@ -30257,14 +29802,6 @@ snapshots:
       react: 19.1.0
       react-native: 0.80.0(@babel/core@7.28.3)(@react-native-community/cli@19.0.0(typescript@5.6.2))(@types/react@19.1.0)(react@19.1.0)
 
-  react-native-fast-encoder@0.2.0(react-native@0.81.0(@babel/core@7.28.3)(@react-native-community/cli@19.0.0(typescript@5.9.2))(@react-native/metro-config@0.81.0(@babel/core@7.28.3))(@types/react@19.1.0)(react@19.1.0))(react@19.1.0):
-    dependencies:
-      big-integer: 1.6.52
-      flatbuffers: 2.0.6
-      react: 19.1.0
-      react-native: 0.81.0(@babel/core@7.28.3)(@react-native-community/cli@19.0.0(typescript@5.9.2))(@react-native/metro-config@0.81.0(@babel/core@7.28.3))(@types/react@19.1.0)(react@19.1.0)
-    optional: true
-
   react-native-get-random-values@1.11.0(react-native@0.81.0(@babel/core@7.27.1)(@react-native-community/cli@19.0.0(typescript@5.6.2))(@react-native/metro-config@0.81.0(@babel/core@7.27.1))(@types/react@19.1.0)(react@19.1.0)):
     dependencies:
       fast-base64-decode: 1.0.0
@@ -30290,12 +29827,6 @@ snapshots:
       react: 19.1.0
       react-native: 0.81.0(@babel/core@7.27.1)(@react-native-community/cli@19.0.0(typescript@5.6.2))(@react-native/metro-config@0.81.0(@babel/core@7.27.1))(@types/react@19.1.0)(react@19.1.0)
 
-  react-native-mmkv@3.3.0(react-native@0.81.0(@babel/core@7.28.3)(@react-native-community/cli@19.0.0(typescript@5.9.2))(@react-native/metro-config@0.81.0(@babel/core@7.28.3))(@types/react@19.1.0)(react@19.1.0))(react@19.1.0):
-    dependencies:
-      react: 19.1.0
-      react-native: 0.81.0(@babel/core@7.28.3)(@react-native-community/cli@19.0.0(typescript@5.9.2))(@react-native/metro-config@0.81.0(@babel/core@7.28.3))(@types/react@19.1.0)(react@19.1.0)
-    optional: true
-
   react-native-nitro-modules@0.26.4(react-native@0.80.0(@babel/core@7.28.3)(@react-native-community/cli@19.0.0(typescript@5.6.2))(@types/react@19.1.0)(react@19.1.0))(react@19.1.0):
     dependencies:
       react: 19.1.0
@@ -30306,22 +29837,10 @@ snapshots:
       react: 19.1.0
       react-native: 0.81.0(@babel/core@7.27.1)(@react-native-community/cli@19.0.0(typescript@5.9.2))(@react-native/metro-config@0.81.0(@babel/core@7.27.1))(@types/react@19.1.0)(react@19.1.0)
 
-  react-native-nitro-modules@0.26.4(react-native@0.81.0(@babel/core@7.28.3)(@react-native-community/cli@19.0.0(typescript@5.9.2))(@react-native/metro-config@0.81.0(@babel/core@7.28.3))(@types/react@19.1.0)(react@19.1.0))(react@19.1.0):
-    dependencies:
-      react: 19.1.0
-      react-native: 0.81.0(@babel/core@7.28.3)(@react-native-community/cli@19.0.0(typescript@5.9.2))(@react-native/metro-config@0.81.0(@babel/core@7.28.3))(@types/react@19.1.0)(react@19.1.0)
-    optional: true
-
   react-native-quick-base64@2.2.0(react-native@0.80.0(@babel/core@7.28.3)(@react-native-community/cli@19.0.0(typescript@5.6.2))(@types/react@19.1.0)(react@19.1.0))(react@19.1.0):
     dependencies:
       react: 19.1.0
       react-native: 0.80.0(@babel/core@7.28.3)(@react-native-community/cli@19.0.0(typescript@5.6.2))(@types/react@19.1.0)(react@19.1.0)
-
-  react-native-quick-base64@2.2.0(react-native@0.81.0(@babel/core@7.28.3)(@react-native-community/cli@19.0.0(typescript@5.9.2))(@react-native/metro-config@0.81.0(@babel/core@7.28.3))(@types/react@19.1.0)(react@19.1.0))(react@19.1.0):
-    dependencies:
-      react: 19.1.0
-      react-native: 0.81.0(@babel/core@7.28.3)(@react-native-community/cli@19.0.0(typescript@5.9.2))(@react-native/metro-config@0.81.0(@babel/core@7.28.3))(@types/react@19.1.0)(react@19.1.0)
-    optional: true
 
   react-native-quick-crypto@1.0.0-beta.20(expo@54.0.0-preview.4(@babel/core@7.28.3)(graphql@16.11.0)(react-native@0.80.0(@babel/core@7.28.3)(@react-native-community/cli@19.0.0(typescript@5.6.2))(@types/react@19.1.0)(react@19.1.0))(react@19.1.0))(react-native-nitro-modules@0.26.4(react-native@0.80.0(@babel/core@7.28.3)(@react-native-community/cli@19.0.0(typescript@5.6.2))(@types/react@19.1.0)(react@19.1.0))(react@19.1.0))(react-native@0.80.0(@babel/core@7.28.3)(@react-native-community/cli@19.0.0(typescript@5.6.2))(@types/react@19.1.0)(react@19.1.0))(react@19.1.0):
     dependencies:
@@ -30335,20 +29854,6 @@ snapshots:
       util: 0.12.5
     optionalDependencies:
       expo: 54.0.0-preview.4(@babel/core@7.28.3)(graphql@16.11.0)(react-native@0.80.0(@babel/core@7.28.3)(@react-native-community/cli@19.0.0(typescript@5.6.2))(@types/react@19.1.0)(react@19.1.0))(react@19.1.0)
-
-  react-native-quick-crypto@1.0.0-beta.20(expo@54.0.0-preview.4(@babel/core@7.28.3)(graphql@16.11.0)(react-native@0.81.0(@babel/core@7.28.3)(@react-native-community/cli@19.0.0(typescript@5.9.2))(@react-native/metro-config@0.81.0(@babel/core@7.28.3))(@types/react@19.1.0)(react@19.1.0))(react@19.1.0))(react-native-nitro-modules@0.26.4(react-native@0.81.0(@babel/core@7.28.3)(@react-native-community/cli@19.0.0(typescript@5.9.2))(@react-native/metro-config@0.81.0(@babel/core@7.28.3))(@types/react@19.1.0)(react@19.1.0))(react@19.1.0))(react-native@0.81.0(@babel/core@7.28.3)(@react-native-community/cli@19.0.0(typescript@5.9.2))(@react-native/metro-config@0.81.0(@babel/core@7.28.3))(@types/react@19.1.0)(react@19.1.0))(react@19.1.0):
-    dependencies:
-      '@craftzdog/react-native-buffer': 6.1.0(react-native@0.81.0(@babel/core@7.28.3)(@react-native-community/cli@19.0.0(typescript@5.9.2))(@react-native/metro-config@0.81.0(@babel/core@7.28.3))(@types/react@19.1.0)(react@19.1.0))(react@19.1.0)
-      events: 3.3.0
-      react: 19.1.0
-      react-native: 0.81.0(@babel/core@7.28.3)(@react-native-community/cli@19.0.0(typescript@5.9.2))(@react-native/metro-config@0.81.0(@babel/core@7.28.3))(@types/react@19.1.0)(react@19.1.0)
-      react-native-nitro-modules: 0.26.4(react-native@0.81.0(@babel/core@7.28.3)(@react-native-community/cli@19.0.0(typescript@5.9.2))(@react-native/metro-config@0.81.0(@babel/core@7.28.3))(@types/react@19.1.0)(react@19.1.0))(react@19.1.0)
-      react-native-quick-base64: 2.2.0(react-native@0.81.0(@babel/core@7.28.3)(@react-native-community/cli@19.0.0(typescript@5.9.2))(@react-native/metro-config@0.81.0(@babel/core@7.28.3))(@types/react@19.1.0)(react@19.1.0))(react@19.1.0)
-      readable-stream: 4.5.2
-      util: 0.12.5
-    optionalDependencies:
-      expo: 54.0.0-preview.4(@babel/core@7.28.3)(graphql@16.11.0)(react-native@0.81.0(@babel/core@7.28.3)(@react-native-community/cli@19.0.0(typescript@5.9.2))(@react-native/metro-config@0.81.0(@babel/core@7.28.3))(@types/react@19.1.0)(react@19.1.0))(react@19.1.0)
-    optional: true
 
   react-native-safe-area-context@5.5.0(react-native@0.81.0(@babel/core@7.27.1)(@react-native-community/cli@19.0.0(typescript@5.6.2))(@react-native/metro-config@0.81.0(@babel/core@7.27.1))(@types/react@19.1.0)(react@19.1.0))(react@19.1.0):
     dependencies:
@@ -30508,54 +30013,6 @@ snapshots:
       - bufferutil
       - supports-color
       - utf-8-validate
-
-  react-native@0.81.0(@babel/core@7.28.3)(@react-native-community/cli@19.0.0(typescript@5.9.2))(@react-native/metro-config@0.81.0(@babel/core@7.28.3))(@types/react@19.1.0)(react@19.1.0):
-    dependencies:
-      '@jest/create-cache-key-function': 29.7.0
-      '@react-native/assets-registry': 0.81.0
-      '@react-native/codegen': 0.81.0(@babel/core@7.28.3)
-      '@react-native/community-cli-plugin': 0.81.0(@react-native-community/cli@19.0.0(typescript@5.9.2))(@react-native/metro-config@0.81.0(@babel/core@7.28.3))
-      '@react-native/gradle-plugin': 0.81.0
-      '@react-native/js-polyfills': 0.81.0
-      '@react-native/normalize-colors': 0.81.0
-      '@react-native/virtualized-lists': 0.81.0(@types/react@19.1.0)(react-native@0.81.0(@babel/core@7.28.3)(@react-native-community/cli@19.0.0(typescript@5.9.2))(@react-native/metro-config@0.81.0(@babel/core@7.28.3))(@types/react@19.1.0)(react@19.1.0))(react@19.1.0)
-      abort-controller: 3.0.0
-      anser: 1.4.10
-      ansi-regex: 5.0.1
-      babel-jest: 29.7.0(@babel/core@7.28.3)
-      babel-plugin-syntax-hermes-parser: 0.29.1
-      base64-js: 1.5.1
-      commander: 12.1.0
-      flow-enums-runtime: 0.0.6
-      glob: 7.2.3
-      invariant: 2.2.4
-      jest-environment-node: 29.7.0
-      memoize-one: 5.2.1
-      metro-runtime: 0.83.1
-      metro-source-map: 0.83.1
-      nullthrows: 1.1.1
-      pretty-format: 29.7.0
-      promise: 8.3.0
-      react: 19.1.0
-      react-devtools-core: 6.1.5
-      react-refresh: 0.14.2
-      regenerator-runtime: 0.13.11
-      scheduler: 0.26.0
-      semver: 7.7.2
-      stacktrace-parser: 0.1.10
-      whatwg-fetch: 3.6.20
-      ws: 6.2.3
-      yargs: 17.7.2
-    optionalDependencies:
-      '@types/react': 19.1.0
-    transitivePeerDependencies:
-      - '@babel/core'
-      - '@react-native-community/cli'
-      - '@react-native/metro-config'
-      - bufferutil
-      - supports-color
-      - utf-8-validate
-    optional: true
 
   react-refresh@0.14.2: {}
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Refactors bench suites to use cojson directly (list/map import/load/update) comparing current vs npm 0.18.18, removes jazz-tools, and bumps cojson-latest to 0.18.18.
> 
> - **Benchmarks**:
>   - `bench/colist.load.bench.ts`:
>     - Replace `jazz-tools` schema setup with direct `cojson` usage and fixture generator.
>     - Add `list import`, `list import + content load`, and `list updating` benches comparing current vs `cojson` 0.18.18; tune iterations.
>   - `bench/comap.create.bench.ts`:
>     - Replace message/map schema flow with direct `cojson` map fixtures.
>     - Add `map import`, `map import + content load`, and `map updating` benches comparing current vs `cojson` 0.18.18; tune iterations.
> - **Dependencies**:
>   - `bench/package.json`: remove `jazz-tools` and `jazz-tools-latest`; update `cojson-latest` to `0.18.18`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2065d4d7919ff869a8f9c485cd045e201dd6a3be. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->