### PR TITLE
Regenerate the InboxSender when active account change

### DIFF
--- a/.changeset/two-feet-report.md
+++ b/.changeset/two-feet-report.md
@@ -1,0 +1,5 @@
+---
+"jazz-tools": patch
+---
+
+fix: regenerate InboxSender when active account changes

--- a/packages/jazz-tools/src/react-core/hooks.ts
+++ b/packages/jazz-tools/src/react-core/hooks.ts
@@ -786,7 +786,8 @@ export function experimental_useInboxSender<
 
       let inbox = await inboxRef.current;
 
-      if (inbox.owner.id !== inboxOwnerID) {
+      // Regenerate the InboxSender if the inbox owner or current account changes
+      if (inbox.owner.id !== inboxOwnerID || inbox.currentAccount !== me) {
         const req = InboxSender.load<I, O>(inboxOwnerID, me);
         inboxRef.current = req;
         inbox = await req;
@@ -794,7 +795,7 @@ export function experimental_useInboxSender<
 
       return inbox.sendMessage(message);
     },
-    [inboxOwnerID],
+    [inboxOwnerID, me.$jazz.id],
   );
 
   return sendMessage;

--- a/packages/jazz-tools/src/react-core/tests/useInboxSender.test.ts
+++ b/packages/jazz-tools/src/react-core/tests/useInboxSender.test.ts
@@ -2,9 +2,16 @@
 
 import { CoMap, Group, Inbox, Loaded, co, z } from "jazz-tools";
 import { describe, expect, it } from "vitest";
-import { experimental_useInboxSender } from "../index.js";
-import { createJazzTestAccount, linkAccounts } from "../testing.js";
-import { renderHook } from "./testUtils.js";
+import {
+  experimental_useInboxSender,
+  useJazzContextManager,
+} from "../index.js";
+import {
+  createJazzTestAccount,
+  linkAccounts,
+  setupJazzTestSync,
+} from "../testing.js";
+import { act, renderHook } from "./testUtils.js";
 
 describe("useInboxSender", () => {
   it("should send the message to the inbox", async () => {
@@ -57,5 +64,32 @@ describe("useInboxSender", () => {
     });
 
     expect(responseMap!.value).toEqual("got it");
+  });
+
+  it("should regenerate the InboxSender if the active account changes", async () => {
+    const account1 = await setupJazzTestSync();
+    const account2 = await createJazzTestAccount();
+    const inboxReceiver = await createJazzTestAccount();
+
+    const { result } = renderHook(
+      () => {
+        const ctx = useJazzContextManager();
+        const send = experimental_useInboxSender(inboxReceiver.$jazz.id);
+        return { ctx, send };
+      },
+      { account: account1 },
+    );
+
+    const before = result.current.send;
+
+    await act(async () => {
+      await result.current.ctx.authenticate({
+        accountID: account2.$jazz.id,
+        accountSecret: account2.$jazz.localNode.getCurrentAgent().agentSecret,
+      });
+    });
+
+    const after = result.current.send;
+    expect(after).not.toBe(before);
   });
 });


### PR DESCRIPTION
# Description

Once the useInboxSender's sendMessage was called, it didn't listen to the active account's changes. If the active account changed, it stopped sending messages without any log.

## Manual testing instructions

In any application with authentication features, use the `useInboxSender` hook:
`const sendInboxMessage = experimental_useInboxSender('co_xyz');`

Send a message with `sendInboxMessage()`.

Then change the account (from anonymous to logged, or vice versa).

Send a new message.

## Tests

- [x] Tests have been added and/or updated
- [ ] Tests have not been updated, because: <!-- Insert reason for not updating tests here -->
- [ ] I need help with writing tests


## Checklist

- [ ] I've updated the part of the docs that are affected the PR changes
- [x] I've generated a changeset, if a version bump is required
- [ ] I've updated the jsDoc comments to the public APIs I've modified, or added them when missing

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Ensure `experimental_useInboxSender` recreates `InboxSender` on active account change and add tests to verify behavior.
> 
> - **Hooks**:
>   - `experimental_useInboxSender` now regenerates `InboxSender` when the inbox owner or current account changes; updates `useCallback` deps to include `me.$jazz.id`.
> - **Tests**:
>   - Add test to verify `InboxSender` regenerates after authentication/account switch; update test utilities and imports.
> - **Release**:
>   - Changeset: patch for `jazz-tools`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 47c7dd3a18bdc4cf6abc7f47874e9d34ae2c56bf. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->