### PR TITLE
fix: create-jazz-app not working with RN after Zod v4 upgrade

### DIFF
--- a/.changeset/dirty-seals-provide.md
+++ b/.changeset/dirty-seals-provide.md
@@ -1,0 +1,5 @@
+---
+"create-jazz-app": patch
+---
+
+fix: create-jazz-app not working with RN after Zod v4 upgrade

--- a/homepage/homepage/content/docs/project-setup/react-native-expo.mdx
+++ b/homepage/homepage/content/docs/project-setup/react-native-expo.mdx
@@ -81,7 +81,7 @@ const { withNativeWind } = require("nativewind/metro");
 
 const config = getDefaultConfig(__dirname);
 
-config.resolver.sourceExts = ["mjs", "js", "json", "ts", "tsx"];
+config.resolver.sourceExts = ["mjs", "js", "json", "ts", "tsx", "cjs"];
 config.resolver.requireCycleIgnorePatterns = [/(^|\/|\\)node_modules($|\/|\\)/];
 
 module.exports = withNativeWind(config, { input: "./src/global.css" });
@@ -114,7 +114,7 @@ config.resolver.nodeModulesPaths = [
   path.resolve(projectRoot, "node_modules"),
   path.resolve(workspaceRoot, "node_modules"),
 ];
-config.resolver.sourceExts = ["mjs", "js", "json", "ts", "tsx"];
+config.resolver.sourceExts = ["mjs", "js", "json", "ts", "tsx", "cjs"];
 config.resolver.requireCycleIgnorePatterns = [/(^|\/|\\)node_modules($|\/|\\)/];
 config.cacheStores = [
   new FileStore({

--- a/homepage/homepage/content/docs/project-setup/react-native.mdx
+++ b/homepage/homepage/content/docs/project-setup/react-native.mdx
@@ -67,7 +67,7 @@ const { getDefaultConfig, mergeConfig } = require('@react-native/metro-config');
 
 const config = {
   resolver: {
-    sourceExts: ["mjs", "js", "json", "ts", "tsx"],
+    sourceExts: ["mjs", "js", "json", "ts", "tsx", "cjs"],
     requireCycleIgnorePatterns: [/(^|\/|\\)node_modules($|\/|\\)/]
   }
 };
@@ -111,7 +111,7 @@ module.exports = makeMetroConfig({
     resolveRequest: MetroSymlinksResolver(),
     extraNodeModules,
     nodeModulesPaths,
-    sourceExts: ["mjs", "js", "json", "ts", "tsx"],
+    sourceExts: ["mjs", "js", "json", "ts", "tsx", "cjs"],
   },
   watchFolders,
 });

--- a/packages/create-jazz-app/src/index.ts
+++ b/packages/create-jazz-app/src/index.ts
@@ -307,7 +307,7 @@ async function scaffoldProject({
         const metroConfig = `const { getDefaultConfig } = require("expo/metro-config");
 const config = getDefaultConfig(__dirname);
 
-config.resolver.sourceExts = ["mjs", "js", "json", "ts", "tsx"];
+config.resolver.sourceExts = ["mjs", "js", "json", "ts", "tsx", "cjs"];
 config.resolver.requireCycleIgnorePatterns = [/(^|\\/|\\\\)node_modules($|\\/|\\\\)/];
 
 module.exports = config;`;


### PR DESCRIPTION
# Description
After upgrading Zod from `3.25.76` to `4.1.11` in https://github.com/garden-co/jazz/pull/2983, React Native projects generated with `create-jazz-app` were not working due to an error in import resolution:

> Metro has encountered an error: While trying to resolve module zod/v4 from file /.../node_modules/jazz-tools/dist/index.js, the package /.../node_modules/zod/v4/package.json was successfully found. However, this package itself specifies a main module field that could not be resolved (/.../node_modules/zod/v4/index.cjs.

The issue was caused by [Zod 4.1.6](https://github.com/colinhacks/zod/pull/5222/files#diff-af75921c98100c36b0ba10db16be2bf8abd330024b5e63a9c219ffe4d9be5cceR130)  changing its `package.json` structure from [a single package.json file](https://github.com/colinhacks/zod/blob/463f03eb8183dcdcdf735b180f2bf40883e66220/packages/zod/package.json#L46) to one package.json stub file per Zod version.

Now each version has this `package.json` shape:
```javascript
{ 
  "type": "module",
  "main": "./index.cjs",
  "module": "./index.js",
  "types": "./index.d.cts" 
}
```

Since Metro tries to resolve the `main` entry point (see [resolverMainFields](https://metrobundler.dev/docs/configuration#resolvermainfields)), it was finding `/v4/index.d.cts` but couldn't include it in the bundle.

The solution was to update Metro's [sourceExts](https://metrobundler.dev/docs/configuration#sourceexts) to allow including .cjs files in the bundle.

## Manual testing instructions

Will run the pre-release starter and confirm the generated app is working before merging.

## Checklist

- [ ] I've updated the part of the docs that are affected the PR changes
- [x] I've generated a changeset, if a version bump is required
- [ ] I've updated the jsDoc comments to the public APIs I've modified, or added them when missing