### PR TITLE
feat(jazz-tools): Support number[] in CoVector vector calculations

### DIFF
--- a/packages/jazz-tools/src/tools/coValues/coVector.ts
+++ b/packages/jazz-tools/src/tools/coValues/coVector.ts
@@ -372,7 +372,7 @@ export class CoVectorJazzApi<V extends CoVector> extends CoValueJazzApi<V> {
   /**
    * Calculate the dot product of this vector and another vector.
    */
-  dotProduct(otherVector: CoVector | Float32Array): number {
+  dotProduct(otherVector: CoVector | Float32Array | number[]): number {
     return VectorCalculation.dotProduct(this.coVector, otherVector);
   }
 
@@ -384,14 +384,19 @@ export class CoVectorJazzApi<V extends CoVector> extends CoValueJazzApi<V> {
    * - `0` means the vectors are orthogonal (i.e. no similarity)
    * - `-1` means the vectors are opposite direction (perfectly dissimilar)
    */
-  cosineSimilarity(otherVector: CoVector | Float32Array): number {
+  cosineSimilarity(otherVector: CoVector | Float32Array | number[]): number {
     return VectorCalculation.cosineSimilarity(this.coVector, otherVector);
   }
 }
 
 const VectorCalculation = {
-  magnitude: (vector: Float32Array) => {
-    return Math.sqrt(vector.reduce((s, x) => s + x * x, 0));
+  magnitude: (vector: Float32Array | number[]) => {
+    let sum = 0;
+    for (let i = 0; i < vector.length; i++) {
+      const v = vector[i]!;
+      sum += v * v;
+    }
+    return Math.sqrt(sum);
   },
   normalize: (vector: Float32Array) => {
     const mag = VectorCalculation.magnitude(vector);
@@ -402,7 +407,7 @@ const VectorCalculation = {
 
     return vector.map((v) => v / mag);
   },
-  dotProduct: (vectorA: Float32Array, vectorB: Float32Array) => {
+  dotProduct: (vectorA: Float32Array, vectorB: Float32Array | number[]) => {
     if (vectorA.length !== vectorB.length) {
       throw new Error(
         `Vector dimensions don't match: ${vectorA.length} vs ${vectorB.length}`,
@@ -411,7 +416,10 @@ const VectorCalculation = {
 
     return vectorA.reduce((sum, a, i) => sum + a * vectorB[i]!, 0);
   },
-  cosineSimilarity: (vectorA: Float32Array, vectorB: Float32Array) => {
+  cosineSimilarity: (
+    vectorA: Float32Array,
+    vectorB: Float32Array | number[],
+  ) => {
     const magnitudeA = VectorCalculation.magnitude(vectorA);
     const magnitudeB = VectorCalculation.magnitude(vectorB);
 

--- a/packages/jazz-tools/src/tools/coValues/coVector.ts
+++ b/packages/jazz-tools/src/tools/coValues/coVector.ts
@@ -392,8 +392,7 @@ export class CoVectorJazzApi<V extends CoVector> extends CoValueJazzApi<V> {
 const VectorCalculation = {
   magnitude: (vector: Float32Array | number[]) => {
     let sum = 0;
-    for (let i = 0; i < vector.length; i++) {
-      const v = vector[i]!;
+    for (const v of vector) {
       sum += v * v;
     }
     return Math.sqrt(sum);

--- a/packages/jazz-tools/src/tools/tests/coVector.test.ts
+++ b/packages/jazz-tools/src/tools/tests/coVector.test.ts
@@ -390,6 +390,7 @@ describe("Vector calculations on .$jazz", async () => {
 
   const vecA = new Float32Array([1, 2, 3, 4, 5]);
   const vecB = new Float32Array([5, 4, 3, 2, 1]);
+  const arrB = [5, 4, 3, 2, 1];
 
   const coVectorA = VectorSchema.create(vecA);
   const coVectorB = VectorSchema.create(vecB);
@@ -417,6 +418,7 @@ describe("Vector calculations on .$jazz", async () => {
     const dotProduct = 35;
 
     test("returns the dot product of the 2 vectors", () => {
+      expect(coVectorA.$jazz.dotProduct(arrB)).toBe(dotProduct);
       expect(coVectorA.$jazz.dotProduct(vecB)).toBe(dotProduct);
       expect(coVectorA.$jazz.dotProduct(coVectorB)).toBe(dotProduct);
     });
@@ -426,6 +428,9 @@ describe("Vector calculations on .$jazz", async () => {
     const similarityApprox: [number, number] = [0.6364, 4];
 
     test("returns the cosine similarity of the 2 vectors", () => {
+      expect(coVectorA.$jazz.cosineSimilarity(arrB)).toBeCloseTo(
+        ...similarityApprox,
+      );
       expect(coVectorA.$jazz.cosineSimilarity(vecB)).toBeCloseTo(
         ...similarityApprox,
       );


### PR DESCRIPTION
# Description
Add support for `number[]` to be the _other vector_ for vector calculation methods.

It makes for better developer API.

The change of code in `magnitude` calculations is to avoid type errors—Float32Array and Array have slightly difference incompatible `reduce` signatures. Doing a simple _for_ loop avoids additional `typeof` checks we'd need to do otherwise.

## Manual testing instructions

<!-- Add any actions required to manually test the changes -->

## Tests

- [x] Tests have been added and/or updated
- [ ] Tests have not been updated, because: <!-- Insert reason for not updating tests here -->
- [ ] I need help with writing tests


## Checklist

- [ ] I've updated the part of the docs that are affected the PR changes
- [ ] I've generated a changeset, if a version bump is required
- [ ] I've updated the jsDoc comments to the public APIs I've modified, or added them when missing

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Allow `number[]` as the other vector for dot product and cosine similarity; update magnitude to handle arrays and add tests.
> 
> - **CoVector calculations**
>   - Broaden inputs to accept `number[]` for `$jazz.dotProduct` and `$jazz.cosineSimilarity` and underlying `VectorCalculation.dotProduct`/`cosineSimilarity`.
>   - Update `VectorCalculation.magnitude` to support `Float32Array | number[]` and replace `reduce` with a simple loop.
> - **Tests**
>   - Add assertions using `number[]` for dot product and cosine similarity in `tools/tests/coVector.test.ts`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 987265ec60b826ccffeef163a840d949ead1d582. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->