### PR TITLE
Adds Svelte Provider

### DIFF
--- a/packages/jazz-tools/src/svelte/Provider.svelte
+++ b/packages/jazz-tools/src/svelte/Provider.svelte
@@ -1,59 +1,67 @@
-<script lang="ts" generics="S extends (AccountClass<Account> & CoValueFromRaw<Account>) | AnyAccountSchema">
-import type { AuthSecretStorage, InstanceOfSchema } from "jazz-tools";
-import {
-  Account,
-  type AccountClass,
-  type AnyAccountSchema,
-  type CoValueFromRaw,
-} from "jazz-tools";
-import {
-  JazzBrowserContextManager,
-  type JazzContextManagerProps,
-} from "jazz-tools/browser";
-import { type Snippet, setContext, untrack } from "svelte";
-import { JAZZ_AUTH_CTX, JAZZ_CTX, type JazzContext } from "./jazz.svelte.js";
+<script
+  lang="ts"
+  generics="S extends (AccountClass<Account> & CoValueFromRaw<Account>) | AnyAccountSchema"
+>
+  import type { AuthSecretStorage, InstanceOfSchema } from "jazz-tools";
+  import {
+    Account,
+    type AccountClass,
+    type AnyAccountSchema,
+    type CoValueFromRaw,
+  } from "jazz-tools";
+  import {
+    JazzBrowserContextManager,
+    type JazzContextManagerProps,
+  } from "jazz-tools/browser";
+  import { type Snippet, setContext, untrack } from "svelte";
+  import { JAZZ_AUTH_CTX, JAZZ_CTX, type JazzContext } from "./jazz.svelte.js";
 
-let props: JazzContextManagerProps<S> & { children?: Snippet } = $props();
+  let props: JazzContextManagerProps<S> & {
+    children?: Snippet;
+    storageKey?: string;
+  } = $props();
 
-const contextManager = new JazzBrowserContextManager<S>();
-
-const ctx = $state<JazzContext<InstanceOfSchema<S>>>({ current: undefined });
-
-setContext<JazzContext<InstanceOfSchema<S>>>(JAZZ_CTX, ctx);
-setContext<AuthSecretStorage>(
-  JAZZ_AUTH_CTX,
-  contextManager.getAuthSecretStorage(),
-);
-
-$effect(() => {
-  props.sync.when;
-  props.sync.peer;
-  props.storage;
-  props.guestMode;
-  return untrack(() => {
-    if (!props.sync) return;
-
-    contextManager
-      .createContext({
-        sync: props.sync,
-        storage: props.storage,
-        guestMode: props.guestMode,
-        AccountSchema: props.AccountSchema,
-        defaultProfileName: props.defaultProfileName,
-        onAnonymousAccountDiscarded: props.onAnonymousAccountDiscarded,
-        onLogOut: props.onLogOut,
-      })
-      .catch((error) => {
-        console.error("Error creating Jazz browser context:", error);
-      });
+  const contextManager = new JazzBrowserContextManager<S>({
+    storageKey: props.storageKey,
   });
-});
 
-$effect(() => {
-  return contextManager.subscribe(() => {
-    ctx.current = contextManager.getCurrentValue();
+  const ctx = $state<JazzContext<InstanceOfSchema<S>>>({ current: undefined });
+
+  setContext<JazzContext<InstanceOfSchema<S>>>(JAZZ_CTX, ctx);
+  setContext<AuthSecretStorage>(
+    JAZZ_AUTH_CTX,
+    contextManager.getAuthSecretStorage(),
+  );
+
+  $effect(() => {
+    props.sync.when;
+    props.sync.peer;
+    props.storage;
+    props.guestMode;
+    return untrack(() => {
+      if (!props.sync) return;
+
+      contextManager
+        .createContext({
+          sync: props.sync,
+          storage: props.storage,
+          guestMode: props.guestMode,
+          AccountSchema: props.AccountSchema,
+          defaultProfileName: props.defaultProfileName,
+          onAnonymousAccountDiscarded: props.onAnonymousAccountDiscarded,
+          onLogOut: props.onLogOut,
+        })
+        .catch((error) => {
+          console.error("Error creating Jazz browser context:", error);
+        });
+    });
   });
-});
+
+  $effect(() => {
+    return contextManager.subscribe(() => {
+      ctx.current = contextManager.getCurrentValue();
+    });
+  });
 </script>
 
 {#if ctx.current}


### PR DESCRIPTION
# Description
Adds the storage key option to the Svelte provider

## Manual testing instructions
N/A

## Tests

- [ ] Tests have been added and/or updated
- [x] Tests have not been updated, because: No Provider tests for Svelte
- [ ] I need help with writing tests


## Checklist

- [ ] I've updated the part of the docs that are affected the PR changes
- [ ] I've generated a changeset, if a version bump is required
- [ ] I've updated the jsDoc comments to the public APIs I've modified, or added them when missing

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Add optional storageKey prop to the Svelte Provider and pass it to JazzBrowserContextManager.
> 
> - **Svelte Provider (`packages/jazz-tools/src/svelte/Provider.svelte`)**:
>   - **Props**: Add optional `storageKey?: string` to `props`.
>   - **Context Manager**: Initialize `JazzBrowserContextManager` with `{ storageKey: props.storageKey }` to propagate the key.
>   - Existing context setup and effects remain unchanged.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit feec5daa36c786005554cc28cc2b83e2450418f1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->