### PR TITLE
Update schema unions documentation to clarify unsupported operations

### DIFF
--- a/homepage/homepage/content/docs/using-covalues/schemaunions.mdx
+++ b/homepage/homepage/content/docs/using-covalues/schemaunions.mdx
@@ -10,6 +10,12 @@ export const metadata = {
 Schema unions allow you to create types that can be one of several different schemas, similar to TypeScript union types.
 They use a discriminator field to determine which specific schema an instance represents at runtime, enabling type-safe polymorphism in your Jazz applications.
 
+The following operations are not available in schema unions:
+
+* `$jazz.ensureLoaded`&hairsp;—&hairsp;use the union schema's `load` method, or narrow the type first
+* `$jazz.subscribe`&hairsp;—&hairsp;use the union schema's `subscribe` method
+* `$jazz.set`&hairsp;—&hairsp;use `$jazz.applyDiff`
+
 ## Creating schema unions
 
 Schema unions are defined with `co.discriminatedUnion()` by providing an array of schemas and a discriminator field.
@@ -249,9 +255,9 @@ function handleResponse(response: co.loaded<typeof ApiResponse>) {
 
 ## Limitations with schema unions
 
-Schema unions have some limitations that you should be aware of. They are due to Typescript behavior with type unions:
-when the type members of the union have methods with generic parameters, Typescript will not allow calling
-those methods on the union type. This affect some of the methods on the `$jazz` namespace.
+Schema unions have some limitations that you should be aware of. They are due to TypeScript behaviour with type unions: when the type members of the union have methods with generic parameters, TypeScript will not allow calling those methods on the union type. This affects some of the methods on the `$jazz` namespace.
+
+Note that these methods may still work at runtime, but their use is not recommended as you will lose type safety.
 
 #### `$jazz.ensureLoaded` and `$jazz.subscribe` not supported
 


### PR DESCRIPTION
# Description
Docs change to make the limitations on discriminated unions a little more prominent.

## Manual testing instructions

N/A

## Tests

- [ ] Tests have been added and/or updated
- [x] Tests have not been updated, because: docs only
- [ ] I need help with writing tests


## Checklist

- [ ] I've updated the part of the docs that are affected the PR changes
- [ ] I've generated a changeset, if a version bump is required
- [ ] I've updated the jsDoc comments to the public APIs I've modified, or added them when missing

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Clarifies unsupported `$jazz` operations for schema unions and recommends alternatives, with tightened wording and notes on type-safety.
> 
> - **Docs — `homepage/homepage/content/docs/using-covalues/schemaunions.mdx`**:
>   - **Unsupported operations (highlighted early)**:
>     - `$jazz.ensureLoaded` — use union schema `load` or narrow first
>     - `$jazz.subscribe` — use union schema `subscribe`
>     - `$jazz.set` — use `$jazz.applyDiff`
>   - **Limitations section**:
>     - Rewritten for clarity and correct TypeScript terminology; notes that generic methods on unions aren’t callable and may work at runtime but lose type safety.
>     - Keeps guidance: use union schema `load`/`subscribe`; use `$jazz.applyDiff` for updates.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bb9fabe2638a083dbbcb195d1e9d8655dde623e7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->