### PR TITLE
Fix macOS trackpad scrollbar bug

### DIFF
--- a/homepage/homepage/components/SideNav.tsx
+++ b/homepage/homepage/components/SideNav.tsx
@@ -1,8 +1,9 @@
+"use client";
 import { SideNavItem } from "@/components/SideNavItem";
 import { DoneStatus } from "@/content/docs/docNavigationItemsTypes";
 import { clsx } from "clsx";
 import Link from "next/link";
-import React from "react";
+import { useEffect, useRef, useState } from "react";
 import { SideNavSection } from "./SideNavSection";
 
 export interface SideNavItem {
@@ -15,6 +16,7 @@ export interface SideNavItem {
   excludeFromNavigation?: boolean;
   startClosed?: boolean;
 }
+
 export function SideNav({
   children,
   className,
@@ -23,7 +25,9 @@ export function SideNav({
   children?: React.ReactNode;
 }) {
   return (
-    <div className={clsx(className, "text-sm h-full flex flex-col gap-4 px-2")}>
+    <div
+      className={clsx(className, "text-sm h-full flex flex-col gap-4 px-2 overflow-y-auto")}
+    >
       {children}
     </div>
   );
@@ -70,10 +74,29 @@ export function SideNavSectionList({ items }: { items?: SideNavItem[] }) {
 }
 
 export function SideNavBody({ children }: { children: React.ReactNode }) {
-  return (
-    <div className="flex-1 relative overflow-y-auto px-2 -mx-2">
-      {children}
+  const ref = useRef<HTMLDivElement>(null);
+  const [extraPadding, setExtraPadding] = useState(false);
 
+  useEffect(() => {
+    const div = ref.current;
+    if (!div) return;
+
+    const updatePadding = () => {
+      const scrollbarWidth = div.offsetWidth - div.clientWidth;
+      // If we're dealing with overlay scroll bars, then we'll set extra padding
+      setExtraPadding(scrollbarWidth === 0)
+    };
+
+    updatePadding();
+    window.addEventListener("resize", updatePadding);
+    return () => window.removeEventListener("resize", updatePadding);
+  }, []);
+
+  return (
+
+    <div ref={ref}
+      className={clsx("flex-1 relative overflow-y-auto -mx-2", extraPadding ? 'px-2 pr-4' : 'px-2')}>
+      {children}
       <div
         aria-hidden
         className={clsx(


### PR DESCRIPTION
# Description
macOS has this weird behaviour where you cannot control overlay scrollbars, they always overlay the content.

This PR adds checks to see if the nav menu's scrollbar is 0 (indicating we have overlay scrollbars), and if so, adds additional right padding so macOS doesn't layer scrollbars over content.

## Manual testing instructions
Unplug your mouse, use a browser with overlay scrollbars (Firefox for example), and check if the nav content is obscured. (I actually couldn't quite get it to overlay the content exactly, but this is not comfortable padding with the summary's marker.

Before:
<img width="376" height="556" alt="Screenshot 2025-10-08 at 17 21 14" src="https://github.com/user-attachments/assets/251e98f8-bd11-4e69-bcaa-867ecb25e836" />

After:
<img width="376" height="556" alt="Screenshot 2025-10-08 at 17 22 40" src="https://github.com/user-attachments/assets/a8c95d50-82d5-44b3-865f-f4139401969e" />

## Tests

- [ ] Tests have been added and/or updated
- [ ] Tests have not been updated, because: N/A
- [ ] I need help with writing tests


## Checklist

- [ ] I've updated the part of the docs that are affected the PR changes
- [ ] I've generated a changeset, if a version bump is required
- [ ] I've updated the jsDoc comments to the public APIs I've modified, or added them when missing