### PR TITLE
fix(homepage): use type import for SyncConfig in Svelte example

### DIFF
--- a/homepage/homepage/content/docs/code-snippets/quickstart/+layout.svelte
+++ b/homepage/homepage/content/docs/code-snippets/quickstart/+layout.svelte
@@ -2,8 +2,8 @@
   import { JazzSvelteProvider } from "jazz-tools/svelte";
   import { JazzFestAccount } from "$lib/schema";
   // @ts-expect-error No real env vars
-	import { PUBLIC_JAZZ_API_KEY } from "$env/static/public";
-  import { SyncConfig } from "jazz-tools";
+  import { PUBLIC_JAZZ_API_KEY } from "$env/static/public";
+  import type { SyncConfig } from "jazz-tools";
 
   const apiKey = PUBLIC_JAZZ_API_KEY;
   let { children } = $props();


### PR DESCRIPTION
## Summary
- Uses `import type` for `SyncConfig` in the Svelte quickstart example, since it's only used as a type
- Fixes inconsistent indentation (tab to spaces)