### PR TITLE
fix: update WebAuthn challenge length to 20 bytes

### DIFF
--- a/.changeset/rich-pillows-study.md
+++ b/.changeset/rich-pillows-study.md
@@ -1,0 +1,5 @@
+---
+"jazz-tools": patch
+---
+
+Increased passkey challenge length to improve compatibility with KeePassXC

--- a/packages/jazz-tools/src/browser/auth/PasskeyAuth.ts
+++ b/packages/jazz-tools/src/browser/auth/PasskeyAuth.ts
@@ -122,7 +122,7 @@ export class BrowserPasskeyAuth {
     try {
       await navigator.credentials.create({
         publicKey: {
-          challenge: this.crypto.randomBytes(20),
+          challenge: new Uint8Array(this.crypto.randomBytes(20)),
           rp: {
             name: this.appName,
             id: this.appHostname,
@@ -156,7 +156,7 @@ export class BrowserPasskeyAuth {
     try {
       const value = await navigator.credentials.get({
         publicKey: {
-          challenge: Uint8Array.from([0, 1, 2]),
+          challenge: new Uint8Array(this.crypto.randomBytes(20)),
           rpId: this.appHostname,
           allowCredentials: [],
           timeout: 60000,


### PR DESCRIPTION
Fix TS issue (crypto.randomBytes allows SharedArrayBuffer-backed Uint8Arrays, but WebAuthn doesn't)

Fixes #2974 

# Description
Increases challenge length to 20 bytes, type fixes.

## Manual testing instructions
N/A

## Tests

- [ ] Tests have been added and/or updated
- [x] Tests have not been updated, because: Current behaviour is permitted by spec, and we are anyway mocking the browser in our tests, so unit testing this would only be testing our mock implementation.
- [ ] I need help with writing tests


## Checklist

- [ ] I've updated the part of the docs that are affected the PR changes
- [x] I've generated a changeset, if a version bump is required
- [ ] I've updated the jsDoc comments to the public APIs I've modified, or added them when missing

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Switches WebAuthn challenges to 20-byte Uint8Arrays for both credential creation and retrieval, adding a patch changeset.
> 
> - **Auth (WebAuthn)**:
>   - `packages/jazz-tools/src/browser/auth/PasskeyAuth.ts`:
>     - `createPasskeyCredentials`: `challenge` now `new Uint8Array(this.crypto.randomBytes(20))` (was `this.crypto.randomBytes(20)`).
>     - `getPasskeyCredentials`: `challenge` now `new Uint8Array(this.crypto.randomBytes(20))` (was `Uint8Array.from([0, 1, 2])`).
> - **Changeset**:
>   - Adds `.changeset/rich-pillows-study.md` (patch for `jazz-tools`) noting increased passkey challenge length for compatibility.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2c01529679000b54bd20ff11ecf1289d68cbe06b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->