### PR TITLE
Extend auth quickstart to demonstrate passkey auth

### DIFF
--- a/homepage/design-system/src/components/molecules/TabbedCodeGroup.tsx
+++ b/homepage/design-system/src/components/molecules/TabbedCodeGroup.tsx
@@ -246,7 +246,7 @@ export function TabbedCodeGroupItem({
   ...props
 }: TabbedCodeGroupItemProps) {
   return (
-    <CodeGroup className={className} {...props}>
+    <CodeGroup className={clsx("[&_span]:[tab-size:2]", className)} {...props}>
       {children}
     </CodeGroup>
   );

--- a/homepage/homepage/components/docs/snippets/GetAPIKey.mdx
+++ b/homepage/homepage/components/docs/snippets/GetAPIKey.mdx
@@ -14,12 +14,12 @@ Sign up for a free API key at [dashboard.jazz.tools](https://dashboard.jazz.tool
 </div>
 
 <TabbedCodeGroup default="react" savedPreferenceKey="framework" id="get-api-key" style={{display: props.hideCodeGroup ? 'none' : ''}}>
-  <TabbedCodeGroupItem label="React" value="react" className="[&_span]:[tab-size:2]" icon={<ReactLogo />} preferWrap>
+  <TabbedCodeGroupItem label="React" value="react" icon={<ReactLogo />} preferWrap>
     ```bash
     NEXT_PUBLIC_JAZZ_API_KEY="you@example.com" # or your API key
     ```
   </TabbedCodeGroupItem>
-  <TabbedCodeGroupItem label="Svelte" value="svelte" className="[&_span]:[tab-size:2]" icon={<SvelteLogo />} preferWrap>
+  <TabbedCodeGroupItem label="Svelte" value="svelte" icon={<SvelteLogo />} preferWrap>
     ```bash
     PUBLIC_JAZZ_API_KEY="you@example.com" # or your API key
     ```

--- a/homepage/homepage/components/docs/snippets/RunDevServer.mdx
+++ b/homepage/homepage/components/docs/snippets/RunDevServer.mdx
@@ -1,12 +1,12 @@
 import { TabbedCodeGroup, TabbedCodeGroupItem } from "@/components/forMdx";
 
 <TabbedCodeGroup savedPreferenceKey="package-manager" id="run-dev-server">
-  <TabbedCodeGroupItem label="npm" value="npm" className="[&_span]:[tab-size:2]">
+  <TabbedCodeGroupItem label="npm" value="npm">
     ```bash
     npm run dev
     ```
   </TabbedCodeGroupItem>
-  <TabbedCodeGroupItem label="pnpm" value="pnpm" className="[&_span]:[tab-size:2]">
+  <TabbedCodeGroupItem label="pnpm" value="pnpm">
     ```bash
     pnpm run dev
     ```

--- a/homepage/homepage/content/docs/authentication/passkey.mdx
+++ b/homepage/homepage/content/docs/authentication/passkey.mdx
@@ -27,7 +27,7 @@ Passkey authentication is based on the [Web Authentication API](https://develope
 Using passkeys in Jazz is as easy as this:
 
 <TabbedCodeGroup default="react" savedPreferenceKey="framework" id="use-passkey-auth">
-<TabbedCodeGroupItem icon={<ReactLogo />} label="React" value="react" className="[&_span]:[tab-size:2]" preferWrap>
+<TabbedCodeGroupItem icon={<ReactLogo />} label="React" value="react" preferWrap>
 ```tsx twoslash
 import * as React from "react";
 import { useState } from "react";
@@ -68,7 +68,7 @@ export function AuthModal({ open, onOpenChange }: AuthModalProps) {
 }
 ```
 </TabbedCodeGroupItem>
-<TabbedCodeGroupItem icon={<SvelteLogo />} label="Svelte" value="svelte" className="[&_span]:[tab-size:2]" preferWrap>
+<TabbedCodeGroupItem icon={<SvelteLogo />} label="Svelte" value="svelte" preferWrap>
 ```svelte
 <script lang="ts">
   import { usePasskeyAuth } from 'jazz-tools/svelte';

--- a/homepage/homepage/content/docs/authentication/passphrase.mdx
+++ b/homepage/homepage/content/docs/authentication/passphrase.mdx
@@ -16,7 +16,7 @@ When a user creates an account with passphrase authentication:
 2. This phrase consists of words from a wordlist
 3. Users save this phrase and enter it when logging in on new devices
 
-You can use one of the ready-to-use wordlists from the [BIP39 repository](https://github.com/bitcoinjs/bip39/tree/a7ecbfe2e60d0214ce17163d610cad9f7b23140c/src/wordlists) or create your own.
+You can use one of the ready-to-use wordlists from the [BIP39 repository](https://github.com/bitcoinjs/bip39/tree/a7ecbfe2e60d0214ce17163d610cad9f7b23140c/src/wordlists) or create your own. If you do decide to create your own wordlist, it's recommended to use at least 2048 unique words (or some higher power of two).
 
 ## Key benefits
 

--- a/homepage/homepage/content/docs/authentication/quickstart.mdx
+++ b/homepage/homepage/content/docs/authentication/quickstart.mdx
@@ -28,7 +28,7 @@ Jazz has a built-in passkey authentication component that you can use to add aut
 </ContentByFramework>
 
 <TabbedCodeGroup savedPreferenceKey="framework" id="add-passkey-auth">
-<TabbedCodeGroupItem label="React" value="react" className="[&_span]:[tab-size:2]" icon={<ReactLogo />} preferWrap>
+<TabbedCodeGroupItem label="React" value="react" icon={<ReactLogo />} preferWrap>
   ```tsx
   "use client"; // tells Next.js that this component can't be server-side rendered. If you're not using Next.js, you can remove it.
   // [!code --:1]
@@ -59,7 +59,7 @@ export function JazzWrapper({ children }: {
 }
   ```
 </TabbedCodeGroupItem>
-<TabbedCodeGroupItem label="Svelte" value="svelte" className="[&_span]:[tab-size:2]" icon={<SvelteLogo />} preferWrap>
+<TabbedCodeGroupItem label="Svelte" value="svelte" icon={<SvelteLogo />} preferWrap>
 ```svelte
 <script lang="ts">
   // [!code --:1]
@@ -67,7 +67,7 @@ export function JazzWrapper({ children }: {
   // [!code ++:1]
   import { JazzSvelteProvider, PasskeyAuthBasicUI } from "jazz-tools/svelte";
   import { JazzFestAccount } from "$lib/schema";
-	import { PUBLIC_JAZZ_API_KEY } from "$env/static/public";
+  import { PUBLIC_JAZZ_API_KEY } from "$env/static/public";
 
   const apiKey = PUBLIC_JAZZ_API_KEY;
   let { children } = $props();
@@ -76,8 +76,9 @@ export function JazzWrapper({ children }: {
 
 <JazzSvelteProvider {sync} AccountSchema={JazzFestAccount}>
   <!-- [!code ++:1] -->
-  <PasskeyAuthBasicUI appName="JazzFest" />
-  {@render children?.()}
+  <PasskeyAuthBasicUI appName="JazzFest">
+    {@render children?.()}
+  </PasskeyAuthBasicUI>
 </JazzSvelteProvider>
 ```
 </TabbedCodeGroupItem>
@@ -87,10 +88,10 @@ export function JazzWrapper({ children }: {
 <details>
 <summary>Already completed the server-side rendering guide?</summary>
 
-You'll need to make a couple of small changes to your structure in order for this to work on the server.
+You'll need to make a couple of small changes to your structure in order for this to work on the server. In particular, we only want to display the passkey auth UI on the client, otherwise, we should just render on the child.
 
 <FileName>app/components/JazzWrapper.tsx</FileName>
-<CodeGroup className="[&_span]:[tab-size:2]" preferWrap>
+<CodeGroup preferWrap>
 ```tsx
 "use client"; // tells Next.js that this component can't be server-side rendered. If you're not using Next.js, you can remove it.
 // [!code --:1]
@@ -152,7 +153,348 @@ You'll also need to be aware that the server agent can only render public CoValu
 
 <StuckCTA />
 
+## Add a recovery method
+
+Passkeys are very convenient for your users because they offer a secure alternative to traditional authentication methods and they're normally synchronised across devices automatically by the user's browser or operating system.
+
+However, they're not available everywhere, and in case the user loses or deletes their passkey by mistake, they won't be able to access their account. 
+
+So, let's add a secondary login method using a passphrase. You can integrate [as many different authentication methods as you like](https://github.com/garden-co/jazz/tree/main/examples/multiauth) in your app.
+
+### Create an `Auth` component
+
+The `PasskeyAuthBasicUI` component is not customisable, so we'll implement our own Auth component so that we can extend it.
+
+<ContentByFramework framework="react">
+  <FileName>app/components/Auth.tsx</FileName>
+</ContentByFramework>
+<ContentByFramework framework="svelte">
+  <FileName>src/lib/components/Auth.svelte</FileName>
+</ContentByFramework>
+
+<TabbedCodeGroup default="react" savedPreferenceKey="framework" id="custom-auth">
+<TabbedCodeGroupItem icon={<ReactLogo />} label="React" value="react" preferWrap>
+```tsx
+import { useState } from 'react';
+import { usePasskeyAuth } from 'jazz-tools/react';
+
+export function Auth({ children }: { 
+  children: React.ReactNode 
+}) {
+  const [name, setName] = useState("");
+
+  const auth = usePasskeyAuth({ // Must be inside the JazzProvider because the hook depends on an active Jazz context.
+    appName: "JazzFest",
+  });
+
+  return (
+    <>
+    <div>
+      <button onClick={() => auth.logIn()}>Log in</button>
+      <input type="text" value={name} onChange={(e) => setName(e.target.value)} />
+      <button onClick={() => auth.signUp(name)}>Sign up</button>
+    </div>
+    {auth.state === "signedIn" && children}
+    </>
+  );
+}
+```
+</TabbedCodeGroupItem>
+<TabbedCodeGroupItem icon={<SvelteLogo />} label="Svelte" value="svelte" preferWrap>
+```svelte
+<script lang="ts">
+  import { usePasskeyAuth } from 'jazz-tools/svelte';
+  const { children } = $props();
+  const auth = usePasskeyAuth({ appName: 'JazzFest' });
+  let name = $state('');
+</script>
+
+{#if auth.current.state === "signedIn"}
+  {@render children?.()}
+{:else}
+  <div>
+    <button onclick={() => auth.current.logIn()}>Log in</button>
+    <input type="text" bind:value={name} />
+    <button onclick={() => auth.current.signUp(name)}>Sign up</button>
+  </div>
+{/if}
+```
+</TabbedCodeGroupItem>
+</TabbedCodeGroup>
+
+### Use your new component
+<ContentByFramework framework="react">
+  <FileName>app/components/JazzWrapper.tsx</FileName>
+</ContentByFramework>
+<ContentByFramework framework="svelte">
+  <FileName>src/routes/+layout.svelte</FileName>
+</ContentByFramework>
+
+<TabbedCodeGroup savedPreferenceKey="framework" id="add-passkey-auth">
+<TabbedCodeGroupItem label="React" value="react" icon={<ReactLogo />} preferWrap>
+  ```tsx
+  "use client"; // tells Next.js that this component can't be server-side rendered. If you're not using Next.js, you can remove it.
+  // [!code --:1]
+import { JazzReactProvider, PasskeyAuthBasicUI } from "jazz-tools/react";
+// [!code ++:1]
+import { JazzReactProvider } from "jazz-tools/react";
+import { JazzFestAccount } from "@/app/schema";
+
+const apiKey = process.env.NEXT_PUBLIC_JAZZ_API_KEY;
+
+export function JazzWrapper({ children }: { 
+  children: React.ReactNode 
+}) {
+  return (
+    <JazzReactProvider
+      sync={{ 
+        peer: `wss://cloud.jazz.tools/?key=${apiKey}` 
+      }}
+      AccountSchema={JazzFestAccount}
+    >
+      {/* [!code ++:3] */}
+      <Auth>
+        {children}
+      </Auth>
+      {/* [!code --:3] */}
+      <PasskeyAuthBasicUI appName="JazzFest">
+        {children}
+      </PasskeyAuthBasicUI>
+    </JazzReactProvider>
+  );
+}
+  ```
+</TabbedCodeGroupItem>
+<TabbedCodeGroupItem label="Svelte" value="svelte" icon={<SvelteLogo />} preferWrap>
+```svelte
+<script lang="ts">
+  // [!code --:1]
+  import { JazzSvelteProvider, PasskeyAuthBasicUI } from "jazz-tools/svelte";
+  // [!code ++:2]
+  import { JazzSvelteProvider } from "jazz-tools/svelte";
+  import Auth from '$lib/components/Auth.svelte';
+  import { JazzFestAccount } from "$lib/schema";
+  import { PUBLIC_JAZZ_API_KEY } from "$env/static/public";
+
+  const apiKey = PUBLIC_JAZZ_API_KEY;
+  let { children } = $props();
+  const sync = { peer: `wss://cloud.jazz.tools/?key=${apiKey}` };
+</script>
+
+<JazzSvelteProvider {sync} AccountSchema={JazzFestAccount}>
+  <!-- [!code --:3] -->
+  <PasskeyAuthBasicUI appName="JazzFest">
+    {@render children?.()}
+  </PasskeyAuthBasicUI>
+  <!-- [!code ++:3] -->
+  <Auth>
+    {@render children?.()}
+  </Auth>
+</JazzSvelteProvider>
+```
+</TabbedCodeGroupItem>
+</TabbedCodeGroup>
+
+### Show recovery key
+
+Jazz allows you to generate a passphrase from a wordlist which can be used to log in to an account. This passphrase will work regardless of how the account was originally created (passkey, Clerk, BetterAuth, etc.). Each account will always have the same recovery key.
+
+You can get started with a wordlist [from here](https://github.com/bitcoinjs/bip39/tree/master/src/wordlists). For example, you could save the `english.json` file in your project and format it as a JavaScript export.
+
+<FileName>wordlist.ts</FileName>
+<CodeGroup>
+```ts
+export const wordlist = [
+  "abandon",
+  // ... many more words
+  "zoo"
+];
+```
+</CodeGroup>
+
+We'll import this, and add a textarea into our auth component which will show the recovery key for the current user's account.
+
+<TabbedCodeGroup default="react" savedPreferenceKey="framework" id="recovery-key">
+<TabbedCodeGroupItem icon={<ReactLogo />} label="React" value="react" preferWrap>
+```tsx
+import { useState } from 'react';
+// [!code --:1]
+import { usePasskeyAuth } from 'jazz-tools/react';
+// [!code ++:2]
+import { usePasskeyAuth, usePassphraseAuth } from 'jazz-tools/react';
+import wordlist from './wordlist'; // or the path to your wordlist
+
+export function Auth({ children }: { 
+  children: React.ReactNode 
+}) {
+  const [name, setName] = useState("");
+
+  const auth = usePasskeyAuth({ // Must be inside the JazzProvider because the hook depends on an active Jazz context.
+    appName: "JazzFest",
+  });
+
+  // [!code ++:1]
+  const passphraseAuth = usePassphraseAuth({ wordlist }) // This should be inside the provider too
+
+  return (
+    <>
+      <div>
+        <button onClick={() => auth.logIn()}>Log in</button>
+        <input type="text" value={name} onChange={(e) => setName(e.target.value)} />
+        <button onClick={() => auth.signUp(name)}>Sign up</button>
+      </div>
+      {auth.state === "signedIn" && <>
+          {children}
+          {/* [!code ++:5]*/}
+          <textarea
+            readOnly
+            value={passphraseAuth.passphrase}
+            rows={5}
+          />
+        </>
+      }
+    </>
+  );
+}
+```
+</TabbedCodeGroupItem>
+<TabbedCodeGroupItem icon={<SvelteLogo />} label="Svelte" value="svelte" preferWrap>
+```svelte
+<script lang="ts">
+  // [!code --:1]
+  import { usePasskeyAuth } from 'jazz-tools/svelte';
+  // [!code ++:3]
+  import { usePasskeyAuth, usePassphraseAuth } from 'jazz-tools/svelte';
+  import { wordlist } from './wordlist';
+  const { children } = $props();
+  const passphraseAuth = usePassphraseAuth({ wordlist });
+  const auth = usePasskeyAuth({ appName: 'JazzFest' });
+  let name = $state('');
+</script>
+
+{#if auth.current.state === "signedIn"}
+  {@render children?.()}
+  <!-- [!code ++:5] -->
+  <textarea
+    readonly
+    value={passphraseAuth.passphrase}
+    rows={5}
+  />
+{:else}
+  <div>
+    <button onclick={() => auth.current.logIn()}>Log in</button>
+    <input type="text" bind:value={name} />
+    <button onclick={() => auth.current.signUp(name)}>Sign up</button>
+  </div>
+{/if}
+```
+</TabbedCodeGroupItem>
+</TabbedCodeGroup>
+
+<Alert variant="warning" title="Security Warning" className="mt-4">
+This 'recovery key' is a method of authenticating into an account, and if compromised, it *cannot* be changed! You should impress on your users the importance of keeping this key secret.
+</Alert>
+
+
+### Allow users to log in with the recovery key
+
+Now you're displaying a recovery key to users, so we'll allow users to login using a saved recovery key by extending the Auth component a little further.
+
+<TabbedCodeGroup default="react" savedPreferenceKey="framework" id="log-in-with-recovery-key">
+<TabbedCodeGroupItem icon={<ReactLogo />} label="React" value="react" preferWrap>
+```tsx
+import { useState } from 'react';
+import { usePasskeyAuth, usePassphraseAuth } from 'jazz-tools/react';
+import wordlist from './wordlist'; // or the path to your wordlist
+
+export function Auth({ children }: { 
+  children: React.ReactNode 
+}) {
+  const [name, setName] = useState("");
+  // [!code ++:1]
+  const [passphraseInput, setPassphraseInput] = useState("");
+
+  const auth = usePasskeyAuth({ // Must be inside the JazzProvider because the hook depends on an active Jazz context.
+    appName: "JazzFest",
+  });
+
+  const passphraseAuth = usePassphraseAuth({ wordlist }) // This should be inside the provider too
+
+  return (
+    <>
+      <div>
+        <button onClick={() => auth.logIn()}>Log in</button>
+        <input type="text" value={name} onChange={(e) => setName(e.target.value)} />
+        <button onClick={() => auth.signUp(name)}>Sign up</button>
+      </div>
+      {auth.state === "signedIn" && <>
+          {children}
+          <textarea
+            readOnly
+            value={passphraseAuth.passphrase}
+            rows={5}
+          />
+        </>
+      }
+      {/* [!code ++:8]*/}
+      {auth.state !== "signedIn" && <>
+        <textarea
+          onChange={(e) => setPassphraseInput(e.target.value)}
+          rows={5}
+        />
+        <button onClick={() => passphraseAuth.logIn(passphraseInput)}>Sign In with Passphrase</button>
+      </>}
+    </>
+  );
+}
+```
+</TabbedCodeGroupItem>
+<TabbedCodeGroupItem icon={<SvelteLogo />} label="Svelte" value="svelte" preferWrap>
+```svelte
+<script lang="ts">
+  import { usePasskeyAuth, usePassphraseAuth } from 'jazz-tools/svelte';
+  import { wordlist } from './wordlist';
+  const { children } = $props();
+  const passphraseAuth = usePassphraseAuth({ wordlist });
+  const auth = usePasskeyAuth({ appName: 'JazzFest' });
+  let name = $state('');
+  // [!code ++:1]
+  let passphrase = $state('');
+</script>
+
+{#if auth.current.state === "signedIn"}
+  {@render children?.()}
+  <textarea
+    readonly
+    value={passphraseAuth.passphrase}
+    rows={5}
+  />
+{:else}
+  <div>
+    <button onclick={() => auth.current.logIn()}>Log in</button>
+    <input type="text" bind:value={name} />
+    <button onclick={() => auth.current.signUp(name)}>Sign up</button>
+    <!-- [!code ++:7] -->
+    <textarea
+      bind:value={passphrase}
+      rows={5}
+    />
+    <button onClick={() => passphraseAuth.logIn(passphrase)}>
+      Sign In with Passphrase
+    </button>
+  </div>
+{/if}
+```
+</TabbedCodeGroupItem>
+</TabbedCodeGroup>
+
+<Alert variant="info" title="Tip" className="mt-4">
+Although we're presenting this as a 'recovery key' here, this key could also be used as the primary method of authenticating users into your app. You could even completely remove passkey support if you wanted.
+</Alert>
+
+**Congratulations! 🎉** You've added authentication to your app, allowing your users to log in from multiple devices, and you've added a recovery method, allowing users to make sure they never lose access to their account.
+
 ## Next steps
-- Learn more about how to [customise the Passkey Auth UI](/docs/authentication/passkey) using the `usePasskeyAuth` hook
 - Check out how to [use other types of authentication](/docs/authentication/overview#available-authentication-methods)
+- Learn more about [sharing and collaboration](/docs/groups/quickstart)
 - Find out how to [use server workers](/docs/server-side/quickstart) to build more complex applications

--- a/homepage/homepage/content/docs/getting-started/quickstart.mdx
+++ b/homepage/homepage/content/docs/getting-started/quickstart.mdx
@@ -79,7 +79,7 @@ Adding a `root` to the user's account gives us a container that can be used to k
 <FileName>src/lib/schema.ts</FileName>
 </ContentByFramework>
 
-<CodeGroup className="[&_span]:[tab-size:2]" preferWrap>
+<CodeGroup preferWrap>
 ```ts
 import { co, z } from "jazz-tools";
 
@@ -113,7 +113,7 @@ Wrap your app with a provider so components can use Jazz.
 
 <ContentByFramework framework="react">
   <FileName>app/components/JazzWrapper.tsx</FileName>
-<CodeGroup className="[&_span]:[tab-size:2]" preferWrap>
+<CodeGroup preferWrap>
 ```tsx
 "use client"; // tells Next.js that this component can't be server-side rendered. If you're not using Next.js, you can remove it.
 import { JazzReactProvider } from "jazz-tools/react";
@@ -146,7 +146,7 @@ export function JazzWrapper({ children }: {
 </ContentByFramework>
 
 <TabbedCodeGroup id="jazz-provider" savedPreferenceKey="framework">
-<TabbedCodeGroupItem label="React" value="react" className="[&_span]:[tab-size:2]" icon={<ReactLogo />} preferWrap>
+<TabbedCodeGroupItem label="React" value="react" icon={<ReactLogo />} preferWrap>
   ```tsx
   import { JazzWrapper } from "@/app/components/JazzWrapper";
 
@@ -167,7 +167,7 @@ export function JazzWrapper({ children }: {
   }
   ```
 </TabbedCodeGroupItem>
-<TabbedCodeGroupItem label="Svelte" value="svelte" className="[&_span]:[tab-size:2]" icon={<SvelteLogo />} preferWrap>
+<TabbedCodeGroupItem label="Svelte" value="svelte" icon={<SvelteLogo />} preferWrap>
 ```svelte
 <script lang="ts">
   import { JazzSvelteProvider } from "jazz-tools/svelte";
@@ -226,7 +226,7 @@ Let's create a simple form to add a new band to the festival. We'll use the `use
 
 <TabbedCodeGroup id="new-band-component" default="react" savedPreferenceKey="framework"
 >
-<TabbedCodeGroupItem label="React" value="react" icon={<ReactLogo />} className="[&_span]:[tab-size:2]" preferWrap>
+<TabbedCodeGroupItem label="React" value="react" icon={<ReactLogo />} preferWrap>
 ```tsx
 "use client";
 import { useAccount } from "jazz-tools/react";
@@ -257,7 +257,7 @@ export function NewBand() {
 }
 ```
 </TabbedCodeGroupItem>
-<TabbedCodeGroupItem label="Svelte" value="svelte" icon={<SvelteLogo />} className="[&_span]:[tab-size:2]" preferWrap>
+<TabbedCodeGroupItem label="Svelte" value="svelte" icon={<SvelteLogo />} preferWrap>
 ```svelte
 <script lang="ts">
 	import { AccountCoState } from "jazz-tools/svelte";
@@ -294,7 +294,7 @@ Now we've got a way to create data, so let's add a component to display it.
 </ContentByFramework>
 
 <TabbedCodeGroup id="my-festival-component" default="react" savedPreferenceKey="framework">
-<TabbedCodeGroupItem icon={<ReactLogo />} label="React" value="react" className="[&_span]:[tab-size:2]" preferWrap>
+<TabbedCodeGroupItem icon={<ReactLogo />} label="React" value="react" preferWrap>
 ```tsx
 "use client";
 import { useAccount } from "jazz-tools/react";
@@ -313,7 +313,7 @@ export function Festival() {
 }
 ```
 </TabbedCodeGroupItem>
-<TabbedCodeGroupItem icon={<SvelteLogo />} label="Svelte" value="svelte" className="[&_span]:[tab-size:2]" preferWrap>
+<TabbedCodeGroupItem icon={<SvelteLogo />} label="Svelte" value="svelte" preferWrap>
 ```svelte
 <script lang="ts">
   import { AccountCoState } from "jazz-tools/svelte";
@@ -343,7 +343,7 @@ You've built all your components, time to put them together.
 </ContentByFramework>
 
 <TabbedCodeGroup id="home-page" default="react" savedPreferenceKey="framework">
-<TabbedCodeGroupItem label="React" value="react" className="[&_span]:[tab-size:2]" icon={<ReactLogo />} preferWrap>
+<TabbedCodeGroupItem label="React" value="react" icon={<ReactLogo />} preferWrap>
 ```tsx
 import { Festival } from "@/app/components/Festival";
 import { NewBand } from "@/app/components/NewBand";
@@ -359,7 +359,7 @@ export default function Home() {
 }
 ```
 </TabbedCodeGroupItem>
-<TabbedCodeGroupItem icon={<SvelteLogo />} label="Svelte" value="svelte" className="[&_span]:[tab-size:2]" preferWrap>
+<TabbedCodeGroupItem icon={<SvelteLogo />} label="Svelte" value="svelte" preferWrap>
 ```svelte
 <script lang="ts">
   import NewBand from "$lib/components/NewBand.svelte";

--- a/homepage/homepage/content/docs/groups/quickstart.mdx
+++ b/homepage/homepage/content/docs/groups/quickstart.mdx
@@ -35,7 +35,7 @@ When we create a link, we can choose what level of permission to grant. Here, we
 </ContentByFramework>
 
 <TabbedCodeGroup default="react" savedPreferenceKey="framework" id="create-invite-link">
-<TabbedCodeGroupItem icon={<ReactLogo />} label="React" value="react" className="[&_span]:[tab-size:2]" preferWrap>
+<TabbedCodeGroupItem icon={<ReactLogo />} label="React" value="react" preferWrap>
 ```tsx
 "use client";
 // [!code --:1]
@@ -74,7 +74,7 @@ export function Festival() {
 }
 ```
 </TabbedCodeGroupItem>
-<TabbedCodeGroupItem icon={<SvelteLogo />} label="Svelte" value="svelte" className="[&_span]:[tab-size:2]" preferWrap>
+<TabbedCodeGroupItem icon={<SvelteLogo />} label="Svelte" value="svelte" preferWrap>
 ```svelte
 <script lang="ts">
   // [!code --:1]
@@ -123,7 +123,7 @@ Jazz provides a handler which we can add to our `Festival` component to accept t
 </ContentByFramework>
 
 <TabbedCodeGroup savedPreferenceKey="framework" id="accept-invite">
-<TabbedCodeGroupItem icon={<ReactLogo />} label="React" value="react" className="[&_span]:[tab-size:2]" preferWrap>
+<TabbedCodeGroupItem icon={<ReactLogo />} label="React" value="react" preferWrap>
 ```tsx
 "use client";
 // [!code --:1]
@@ -171,7 +171,7 @@ export function Festival() {
 }
 ```
 </TabbedCodeGroupItem>
-<TabbedCodeGroupItem icon={<SvelteLogo />} label="Svelte" value="svelte" className="[&_span]:[tab-size:2]" preferWrap>
+<TabbedCodeGroupItem icon={<SvelteLogo />} label="Svelte" value="svelte" preferWrap>
 ```svelte
 <script lang="ts">
   // [!code --:2]
@@ -300,7 +300,7 @@ We're going to continue updating our existing `Festival` component so that it ca
 </ContentByFramework>
 
 <TabbedCodeGroup default="react" savedPreferenceKey="framework">
-<TabbedCodeGroupItem icon={<ReactLogo />} label="React" value="react" className="[&_span]:[tab-size:2]" preferWrap>
+<TabbedCodeGroupItem icon={<ReactLogo />} label="React" value="react" preferWrap>
 ```tsx
 "use client";
 import {
@@ -365,7 +365,7 @@ export function Festival({id}: {id?: string}) {
 }
 ```
 </TabbedCodeGroupItem>
-<TabbedCodeGroupItem label="Svelte" value="svelte" icon={<SvelteLogo />} className="[&_span]:[tab-size:2]" preferWrap>
+<TabbedCodeGroupItem label="Svelte" value="svelte" icon={<SvelteLogo />} preferWrap>
 ```svelte
 <script lang="ts">
   // [!code --:1]
@@ -431,7 +431,7 @@ We'll also update our `NewBand` component so that it can take a prop for the fes
 
 <TabbedCodeGroup default="react" savedPreferenceKey="framework"
 >
-<TabbedCodeGroupItem label="React" value="react" icon={<ReactLogo />} className="[&_span]:[tab-size:2]" preferWrap>
+<TabbedCodeGroupItem label="React" value="react" icon={<ReactLogo />} preferWrap>
 ```tsx
 "use client";
 // [!code --:2]
@@ -479,7 +479,7 @@ export function NewBand({ id }: { id?: string }) {
 }
 ```
 </TabbedCodeGroupItem>
-<TabbedCodeGroupItem label="Svelte" value="svelte" icon={<SvelteLogo />} className="[&_span]:[tab-size:2]" preferWrap>
+<TabbedCodeGroupItem label="Svelte" value="svelte" icon={<SvelteLogo />} preferWrap>
 ```svelte
 <script lang="ts">
   // [!code --:2]
@@ -528,7 +528,7 @@ export function NewBand({ id }: { id?: string }) {
 </ContentByFramework>
 
 <TabbedCodeGroup savedPreferenceKey="framework" id="create-festival-page">
-<TabbedCodeGroupItem icon={<ReactLogo />} label="React" value="react" className="[&_span]:[tab-size:2]" preferWrap>
+<TabbedCodeGroupItem icon={<ReactLogo />} label="React" value="react" preferWrap>
 ```tsx
 "use client";
 import { use } from "react";
@@ -550,7 +550,7 @@ export default function FestivalPage(props: {
 }
 ```
 </TabbedCodeGroupItem>
-<TabbedCodeGroupItem icon={<SvelteLogo />} label="Svelte" value="svelte" className="[&_span]:[tab-size:2]" preferWrap>
+<TabbedCodeGroupItem icon={<SvelteLogo />} label="Svelte" value="svelte" preferWrap>
 ```svelte
 <script lang="ts">
 	import { page } from '$app/state';
@@ -578,4 +578,9 @@ Now we can test it out by inviting someone to collaborate on our festival.
 4. You should be able to invite someone to collaborate on the festival.
 5. Paste the invite link into the incognito window. You should be able to add bands to the festival!
 
-**Congratulations! 🎉** You've added authentication and public sharing to your app! You've also learned about how to migrate data from anonymous to authenticated accounts, and have begun to see how you can use groups and permissions to control access to your data.
+**Congratulations! 🎉** You've added public sharing to your app! You've learned what groups are, and how Jazz manages permissions, as well as how to invite others to collaborate on data in your app with you.
+
+## Next steps
+- Learn how to [authenticate users](/docs/authentication/quickstart) so you can access data wherever you are.
+- Discover how you can use [groups as members of other groups](/docs/groups/inheritance) to build advanced permissions structures.
+- Find out how to [use server workers](/docs/server-side/quickstart) to build more complex applications

--- a/homepage/homepage/content/docs/project-setup.mdx
+++ b/homepage/homepage/content/docs/project-setup.mdx
@@ -71,7 +71,7 @@ Wrap your application with a provider to connect to the Jazz network and define 
 </ContentByFramework>
 
 <TabbedCodeGroup savedPreferenceKey="framework" id="add-provider">
-<TabbedCodeGroupItem label="React" value="react" className="[&_span]:[tab-size:2]" icon={<ReactLogo />} preferWrap>
+<TabbedCodeGroupItem label="React" value="react" icon={<ReactLogo />} preferWrap>
 ```tsx
 import { JazzReactProvider } from "jazz-tools/react";
 import { MyAppAccount } from "./schema";
@@ -86,7 +86,7 @@ createRoot(document.getElementById("root")!).render(
 );
 ```
 </TabbedCodeGroupItem>
-<TabbedCodeGroupItem label="Svelte" value="svelte" className="[&_span]:[tab-size:2]" icon={<SvelteLogo />} preferWrap>
+<TabbedCodeGroupItem label="Svelte" value="svelte" icon={<SvelteLogo />} preferWrap>
 ```svelte
 <script lang="ts">
   import { JazzSvelteProvider } from "jazz-tools/svelte";
@@ -134,7 +134,7 @@ In order to tell Jazz to allow children to be loaded even in an account-less con
 </ContentByFramework>
 
 <TabbedCodeGroup savedPreferenceKey="framework" id="add-ssr">
-<TabbedCodeGroupItem label="React" value="react" className="[&_span]:[tab-size:2]" icon={<ReactLogo />} preferWrap>
+<TabbedCodeGroupItem label="React" value="react" icon={<ReactLogo />} preferWrap>
 ```tsx
 import { JazzReactProvider } from "jazz-tools/react";
 import { MyAppAccount } from "./schema";
@@ -152,7 +152,7 @@ export function JazzWrapper({ children }: { children: React.ReactNode }) {
 }
 ```
 </TabbedCodeGroupItem>
-<TabbedCodeGroupItem label="Svelte" value="svelte" className="[&_span]:[tab-size:2]" icon={<SvelteLogo />} preferWrap>
+<TabbedCodeGroupItem label="Svelte" value="svelte" icon={<SvelteLogo />} preferWrap>
 ```svelte
 <script lang="ts">
   import { JazzSvelteProvider } from "jazz-tools/svelte";
@@ -188,7 +188,7 @@ In order to actually load and render data, you need to tell Jazz how to do this 
 </ContentByFramework>
 
 <TabbedCodeGroup savedPreferenceKey="framework" id="ssr-page">
-<TabbedCodeGroupItem label="React" value="react" className="[&_span]:[tab-size:2]" icon={<ReactLogo />} preferWrap>
+<TabbedCodeGroupItem label="React" value="react" icon={<ReactLogo />} preferWrap>
 ```tsx
 import { createSSRJazzAgent } from "jazz-tools/ssr";
 import { TodoItem } from "./schema";
@@ -220,7 +220,7 @@ export default async function ServerSidePage(props: {
 }
 ```
 </TabbedCodeGroupItem>
-<TabbedCodeGroupItem label="Svelte" value="svelte" className="[&_span]:[tab-size:2]" icon={<SvelteLogo />} preferWrap>
+<TabbedCodeGroupItem label="Svelte" value="svelte" icon={<SvelteLogo />} preferWrap>
 ```svelte
 <script lang="ts">
   import { page } from '$app/state';

--- a/homepage/homepage/content/docs/project-setup/ssr.mdx
+++ b/homepage/homepage/content/docs/project-setup/ssr.mdx
@@ -50,7 +50,7 @@ Normally, Jazz expects a logged in user (or an anonymous user) to be accessing d
 </ContentByFramework>
 
 <TabbedCodeGroup savedPreferenceKey="framework" id="enable-ssr">
-<TabbedCodeGroupItem label="React" value="react" className="[&_span]:[tab-size:2]" icon={<ReactLogo />} preferWrap>
+<TabbedCodeGroupItem label="React" value="react" icon={<ReactLogo />} preferWrap>
 ```tsx
 "use client";
 import { JazzReactProvider } from "jazz-tools/react";
@@ -72,7 +72,7 @@ export function JazzWrapper({ children }: { children: React.ReactNode }) {
 }
 ```
 </TabbedCodeGroupItem>
-<TabbedCodeGroupItem label="Svelte" value="svelte" className="[&_span]:[tab-size:2]" icon={<SvelteLogo />} preferWrap>
+<TabbedCodeGroupItem label="Svelte" value="svelte" icon={<SvelteLogo />} preferWrap>
 ```svelte
 <script lang="ts">
   import { JazzSvelteProvider } from "jazz-tools/svelte";
@@ -99,7 +99,7 @@ By default, when you create data in Jazz, it's private and only accessible to th
 However, the SSR agent is credential-less and unauthenticated, so it can only read data which has been made public. Although Jazz allows you to define [complex, role-based permissions](docs/svelte/groups/intro), here, we'll focus on making the CoValues public.
 
 <FileName>app/schema.ts</FileName>
-<CodeGroup className="[&_span]:[tab-size:2]" preferWrap>
+<CodeGroup preferWrap>
 ```ts
 import { co, z } from "jazz-tools";
 
@@ -147,7 +147,7 @@ Now let's set up a page which will be read by the agent we created earlier, and 
 </ContentByFramework>
 
 <TabbedCodeGroup savedPreferenceKey="framework" id="add-wrapper">
-<TabbedCodeGroupItem label="React" value="react" className="[&_span]:[tab-size:2]" icon={<ReactLogo />} preferWrap>
+<TabbedCodeGroupItem label="React" value="react" icon={<ReactLogo />} preferWrap>
 ```tsx
 import { jazzSSR } from "@/app/jazzSSR";
 import { Festival } from "@/app/schema";
@@ -180,7 +180,7 @@ export default async function ServerSidePage(props: {
 }
 ```
 </TabbedCodeGroupItem>
-<TabbedCodeGroupItem label="Svelte" value="svelte" className="[&_span]:[tab-size:2]" icon={<SvelteLogo />} preferWrap>
+<TabbedCodeGroupItem label="Svelte" value="svelte" icon={<SvelteLogo />} preferWrap>
 ```svelte
 <script lang="ts">
   import { jazzSSR } from "$lib/jazzSSR";
@@ -233,7 +233,7 @@ The last step is to link to your server-rendered page from your `Festival` compo
 </ContentByFramework>
 
 <TabbedCodeGroup savedPreferenceKey="framework" id="link-to-page">
-<TabbedCodeGroupItem label="React" value="react" className="[&_span]:[tab-size:2]" icon={<ReactLogo />} preferWrap>
+<TabbedCodeGroupItem label="React" value="react" icon={<ReactLogo />} preferWrap>
 ```tsx
 "use client";
 import { useAccount } from "jazz-tools/react";
@@ -262,7 +262,7 @@ export function Festival() {
 }
 ```
 </TabbedCodeGroupItem>
-<TabbedCodeGroupItem label="Svelte" value="svelte" className="[&_span]:[tab-size:2]" icon={<SvelteLogo />} preferWrap>
+<TabbedCodeGroupItem label="Svelte" value="svelte" icon={<SvelteLogo />} preferWrap>
 ```svelte
 <script lang="ts">
   import { AccountCoState } from "jazz-tools/svelte";

--- a/homepage/homepage/content/docs/server-side/quickstart.mdx
+++ b/homepage/homepage/content/docs/server-side/quickstart.mdx
@@ -139,7 +139,7 @@ You can copy the output of this command and paste it directly into your `.env` f
 
 <FileName>.env</FileName>
 <TabbedCodeGroup id="worker-env-vars" default="react" savedPreferenceKey="framework">
-<TabbedCodeGroupItem label="Next.js" icon={<ReactLogo />} value="react" className="[&_span]:[tab-size:2]" preferWrap>
+<TabbedCodeGroupItem label="Next.js" icon={<ReactLogo />} value="react" preferWrap>
 ```bash
 NEXT_PUBLIC_JAZZ_API_KEY=you@example.com # or your API key
 #[!code ++:2]
@@ -147,7 +147,7 @@ NEXT_PUBLIC_JAZZ_WORKER_ACCOUNT=co_z...
 JAZZ_WORKER_SECRET=sealerSecret_z.../signerSecret_z...
 ```
 </TabbedCodeGroupItem>
-<TabbedCodeGroupItem label="SvelteKit" icon={<SvelteLogo />} value="svelte" className="[&_span]:[tab-size:2]" preferWrap>
+<TabbedCodeGroupItem label="SvelteKit" icon={<SvelteLogo />} value="svelte" preferWrap>
 ```bash
 PUBLIC_JAZZ_API_KEY=you@example.com # or your API key
 #[!code ++:2]
@@ -172,7 +172,7 @@ We also need to tell Jazz which keys should be treated as loaded in the request 
 <FileName>src/lib/announceBandSchema.ts</FileName>
 </ContentByFramework>
 <TabbedCodeGroup id="request-schema" default="react" savedPreferenceKey="framework">
-<TabbedCodeGroupItem label="Next.js" icon={<ReactLogo />} value="react" className="[&_span]:[tab-size:2]" preferWrap>
+<TabbedCodeGroupItem label="Next.js" icon={<ReactLogo />} value="react" preferWrap>
 ```ts
 import { experimental_defineRequest } from "jazz-tools";
 import { Band, BandList } from "./schema";
@@ -189,7 +189,7 @@ export const announceBand = experimental_defineRequest({
 });
 ```
 </TabbedCodeGroupItem>
-<TabbedCodeGroupItem label="SvelteKit" icon={<SvelteLogo />} value="svelte" className="[&_span]:[tab-size:2]" preferWrap>
+<TabbedCodeGroupItem label="SvelteKit" icon={<SvelteLogo />} value="svelte" preferWrap>
 ```ts
 import { experimental_defineRequest } from "jazz-tools";
 import { Band, BandList } from "./schema";
@@ -222,7 +222,7 @@ We'll also use a `resolve` query here to make sure that the `bandList` is loaded
 <FileName>src/routes/api/announce-band/+server.ts</FileName>
 </ContentByFramework>
 <TabbedCodeGroup id="worker-config" default="react" savedPreferenceKey="framework">
-<TabbedCodeGroupItem label="Next.js" icon={<ReactLogo />} value="react" className="[&_span]:[tab-size:2]" preferWrap>
+<TabbedCodeGroupItem label="Next.js" icon={<ReactLogo />} value="react" preferWrap>
 ```ts
 import { startWorker } from "jazz-tools/worker";
 import { announceBand } from "@/app/announceBandSchema";
@@ -255,7 +255,7 @@ export async function POST(request: Request) {
 }
 ```
 </TabbedCodeGroupItem>
-<TabbedCodeGroupItem label="SvelteKit" icon={<SvelteLogo />} value="svelte" className="[&_span]:[tab-size:2]" preferWrap>
+<TabbedCodeGroupItem label="SvelteKit" icon={<SvelteLogo />} value="svelte" preferWrap>
 ```ts
 import { startWorker } from "jazz-tools/worker";
 import { announceBand } from "$lib/announceBandSchema";
@@ -338,7 +338,7 @@ We're going to wrap our SvelteKit app in a `JazzSvelteProvider` so that we can u
 </ContentByFramework>
 
 <TabbedCodeGroup id="add-provider" savedPreferenceKey="framework">
-<TabbedCodeGroupItem label="React" value="react" className="[&_span]:[tab-size:2]" icon={<ReactLogo />} preferWrap>
+<TabbedCodeGroupItem label="React" value="react" icon={<ReactLogo />} preferWrap>
   ```tsx
   import { JazzReactProvider } from "jazz-tools/react";
 
@@ -363,7 +363,7 @@ We're going to wrap our SvelteKit app in a `JazzSvelteProvider` so that we can u
   }
   ```
 </TabbedCodeGroupItem>
-<TabbedCodeGroupItem label="Svelte" value="svelte" className="[&_span]:[tab-size:2]" icon={<SvelteLogo />} preferWrap>
+<TabbedCodeGroupItem label="Svelte" value="svelte" icon={<SvelteLogo />} preferWrap>
 ```svelte
 <script lang="ts">
   import { JazzSvelteProvider } from "jazz-tools/svelte";
@@ -391,7 +391,7 @@ We're going to send a request to our server worker to announce a new band. Our w
 </ContentByFramework>
 
 <TabbedCodeGroup id="page-component" default="react" savedPreferenceKey="framework">
-<TabbedCodeGroupItem label="React" value="react" className="[&_span]:[tab-size:2]" icon={<ReactLogo />} preferWrap>
+<TabbedCodeGroupItem label="React" value="react" icon={<ReactLogo />} preferWrap>
 ```tsx
 "use client";
 import type { co } from "jazz-tools";
@@ -432,7 +432,7 @@ export default function Home() {
 }
 ```
 </TabbedCodeGroupItem>
-<TabbedCodeGroupItem label="Svelte" value="svelte" className="[&_span]:[tab-size:2]" icon={<SvelteLogo />} preferWrap>
+<TabbedCodeGroupItem label="Svelte" value="svelte" icon={<SvelteLogo />} preferWrap>
 ```svelte
 <script lang="ts">
   import type { co } from "jazz-tools";

--- a/homepage/homepage/content/docs/using-covalues/subscription-and-loading.mdx
+++ b/homepage/homepage/content/docs/using-covalues/subscription-and-loading.mdx
@@ -31,7 +31,7 @@ The `CoState` class allows you to reactively subscribe to CoValues in your Svelt
 </ContentByFramework>
 
 <TabbedCodeGroup id="usecostate" default="react" savedPreferenceKey="framework">
-<TabbedCodeGroupItem label="React" value="react" className="[&_span]:[tab-size:2]" icon={<ReactLogo />} preferWrap>
+<TabbedCodeGroupItem label="React" value="react" icon={<ReactLogo />} preferWrap>
 ```tsx
 import { useCoState } from "jazz-tools/react";
 
@@ -60,7 +60,7 @@ function ProjectView({ projectId }: { projectId: string }) {
 }
 ```
 </TabbedCodeGroupItem>
-<TabbedCodeGroupItem label="Svelte" value="svelte" className="[&_span]:[tab-size:2]" icon={<SvelteLogo />} preferWrap>
+<TabbedCodeGroupItem label="Svelte" value="svelte" icon={<SvelteLogo />} preferWrap>
 ```svelte
 <script lang="ts">
   import { CoState } from "jazz-tools/svelte";
@@ -102,7 +102,7 @@ function ProjectView({ projectId }: { projectId: string }) {
 </ContentByFramework>
 
 <TabbedCodeGroup id="usecostate" default="react" savedPreferenceKey="framework">
-<TabbedCodeGroupItem label="React" value="react" className="[&_span]:[tab-size:2]" icon={<ReactLogo />} preferWrap>
+<TabbedCodeGroupItem label="React" value="react" icon={<ReactLogo />} preferWrap>
 ```tsx
 import { useAccount } from "jazz-tools/react";
 
@@ -123,7 +123,7 @@ function ProjectList() {
 }
 ```
 </TabbedCodeGroupItem>
-<TabbedCodeGroupItem label="Svelte" value="svelte" className="[&_span]:[tab-size:2]" icon={<SvelteLogo />} preferWrap>
+<TabbedCodeGroupItem label="Svelte" value="svelte" icon={<SvelteLogo />} preferWrap>
 ```svelte
 <script lang="ts">
   import { AccountCoState } from "jazz-tools/svelte";
@@ -262,7 +262,7 @@ Expecting data to be there which is not explicitly included in your `resolve` qu
 The syntax for resolve queries is shared throughout Jazz. As well as using them in `load` and `subscribe` method calls, you can pass a resolve query to a front-end hook.
 
 <TabbedCodeGroup id="resolve" default="react" savedPreferenceKey="framework">
-<TabbedCodeGroupItem label="React" value="react" className="[&_span]:[tab-size:2]" icon={<ReactLogo />} preferWrap>
+<TabbedCodeGroupItem label="React" value="react" icon={<ReactLogo />} preferWrap>
 ```tsx
 const projectWithTasksShallow = useCoState(Project, projectId, {
   resolve: {
@@ -271,7 +271,7 @@ const projectWithTasksShallow = useCoState(Project, projectId, {
 });
 ```
 </TabbedCodeGroupItem>
-<TabbedCodeGroupItem label="Svelte" value="svelte" className="[&_span]:[tab-size:2]" icon={<SvelteLogo />} preferWrap>
+<TabbedCodeGroupItem label="Svelte" value="svelte" icon={<SvelteLogo />} preferWrap>
 ```svelte
 <script lang="ts">
   import { CoState } from "jazz-tools/svelte";
@@ -434,7 +434,7 @@ You can tell your application how deeply your data is loaded by using the `co.lo
 The `co.loaded` type is especially useful when passing data between components, because it allows TypeScript to check at compile time whether data your application depends is properly loaded. The second argument lets you pass a `resolve` query to specify how deeply your data is loaded.
 
 <TabbedCodeGroup id="coloaded" default="react" savedPreferenceKey="framework">
-<TabbedCodeGroupItem label="React" value="react" className="[&_span]:[tab-size:2]" icon={<ReactLogo />} preferWrap>
+<TabbedCodeGroupItem label="React" value="react" icon={<ReactLogo />} preferWrap>
 ```tsx
 type ProjectWithTasks = co.loaded<typeof Project, 
   {
@@ -457,7 +457,7 @@ function TaskList({ project }: { project: ProjectWithTasks }) {
 }
 ```
 </TabbedCodeGroupItem>
-<TabbedCodeGroupItem label="Svelte" value="svelte" className="[&_span]:[tab-size:2]" icon={<SvelteLogo />} preferWrap>
+<TabbedCodeGroupItem label="Svelte" value="svelte" icon={<SvelteLogo />} preferWrap>
 ```svelte
 <script lang="ts">
   import { co } from "jazz-tools";


### PR DESCRIPTION
# Description
Extends the existing quickstart auth to demonstrate passkey auth (showing how to use multiple auth methods)

## Manual testing instructions
Review the docs/authentication/quickstart guide

## Tests

- [ ] Tests have been added and/or updated
- [x] Tests have not been updated, because: Docs
- [ ] I need help with writing tests


## Checklist
- [ ] I've updated the part of the docs that are affected the PR changes
- [ ] I've generated a changeset, if a version bump is required
- [ ] I've updated the jsDoc comments to the public APIs I've modified, or added them when missing