### PR TITLE
New SuperAdmin role

### DIFF
--- a/.changeset/stupid-ducks-try.md
+++ b/.changeset/stupid-ducks-try.md
@@ -1,0 +1,6 @@
+---
+"jazz-tools": minor
+"cojson": minor
+---
+
+feat: introduced new "super-admin" role available when creating the group. Group.removeMember() now throws in case of invalid permissions.

--- a/packages/cojson/src/coValues/group.ts
+++ b/packages/cojson/src/coValues/group.ts
@@ -51,7 +51,8 @@ export type ParentGroupReferenceRole =
   | "extend"
   | "reader"
   | "writer"
-  | "admin";
+  | "admin"
+  | "superAdmin";
 
 export type GroupShape = {
   profile: CoID<RawCoMap> | null;
@@ -311,7 +312,15 @@ export class RawGroup<
     account: RawAccount | ControlledAccountOrAgent | AgentID | Everyone,
     role: Role,
   ) {
-    if (account === EVERYONE) {
+    const memberKey = typeof account === "string" ? account : account.id;
+    const previousRole = this.get(memberKey);
+
+    // if the role is the same, we don't need to do anything
+    if (previousRole === role) {
+      return;
+    }
+
+    if (memberKey === EVERYONE) {
       if (!(role === "reader" || role === "writer" || role === "writeOnly")) {
         throw new Error(
           "Can't make everyone something other than reader, writer or writeOnly",
@@ -323,22 +332,13 @@ export class RawGroup<
         throw new Error("Can't add member without read key secret");
       }
 
-      const previousRole = this.get(account);
+      const previousRole = this.get(memberKey);
 
-      this.set(account, role, "trusting");
+      this.set(memberKey, role, "trusting");
 
-      if (this.get(account) !== role) {
-        // The role was not set correctly; this presents three scenarios:
-        // 1. The current user is an administrator trying to set another administrator to a lower role
-        // 2. The current user is an administrator but something has gone wrong with the role assignment
-        // 3. The current user is not an administrator and does not have sufficient permissions to set the role
-        const myRole = this.myRole();
+      if (this.get(memberKey) !== role) {
         throw new Error(
-          myRole === "admin"
-            ? this.get(account) === "admin"
-              ? "Administrators cannot demote other administrators in a group"
-              : "Failed to set role"
-            : `Failed to set role due to insufficient permissions (role of current account is ${myRole})`,
+          `Failed to set role ${role} to ${memberKey} (role of current account is ${this.myRole()})`,
         );
       }
 
@@ -359,9 +359,12 @@ export class RawGroup<
       return;
     }
 
-    const memberKey = typeof account === "string" ? account : account.id;
     const agent =
       typeof account === "string" ? account : account.currentAgentID();
+
+    if (agent === EVERYONE) {
+      throw new Error("Agent should not be everyone");
+    }
 
     /**
      * WriteOnly members can only see their own changes.
@@ -374,26 +377,23 @@ export class RawGroup<
      * invite.
      */
     if (role === "writeOnly" || role === "writeOnlyInvite") {
-      const previousRole = this.get(memberKey);
-
-      if (
-        previousRole === "admin" &&
-        memberKey !== this.core.node.getCurrentAgent().id
-      ) {
-        throw new Error(
-          "Administrators cannot demote other administrators in a group",
-        );
-      }
-
       if (
         previousRole === "reader" ||
         previousRole === "writer" ||
-        previousRole === "admin"
+        previousRole === "admin" ||
+        previousRole === "superAdmin"
       ) {
         this.rotateReadKey(memberKey);
       }
 
       this.set(memberKey, role, "trusting");
+
+      if (this.get(memberKey) !== role) {
+        throw new Error(
+          `Failed to set role ${role} to ${memberKey} (role of current account is ${this.myRole()})`,
+        );
+      }
+
       this.internalCreateWriteOnlyKeyForMember(memberKey, agent);
     } else {
       const currentReadKey = this.getCurrentReadKey();
@@ -405,13 +405,8 @@ export class RawGroup<
       this.set(memberKey, role, "trusting");
 
       if (this.get(memberKey) !== role) {
-        const myRole = this.myRole();
         throw new Error(
-          myRole === "admin"
-            ? this.get(memberKey) === "admin"
-              ? "Administrators cannot demote other administrators in a group"
-              : "Failed to set role"
-            : `Failed to set role due to insufficient permissions (role of current account is ${myRole})`,
+          `Failed to set role ${role} to ${memberKey} (role of current account is ${this.myRole()})`,
         );
       }
 
@@ -458,6 +453,7 @@ export class RawGroup<
         memberRole === "reader" ||
         memberRole === "writer" ||
         memberRole === "admin" ||
+        memberRole === "superAdmin" ||
         memberRole === "readerInvite" ||
         memberRole === "writerInvite" ||
         memberRole === "adminInvite"
@@ -960,13 +956,13 @@ export class RawGroup<
 
   extend(
     parent: RawGroup,
-    role: "reader" | "writer" | "admin" | "inherit" = "inherit",
+    role: "reader" | "writer" | "admin" | "superAdmin" | "inherit" = "inherit",
   ) {
     if (this.isSelfExtension(parent)) {
       return;
     }
 
-    if (this.myRole() !== "admin") {
+    if (this.myRole() !== "admin" && this.myRole() !== "superAdmin") {
       throw new Error(
         "To extend a group, the current account must be an admin in the child group",
       );
@@ -1046,7 +1042,7 @@ export class RawGroup<
   }
 
   revokeExtend(parent: RawGroup) {
-    if (this.myRole() !== "admin") {
+    if (this.myRole() !== "admin" && this.myRole() !== "superAdmin") {
       throw new Error(
         "To unextend a group, the current account must be an admin in the child group",
       );
@@ -1085,11 +1081,17 @@ export class RawGroup<
   removeMember(account: RawAccount | ControlledAccountOrAgent | Everyone) {
     const memberKey = typeof account === "string" ? account : account.id;
 
-    if (this.myRole() === "admin") {
+    if (this.myRole() === "admin" || this.myRole() === "superAdmin") {
       this.rotateReadKey(memberKey);
     }
 
     this.set(memberKey, "revoked", "trusting");
+
+    if (this.get(memberKey) !== "revoked") {
+      throw new Error(
+        `Failed to revoke role to ${memberKey} (role of current account is ${this.myRole()})`,
+      );
+    }
   }
 
   /**
@@ -1254,21 +1256,29 @@ export class RawGroup<
 
 export function isInheritableRole(
   roleInParent: Role | undefined,
-): roleInParent is "revoked" | "admin" | "writer" | "reader" {
+): roleInParent is "revoked" | "admin" | "superAdmin" | "writer" | "reader" {
   return (
     roleInParent === "revoked" ||
     roleInParent === "admin" ||
+    roleInParent === "superAdmin" ||
     roleInParent === "writer" ||
     roleInParent === "reader"
   );
 }
 
 function isMorePermissiveAndShouldInherit(
-  roleInParent: "revoked" | "admin" | "writer" | "reader",
+  roleInParent: "revoked" | "admin" | "superAdmin" | "writer" | "reader",
   roleInChild: Role | undefined,
 ) {
   if (roleInParent === "revoked") {
     return true;
+  }
+
+  // TODO: verify
+  if (roleInParent === "superAdmin") {
+    return (
+      !roleInChild || (roleInChild !== "superAdmin" && roleInChild !== "admin")
+    );
   }
 
   if (roleInParent === "admin") {
@@ -1314,6 +1324,7 @@ const canRead = (
   const role = group.get(key);
   return (
     role === "admin" ||
+    role === "superAdmin" ||
     role === "writer" ||
     role === "reader" ||
     role === "adminInvite" ||

--- a/packages/cojson/src/localNode.ts
+++ b/packages/cojson/src/localNode.ts
@@ -617,6 +617,7 @@ export class LocalNode {
     const existingRole = group.get(account.id);
 
     if (
+      existingRole === "superAdmin" ||
       existingRole === "admin" ||
       (existingRole === "writer" && inviteRole === "writerInvite") ||
       (existingRole === "writer" && inviteRole === "reader") ||
@@ -638,13 +639,15 @@ export class LocalNode {
 
     groupAsInvite.addMemberInternal(
       account,
-      inviteRole === "adminInvite"
-        ? "admin"
-        : inviteRole === "writerInvite"
-          ? "writer"
-          : inviteRole === "writeOnlyInvite"
-            ? "writeOnly"
-            : "reader",
+      inviteRole === "superAdminInvite"
+        ? "superAdmin"
+        : inviteRole === "adminInvite"
+          ? "admin"
+          : inviteRole === "writerInvite"
+            ? "writer"
+            : inviteRole === "writeOnlyInvite"
+              ? "writeOnly"
+              : "reader",
     );
 
     const contentPieces =
@@ -725,7 +728,12 @@ export class LocalNode {
 
   createGroup(
     uniqueness: CoValueUniqueness = this.crypto.createdNowUnique(),
+    role: "admin" | "superAdmin" = "admin",
   ): RawGroup {
+    if (role !== "admin" && role !== "superAdmin") {
+      throw new Error("Initial role must be admin or superAdmin");
+    }
+
     const account = this.getCurrentAgent();
 
     const groupCoValue = this.createCoValue({
@@ -737,7 +745,7 @@ export class LocalNode {
 
     const group = expectGroup(groupCoValue.getCurrentContent());
 
-    group.set(account.id, "admin", "trusting");
+    group.set(account.id, role, "trusting");
 
     const readKey = this.crypto.newRandomKeySecret();
 

--- a/packages/cojson/src/tests/group.addMember.test.ts
+++ b/packages/cojson/src/tests/group.addMember.test.ts
@@ -1,193 +1,548 @@
 import { beforeEach, describe, expect, test } from "vitest";
-import { expectMap } from "../coValue.js";
 import {
   SyncMessagesLog,
   loadCoValueOrFail,
   setupTestAccount,
   setupTestNode,
-  waitFor,
 } from "./testUtils.js";
+import { Role } from "../permissions.js";
 
 beforeEach(async () => {
   SyncMessagesLog.clear();
   setupTestNode({ isSyncServer: true });
 });
 
+// [sourceRole, from, to, canGrant]
+const GRANT_MATRIX: [Role, Role | undefined, Role, boolean][] = [
+  // Super admin can grant any role to anyone
+  ["superAdmin", undefined, "superAdmin", true],
+  ["superAdmin", undefined, "admin", true],
+  ["superAdmin", undefined, "writer", true],
+  ["superAdmin", undefined, "reader", true],
+  ["superAdmin", undefined, "writeOnly", true],
+
+  // Super admin can grant any role to anyone
+  ["superAdmin", "superAdmin", "superAdmin", true],
+  ["superAdmin", "superAdmin", "admin", true],
+  ["superAdmin", "superAdmin", "writer", true],
+  ["superAdmin", "superAdmin", "reader", true],
+  ["superAdmin", "superAdmin", "writeOnly", true],
+  ["superAdmin", "admin", "superAdmin", true],
+  ["superAdmin", "admin", "admin", true],
+  ["superAdmin", "admin", "writer", true],
+  ["superAdmin", "admin", "reader", true],
+  ["superAdmin", "admin", "writeOnly", true],
+
+  ["superAdmin", "writer", "superAdmin", true],
+  ["superAdmin", "writer", "admin", true],
+  ["superAdmin", "writer", "writer", true],
+  ["superAdmin", "writer", "reader", true],
+  ["superAdmin", "writer", "writeOnly", true],
+
+  ["superAdmin", "reader", "superAdmin", true],
+  ["superAdmin", "reader", "admin", true],
+  ["superAdmin", "reader", "writer", true],
+  ["superAdmin", "reader", "reader", true],
+  ["superAdmin", "reader", "writeOnly", true],
+
+  ["superAdmin", "writeOnly", "superAdmin", true],
+  ["superAdmin", "writeOnly", "admin", true],
+  ["superAdmin", "writeOnly", "writer", true],
+  ["superAdmin", "writeOnly", "reader", true],
+  ["superAdmin", "writeOnly", "writeOnly", true],
+
+  // Admin can grant any role to anyone except super-admin
+  ["admin", undefined, "superAdmin", false],
+  ["admin", undefined, "admin", true],
+  ["admin", undefined, "writer", true],
+  ["admin", undefined, "reader", true],
+  ["admin", undefined, "writeOnly", true],
+
+  // Admin can't change other admins or super-admins
+  ["admin", "superAdmin", "superAdmin", true],
+  ["admin", "superAdmin", "admin", false],
+  ["admin", "superAdmin", "writer", false],
+  ["admin", "superAdmin", "reader", false],
+  ["admin", "superAdmin", "writeOnly", false],
+
+  ["admin", "admin", "superAdmin", false],
+  ["admin", "admin", "admin", true],
+  ["admin", "admin", "writer", false],
+  ["admin", "admin", "reader", false],
+  ["admin", "admin", "writeOnly", false],
+
+  ["admin", "writer", "superAdmin", false],
+  ["admin", "writer", "admin", true],
+  ["admin", "writer", "writer", true],
+  ["admin", "writer", "reader", true],
+  ["admin", "writer", "writeOnly", true],
+
+  ["admin", "reader", "superAdmin", false],
+  ["admin", "reader", "admin", true],
+  ["admin", "reader", "writer", true],
+  ["admin", "reader", "reader", true],
+  ["admin", "reader", "writeOnly", true],
+
+  ["admin", "writeOnly", "superAdmin", false],
+  ["admin", "writeOnly", "admin", true],
+  ["admin", "writeOnly", "writer", true],
+  ["admin", "writeOnly", "reader", true],
+  ["admin", "writeOnly", "writeOnly", true],
+
+  ...["superAdmin", "admin", "writer", "reader", "writeOnly"].map(
+    (role) =>
+      ["writer", undefined, role, false] as [
+        Role,
+        Role | undefined,
+        Role,
+        boolean,
+      ],
+  ),
+  ...["superAdmin", "admin", "writer", "reader", "writeOnly"].map(
+    (role) =>
+      ["writer", "superAdmin", role, false] as [
+        Role,
+        Role | undefined,
+        Role,
+        boolean,
+      ],
+  ),
+  ...["superAdmin", "admin", "writer", "reader", "writeOnly"].map(
+    (role) =>
+      ["writer", "admin", role, false] as [
+        Role,
+        Role | undefined,
+        Role,
+        boolean,
+      ],
+  ),
+  ...["superAdmin", "admin", "writer", "reader", "writeOnly"].map(
+    (role) =>
+      ["writer", "writer", role, false] as [
+        Role,
+        Role | undefined,
+        Role,
+        boolean,
+      ],
+  ),
+  ...["superAdmin", "admin", "writer", "reader", "writeOnly"].map(
+    (role) =>
+      ["writer", "reader", role, false] as [
+        Role,
+        Role | undefined,
+        Role,
+        boolean,
+      ],
+  ),
+  ...["superAdmin", "admin", "writer", "reader", "writeOnly"].map(
+    (role) =>
+      ["writer", "writeOnly", role, false] as [
+        Role,
+        Role | undefined,
+        Role,
+        boolean,
+      ],
+  ),
+
+  ...["superAdmin", "admin", "writer", "reader", "writeOnly"].map(
+    (role) =>
+      ["reader", undefined, role, false] as [
+        Role,
+        Role | undefined,
+        Role,
+        boolean,
+      ],
+  ),
+  ...["superAdmin", "admin", "writer", "reader", "writeOnly"].map(
+    (role) =>
+      ["reader", "superAdmin", role, false] as [
+        Role,
+        Role | undefined,
+        Role,
+        boolean,
+      ],
+  ),
+  ...["superAdmin", "admin", "writer", "reader", "writeOnly"].map(
+    (role) =>
+      ["reader", "admin", role, false] as [
+        Role,
+        Role | undefined,
+        Role,
+        boolean,
+      ],
+  ),
+  ...["superAdmin", "admin", "writer", "reader", "writeOnly"].map(
+    (role) =>
+      ["reader", "writer", role, false] as [
+        Role,
+        Role | undefined,
+        Role,
+        boolean,
+      ],
+  ),
+  ...["superAdmin", "admin", "writer", "reader", "writeOnly"].map(
+    (role) =>
+      ["reader", "reader", role, false] as [
+        Role,
+        Role | undefined,
+        Role,
+        boolean,
+      ],
+  ),
+  ...["superAdmin", "admin", "writer", "reader", "writeOnly"].map(
+    (role) =>
+      ["reader", "writeOnly", role, false] as [
+        Role,
+        Role | undefined,
+        Role,
+        boolean,
+      ],
+  ),
+
+  ...["superAdmin", "admin", "writer", "reader", "writeOnly"].map(
+    (role) =>
+      ["writeOnly", undefined, role, false] as [
+        Role,
+        Role | undefined,
+        Role,
+        boolean,
+      ],
+  ),
+  ...["superAdmin", "admin", "writer", "reader", "writeOnly"].map(
+    (role) =>
+      ["writeOnly", "superAdmin", role, false] as [
+        Role,
+        Role | undefined,
+        Role,
+        boolean,
+      ],
+  ),
+  ...["superAdmin", "admin", "writer", "reader", "writeOnly"].map(
+    (role) =>
+      ["writeOnly", "admin", role, false] as [
+        Role,
+        Role | undefined,
+        Role,
+        boolean,
+      ],
+  ),
+  ...["superAdmin", "admin", "writer", "reader", "writeOnly"].map(
+    (role) =>
+      ["writeOnly", "writer", role, false] as [
+        Role,
+        Role | undefined,
+        Role,
+        boolean,
+      ],
+  ),
+  ...["superAdmin", "admin", "writer", "reader", "writeOnly"].map(
+    (role) =>
+      ["writeOnly", "reader", role, false] as [
+        Role,
+        Role | undefined,
+        Role,
+        boolean,
+      ],
+  ),
+  ...["superAdmin", "admin", "writer", "reader", "writeOnly"].map(
+    (role) =>
+      ["writeOnly", "writeOnly", role, false] as [
+        Role,
+        Role | undefined,
+        Role,
+        boolean,
+      ],
+  ),
+];
+
 describe("Group.addMember", () => {
-  test("an admin should be able to grant read access", async () => {
-    const admin = await setupTestAccount({
+  for (const [sourceRole, from, to, canGrant] of GRANT_MATRIX) {
+    test(`${sourceRole} should ${canGrant ? "be able" : "not be able"} to grant ${from !== undefined ? `${from} -> ` : ""}${to} role`, async () => {
+      const source = await setupTestAccount({
+        connected: true,
+      });
+
+      const member = await setupTestAccount({
+        connected: true,
+      });
+
+      const memberOnSourceNode = await loadCoValueOrFail(
+        source.node,
+        member.accountID,
+      );
+
+      const group = source.node.createGroup(undefined, "superAdmin");
+
+      // setup initial role for member
+      if (from !== undefined) {
+        group.addMember(memberOnSourceNode, from);
+      }
+
+      // downgrade super-admin if needed
+      if (sourceRole !== "superAdmin") {
+        group.addMember(
+          await loadCoValueOrFail(source.node, source.accountID),
+          sourceRole as Role,
+        );
+
+        expect(group.roleOf(source.accountID)).toEqual(sourceRole);
+      }
+
+      if (canGrant || from === to) {
+        group.addMember(memberOnSourceNode, to);
+
+        expect(group.roleOf(member.accountID)).toEqual(to);
+      } else {
+        expect(() => {
+          group.addMember(memberOnSourceNode, to);
+        }).toThrow(
+          `Failed to set role ${to} to ${member.accountID} (role of current account is ${sourceRole})`,
+        );
+
+        expect(group.roleOf(member.accountID)).toEqual(from);
+      }
+    });
+  }
+
+  test.each(["superAdmin", "admin", "writer", "reader", "writeOnly"] as Role[])(
+    "superAdmin should be able to self downgrade to %s role",
+    async (role) => {
+      const source = await setupTestAccount({
+        connected: true,
+      });
+      const memberOnSourceNode = await loadCoValueOrFail(
+        source.node,
+        source.accountID,
+      );
+
+      const group = source.node.createGroup(undefined, "superAdmin");
+
+      group.addMember(memberOnSourceNode, role);
+
+      expect(group.roleOf(source.accountID)).toEqual(role);
+    },
+  );
+
+  test.each(["admin", "writer", "reader", "writeOnly"] as Role[])(
+    "admin should be able to self downgrade to %s role",
+    async (role) => {
+      const source = await setupTestAccount({
+        connected: true,
+      });
+      const memberOnSourceNode = await loadCoValueOrFail(
+        source.node,
+        source.accountID,
+      );
+
+      const group = source.node.createGroup();
+
+      group.addMember(memberOnSourceNode, role);
+
+      expect(group.roleOf(source.accountID)).toEqual(role);
+    },
+  );
+
+  test("admin should not be able to self upgrade to super-admin role", async () => {
+    const source = await setupTestAccount({
       connected: true,
     });
-
-    const reader = await setupTestAccount({
-      connected: true,
-    });
-
-    const group = admin.node.createGroup();
-    const person = group.createMap({
-      name: "John Doe",
-    });
-
-    const personOnReaderNode = await loadCoValueOrFail(reader.node, person.id);
-
-    expect(personOnReaderNode.get("name")).toEqual(undefined);
-
-    const readerOnAdminNode = await loadCoValueOrFail(
-      admin.node,
-      reader.accountID,
+    const memberOnSourceNode = await loadCoValueOrFail(
+      source.node,
+      source.accountID,
     );
-    group.addMember(readerOnAdminNode, "reader");
 
-    expect(group.roleOf(reader.accountID)).toEqual("reader");
+    const group = source.node.createGroup();
 
-    await waitFor(() => {
-      expect(
-        expectMap(personOnReaderNode.core.getCurrentContent()).get("name"),
-      ).toEqual("John Doe");
-    });
+    group.addMember(memberOnSourceNode, "admin");
+
+    expect(group.roleOf(source.accountID)).toEqual("admin");
+
+    expect(() => {
+      group.addMember(memberOnSourceNode, "superAdmin");
+    }).toThrow(
+      `Failed to set role superAdmin to ${source.accountID} (role of current account is admin)`,
+    );
   });
 
-  test("an admin should be able to grant write access", async () => {
-    const admin = await setupTestAccount({
-      connected: true,
-    });
+  test.each(["admin", "superAdmin", "reader", "writeOnly"] as Role[])(
+    "writer should not be able to self upgrade to %s role",
+    async (role) => {
+      const source = await setupTestAccount({
+        connected: true,
+      });
+      const memberOnSourceNode = await loadCoValueOrFail(
+        source.node,
+        source.accountID,
+      );
 
-    const writer = await setupTestAccount({
-      connected: true,
-    });
+      const group = source.node.createGroup();
 
-    const group = admin.node.createGroup();
-    const person = group.createMap({
-      name: "John Doe",
-    });
+      group.addMember(memberOnSourceNode, "writer");
 
-    const personOnWriterNode = await loadCoValueOrFail(writer.node, person.id);
+      expect(group.roleOf(source.accountID)).toEqual("writer");
 
-    expect(personOnWriterNode.get("name")).toEqual(undefined);
+      expect(() => {
+        group.addMember(memberOnSourceNode, role);
+      }).toThrow(
+        `Failed to set role ${role} to ${source.accountID} (role of current account is writer)`,
+      );
+    },
+  );
 
-    const writerOnAdminNode = await loadCoValueOrFail(
-      admin.node,
-      writer.accountID,
-    );
-    group.addMember(writerOnAdminNode, "writer");
-    expect(group.roleOf(writer.accountID)).toEqual("writer");
+  test.each(["admin", "superAdmin", "writer", "writeOnly"] as Role[])(
+    "reader should not be able to self upgrade to %s role",
+    async (role) => {
+      const source = await setupTestAccount({
+        connected: true,
+      });
+      const memberOnSourceNode = await loadCoValueOrFail(
+        source.node,
+        source.accountID,
+      );
 
-    await waitFor(() => {
-      expect(
-        expectMap(personOnWriterNode.core.getCurrentContent()).get("name"),
-      ).toEqual("John Doe");
-    });
+      const group = source.node.createGroup();
 
-    personOnWriterNode.set("name", "Jane Doe");
-    expect(personOnWriterNode.get("name")).toEqual("Jane Doe");
-  });
+      group.addMember(memberOnSourceNode, "reader");
 
-  test("an admin should be able to grant writeOnly access", async () => {
-    const admin = await setupTestAccount({
-      connected: true,
-    });
+      expect(group.roleOf(source.accountID)).toEqual("reader");
 
-    const writeOnlyUser = await setupTestAccount({
-      connected: true,
-    });
+      expect(() => {
+        group.addMember(memberOnSourceNode, role);
+      }).toThrow(
+        `Failed to set role ${role} to ${source.accountID} (role of current account is reader)`,
+      );
+    },
+  );
 
-    const group = admin.node.createGroup();
-    const person = group.createMap({
-      name: "John Doe",
-    });
+  test.each(["admin", "superAdmin", "writer", "reader"] as Role[])(
+    "writeOnly should not be able to self upgrade to %s role",
+    async (role) => {
+      const source = await setupTestAccount({
+        connected: true,
+      });
+      const memberOnSourceNode = await loadCoValueOrFail(
+        source.node,
+        source.accountID,
+      );
 
-    const writeOnlyUserOnAdminNode = await loadCoValueOrFail(
-      admin.node,
-      writeOnlyUser.accountID,
-    );
-    group.addMember(writeOnlyUserOnAdminNode, "writeOnly");
-    expect(group.roleOf(writeOnlyUser.accountID)).toEqual("writeOnly");
-    const personOnWriteOnlyNode = await loadCoValueOrFail(
-      writeOnlyUser.node,
-      person.id,
-    );
+      const group = source.node.createGroup();
 
-    // Should not be able to read
-    expect(personOnWriteOnlyNode.get("name")).toEqual(undefined);
+      group.addMember(memberOnSourceNode, "writeOnly");
 
-    // Should be able to write
-    personOnWriteOnlyNode.set("name", "Jane Doe");
+      expect(group.roleOf(source.accountID)).toEqual("writeOnly");
 
-    expect(personOnWriteOnlyNode.get("name")).toEqual("Jane Doe");
-  });
+      expect(() => {
+        group.addMember(memberOnSourceNode, role);
+      }).toThrow(
+        `Failed to set role ${role} to ${source.accountID} (role of current account is writeOnly)`,
+      );
+    },
+  );
 
-  test("an admin should be able to grant admin access", async () => {
-    const admin = await setupTestAccount({
-      connected: true,
-    });
+  test.each(["admin", "superAdmin"] as Role[])(
+    "%s should be able to set writer role to EVERYONE",
+    async (role) => {
+      const source = await setupTestAccount({
+        connected: true,
+      });
+      const memberOnSourceNode = await loadCoValueOrFail(
+        source.node,
+        source.accountID,
+      );
 
-    const otherAdmin = await setupTestAccount({
-      connected: true,
-    });
+      const group = source.node.createGroup(undefined, "superAdmin");
 
-    const reader = await setupTestAccount({
-      connected: true,
-    });
+      group.addMember(memberOnSourceNode, role);
+      expect(group.roleOf(source.accountID)).toEqual(role);
 
-    const group = admin.node.createGroup();
-    const person = group.createMap({
-      name: "John Doe",
-    });
+      group.addMember("everyone", "writer");
+      expect(group.roleOf("everyone")).toEqual("writer");
+    },
+  );
 
-    const otherAdminOnAdminNode = await loadCoValueOrFail(
-      admin.node,
-      otherAdmin.accountID,
-    );
-    group.addMember(otherAdminOnAdminNode, "admin");
+  test.each(["admin", "superAdmin"] as Role[])(
+    "%s should be able to set writeOnly role to EVERYONE",
+    async (role) => {
+      const source = await setupTestAccount({
+        connected: true,
+      });
+      const memberOnSourceNode = await loadCoValueOrFail(
+        source.node,
+        source.accountID,
+      );
 
-    const personOnReaderNode = await loadCoValueOrFail(reader.node, person.id);
+      const group = source.node.createGroup(undefined, "superAdmin");
 
-    expect(personOnReaderNode.get("name")).toEqual(undefined);
+      group.addMember(memberOnSourceNode, role);
+      expect(group.roleOf(source.accountID)).toEqual(role);
 
-    const readerOnOtherAdminNode = await loadCoValueOrFail(
-      otherAdmin.node,
-      reader.accountID,
-    );
-    group.addMember(readerOnOtherAdminNode, "reader");
+      group.addMember("everyone", "writeOnly");
+      expect(group.roleOf("everyone")).toEqual("writeOnly");
+    },
+  );
 
-    await waitFor(() => {
-      expect(
-        expectMap(personOnReaderNode.core.getCurrentContent()).get("name"),
-      ).toEqual("John Doe");
-    });
-  });
+  test.each(["admin", "superAdmin"] as Role[])(
+    "%s should be able to set reader role to EVERYONE",
+    async (role) => {
+      const source = await setupTestAccount({
+        connected: true,
+      });
+      const memberOnSourceNode = await loadCoValueOrFail(
+        source.node,
+        source.accountID,
+      );
 
-  test("an admin should be able downgrade a writer to reader", async () => {
-    const admin = await setupTestAccount({
-      connected: true,
-    });
+      const group = source.node.createGroup(undefined, "superAdmin");
 
-    const writer = await setupTestAccount({
-      connected: true,
-    });
+      group.addMember(memberOnSourceNode, role);
+      expect(group.roleOf(source.accountID)).toEqual(role);
 
-    const group = admin.node.createGroup();
-    const person = group.createMap({
-      name: "John Doe",
-    });
+      group.addMember("everyone", "reader");
+      expect(group.roleOf("everyone")).toEqual("reader");
+    },
+  );
 
-    const writerOnAdminNode = await loadCoValueOrFail(
-      admin.node,
-      writer.accountID,
-    );
-    group.addMember(writerOnAdminNode, "writer");
-    group.addMember(writerOnAdminNode, "reader");
+  test.each(["writer", "reader", "writeOnly"] as Role[])(
+    "%s should not be able to set any role to EVERYONE",
+    async (role) => {
+      const source = await setupTestAccount({
+        connected: true,
+      });
+      const memberOnSourceNode = await loadCoValueOrFail(
+        source.node,
+        source.accountID,
+      );
 
-    expect(group.roleOf(writer.accountID)).toEqual("reader");
+      const group = source.node.createGroup();
 
-    // Verify writer can read and write
-    const personOnWriterNode = await loadCoValueOrFail(writer.node, person.id);
+      group.addMember(memberOnSourceNode, role);
+      expect(group.roleOf(source.accountID)).toEqual(role);
 
-    // Should not be able to write
-    personOnWriterNode.set("name", "Jane Doe");
+      expect(() => {
+        group.addMember("everyone", "writer");
+      }).toThrow(
+        `Failed to set role writer to everyone (role of current account is ${role})`,
+      );
 
-    expect(personOnWriterNode.get("name")).toEqual("John Doe");
-  });
+      expect(group.roleOf("everyone")).toEqual(undefined);
+
+      expect(() => {
+        group.addMember("everyone", "reader");
+      }).toThrow(
+        `Failed to set role reader to everyone (role of current account is ${role})`,
+      );
+
+      expect(group.roleOf("everyone")).toEqual(undefined);
+
+      expect(() => {
+        group.addMember("everyone", "writeOnly");
+      }).toThrow(
+        `Failed to set role writeOnly to everyone (role of current account is ${role})`,
+      );
+
+      expect(group.roleOf("everyone")).toEqual(undefined);
+    },
+  );
 
   test("an admin should be able downgrade a reader to writeOnly", async () => {
     const admin = await setupTestAccount({
@@ -217,223 +572,5 @@ describe("Group.addMember", () => {
     const personOnReaderNode = await loadCoValueOrFail(reader.node, person.id);
 
     expect(personOnReaderNode.get("name")).toEqual(undefined);
-  });
-
-  test.each(["writer", "reader", "writeOnly"] as const)(
-    "an admin should not be able to downgrade an admin to %s",
-    async (targetRole) => {
-      const admin = await setupTestAccount({
-        connected: true,
-      });
-
-      const otherAdmin = await setupTestAccount({
-        connected: true,
-      });
-
-      const group = admin.node.createGroup();
-      const person = group.createMap({
-        name: "John Doe",
-      });
-
-      const otherAdminOnAdminNode = await loadCoValueOrFail(
-        admin.node,
-        otherAdmin.accountID,
-      );
-      group.addMember(otherAdminOnAdminNode, "admin");
-
-      // Try to downgrade other admin
-      expect(() => group.addMember(otherAdminOnAdminNode, targetRole)).toThrow(
-        "Administrators cannot demote other administrators in a group",
-      );
-
-      expect(group.roleOf(otherAdmin.accountID)).toEqual("admin");
-
-      // Verify other admin still has admin access by adding a new member
-      const reader = await setupTestAccount({
-        connected: true,
-      });
-
-      const readerOnOtherAdminNode = await loadCoValueOrFail(
-        otherAdmin.node,
-        reader.accountID,
-      );
-      group.addMember(readerOnOtherAdminNode, "reader");
-
-      const personOnReaderNode = await loadCoValueOrFail(
-        reader.node,
-        person.id,
-      );
-
-      await waitFor(() => {
-        expect(
-          expectMap(personOnReaderNode.core.getCurrentContent()).get("name"),
-        ).toEqual("John Doe");
-      });
-    },
-  );
-
-  test.each(["writer", "reader", "writeOnly"] as const)(
-    "an admin should be able downgrade themselves to %s",
-    async (targetRole) => {
-      const admin = await setupTestAccount({
-        connected: true,
-      });
-
-      const group = admin.node.createGroup();
-
-      const account = await loadCoValueOrFail(admin.node, admin.accountID);
-
-      // Downgrade self to target role
-      group.addMember(account, targetRole);
-      expect(group.roleOf(admin.accountID)).toEqual(targetRole);
-    },
-  );
-
-  test("an admin should be able downgrade a writeOnly to reader", async () => {
-    const admin = await setupTestAccount({
-      connected: true,
-    });
-
-    const writeOnlyUser = await setupTestAccount({
-      connected: true,
-    });
-
-    const group = admin.node.createGroup();
-    const person = group.createMap({
-      name: "John Doe",
-    });
-
-    const writeOnlyUserOnAdminNode = await loadCoValueOrFail(
-      admin.node,
-      writeOnlyUser.accountID,
-    );
-    group.addMember(writeOnlyUserOnAdminNode, "writeOnly");
-    group.addMember(writeOnlyUserOnAdminNode, "reader");
-
-    expect(group.roleOf(writeOnlyUser.accountID)).toEqual("reader");
-
-    const personOnWriteOnlyNode = await loadCoValueOrFail(
-      writeOnlyUser.node,
-      person.id,
-    );
-
-    expect(personOnWriteOnlyNode.get("name")).toEqual("John Doe");
-  });
-
-  test("a reader should not be able to add a member", async () => {
-    const admin = await setupTestAccount({
-      connected: true,
-    });
-
-    const reader = await setupTestAccount({
-      connected: true,
-    });
-
-    const newUser = await setupTestAccount({
-      connected: true,
-    });
-
-    const group = admin.node.createGroup();
-    const readerOnAdminNode = await loadCoValueOrFail(
-      admin.node,
-      reader.accountID,
-    );
-    group.addMember(readerOnAdminNode, "reader");
-
-    const newUserOnReaderNode = await loadCoValueOrFail(
-      reader.node,
-      newUser.accountID,
-    );
-
-    const groupOnReaderNode = await loadCoValueOrFail(reader.node, group.id);
-
-    // Try to add member as reader
-    try {
-      groupOnReaderNode.addMember(newUserOnReaderNode, "reader");
-      throw new Error("Should not be able to add member as reader");
-    } catch (e) {
-      expect(e).toBeDefined();
-    }
-
-    expect(groupOnReaderNode.roleOf(newUser.accountID)).toBeUndefined();
-  });
-
-  test("a writer should not be able to add a member", async () => {
-    const admin = await setupTestAccount({
-      connected: true,
-    });
-
-    const writer = await setupTestAccount({
-      connected: true,
-    });
-
-    const newUser = await setupTestAccount({
-      connected: true,
-    });
-
-    const group = admin.node.createGroup();
-    const writerOnAdminNode = await loadCoValueOrFail(
-      admin.node,
-      writer.accountID,
-    );
-    group.addMember(writerOnAdminNode, "writer");
-
-    const newUserOnWriterNode = await loadCoValueOrFail(
-      writer.node,
-      newUser.accountID,
-    );
-
-    const groupOnWriterNode = await loadCoValueOrFail(writer.node, group.id);
-
-    // Try to add member as writer
-    try {
-      groupOnWriterNode.addMember(newUserOnWriterNode, "reader");
-      throw new Error("Should not be able to add member as writer");
-    } catch (e) {
-      expect(e).toBeDefined();
-    }
-
-    expect(groupOnWriterNode.roleOf(newUser.accountID)).toBeUndefined();
-  });
-
-  test("a writeOnly should not be able to add a member", async () => {
-    const admin = await setupTestAccount({
-      connected: true,
-    });
-
-    const writeOnlyUser = await setupTestAccount({
-      connected: true,
-    });
-
-    const newUser = await setupTestAccount({
-      connected: true,
-    });
-
-    const group = admin.node.createGroup();
-    const writeOnlyUserOnAdminNode = await loadCoValueOrFail(
-      admin.node,
-      writeOnlyUser.accountID,
-    );
-    group.addMember(writeOnlyUserOnAdminNode, "writeOnly");
-
-    const newUserOnWriteOnlyNode = await loadCoValueOrFail(
-      writeOnlyUser.node,
-      newUser.accountID,
-    );
-
-    const groupOnWriteOnlyNode = await loadCoValueOrFail(
-      writeOnlyUser.node,
-      group.id,
-    );
-
-    // Try to add member as writeOnly user
-    try {
-      groupOnWriteOnlyNode.addMember(newUserOnWriteOnlyNode, "reader");
-      throw new Error("Should not be able to add member as writeOnly user");
-    } catch (e) {
-      expect(e).toBeDefined();
-    }
-
-    expect(groupOnWriteOnlyNode.roleOf(newUser.accountID)).toBeUndefined();
   });
 });

--- a/packages/cojson/src/tests/group.test.ts
+++ b/packages/cojson/src/tests/group.test.ts
@@ -3,7 +3,7 @@ import { RawCoList } from "../coValues/coList.js";
 import { RawCoMap } from "../coValues/coMap.js";
 import { RawCoStream } from "../coValues/coStream.js";
 import { RawBinaryCoStream } from "../coValues/coStream.js";
-import type { RawCoValue, RawGroup } from "../exports.js";
+import type { RawCoValue, RawGroup, Role } from "../exports.js";
 import type { NewContentMessage } from "../sync.js";
 import {
   createThreeConnectedNodes,
@@ -24,6 +24,37 @@ function expectGroup(content: RawCoValue): RawGroup {
 
   return content as RawGroup;
 }
+
+test("User is admin of a group he created", () => {
+  const node = nodeWithRandomAgentAndSessionID();
+  const group = node.createGroup();
+
+  expect(group.myRole()).toEqual("admin");
+});
+
+test("User can set itself as super-admin of a group he created", () => {
+  const node = nodeWithRandomAgentAndSessionID();
+  const group = node.createGroup(undefined, "superAdmin");
+
+  expect(group.myRole()).toEqual("superAdmin");
+});
+
+test("User can set itself as admin of a group he created", () => {
+  const node = nodeWithRandomAgentAndSessionID();
+  const group = node.createGroup(undefined, "admin");
+
+  expect(group.myRole()).toEqual("admin");
+});
+
+test.each(["writer", "reader", "writeOnly"] as Role[])(
+  "User can't set itself as %s of a group he created",
+  (role) => {
+    const node = nodeWithRandomAgentAndSessionID();
+    expect(() => {
+      node.createGroup(undefined, role as any);
+    }).toThrow("Initial role must be admin or superAdmin");
+  },
+);
 
 test("Can create a RawCoMap in a group", () => {
   const node = nodeWithRandomAgentAndSessionID();

--- a/packages/cojson/src/tests/permissions.test.ts
+++ b/packages/cojson/src/tests/permissions.test.ts
@@ -81,7 +81,7 @@ test("Admins can't demote other admins in a group (high level)", async () => {
   );
 
   expect(() => groupAsOtherAdmin.addMemberInternal(admin.id, "writer")).toThrow(
-    "Administrators cannot demote other administrators in a group",
+    `Failed to set role writer to ${admin.id} (role of current account is admin)`,
   );
 
   expect(groupAsOtherAdmin.get(admin.id)).toEqual("admin");
@@ -133,13 +133,13 @@ test("Admins an add writers to a group, who can't add admins, writers, or reader
   const otherAgent = createAccountInNode(groupAsWriter.core.node);
 
   expect(() => groupAsWriter.addMember(otherAgent, "admin")).toThrow(
-    "Failed to set role due to insufficient permissions (role of current account is writer)",
+    `Failed to set role admin to ${otherAgent.id} (role of current account is writer)`,
   );
   expect(() => groupAsWriter.addMember(otherAgent, "writer")).toThrow(
-    "Failed to set role due to insufficient permissions (role of current account is writer)",
+    `Failed to set role writer to ${otherAgent.id} (role of current account is writer)`,
   );
   expect(() => groupAsWriter.addMember(otherAgent, "reader")).toThrow(
-    "Failed to set role due to insufficient permissions (role of current account is writer)",
+    `Failed to set role reader to ${otherAgent.id} (role of current account is writer)`,
   );
 
   expect(groupAsWriter.get(otherAgent.id)).toBeUndefined();
@@ -190,13 +190,13 @@ test("Admins can add readers to a group, who can't add admins, writers, or reade
   const otherAgent = createAccountInNode(groupAsReader.core.node);
 
   expect(() => groupAsReader.addMember(otherAgent, "admin")).toThrow(
-    "Failed to set role due to insufficient permissions (role of current account is reader)",
+    `Failed to set role admin to ${otherAgent.id} (role of current account is reader)`,
   );
   expect(() => groupAsReader.addMember(otherAgent, "writer")).toThrow(
-    "Failed to set role due to insufficient permissions (role of current account is reader)",
+    `Failed to set role writer to ${otherAgent.id} (role of current account is reader)`,
   );
   expect(() => groupAsReader.addMember(otherAgent, "reader")).toThrow(
-    "Failed to set role due to insufficient permissions (role of current account is reader)",
+    `Failed to set role reader to ${otherAgent.id} (role of current account is reader)`,
   );
 
   expect(groupAsReader.get(otherAgent.id)).toBeUndefined();

--- a/packages/jazz-tools/src/tools/coValues/account.ts
+++ b/packages/jazz-tools/src/tools/coValues/account.ts
@@ -167,6 +167,7 @@ export class Account extends CoValueBase implements CoValue {
     const role = valueOwner.getRoleOf(this.$jazz.id);
 
     return (
+      role === "superAdmin" ||
       role === "admin" ||
       role === "writer" ||
       role === "reader" ||
@@ -179,7 +180,11 @@ export class Account extends CoValueBase implements CoValue {
     if (!valueOwner) {
       if (value[TypeSym] === "Group") {
         const roleInGroup = (value as Group).getRoleOf(this.$jazz.id);
-        return roleInGroup === "admin" || roleInGroup === "writer";
+        return (
+          roleInGroup === "superAdmin" ||
+          roleInGroup === "admin" ||
+          roleInGroup === "writer"
+        );
       }
       if (value[TypeSym] === "Account") {
         return value.$jazz.id === this.$jazz.id;
@@ -188,7 +193,12 @@ export class Account extends CoValueBase implements CoValue {
     }
     const role = valueOwner.getRoleOf(this.$jazz.id);
 
-    return role === "admin" || role === "writer" || role === "writeOnly";
+    return (
+      role === "superAdmin" ||
+      role === "admin" ||
+      role === "writer" ||
+      role === "writeOnly"
+    );
   }
 
   canAdmin(value: CoValue): boolean {
@@ -196,14 +206,18 @@ export class Account extends CoValueBase implements CoValue {
     if (!valueOwner) {
       if (value[TypeSym] === "Group") {
         const roleInGroup = (value as Group).getRoleOf(this.$jazz.id);
-        return roleInGroup === "admin";
+        return roleInGroup === "superAdmin" || roleInGroup === "admin";
       }
       if (value[TypeSym] === "Account") {
         return value.$jazz.id === this.$jazz.id;
       }
       return false;
     }
-    return valueOwner.getRoleOf(this.$jazz.id) === "admin";
+
+    return (
+      valueOwner.getRoleOf(this.$jazz.id) === "admin" ||
+      valueOwner.getRoleOf(this.$jazz.id) === "superAdmin"
+    );
   }
 
   /** @private */

--- a/packages/jazz-tools/src/tools/coValues/inbox.ts
+++ b/packages/jazz-tools/src/tools/coValues/inbox.ts
@@ -430,12 +430,14 @@ export class InboxSender<I extends CoValue, O extends CoValue | undefined> {
       throw new Error("Failed to load the inbox owner profile");
     }
 
+    const inboxOwnerRole = inboxOwnerProfileRaw.group.roleOf(
+      currentAccount.$jazz.raw.id,
+    );
+
     if (
-      inboxOwnerProfileRaw.group.roleOf(currentAccount.$jazz.raw.id) !==
-        "reader" &&
-      inboxOwnerProfileRaw.group.roleOf(currentAccount.$jazz.raw.id) !==
-        "writer" &&
-      inboxOwnerProfileRaw.group.roleOf(currentAccount.$jazz.raw.id) !== "admin"
+      !["reader", "writer", "admin", "superAdmin"].includes(
+        inboxOwnerRole ?? "",
+      )
     ) {
       throw new Error(
         "Insufficient permissions to access the inbox, make sure its user profile is publicly readable.",

--- a/packages/jazz-tools/src/tools/coValues/interfaces.ts
+++ b/packages/jazz-tools/src/tools/coValues/interfaces.ts
@@ -433,17 +433,24 @@ export function parseGroupCreateOptions(
   options:
     | {
         owner?: Account;
+        role?: "superAdmin" | "admin";
       }
     | Account
     | undefined,
-) {
+): {
+  owner: Account;
+  role?: "superAdmin" | "admin";
+} {
   if (!options) {
     return { owner: activeAccountContext.get() };
   }
 
   return TypeSym in options && isAccountInstance(options)
     ? { owner: options }
-    : { owner: options.owner ?? activeAccountContext.get() };
+    : {
+        owner: options.owner ?? activeAccountContext.get(),
+        role: options.role,
+      };
 }
 
 /**


### PR DESCRIPTION
Ref #1235 

`superAdmin` is a new role available when creating a Group. 
Despite the `admin` role, the new role has unrestricted power in managing other roles. It can add new admins and super admins, but it can also remove them. 

Due to its dangerous behaviour, the default role is still `admin`.

```ts
const group = Group.create();
expect(group.getRoleOf("me")).toBe("admin");

const group = Group.create({role: "superAdmin"});
expect(group.getRoleOf("me")).toBe("superAdmin");
```

---

This PR also introduces a refactoring on addMember/removeMember to validate permissions at a lower level (inside permission.ts) 

Previously, cojson/group.ts was trying to understand why an operation failed. Now, if the role setting fails, the error message is unified and enriched by useful information for debugging: `Failed to set role ${role} to ${memberKey} (role of current account is ${this.myRole()})`.

To be consistent and to give appropriate feedback, `group.removeMember` now throws an error if it fails (it was failing silently before). Due to this change, this might be considered a minor update instead of a patch.