### PR TITLE
feat(docs): Add `CoVectors` page

### DIFF
--- a/homepage/homepage/content/docs/docNavigationItems.js
+++ b/homepage/homepage/content/docs/docNavigationItems.js
@@ -191,6 +191,11 @@ export const docNavigationItems = [
         done: 80,
       },
       {
+        name: "CoVectors",
+        href: "/docs/using-covalues/covectors",
+        done: 100,
+      },
+      {
         name: "ImageDefinition",
         href: "/docs/using-covalues/imagedef",
         done: {

--- a/homepage/homepage/content/docs/using-covalues/covectors.mdx
+++ b/homepage/homepage/content/docs/using-covalues/covectors.mdx
@@ -190,11 +190,15 @@ Wrapping each item with its similarity score makes it easy to sort, filter, and 
 
 ### Cosine Similarity
 
-The `$jazz.cosineSimilarity` method returns a similarity of CoVector to another vector. Cosine similarity returns a value between `-1` and `1`:
+To compare how similar two vectors are, we use their [cosine similarity](https://en.wikipedia.org/wiki/Cosine_similarity). This returns a value between `-1` and `1`, describing how similar the vectors are:
 
 - `1` means the vectors are identical
 - `0` means the vectors are orthogonal (i.e. no similarity)
 - `-1` means the vectors are opposite direction (perfectly dissimilar).
+
+If you sort items by their cosine similarity, the ones which are most similar will appear at the top of the list.
+
+Jazz provides a built-in `$jazz.cosineSimilarity` method to calculate this for you.
 
 
 ## Embedding Models

--- a/homepage/homepage/content/docs/using-covalues/covectors.mdx
+++ b/homepage/homepage/content/docs/using-covalues/covectors.mdx
@@ -1,0 +1,220 @@
+import { CodeGroup, ContentByFramework, TabbedCodeGroup, TabbedCodeGroupItem } from "@/components/forMdx";
+import { JavascriptLogo } from "@/components/icons/JavascriptLogo";
+import { ReactLogo } from "@/components/icons/ReactLogo";
+
+
+export const metadata = {
+  description: "CoVectors store high-dimensional vectors on-device and enable local-first semantic search and similarity operations."
+};
+
+# CoVectors
+
+CoVectors let you store and query high‑dimensional vectors directly in Jazz apps. They are ideal for semantic search, or personalization features that work offline, sync across devices, and remain end‑to‑end encrypted.
+
+
+The [Journal example](https://github.com/garden-co/jazz/tree/main/examples/vector-search) demonstrates semantic search using of CoVector.
+
+CoVectors are defined using `co.vector()`, and are often used as fields in a CoMap within a CoList (making it easy to perform vector search across list items).
+
+<CodeGroup>
+```ts twoslash
+import { co, z } from "jazz-tools";
+
+const Embedding = co.vector(384); // Define 384-dimensional embedding
+
+const Document = co.map({
+  content: z.string(),
+  embedding: Embedding,
+});
+
+export const DocumentsList = co.list(Document);
+```
+</CodeGroup>
+
+The number of dimensions matches the embedding model used in your app. Many small sentence transformers produce 384‑dim vectors; others use 512, 768, 1024 or more.
+
+
+## Creating CoVectors
+
+You can create vectors in your Jazz application from an array of numbers, or Float32Array instance.
+
+<CodeGroup>
+```ts twoslash
+import { co, z } from "jazz-tools";
+const Embedding = co.vector(384); 
+const Document = co.map({
+  content: z.string(),
+  embedding: Embedding,
+});
+export const DocumentsList = co.list(Document);
+const documents = DocumentsList.create([]);
+const createEmbedding: (text: string) => Promise<number[]> = async () => ([]);
+
+// ---cut---
+// Generate embeddings (bring your own embeddings model)
+const vectorData = await createEmbedding("Text");
+
+const newDocument = Document.create({
+  content: "Text",
+  embedding: Embedding.create(vectorData),
+});
+
+documents.$jazz.push(newDocument);
+```
+</CodeGroup>
+
+### Ownership
+
+Like other CoValues, you can specify ownership when creating CoVectors.
+
+<CodeGroup>
+```ts twoslash
+import { Group, co, z } from "jazz-tools";
+import { createJazzTestAccount } from 'jazz-tools/testing';
+const me = await createJazzTestAccount();
+const colleagueAccount = await createJazzTestAccount();
+const vector: number[] = [];
+
+// ---cut---
+// Create with shared ownership
+const teamGroup = Group.create();
+teamGroup.addMember(colleagueAccount, "writer");
+
+const teamList = co.vector(384).create(vector, { owner: teamGroup });
+```
+</CodeGroup>
+
+See [Groups as permission scopes](/docs/groups/intro) for more information on how to use groups to control access to CoVectors.
+
+### Immutability
+
+Once a CoVector is created, its values should not be changed. If you need to update a CoVector, you should create a new one with the desired values, then replace the former.
+
+
+## Semantic Search
+
+Semantic search lets you find data based on meaning, not just keywords. In Jazz, you can easily sort results by how similar they are to your search query.
+
+<ContentByFramework framework="react">
+Use the `useCoStateWithSelector` hook to load your data and sort it by similarity to your query embedding:
+</ContentByFramework>
+<ContentByFramework framework="vanilla">
+You can load your data using the `.load` method, then compute and sort the results by similarity to your query embedding:
+</ContentByFramework>
+
+<TabbedCodeGroup id="vectorsearch" default="react" savedPreferenceKey="framework">
+<TabbedCodeGroupItem label="React" value="react" className="[&_span]:[tab-size:2]" icon={<ReactLogo />} preferWrap>
+```ts twoslash
+import { co, z } from "jazz-tools";
+const Document = co.map({
+  content: z.string(),
+  embedding: co.vector(384),
+});
+export const DocumentsList = co.list(Document);
+const documents = DocumentsList.create([]);
+const documentsListId: string = 'co_876TBN';
+
+type YourCustomHook = { queryEmbedding: number[] | null; createQueryEmbedding: (text: string) => Promise<number[]> }
+const useCreateEmbedding: () => YourCustomHook =
+  () => ({
+    queryEmbedding: null,
+    createQueryEmbedding: async (s) => ([]),
+  });
+
+// ---cut---
+import { useCoStateWithSelector } from "jazz-tools/react";
+
+const { queryEmbedding, createQueryEmbedding } = useCreateEmbedding();
+
+const foundDocuments = useCoStateWithSelector(
+  DocumentsList,
+  documentsListId,
+  {
+    resolve: { 
+      $each: { embedding: true }
+    },
+    select(documents) {
+      if (!documents) return;
+
+      // If no query embedding, return all entries
+      if (!queryEmbedding) return documents.map((value) => ({ value }));
+
+      return documents
+        .map((value) => ({
+          value,
+          similarity: value.embedding.$jazz.cosineSimilarity(queryEmbedding), // [!code ++]
+        }))
+        .sort((a, b) => b.similarity - a.similarity)
+        .filter((result) => result.similarity > 0.5);
+    },
+  },
+);
+```
+</TabbedCodeGroupItem>
+<TabbedCodeGroupItem label="VanillaJS" value="vanilla" className="[&_span]:[tab-size:2]" icon={<JavascriptLogo />} preferWrap>
+```ts twoslash
+import { co, z } from "jazz-tools";
+const Document = co.map({
+  content: z.string(),
+  embedding: co.vector(384),
+});
+export const DocumentsList = co.list(Document);
+const documentsListId: string = 'co_876TBN';
+const createEmbedding: (text: string) => Promise<number[]> = async () => ([]);
+
+// ---cut---
+// 1) Load your documents
+const documents = await DocumentsList.load(documentsListId, {
+  resolve: { 
+    $each: { embedding: true }
+  }
+})
+
+// 2) Obtain vector for your search query
+const queryEmbedding = await createEmbedding("search query");
+
+// 3) Sort documents by vector similarity
+const similarDocuments = documents
+  ?.map((value) => ({
+    value,
+    similarity: value.embedding.$jazz.cosineSimilarity(queryEmbedding), // [!code ++]
+  }))
+  .sort((a, b) => b.similarity - a.similarity)
+  .filter((result) => result.similarity > 0.5);
+```
+</TabbedCodeGroupItem>
+</TabbedCodeGroup>
+
+Wrapping each item with its similarity score makes it easy to sort, filter, and display the most relevant results. This approach is widely used in vector search and recommendation systems, since it keeps both the data and its relevance together for further processing or display.
+
+
+### Cosine Similarity
+
+The `$jazz.cosineSimilarity` method returns a similarity of CoVector to another vector. Cosine similarity returns a value between `-1` and `1`:
+
+- `1` means the vectors are identical
+- `0` means the vectors are orthogonal (i.e. no similarity)
+- `-1` means the vectors are opposite direction (perfectly dissimilar).
+
+
+## Embedding Models
+
+CoVectors handles storage and search, you provide the vectors. Generate embeddings with any model you prefer (Hugging Face, OpenAI, custom, etc).
+
+**Recommended:** Run models locally for privacy and offline support using [Transformers.js](https://huggingface.co/docs/transformers.js):
+
+- [Xenova/all-MiniLM-L6-v2](https://huggingface.co/Xenova/all-MiniLM-L6-v2) — 384 dimensions, ~23 MB
+- [Xenova/paraphrase-multilingual-mpnet-base-v2](https://huggingface.co/Xenova/paraphrase-multilingual-mpnet-base-v2) — 768 dimensions, ~279 MB
+- [mixedbread-ai/mxbai-embed-large-v1](https://huggingface.co/mixedbread-ai/mxbai-embed-large-v1) — 1024 dimensions, ~337 MB
+- [Browse more models →](https://huggingface.co/models?pipeline_tag=feature-extraction&library=transformers.js)
+
+Alternatively, you can generate embeddings using server-side or commercial APIs (such as OpenAI or Anthropic).
+
+## Best Practices
+
+### Changing embedding models
+
+**Always use the same embedding model for all vectors you intend to compare.**  
+Mixing vectors from different models (or even different versions of the same model) will result in meaningless similarity scores, as the vector spaces are not compatible.
+
+If you need to switch models, consider storing the model identifier alongside each vector, and re-embedding your data as needed.

--- a/homepage/homepage/content/docs/using-covalues/covectors.mdx
+++ b/homepage/homepage/content/docs/using-covalues/covectors.mdx
@@ -1,5 +1,6 @@
 import { CodeGroup, ContentByFramework, TabbedCodeGroup, TabbedCodeGroupItem } from "@/components/forMdx";
 import { JavascriptLogo } from "@/components/icons/JavascriptLogo";
+import { SvelteLogo } from "@/components/icons/SvelteLogo";
 import { ReactLogo } from "@/components/icons/ReactLogo";
 
 
@@ -181,6 +182,41 @@ const similarDocuments = documents
   }))
   .sort((a, b) => b.similarity - a.similarity)
   .filter((result) => result.similarity > 0.5);
+```
+</TabbedCodeGroupItem>
+<TabbedCodeGroupItem label="Svelte" value="svelte" className="[&_span]:[tab-size:2]" icon={<SvelteLogo />} preferWrap>
+```svelte
+<script lang="ts">
+  import { CoState } from "jazz-tools/svelte";
+
+  export let queryEmbedding: number[] | null;
+  export let documentsListId: string;
+
+  // 1) Load your documents
+  const documents = new CoState(DocumentsList, documentsListId, {
+    resolve: {
+      $each: { embedding: true },
+    }
+  });
+
+  // 2) Sort documents by vector similarity
+  const foundDocuments = $derived((() => {
+    const docs = documents.current;
+    if (!docs) return;
+
+    if (!queryEmbedding) {
+      return docs.map((value) => ({ value }));
+    }
+
+    return docs
+      .map((value) => ({
+        value,
+        similarity: value.embedding.$jazz.cosineSimilarity(queryEmbedding), // [!code ++]
+      }))
+      .sort((a, b) => b.similarity - a.similarity)
+      .filter((result) => result.similarity > 0.5);
+  })());
+</script>
 ```
 </TabbedCodeGroupItem>
 </TabbedCodeGroup>

--- a/homepage/homepage/content/docs/using-covalues/covectors.mdx
+++ b/homepage/homepage/content/docs/using-covalues/covectors.mdx
@@ -88,7 +88,7 @@ See [Groups as permission scopes](/docs/groups/intro) for more information on ho
 
 ### Immutability
 
-Once a CoVector is created, its values should not be changed. If you need to update a CoVector, you should create a new one with the desired values, then replace the former.
+CoVectors cannot be changed after creation. Instead, create a new CoVector with the updated values and replace the previous one.
 
 
 ## Semantic Search

--- a/homepage/homepage/content/docs/using-covalues/covectors.mdx
+++ b/homepage/homepage/content/docs/using-covalues/covectors.mdx
@@ -205,7 +205,9 @@ Jazz provides a built-in `$jazz.cosineSimilarity` method to calculate this for y
 
 CoVectors handles storage and search, you provide the vectors. Generate embeddings with any model you prefer (Hugging Face, OpenAI, custom, etc).
 
-**Recommended:** Run models locally for privacy and offline support using [Transformers.js](https://huggingface.co/docs/transformers.js):
+**Recommended:** Run models locally for privacy and offline support using [Transformers.js](https://huggingface.co/docs/transformers.js). Check our [Journal app example](https://github.com/garden-co/jazz/tree/main/examples/vector-search) to see how to do this.
+
+The following models offer a good balance between accuracy and performance:
 
 - [Xenova/all-MiniLM-L6-v2](https://huggingface.co/Xenova/all-MiniLM-L6-v2) — 384 dimensions, ~23 MB
 - [Xenova/paraphrase-multilingual-mpnet-base-v2](https://huggingface.co/Xenova/paraphrase-multilingual-mpnet-base-v2) — 768 dimensions, ~279 MB


### PR DESCRIPTION
# Description
Adding a documentation page about new CoVector type, and how to run the simple vector similarity search in React & vanilla JS.

References an example app still [available only in a non-prod branch](https://github.com/garden-co/jazz/pull/2950).

## Manual testing instructions

👉 Live version: https://jazz-homepage-git-feat-vector-docs-gcmp.vercel.app/docs/react/using-covalues/covectors

## Tests

- [ ] Tests have been added and/or updated
- [x] Tests have not been updated, because: *adding a docs page only*
- [ ] I need help with writing tests


## Checklist

- [ ] I've updated the part of the docs that are affected the PR changes
- [ ] I've generated a changeset, if a version bump is required
- [ ] I've updated the jsDoc comments to the public APIs I've modified, or added them when missing

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a new `CoVectors` documentation page and links it in the "Using CoValues" navigation.
> 
> - **Docs**:
>   - **New Page**: `homepage/content/docs/using-covalues/covectors.mdx`
>     - Introduces `co.vector(dim)` and `CoVectors` usage in schemas (`CoMap`, `CoList`).
>     - Creation APIs, ownership via `Group`, and immutability guidance.
>     - Semantic search examples (React `useCoStateWithSelector`; Vanilla JS) using `$jazz.cosineSimilarity`.
>     - Embedding model recommendations (dimensions, local models) and best practices for model consistency.
>   - **Navigation**: Adds `CoVectors` item to `homepage/content/docs/docNavigationItems.js` under "Using CoValues".
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c64b0f6141e891f3cfa71be03d2a5651a366087c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->