### PR TITLE
Improve Copy Behaviour on CodeGroup

### DIFF
--- a/homepage/design-system/src/components/molecules/CodeGroup.tsx
+++ b/homepage/design-system/src/components/molecules/CodeGroup.tsx
@@ -105,7 +105,7 @@ export function CodeGroup({
         node.classList.contains("twoslash-completion-cursor") ||
         node.classList.contains("remove"))
     ) {
-      return ""; // Empty the line if it's a 'remove'. I
+      return "";
     }
     if (node.nodeType === Node.TEXT_NODE) {
       return node.textContent ?? "";

--- a/homepage/design-system/src/components/molecules/CodeGroup.tsx
+++ b/homepage/design-system/src/components/molecules/CodeGroup.tsx
@@ -102,9 +102,10 @@ export function CodeGroup({
     if (
       node instanceof Element &&
       (node.classList.contains("twoslash-popup-container") ||
-        node.classList.contains("twoslash-completion-cursor"))
+        node.classList.contains("twoslash-completion-cursor") ||
+        node.classList.contains("remove"))
     ) {
-      return "";
+      return ""; // Empty the line if it's a 'remove'. I
     }
     if (node.nodeType === Node.TEXT_NODE) {
       return node.textContent ?? "";


### PR DESCRIPTION
# Description
The current Copy behaviour on CodeGroups results in diffed out lines being included in the copied text.

This PR filters them out.

## Manual testing instructions

Find a code snippet with diffed out lines (e.g. here docs/react/groups/quickstart) and copy it.

## Tests

- [ ] Tests have been added and/or updated
- [x] Tests have not been updated, because: No existing tests
- [ ] I need help with writing tests

## Checklist

- [ ] I've updated the part of the docs that are affected the PR changes
- [ ] I've generated a changeset, if a version bump is required
- [ ] I've updated the jsDoc comments to the public APIs I've modified, or added them when missing