### PR TITLE
perf: pause transaction processing during applyDiff

### DIFF
--- a/.changeset/colist-applydiff-perf.md
+++ b/.changeset/colist-applydiff-perf.md
@@ -1,0 +1,6 @@
+---
+"cojson": patch
+"jazz-tools": patch
+---
+
+Improve performance of `applyDiff` operations on CoList and CoPlainText by pausing transaction processing during the patch operations.

--- a/packages/cojson/src/coValues/coList.ts
+++ b/packages/cojson/src/coValues/coList.ts
@@ -190,7 +190,22 @@ export class RawCoList<
     list.push(value);
   }
 
+  // Helps us to off updates in the middle of applyDiff to improve the performance
+  private shouldProcessNewTransactions = true;
+  pauseTransactionProcessing() {
+    this.shouldProcessNewTransactions = false;
+  }
+
+  resumeTransactionProcessing() {
+    this.shouldProcessNewTransactions = true;
+    this.processNewTransactions();
+  }
+
   processNewTransactions() {
+    if (!this.shouldProcessNewTransactions) {
+      return;
+    }
+
     const transactions = this.core.getValidSortedTransactions({
       ignorePrivateTransactions: false,
       knownTransactions: this.knownTransactions,

--- a/packages/jazz-tools/src/tools/coValues/coList.ts
+++ b/packages/jazz-tools/src/tools/coValues/coList.ts
@@ -738,10 +738,13 @@ export class CoListJazzApi<L extends CoList> extends CoValueJazzApi<L> {
         }
       : undefined;
 
+    // Turns off updates in the middle of applyDiff to improve the performance
+    this.raw.pauseTransactionProcessing();
     const patches = [...calcPatch(current, result, comparator)];
     for (const [from, to, insert] of patches.reverse()) {
       this.splice(from, to - from, ...insert);
     }
+    this.raw.resumeTransactionProcessing();
     return this.coList;
   }
 

--- a/packages/jazz-tools/src/tools/coValues/coPlainText.ts
+++ b/packages/jazz-tools/src/tools/coValues/coPlainText.ts
@@ -246,6 +246,9 @@ export class CoTextJazzApi<T extends CoPlainText> extends CoValueJazzApi<T> {
     // Calculate the diff on grapheme arrays
     const patches = [...calcPatch(currentGraphemes, otherGraphemes)];
 
+    // Turns off updates in the middle of applyDiff to improve the performance
+    this.raw.pauseTransactionProcessing();
+
     // Apply patches in reverse order to avoid index shifting issues
     for (const [from, to, insert] of patches.reverse()) {
       if (to > from) {
@@ -256,6 +259,8 @@ export class CoTextJazzApi<T extends CoPlainText> extends CoValueJazzApi<T> {
         this.coText.insertBefore(from, this.raw.fromGraphemes(insert));
       }
     }
+
+    this.raw.resumeTransactionProcessing();
   }
 
   /**


### PR DESCRIPTION
# Description

Improve performance of `applyDiff` operations on CoList and CoPlainText by pausing transaction processing during bulk operations.

Benchmarks:
<img width="1243" height="189" alt="Screenshot 2025-09-29 at 11 57 32" src="https://github.com/user-attachments/assets/2af40021-62f6-4023-8f1c-8a55c29b4b37" />

In the future we could batch the changes in a single transaction, but we must be careful because we may break co.list

Tracked in #2975 

## Tests

- [x] Tests have been added and/or updated
- [ ] Tests have not been updated, because: <!-- Insert reason for not updating tests here -->
- [ ] I need help with writing tests


## Checklist

- [ ] I've updated the part of the docs that are affected the PR changes
- [x] I've generated a changeset, if a version bump is required
- [ ] I've updated the jsDoc comments to the public APIs I've modified, or added them when missing

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Pauses transaction processing during applyDiff for CoList and CoPlainText to reduce overhead, adding pause/resume controls in cojson and using them in jazz-tools, with a validating test.
> 
> - **Performance: applyDiff batching**
>   - **cojson**:
>     - Add `pauseTransactionProcessing()`/`resumeTransactionProcessing()` and internal `shouldProcessNewTransactions` flag to `packages/cojson/src/coValues/coList.ts` (`RawCoList`).
>     - `processNewTransactions()` now early-returns when paused.
>   - **jazz-tools**:
>     - `CoList.$jazz.applyDiff` wraps patch application with `raw.pauseTransactionProcessing()`/`raw.resumeTransactionProcessing()`.
>     - `CoPlainText.$jazz.applyDiff` does the same around delete/insert patching.
> - **Tests**:
>   - Add test ensuring pause/resume defers and then processes queued list updates in `packages/cojson/src/tests/coList.test.ts`.
> - **Changeset**:
>   - Patch bumps for `cojson` and `jazz-tools`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3c6412b6dff185254df4ce6eb4c62b0f5273b2ab. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->