### PR TITLE
feat(create-jazz-app): seed AGENTS.md and .skills in scaffolded projects

### DIFF
--- a/.changeset/create-jazz-app-agents-md.md
+++ b/.changeset/create-jazz-app-agents-md.md
@@ -1,0 +1,5 @@
+---
+"create-jazz-app": patch
+---
+
+Scaffold AGENTS.md and .skills/ directory in new projects, providing an AI agent-ready docs index and Jazz skill files out of the box.

--- a/biome.json
+++ b/biome.json
@@ -21,6 +21,7 @@
       "!**/examples/server-worker-inbox/src/routeTree.gen.ts",
       "!**/homepage/homepage/**",
       "!**/.cursor/skills/**",
+      "!**/.skills/**",
       "!**/package.json",
       "!**/*svelte*/**"
     ]

--- a/homepage/homepage/package.json
+++ b/homepage/homepage/package.json
@@ -11,7 +11,7 @@
     "check": "concurrently --kill-others-on-fail 'pnpm validate:docs-links' 'pnpm generate:snippet-paths' && concurrently --kill-others-on-fail 'tsc --noEmit -p tsconfig.snippets.json' 'svelte-check --tsconfig tsconfig.snippets.json' && pnpm run generate:llm-docs",
     "format-and-lint": "biome check .",
     "format-and-lint:fix": "biome check . --write",
-    "generate:llm-docs": "node generate-docs/llms-full.mjs && node scripts/add-docs-links-to-agents.mjs",
+    "generate:llm-docs": "node generate-docs/llms-full.mjs && node scripts/add-docs-links-to-agents.mjs && node scripts/generate-user-agents-md.mjs",
     "generate:snippet-paths": "node scripts/generate-snippet-paths.mjs",
     "validate:docs-links": "node scripts/validate-docs-links.mjs",
     "test": "pnpm test:unit",

--- a/homepage/homepage/public/AGENTS.md
+++ b/homepage/homepage/public/AGENTS.md
@@ -1,0 +1,67 @@
+# AGENTS.md
+
+Guidelines for AI agents working on this Jazz app.
+
+## Jazz Overview
+
+Jazz is a framework for building local-first apps with real-time sync, offline support, and end-to-end encryption. Data is defined as collaborative values (CoValues) that sync automatically between clients.
+
+### Key Concepts
+
+- **CoValue**: Core collaborative data type. Variants: `CoMap` (key-value), `CoList` (ordered list), `CoFeed` (per-user streams), `CoPlainText` (collaborative text), `FileStream` (files/images)
+- **Group**: Permission entity that controls read/write access to CoValues
+- **Account**: User identity with profile and root data
+- **Schema**: Define your data model using `co.map()`, `co.list()`, etc. with Zod-style field types
+
+### Schema Conventions
+
+- Define schemas in a dedicated `schema.ts` file
+- Use `co.map({...})` for structured data, `co.list(ItemType)` for ordered collections
+- Reference other CoValues by type (e.g., `tasks: co.list(Task)`) for automatic deep loading
+- Use `z.string()`, `z.number()`, `z.boolean()`, `z.literal()`, `z.enum()` for primitive fields
+
+### Import Patterns
+
+- Import schema helpers from `jazz-tools`: `import { co, z, Group } from "jazz-tools"`
+- Import framework bindings from your framework package (e.g., `jazz-react`, `jazz-svelte`)
+- Use `useCoState` (React) or equivalent to subscribe to CoValue changes
+
+## Skills
+
+You have the following skills available:
+
+- [Jazz Schema Design](.skills/jazz-schema-design/SKILL.md) — designing and evolving Jazz schemas
+- [Jazz Performance](.skills/jazz-performance/SKILL.md) — optimising Jazz app performance
+- [Jazz Permissions & Security](.skills/jazz-permissions-security/SKILL.md) — groups, roles, and access control
+- [Jazz Testing](.skills/jazz-testing/SKILL.md) — testing Jazz apps
+- [Jazz UI Development](.skills/jazz-ui-development/SKILL.md) — building UIs with Jazz framework bindings
+
+## Full Documentation
+
+For comprehensive docs, see [.cursor/docs/llms-full.md](.cursor/docs/llms-full.md).
+
+## Docs Index
+
+The index below provides a compact map of all available documentation pages.
+
+<!--DOCS_INDEX_START-->
+
+[Jazz Docs Index]|root:https://jazz.tools/docs
+|LEGEND: b=base (no prefix), r=react, rn=react-native, rne=react-native-expo, s=svelte, v=vanilla, ss=server-side
+|RULES: All files are .md. Resolve `[fw]/[dir]/[file].md`. If variant is 'b', path is `[dir]/[file].md`.
+
+|.:{api-reference:b|r|rn|rne|s|v{#Defining Schemas#Creating CoValues#Loading and Reading CoValues},index:b|r|rn|rne|s|v{#Quickstart#How it works#A Minimal Jazz App},project-setup:b|r|rn|rne|s|v{#Install dependencies#Write your schema#Give your app context},quickstart:b|r|rn|rne|s|v{#Create your App#Install Jazz#Get your free API key},troubleshooting:b|r|rn|rne|s|v{#Node.js version requirements#npx jazz-run: command not found},react-native-expo:b{#Quickstart#How it works#A Minimal Jazz App},react-native:b{#Quickstart#How it works#A Minimal Jazz App},react:b{#Quickstart#How it works#A Minimal Jazz App},svelte:b{#Quickstart#How it works#A Minimal Jazz App},vanilla:b{#Quickstart#How it works#A Minimal Jazz App}}
+|core-concepts:{deleting:b|r|rn|rne|s|v{#Basic Usage#Deleting Nested CoValues#Handling Inaccessible Data},subscription-and-loading:b|r|rn|rne|s|v{#Subscription Hooks#Deep Loading#Loading Errors},sync-and-storage:b|r|rn|rne|s|v{#Using Jazz Cloud#Self-hosting your sync server}}
+|core-concepts/covalues:{cofeeds:b|r|rn|rne|s|v{#Creating CoFeeds#Reading from CoFeeds#Writing to CoFeeds},colists:b|r|rn|rne|s|v{#Creating CoLists#Reading from CoLists#Updating CoLists},comaps:b|r|rn|rne|s|v{#Creating CoMaps#Reading from CoMaps#Updating CoMaps},cotexts:b|r|rn|rne|s|v{#`co.plainText()` vs `z.string()`#Creating CoText Values#Reading Text},covectors:b|r|rn|rne|s|v{#Creating CoVectors#Semantic Search#Embedding Models},filestreams:b|r|rn|rne|s|v{#Creating FileStreams#Reading from FileStreams#Writing to FileStreams},imagedef:b|r|rn|rne|s|v{#Installation \[!framework=react-native\]#Installation \[!framework=react-native-exp\]#Creating Images#Displaying Images#Custom image manipulation implementations},overview:b|r|rn|rne|s|v{#Start your app with a schema#Types of CoValues#CoValue field/item types}}
+|core-concepts/schemas:{accounts-and-migrations:b|r|rn|rne|s|v{#CoValues as a graph of data rooted in accounts#Resolving CoValues starting at `profile` or `root`#Populating and evolving `root` and `profile` schemas with migrations},codecs:b|r|rn|rne|s|v{#Using Zod codecs},connecting-covalues:b|r|rn|rne|s|v,schemaunions:b|r|rn|rne|s|v{#Creating schema unions#Narrowing unions#Loading schema unions}}
+|key-features:{history:b|r|rn|rne|s|v{#The $jazz.getEdits() method#Edit Structure#Accessing History},version-control:b|r|rn|rne|s|v{#Working with branches#Conflict Resolution#Private branches}}
+|key-features/authentication:{authentication-states:b|r|rn|rne|s|v{#Anonymous Authentication#Authenticated Account#Guest Mode},better-auth-database-adapter:b|r|rn|rne|s|v{#Getting started#How it works#How to access the database},better-auth:b|r|rn|rne|s|v{#How it works#Authentication methods and plugins#Getting started},clerk:b|r|rn|rne|s|v{#How it works#Key benefits#Implementation},overview:b|r|rn|rne|s|v{#Authentication Flow#Available Authentication Methods},passkey:b|r|rn|rne|s|v{#How it works#Key benefits#Implementation},passphrase:b|r|rn|rne|s|v{#How it works#Key benefits#Implementation},quickstart:b|r|rn|rne|s|v{#Add passkey authentication#Give it a go!#Add a recovery method}}
+|permissions-and-sharing:{cascading-permissions:b|r|rn|rne|s|v{#Basic usage#Levels of inheritance#Roles},overview:b|r|rn|rne|s|v{#Role Matrix#Creating a Group#Adding group members by ID},quickstart:b|r|rn|rne|s|v{#Understanding Groups#Create an invite link#Accept an invite},sharing:b|r|rn|rne|s|v{#Public sharing#Invites}}
+|project-setup:{providers:b|r|rn|rne|s|v{#Setting up the Provider#Provider Options#Authentication}}
+|reference:{data-modelling:b|r|rn|rne|s|v{#Jazz as a Collaborative Graph#Permissions are part of the data model#Choosing your building blocks},encryption:b|r|rn|rne|s|v{#How encryption works#Key rotation and security#Streaming encryption},faq:b|r|rn|rne|s|v{#How established is Jazz?#Will Jazz be around long-term?#How secure is my data?},performance:b|r|rn|rne|s|v{#Use the best crypto implementation for your platform#Initialize WASM asynchronously#Minimise group extensions},testing:b|r|rn|rne|s|v{#Core test helpers#Managing active Accounts#Managing Context},workflow-world:b|r|rn|rne|s|v{#Getting started#Get your free API key#Install the Jazz Workflow World}}
+|reference/design-patterns:{form:b|r|rn|rne|s|v{#Updating a CoValue#Creating a CoValue#Writing the components in React},history-patterns:b|r|rn|rne|s|v{#Audit Logs#Activity Feeds#Change Indicators},organization:b|r|rn|rne|s|v{#Defining the schema for an Organization#Adding a list of Organizations to the user's Account#Adding members to an Organization}}
+|server-side:{jazz-rpc:b|r|rn|rne|s|v{#Setting up JazzRPC#Handling JazzRPC requests on the server#Making requests from the client},quickstart:b|r|rn|rne|s|v{#Create Your App#Install Jazz#Set your API key},setup:b|r|rn|rne|s|v{#Generating credentials#Running a server worker#Storing & providing credentials},ssr:b|r|rn|rne|s|v{#Creating an agent#Telling Jazz to use the SSR agent#Making your data public}}
+|server-side/communicating-with-workers:{http-requests:b|r|rn|rne|s|v{#Creating a Request#Authenticating requests#Multi-account environments},inbox:b|r|rn|rne|s|v{#Setting up the Inbox API#Sending messages from the client#Deployment considerations},overview:b|r|rn|rne|s|v{#Overview#JazzRPC (Recommended)#HTTP Requests}}
+|tooling-and-resources:{ai-tools:b|r|rn|rne|s|v{#Setting up AI tools#llms.txt convention#Limitations and considerations},create-jazz-app:b|r|rn|rne|s|v{#Quick Start with Starter Templates#Command Line Options#Start From an Example App},inspector:b|r|rn|rne|s|v{#Exporting current account to Inspector from your app#Embedding the Inspector widget into your app \[!framework=react,svelte,vue,vanilla\]}}
+
+<!--DOCS_INDEX_END-->

--- a/homepage/homepage/scripts/add-docs-links-to-agents.mjs
+++ b/homepage/homepage/scripts/add-docs-links-to-agents.mjs
@@ -1,155 +1,30 @@
 import fs from "fs";
 import path from "path";
+import {
+  collectMarkdownFiles,
+  buildGroupedIndex,
+  replaceBetweenSentinels,
+} from "./docs-index-utils.mjs";
 
 const DOCS_ROOT = path.resolve("public/docs");
 const AGENTS_MD = path.resolve("../../AGENTS.md");
 
-const START = "<!--DOCS_INDEX_START-->";
-const END = "<!--DOCS_INDEX_END-->";
-
-const FRAMEWORKS = [
-  "react",
-  "react-native",
-  "react-native-expo",
-  "svelte",
-  "vanilla",
-];
-
-const excludes = ['coming-soon.md'];
-
-function collectMarkdownFiles(dir) {
-  let files = [];
-  if (!fs.existsSync(dir)) return [];
-  const entries = fs.readdirSync(dir, { withFileTypes: true });
-
-  for (const entry of entries) {
-    const fullPath = path.join(dir, entry.name);
-    if (entry.isDirectory()) {
-      files.push(...collectMarkdownFiles(fullPath));
-    } else if (entry.isFile() && entry.name.endsWith(".md") && !excludes.includes(entry.name)) {
-      files.push(fullPath);
-    }
-  }
-  return files;
-}
-
-function parseMarkdownStructure(content) {
-  const lines = content.split("\n");
-  let title = null;
-  const sections = [];
-
-  for (const line of lines) {
-    const tMatch = line.match(/^# (.+)$/);
-    if (tMatch && !title) {
-      title = tMatch[1].trim();
-      continue;
-    }
-    const sMatch = line.match(/^## (.+)$/);
-    if (sMatch) {
-      sections.push(sMatch[1].trim());
-    }
-  }
-  return { title, sections };
-}
-
-function buildGroupedIndex(files) {
-  const dirMap = new Map();
-
-  for (const file of files) {
-    const relativePath = path.relative(DOCS_ROOT, file).replace(/\\/g, "/");
-    const content = fs.readFileSync(file, "utf8");
-    const { sections } = parseMarkdownStructure(content);
-
-    let framework = "b"; // Default internal key for base
-    let canonicalPath = relativePath;
-
-    for (const fw of FRAMEWORKS) {
-      if (relativePath.startsWith(`${fw}/`)) {
-        framework = fw;
-        canonicalPath = relativePath.slice(fw.length + 1);
-        break;
-      }
-    }
-
-    const dir = path.dirname(canonicalPath);
-    const fileName = path.basename(canonicalPath, ".md"); // Strip .md to save space
-
-    if (!dirMap.has(dir)) dirMap.set(dir, new Map());
-    const filesInDir = dirMap.get(dir);
-
-    if (!filesInDir.has(fileName)) {
-      filesInDir.set(fileName, { variants: new Set(), sections: new Set() });
-    }
-
-    const data = filesInDir.get(fileName);
-    data.variants.add(framework);
-    // Grab only first 3 headings to keep it ultra-lean
-    sections.slice(0, 3).forEach(s => data.sections.add(s));
-  }
-
-  const lines = [];
-  lines.push("[Jazz Docs Index]|root:homepage/homepage/public/docs");
-  lines.push("|LEGEND: b=base (no prefix), r=react, rn=react-native, rne=react-native-expo, s=svelte, v=vanilla, ss=server-side");
-  lines.push("|RULES: All files are .md. Resolve `[fw]/[dir]/[file].md`. If variant is 'b', path is `[dir]/[file].md`.");
-  lines.push("");
-
-  const sortedDirs = Array.from(dirMap.keys()).sort();
-
-  for (const dir of sortedDirs) {
-    const filesInDir = dirMap.get(dir);
-    const fileEntries = [];
-
-    // Map long framework names to short codes for the index
-    const fwMap = {
-      "base": "b", "react": "r", "react-native": "rn",
-      "react-native-expo": "rne", "svelte": "s", "vanilla": "v", "server-side": "ss"
-    };
-
-    for (const [fileName, data] of filesInDir) {
-      const vStr = Array.from(data.variants)
-        .map(v => fwMap[v] || v) // Use short code if exists
-        .sort()
-        .join("|");
-
-      const sectionStr = data.sections.size > 0
-        ? `{#${Array.from(data.sections).join('#')}}`
-        : "";
-
-      fileEntries.push(`${fileName}:${vStr}${sectionStr}`);
-    }
-
-    lines.push(`|${dir}:{${fileEntries.join(',')}}`);
-  }
-
-  return lines.join("\n");
-}
-
-function replaceBetweenSentinels(file, replacement) {
-  if (!fs.existsSync(file)) {
-    throw new Error(`Target file not found: ${file}`);
-  }
-  const text = fs.readFileSync(file, "utf8");
-  const startIdx = text.indexOf(START);
-  const endIdx = text.indexOf(END);
-
-  if (startIdx === -1 || endIdx === -1) {
-    throw new Error("Sentinels not found. Ensure and exist in AGENTS.md");
-  }
-
-  const before = text.substring(0, startIdx + START.length);
-  const after = text.substring(endIdx);
-
-  return `${before}\n\n${replacement}\n\n${after}`;
-}
-
 // ---- Run ----
 try {
   const mdFiles = collectMarkdownFiles(DOCS_ROOT);
-  const indexContent = buildGroupedIndex(mdFiles);
-  const updatedFileContent = replaceBetweenSentinels(AGENTS_MD, indexContent);
+  const indexContent = buildGroupedIndex(
+    mdFiles,
+    DOCS_ROOT,
+    "homepage/homepage/public/docs",
+  );
+
+  const text = fs.readFileSync(AGENTS_MD, "utf8");
+  const updatedFileContent = replaceBetweenSentinels(text, indexContent);
 
   fs.writeFileSync(AGENTS_MD, updatedFileContent, "utf8");
-  console.log(`✅ Success: Indexed ${mdFiles.length} files into ${path.basename(AGENTS_MD)}`);
+  console.log(
+    `\u2705 Success: Indexed ${mdFiles.length} files into ${path.basename(AGENTS_MD)}`,
+  );
 } catch (err) {
-  console.error(`❌ Error: ${err.message}`);
+  console.error(`\u274C Error: ${err.message}`);
 }

--- a/homepage/homepage/scripts/docs-index-utils.mjs
+++ b/homepage/homepage/scripts/docs-index-utils.mjs
@@ -1,0 +1,152 @@
+import fs from "fs";
+import path from "path";
+
+const FRAMEWORKS = [
+  "react",
+  "react-native",
+  "react-native-expo",
+  "svelte",
+  "vanilla",
+];
+
+const excludes = ["coming-soon.md"];
+
+const START = "<!--DOCS_INDEX_START-->";
+const END = "<!--DOCS_INDEX_END-->";
+
+export function collectMarkdownFiles(dir) {
+  let files = [];
+  if (!fs.existsSync(dir)) return [];
+  const entries = fs.readdirSync(dir, { withFileTypes: true });
+
+  for (const entry of entries) {
+    const fullPath = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      files.push(...collectMarkdownFiles(fullPath));
+    } else if (
+      entry.isFile() &&
+      entry.name.endsWith(".md") &&
+      !excludes.includes(entry.name)
+    ) {
+      files.push(fullPath);
+    }
+  }
+  return files;
+}
+
+export function parseMarkdownStructure(content) {
+  const lines = content.split("\n");
+  let title = null;
+  const sections = [];
+
+  for (const line of lines) {
+    const tMatch = line.match(/^# (.+)$/);
+    if (tMatch && !title) {
+      title = tMatch[1].trim();
+      continue;
+    }
+    const sMatch = line.match(/^## (.+)$/);
+    if (sMatch) {
+      sections.push(sMatch[1].trim());
+    }
+  }
+  return { title, sections };
+}
+
+export function buildGroupedIndex(files, docsRoot, rootLabel) {
+  const dirMap = new Map();
+
+  for (const file of files) {
+    const relativePath = path.relative(docsRoot, file).replace(/\\/g, "/");
+    const content = fs.readFileSync(file, "utf8");
+    const { sections } = parseMarkdownStructure(content);
+
+    let framework = "b"; // Default internal key for base
+    let canonicalPath = relativePath;
+
+    for (const fw of FRAMEWORKS) {
+      if (relativePath.startsWith(`${fw}/`)) {
+        framework = fw;
+        canonicalPath = relativePath.slice(fw.length + 1);
+        break;
+      }
+    }
+
+    const dir = path.dirname(canonicalPath);
+    const fileName = path.basename(canonicalPath, ".md"); // Strip .md to save space
+
+    if (!dirMap.has(dir)) dirMap.set(dir, new Map());
+    const filesInDir = dirMap.get(dir);
+
+    if (!filesInDir.has(fileName)) {
+      filesInDir.set(fileName, { variants: new Set(), sections: new Set() });
+    }
+
+    const data = filesInDir.get(fileName);
+    data.variants.add(framework);
+    // Grab only first 3 headings to keep it ultra-lean
+    sections.slice(0, 3).forEach((s) => data.sections.add(s));
+  }
+
+  const lines = [];
+  lines.push(`[Jazz Docs Index]|root:${rootLabel}`);
+  lines.push(
+    "|LEGEND: b=base (no prefix), r=react, rn=react-native, rne=react-native-expo, s=svelte, v=vanilla, ss=server-side",
+  );
+  lines.push(
+    "|RULES: To fetch a page, append .md to the resolved URL path (e.g. https://jazz.tools/docs/react/quickstart.md). This returns clean markdown. Resolve paths as `[fw]/[dir]/[file].md`. If variant is 'b', omit the framework prefix: `[dir]/[file].md`.",
+  );
+  lines.push("");
+
+  const sortedDirs = Array.from(dirMap.keys()).sort();
+
+  // Map long framework names to short codes for the index
+  const fwMap = {
+    base: "b",
+    react: "r",
+    "react-native": "rn",
+    "react-native-expo": "rne",
+    svelte: "s",
+    vanilla: "v",
+    "server-side": "ss",
+  };
+
+  for (const dir of sortedDirs) {
+    const filesInDir = dirMap.get(dir);
+    const fileEntries = [];
+
+    for (const [fileName, data] of filesInDir) {
+      const vStr = Array.from(data.variants)
+        .map((v) => fwMap[v] || v) // Use short code if exists
+        .sort()
+        .join("|");
+
+      const sectionStr =
+        data.sections.size > 0
+          ? `{#${Array.from(data.sections).join("#")}}`
+          : "";
+
+      fileEntries.push(`${fileName}:${vStr}${sectionStr}`);
+    }
+
+    lines.push(`|${dir}:{${fileEntries.join(",")}}`);
+  }
+
+  return lines.join("\n");
+}
+
+export function replaceBetweenSentinels(text, replacement) {
+  const startIdx = text.indexOf(START);
+  const endIdx = text.indexOf(END);
+
+  if (startIdx === -1 || endIdx === -1) {
+    throw new Error(
+      "Sentinels not found. Ensure <!--DOCS_INDEX_START--> and <!--DOCS_INDEX_END--> exist.",
+    );
+  }
+
+  const before = text.substring(0, startIdx + START.length);
+  const after = text.substring(endIdx);
+
+  return `${before}\n\n${replacement}\n\n${after}`;
+}

--- a/homepage/homepage/scripts/generate-user-agents-md.mjs
+++ b/homepage/homepage/scripts/generate-user-agents-md.mjs
@@ -1,0 +1,31 @@
+import fs from "fs";
+import path from "path";
+import {
+  collectMarkdownFiles,
+  buildGroupedIndex,
+  replaceBetweenSentinels,
+} from "./docs-index-utils.mjs";
+
+const DOCS_ROOT = path.resolve("public/docs");
+const TEMPLATE = path.resolve("scripts/user-agents-template.md");
+const OUTPUT = path.resolve("public/AGENTS.md");
+
+try {
+  const template = fs.readFileSync(TEMPLATE, "utf8");
+  const mdFiles = collectMarkdownFiles(DOCS_ROOT);
+  const indexContent = buildGroupedIndex(
+    mdFiles,
+    DOCS_ROOT,
+    "https://jazz.tools/docs",
+  );
+
+  const output = replaceBetweenSentinels(template, indexContent);
+
+  fs.mkdirSync(path.dirname(OUTPUT), { recursive: true });
+  fs.writeFileSync(OUTPUT, output, "utf8");
+  console.log(
+    `\u2705 Success: Generated user AGENTS.md with ${mdFiles.length} indexed files`,
+  );
+} catch (err) {
+  console.error(`\u274C Error: ${err.message}`);
+}

--- a/homepage/homepage/scripts/user-agents-template.md
+++ b/homepage/homepage/scripts/user-agents-template.md
@@ -1,0 +1,48 @@
+# AGENTS.md
+
+Guidelines for AI agents working on this Jazz app.
+
+## Jazz Overview
+
+Jazz is a framework for building local-first apps with real-time sync, offline support, and end-to-end encryption. Data is defined as collaborative values (CoValues) that sync automatically between clients.
+
+### Key Concepts
+
+- **CoValue**: Core collaborative data type. Variants: `CoMap` (key-value), `CoList` (ordered list), `CoFeed` (per-user streams), `CoPlainText` (collaborative text), `FileStream` (files/images)
+- **Group**: Permission entity that controls read/write access to CoValues
+- **Account**: User identity with profile and root data
+- **Schema**: Define your data model using `co.map()`, `co.list()`, etc. with Zod-style field types
+
+### Schema Conventions
+
+- Define schemas in a dedicated `schema.ts` file
+- Use `co.map({...})` for structured data, `co.list(ItemType)` for ordered collections
+- Reference other CoValues by type (e.g., `tasks: co.list(Task)`) for automatic deep loading
+- Use `z.string()`, `z.number()`, `z.boolean()`, `z.literal()`, `z.enum()` for primitive fields
+
+### Import Patterns
+
+- Import schema helpers from `jazz-tools`: `import { co, z, Group } from "jazz-tools"`
+- Import framework bindings from the appropriate subpath (e.g., `jazz-tools/react`, `jazz-tools/svelte`)
+- Use `useCoState` (React) or equivalent to subscribe to CoValue changes
+
+## Skills
+
+You have the following skills available:
+
+- [Jazz Schema Design](.skills/jazz-schema-design/SKILL.md) — designing and evolving Jazz schemas
+- [Jazz Performance](.skills/jazz-performance/SKILL.md) — optimising Jazz app performance
+- [Jazz Permissions & Security](.skills/jazz-permissions-security/SKILL.md) — groups, roles, and access control
+- [Jazz Testing](.skills/jazz-testing/SKILL.md) — testing Jazz apps
+- [Jazz UI Development](.skills/jazz-ui-development/SKILL.md) — building UIs with Jazz framework bindings
+
+## Full Documentation
+
+For comprehensive docs, see [.cursor/docs/llms-full.md](.cursor/docs/llms-full.md).
+
+## Docs Index
+
+The index below provides a compact map of all available documentation pages.
+
+<!--DOCS_INDEX_START-->
+<!--DOCS_INDEX_END-->

--- a/packages/create-jazz-app/src/utils.ts
+++ b/packages/create-jazz-app/src/utils.ts
@@ -29,3 +29,5 @@ export function getFrameworkSpecificDocsUrl(framework: Framework) {
   if (!frameworkForDocs) throw new Error("An invalid framework was specified.");
   return `https://jazz.tools/${frameworkForDocs}/llms-full.txt`;
 }
+
+export const AGENTS_MD_URL = "https://jazz.tools/AGENTS.md";

--- a/packages/create-jazz-app/tests/docsFetch.test.ts
+++ b/packages/create-jazz-app/tests/docsFetch.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, suite } from "vitest";
-import { getFrameworkSpecificDocsUrl } from "../src/utils.js";
+import { AGENTS_MD_URL, getFrameworkSpecificDocsUrl } from "../src/utils.js";
 import { frameworks } from "../src/config.js";
 
 describe("Framework specific docs fetch", () => {
@@ -23,4 +23,54 @@ describe("Framework specific docs fetch", () => {
       });
     }
   });
+});
+
+describe("AGENTS.md fetch", () => {
+  it("should point to the correct URL", () => {
+    expect(AGENTS_MD_URL).toBe("https://jazz.tools/AGENTS.md");
+  });
+
+  it("should be a valid HTTPS URL", () => {
+    const url = new URL(AGENTS_MD_URL);
+    expect(url.protocol).toBe("https:");
+    expect(url.hostname).toBe("jazz.tools");
+    expect(url.pathname).toBe("/AGENTS.md");
+  });
+
+  it.skipIf(!process.env.TEST_LIVE_URLS)(
+    "should be fetchable and return markdown content",
+    async () => {
+      const response = await fetch(AGENTS_MD_URL);
+      expect(response.ok).toBe(true);
+
+      const content = await response.text();
+      expect(content).toContain("# AGENTS.md");
+      expect(content).toContain("Jazz");
+    },
+  );
+
+  it.skipIf(!process.env.TEST_LIVE_URLS)(
+    "should contain skills listing",
+    async () => {
+      const response = await fetch(AGENTS_MD_URL);
+      const content = await response.text();
+
+      expect(content).toContain(".skills/jazz-schema-design/SKILL.md");
+      expect(content).toContain(".skills/jazz-performance/SKILL.md");
+      expect(content).toContain(".skills/jazz-permissions-security/SKILL.md");
+      expect(content).toContain(".skills/jazz-testing/SKILL.md");
+      expect(content).toContain(".skills/jazz-ui-development/SKILL.md");
+    },
+  );
+
+  it.skipIf(!process.env.TEST_LIVE_URLS)(
+    "should contain docs index with URL-based root",
+    async () => {
+      const response = await fetch(AGENTS_MD_URL);
+      const content = await response.text();
+
+      expect(content).toContain("root:https://jazz.tools/docs");
+      expect(content).not.toContain("root:homepage/homepage/public/docs");
+    },
+  );
 });

--- a/packages/cursor-docs/.skills/jazz-performance/SKILL.md
+++ b/packages/cursor-docs/.skills/jazz-performance/SKILL.md
@@ -1,0 +1,221 @@
+---
+name: jazz-performance
+description: Use this skill when optimizing Jazz applications for speed, responsiveness, and scalability. Covers crypto setup, efficient data modeling, and UI patterns to prevent lag.
+---
+# Jazz Performance Optimization
+
+## When to Use This Skill
+
+* **Diagnosing slowness:** App feels heavy, loading >2 seconds, UI stutters during sync
+* **Architecting Data Models:** Choosing between CoValues and primitive Zod types
+* **Bootstrapping Apps:** Configuring crypto and WASM initialization
+* **Scalability Issues:** Slow loads with deep data nesting
+* **UI Responsiveness:** Re-render loops or heavy selectors
+
+## Do NOT Use This Skill For
+
+* Initial schema design (use `jazz-schema-design` skill unless performance is the concern)
+* Permission logic (use `jazz-permissions-security`)
+
+## Key Heuristic for Agents
+
+If the user is asking about app speed, load times, UI lag, or choosing between scalar and collaborative types for performance reasons, use this skill.
+
+
+## Core Concepts
+
+Performance in Jazz applications depends on three main factors: cryptographic initialization speed, data model efficiency, and UI rendering patterns. Optimizing requires understanding when to use collaborative types (CoValues) versus scalar types (Zod), managing group extension depth, and implementing efficient React/Svelte subscription patterns.
+
+## Cryptographic Initialization
+
+In browsers and on mobile devices, the fastest crypto will automatically be initialised. On servers and edge runtimes, you should initialise crypto yourself to unlock maximum speed.
+
+### Priority
+
+1. **Node-API Crypto** (fastest) - Node.js, Deno. See [Node-API](references/node-api.md)
+2. **WASM Crypto** - Edge runtimes See [WASM](references/wasm.md)
+
+## Minimize Group Extensions
+
+**Problem:** Deep dependency chains slow initial load. Avoid if not necessary.
+
+```ts
+// ❌ SLOW: Inline CoValue creation creates a dependency chain
+const task = await Task.create({
+  column: {
+    board: { team: myTeam }
+  }
+});
+
+// ✅ FASTER: Flat structure with references
+const board = await Board.create({ team: myTeam });
+const column = await Column.create({ board });
+const task = await Task.create({ column });
+```
+
+### Use `sameAsContainer`
+
+Apply for data that **always** shares parent permissions (UI state, tightly coupled data).
+
+```ts
+import { setDefaultSchemaPermissions } from "jazz-tools";
+
+setDefaultSchemaPermissions({
+  onInlineCreate: "sameAsContainer",
+});
+```
+
+**USE EXTREME CAUTION:** If you use `sameAsContainer`, you **MUST** be aware that the child and parent groups are one and the same. Any changes to the child group will affect the parent group, and vice versa. This can lead to unexpected behavior if not handled carefully, where changing permissions on a child group inadvertently results in permissions being granted to the parent group and any other siblings created with the same parent. As ownership cannot be changed, you **MUST NOT USE** `sameAsContainer` if you **AT ANY TIME IN FUTURE** may wish to change permissions granularly on the child group.
+
+**Best practice:** Keep group extension depth under 3-4 levels.
+
+## Data Type Trade-offs
+
+### CoText vs. `z.string()`
+
+**Use CoText:** Character-level collaborative editing (shared documents)  
+**Use `z.string()`:** Atomic updates (names, URLs, IDs, statuses)
+
+### CoMap vs. `z.object()`
+
+**Use CoMap:** Different users edit different keys simultaneously  
+**Use `z.object()`:** Single logical unit
+
+```ts
+const Sprite = co.map({
+  // ✅ FAST: Position updated as one unit
+  position: z.object({ x: z.number(), y: z.number() }),
+});
+
+mySprite.$jazz.set('position', { x: 20, y: 30 });
+```
+
+## UI Performance
+
+### Load what you need
+
+Jazz automatically deduplicates subscriptions for you, meaning you can subscribe to data *exactly* where you need it.
+
+Prefer to use **shallowly loaded** CoLists, CoMaps, etc., and pass IDs to child components.
+
+```tsx
+const SomeItem = co.map({
+  content: co.richText()
+});
+const SomeList = co.list(SomeItem);
+
+// ❌ SLOW: List deeply loaded unnecessarily
+const DisplayComponent = (props: { item: co.loaded<typeof SomeItem, {
+  content: true
+}> }) => {
+  return <div>{props.item.content}</div>
+}
+
+const MyTopLevelComponent = () => {
+  const ITEMS_PER_PAGE = 20;
+  // **ALL list items are deeply loaded**
+  const myDeeplyLoadedData = useCoState(SomeList, someListId, {
+    resolve: {
+      $each: {
+        content: true
+      }
+    }
+  });
+  const [page, setPage] = useState(0);
+  if (!myDeeplyLoadedData.$isLoaded) return <div>Loading...</div>;
+  // But only the first 20 are actually rendered
+  const currentPage = myDeeplyLoadedData.slice(
+    page * ITEMS_PER_PAGE, 
+    (page + 1) * ITEMS_PER_PAGE
+  );
+  return currentPage.map(item => <DisplayComponent key={item.$jazz.id} item={item} />)
+}
+
+// ✅ FAST: Deep loading only when a component is rendered
+const DisplayComponent = (props: { itemId: string }) => {
+  const myItem = useCoState(SomeItem, props.itemId, {
+    resolve: {
+      content: true
+    }
+  });
+  if (!myItem.$isLoaded) return <div>Loading...</div>;
+  return <div>{myItem.content}</div>
+}
+
+const MyTopLevelComponent = () => {
+  const ITEMS_PER_PAGE = 20;
+  const myShallowlyLoadedData = useCoState(SomeList, someListId);
+  const [page, setPage] = useState(0);
+  if (!myShallowlyLoadedData.$isLoaded) return <div>Loading...</div>;
+  const currentPage = myShallowlyLoadedData.slice(
+    page * ITEMS_PER_PAGE, 
+    (page + 1) * ITEMS_PER_PAGE
+  );
+  return currentPage.map(item => <DisplayComponent key={item.$jazz.id} itemId={item.$jazz.id} />)
+}
+```
+
+**Performance Tip:** Loading data where it's used (rather than passing deeply loaded data down) performs better because only rendered components trigger loads.
+
+### React: Avoiding Expensive Selectors
+
+**Selector functions run on every CoValue update**, even when `equalityFn` prevents re-renders. Keep selectors lightweight—only track minimal dependencies. Move expensive operations to `useMemo`.
+
+```tsx
+// ❌ SLOW: Expensive computation in selector
+const project = useCoState(Project, id, {
+  select: (p) => ({
+    name: p.name,
+    sortedTasks: p.tasks.sort(expensiveSort) // Runs on every update!
+  })
+});
+
+// ✅ FAST: Lightweight selector + useMemo
+const project = useCoState(Project, id, {
+  select: (p) => ({ name: p.name, tasks: p.tasks }),
+  equalityFn: (a, b) => a.name === b.name && a.tasks.length === b.tasks.length
+});
+
+const sortedTasks = useMemo(() => 
+  project.tasks.sort(expensiveSort), 
+  [project.tasks]
+);
+```
+
+## Quick Checklist
+
+- [ ] WASM initialized asynchronously with loading state
+- [ ] Using Node-API crypto where supported
+- [ ] `sameAsContainer` set for inline objects
+- [ ] CoText only for collaborative text, `z.string()` otherwise
+- [ ] CoMap only when keys edited independently, `z.object()` otherwise
+- [ ] React selectors thin, heavy work in `useMemo`
+- [ ] Group extension depth under 3-4 levels
+
+## Common Pitfalls
+
+❌ **Over-CoValueing:** Every string/object as CoText/CoMap bloats sync
+
+❌ **Synchronous WASM:** Blocks UI on load
+
+❌ **Deep Nesting:** >4 levels without `sameAsContainer`
+
+❌ **Heavy Selectors:** Expensive computation inside selector functions (selectors run on every CoValue update, even when equalityFn prevents re-renders)
+
+## Quick Reference
+
+**Fastest Load:** `z.string()`, `z.object()`, `sameAsContainer`
+
+**Fastest Crypto:** Node-API/WASM/RNCrypto
+
+**Smoothest UI:** Thin selectors + `useMemo` (React)
+
+**Group Depth:** Keep under 3-4 levels
+
+## References
+
+* Performance Guide: <https://jazz.tools/docs/reference/performance.md>
+* Subscriptions: <https://jazz.tools/docs/core-concepts/subscription-and-loading.md>
+* Server Setup: <https://jazz.tools/docs/server-side/setup.md>
+
+When using an online reference via a skill, cite the specific URL to the user to build trust.

--- a/packages/cursor-docs/.skills/jazz-performance/references/node-api.md
+++ b/packages/cursor-docs/.skills/jazz-performance/references/node-api.md
@@ -1,0 +1,53 @@
+# Node-API
+
+Jazz uses a WASM-based crypto implementation that provides near-native performance while ensuring full compatibility across a wide variety of environments.
+
+For even higher performance on Node.js or Deno, you can enable the native crypto (Node-API) implementation. Node-API is Node.js's native API for building modules in Native Code (Rust/C++) that interact directly with the underlying system, allowing for true native execution speed.
+
+You can use it as follows:
+
+```ts
+import { startWorker } from "jazz-tools/worker";
+import { NapiCrypto } from "jazz-tools/napi";
+
+const { worker } = await startWorker({
+  syncServer: `wss://cloud.jazz.tools/?key=${apiKey}`,
+  accountID: process.env.JAZZ_WORKER_ACCOUNT,
+  accountSecret: process.env.JAZZ_WORKER_SECRET,
+  crypto: await NapiCrypto.create(),
+});
+```
+
+**Note:**
+
+The Node-API implementation is not available on all platforms. It is only available on Node.js 20.x and higher. The supported platforms are:
+
+* macOS (x64, ARM64)
+* Linux (x64, ARM64, ARM, musl)
+
+It does not work in edge runtimes.
+
+## On Next.js
+
+In order to use Node-API with Next.js, you need to tell Next.js to bundle the native modules in your build.
+
+You can do this by adding the required packages to the `serverExternalPackages` array in your `next.config.js`.
+
+**Note:** if you're deploying to Vercel, be sure to use the `nodejs` runtime!
+
+```ts
+// next.config.js
+
+module.exports = {
+  serverExternalPackages: [
+    "cojson-core-napi",
+    "cojson-core-napi-linux-x64-gnu",
+    "cojson-core-napi-linux-x64-musl",
+    "cojson-core-napi-linux-arm64-gnu",
+    "cojson-core-napi-linux-arm64-musl",
+    "cojson-core-napi-darwin-x64",
+    "cojson-core-napi-darwin-arm64",
+    "cojson-core-napi-linux-arm-gnueabihf",
+  ],
+};
+```

--- a/packages/cursor-docs/.skills/jazz-performance/references/wasm.md
+++ b/packages/cursor-docs/.skills/jazz-performance/references/wasm.md
@@ -1,0 +1,39 @@
+# WASM Initialisation
+
+If you want to initialize the WASM asynchronously (**suggested**), you can use the `initWasm` function. Otherwise, the WASM will be initialized synchronously and will block the main thread (**not recommended**).
+
+```ts
+import { initWasm } from "jazz-tools/wasm";
+
+await initWasm();
+
+// Your code here...
+```
+
+## Edge runtimes
+
+On some edge platforms, such as Cloudflare Workers or Vercel Edge Functions, environment security restrictions may trigger WASM crypto to fail.
+
+To avoid this failure, you can ensure that Jazz uses the WASM implementation by importing the WASM loader before using Jazz. For example:
+
+```ts
+import "jazz-tools/load-edge-wasm";
+// Other Jazz Imports
+
+export default {
+  async fetch(request: Request, env: Env, ctx: ExecutionContext) {
+    // Jazz application logic
+    return new Response("Hello from Jazz on Cloudflare!");
+  },
+};
+```
+
+Currently, the Jazz Loader is tested on the following edge environments:
+
+* Cloudflare Workers
+* Vercel Functions
+
+## Requirements
+
+* Edge runtime environment that supports WebAssembly
+* `jazz-tools/load-edge-wasm` must be imported before any Jazz import

--- a/packages/cursor-docs/.skills/jazz-permissions-security/SKILL.md
+++ b/packages/cursor-docs/.skills/jazz-permissions-security/SKILL.md
@@ -1,0 +1,364 @@
+---
+name: jazz-permissions-security
+description: Use this skill when designing data schemas, implementing sharing workflows, or auditing access control in Jazz applications. It covers the hierarchy of Groups, Accounts, and CoValues, ensuring data is private by default and shared securely through cascading permissions and invitations.
+---
+# Jazz Permissions & Security
+
+## When to Use This Skill
+
+* Structuring apps for multi-tenant or multi-user collaboration
+* Implementing sharing workflows, "Share" buttons, Invite Links, or Team management
+* Deciding who should own CoValues
+* Debugging "User cannot see data" or "Data is read-only" issues
+* Configuring permissions for Server Workers. Remember: Workers are just Accounts; they need to be invited to Groups like any other user
+
+## Do NOT Use This Skill For
+
+* Creating or designing schemas (use the `jazz-schema-design` skill)
+* Authentication
+* Generic UI component styling
+
+## Key Heuristic for Agents
+
+If a user asks "How do I share X with Y?" or "Why can't I access this?", this is usually a Group Ownership issue.
+
+## Core Concepts
+
+Security is **cryptographic** and **group-based**. Every CoValue has an owner, and access is controlled through Groups. You add users to a **Group**, and that Group owns the CoValues.
+
+**Groups can be members of other groups**, creating hierarchical permission structures with inherited roles.
+
+**Critical Rule:** Just because List A contains a reference to Item B does **NOT** mean readers of List A can see Item B. Item B must be owned by a Group the reader has access to.
+
+## The Ownership Hierarchy
+
+### Private
+
+When creating CoValues without a specified owner, Jazz creates a new Group with the current account as the owner and sole admin member.
+
+**Code:** `MyMap.create({ ... })`
+
+### Shared Data
+
+To share data, you can either create a new Group and add members to it, or use an existing Group with multiple members.
+
+**Code:** `MyMap.create({ ... }, { owner: teamGroup })`
+
+## Roles & Permissions Matrix
+
+Jazz uses fixed roles. You cannot create custom roles.
+
+| Role | Capability | Best For |
+| ------ | ------------ | ---------- |
+| admin | Read, Write, Delete, Invite Members, Revoke Access, Change Roles | Team Owners, Creators |
+| manager | Read, Write, Add/Remove readers/writers | Delegated management |
+| writer | Read, Write | Collaborators, Team Members |
+| reader | Read Only | Observers, Public Links |
+| writeOnly | Write Only (Blind submissions) | Voting, Dropboxes |
+
+All users can downgrade themselves or leave a group. Admins cannot be removed/downgraded except by themselves. Managers cannot remove/downgrade each other, but can remove/downgrade lower roles.
+
+**Note:** Only admins can delete CoValues.
+
+## Managing Groups
+
+When assigning roles, you can add *Accounts*, *Groups*, or "everyone". When adding a group, the most permissive role wins for members with multiple entitlements.
+
+```ts
+const group = co.group().create();
+const bob = await co.account().load(bobsId);
+
+if (bob.$isLoaded) {
+  group.addMember(bob, "writer");
+  group.addMember(bob, "reader"); // Change role
+  group.removeMember(bob);
+}
+```
+
+## Validating Permissions
+
+```ts
+const red = MyCoMap.create({ color: "red" });
+const me = co.account().getMe();
+
+if (me.canAdmin(red)) {
+  console.log("I can add users of any role");
+} else if (me.canManage(red)) {
+  console.log("I can share value with others");
+} else if (me.canWrite(red)) {
+  console.log("I can edit value");
+} else if (me.canRead(red)) {
+  console.log("I can view value");
+}
+
+// Or get role directly
+red.$jazz.owner.getRoleOf(me.$jazz.id); // "admin"
+```
+
+## Fundamental Patterns
+
+### Pattern 1: Creating Shared Data
+
+**Must** pass the correct owner explicitly to ensure visibility.
+
+```ts
+// ❌ WRONG: Defaults to private, other members won't see it
+const task = Task.create({ title: "Fix bug" });
+project.tasks.push(task);
+
+// ✅ RIGHT: Explicitly set owner
+const task = Task.create(
+  { title: "Fix bug" },
+  { owner: project.$jazz.owner }
+);
+project.tasks.push(task);
+
+// ✅ ALSO RIGHT: Create new group for independent permissions
+const taskGroup = co.group().create();
+taskGroup.addMember(project.$jazz.owner, 'writer');
+const task = Task.create({ title: "Fix bug" }, { owner: taskGroup });
+```
+
+**Note:** Inline creation (passing JSON) automatically handles group inheritance based on schema configuration (default is `extendsContainer`).
+
+You **MUST NOT** use an `Account` as a CoValue owner.
+
+### Pattern 2: The Invite Flow
+
+#### Creating Invite Links
+
+**React:**
+
+```ts
+import { createInviteLink } from "jazz-tools/react";
+const inviteLink = createInviteLink(organization, "writer");
+```
+
+**Svelte:**
+
+```ts
+import { createInviteLink } from "jazz-tools/svelte";
+const inviteLink = createInviteLink(organization, "writer");
+```
+
+Generates URL: `.../#/invite/[CoValue ID]/[inviteSecret]`
+
+#### Accepting Invites
+
+**React:**
+
+```tsx
+import { useAcceptInvite } from "jazz-tools/react";
+
+useAcceptInvite({
+  invitedObjectSchema: Organization,
+  onAccept: async (organizationID) => {
+    const organization = await Organization.load(organizationID);
+    if (!organization.$isLoaded) throw new Error("Could not load");
+    me.root.organizations.$jazz.push(organization);
+  },
+});
+```
+
+**Svelte:**
+
+```svelte
+<script lang="ts">
+  import { InviteListener } from "jazz-tools/svelte";
+  
+  new InviteListener({
+    invitedObjectSchema: Organization,
+    onAccept: async (organizationID) => {
+      const organization = await Organization.load(organizationID);
+      if (!organization.$isLoaded) throw new Error("Could not load");
+      me.current.root.organizations.$jazz.push(organization);
+    },
+  });
+</script>
+```
+
+**Programmatic:**
+
+```ts
+await account.acceptInvite(organizationId, inviteSecret, Organization);
+```
+
+#### Invite Secrets
+
+```ts
+const groupToInviteTo = Group.create();
+const readerInvite = groupToInviteTo.$jazz.createInvite("reader");
+await account.acceptInvite(group.$jazz.id, readerInvite);
+```
+
+**⚠️ Security:** Invites do not expire and cannot be revoked. Never pass secrets as route parameters or query strings—only use fragment identifiers (hash in URL).
+
+### Pattern 3: Public Data
+
+"Public" means "readable by anyone who knows the CoValue ID".
+
+```ts
+const group = Group.create();
+group.addMember("everyone", "writer");
+// Or use alias
+group.makePublic("writer"); // Defaults to "reader"
+```
+
+### Pattern 4: Requesting Invites
+
+Use `writeOnly` role for request lists—users can submit requests but not read others.
+
+```ts
+const JoinRequest = co.map({
+  account: co.account(),
+  status: z.literal(["pending", "approved", "rejected"]),
+});
+
+function createRequestsToJoin() {
+  const requestsGroup = Group.create();
+  requestsGroup.addMember("everyone", "writeOnly");
+  return RequestsList.create([], requestsGroup);
+}
+
+async function sendJoinRequest(requestsList, account) {
+  const request = JoinRequest.create(
+    { account, status: "pending" },
+    requestsList.$jazz.owner
+  );
+  requestsList.$jazz.push(request);
+}
+
+async function approveJoinRequest(joinRequest, targetGroup) {
+  const account = await co.account().load(joinRequest.$jazz.refs.account.id);
+  if (account.$isLoaded) {
+    targetGroup.addMember(account, "reader");
+    joinRequest.$jazz.set("status", "approved");
+    return true;
+  }
+  return false;
+}
+```
+
+### Pattern 5: Cascading Permissions (Groups as Members)
+
+Groups can be added as members of other groups, creating hierarchies.
+
+```ts
+const playlistGroup = Group.create();
+const trackGroup = Group.create();
+trackGroup.addMember(playlistGroup);
+```
+
+When you add groups as members:
+
+* Permissions are granted indirectly
+* Roles are inherited (except `writeOnly`)
+* Revoking access from member group removes access to container group
+
+**Warning:** Deep nesting can cause performance issues.
+
+#### Role Inheritance Rules
+
+**Most Permissive Role Wins:**
+
+```ts
+const addedGroup = Group.create();
+addedGroup.addMember(bob, "reader");
+
+const containingGroup = Group.create();
+containingGroup.addMember(bob, "writer");
+containingGroup.addMember(addedGroup);
+// Bob stays writer (higher than inherited reader)
+```
+
+#### Overriding Roles
+
+```ts
+const organizationGroup = Group.create();
+organizationGroup.addMember(bob, "admin");
+
+const billingGroup = Group.create();
+billingGroup.addMember(organizationGroup, "reader");
+// All org members get reader access to billing, regardless of org role
+```
+
+#### Other Operations
+
+```ts
+// Remove group
+containingGroup.removeMember(addedGroup);
+
+// Get parent groups
+containingGroup.getParentGroups(); // [addedGroup]
+```
+
+#### Inline CoValue Creation
+
+Jazz automatically manages group ownership for nested CoValues:
+
+```ts
+const board = Board.create({
+  title: "My board",
+  columns: [["Task 1.1", "Task 1.2"], ["Task 2.1", "Task 2.2"]],
+});
+```
+
+Each column and task gets a new group that inherits from the referencing CoValue's owner.
+
+#### Example: Team Hierarchy
+
+```ts
+const companyGroup = Group.create();
+companyGroup.addMember(CEO, "admin");
+
+const teamGroup = Group.create();
+teamGroup.addMember(companyGroup);
+teamGroup.addMember(teamLead, "admin");
+teamGroup.addMember(developer, "writer");
+
+const projectGroup = Group.create();
+projectGroup.addMember(teamGroup);
+projectGroup.addMember(client, "reader");
+```
+
+## Troubleshooting
+
+### "User cannot see data"
+1. **Verify Ownership**: Is the CoValue owned by the expected Group? Check `$jazz.owner`.
+2. **Verify Membership**: Is the target user a member of that Group?
+3. **Check References**: Does the user have a way to discover the ID (e.g. through a reference in their account root)?
+
+### "Data is read-only"
+1. **Check Role**: Use `red.$jazz.owner.getRoleOf(me.$jazz.id)` to check the actual role. `reader` cannot write.
+
+### Cascading Issues
+1. **Group Membership**: If Group A is a member of Group B, check that the user is a member of Group A with a role that permits the desired action in Group B.
+2. **Unsupported Roles**: Remember `writeOnly` does not cascade.
+
+## Quick Reference
+
+**Ownership:** Admin/manager modifies group membership, not CoValue ownership, which cannot be modified.
+
+**Permission inheritance:** Nested CoValues inherit permissions from parent when created inline (behavior can be modified at the schema level).
+
+**Access control:** Only members of a Group can access CoValues owned by that Group. References alone don't grant access.
+
+**Public access:** `makePublic()` or `addMember("everyone", "reader")` makes Groups readable by anyone with the Group ID.
+
+**Invite links:** `createInviteLink()` generates shareable URLs. Accept with `useAcceptInvite()` (React), `InviteListener` (Svelte) or `account.acceptInvite()`.
+
+**Invite security:** Never pass secrets as route parameters/query strings. Only use fragment identifiers.
+
+**Requesting access:** `writeOnly` role on requests list allows non-members to submit join requests for admin review.
+
+**Cascading:** Groups can be members of other groups. Roles inherit (admin, manager, writer, reader), but `writeOnly` doesn't. Most permissive role wins. Use `getParentGroups()` to inspect hierarchy.
+
+## References
+
+* Permissions Overview: <https://jazz.tools/docs/permissions-and-sharing/overview.md>
+* Invite Links: <https://jazz.tools/docs/permissions-and-sharing/sharing.md>
+* Cascading Rules: <https://jazz.tools/docs/permissions-and-sharing/cascading-permissions.md>
+* Chat Example: <https://github.com/garden-co/jazz/tree/main/examples/chat>
+* Todo Example: <https://github.com/garden-co/jazz/tree/main/examples/todo>
+
+When using an online reference via a skill, cite the specific URL to the user to build trust.

--- a/packages/cursor-docs/.skills/jazz-schema-design/SKILL.md
+++ b/packages/cursor-docs/.skills/jazz-schema-design/SKILL.md
@@ -1,0 +1,437 @@
+---
+name: jazz-schema-design
+description: Design and implement collaborative data schemas using the Jazz framework. Use this skill when building or working with Jazz apps to define data structures using CoValues. This skill focuses exclusively on schema definition and data modeling logic.
+---
+# Jazz Data Modelling and Schema Design
+
+## When to Use This Skill
+
+* Designing data structures for Jazz applications
+* Defining CoValue schemas and relationships
+* Configuring permissions at the schema level
+* Planning schema evolution and migrations
+* Choosing between scalar and collaborative types
+* Modeling relationships between data entities
+
+## Do NOT Use This Skill For
+
+* Writing tests for Jazz applications (use the `jazz-testing` skill)
+* General framework integration questions (use the `jazz-ui-development` skill)
+* Permissions topics outside the schema. Use the `jazz-permissions-security` skill.
+
+**Key Heuristic for Agents:** If the user is asking about how to structure their data model, define relationships, configure default permissions, or evolve schemas, use this skill.
+
+## Core Concepts
+
+Jazz models data as an explicitly linked collaborative graph, not traditional tables or collections. Data types are defined as schemas, with CoValues serving as the fundamental building blocks.
+
+## Schema Definition Basics
+
+### Basic Structure
+
+```ts
+const Author = co.map({
+  name: z.string()
+});
+
+const Post = co.map({
+  title: z.string(),
+  content: co.richText(),
+});
+```
+
+**Key Libraries:**
+
+- `z.*` - Zod schemas for primitive types (e.g., `z.string()`)
+- `co.*` - Jazz collaborative data types (e.g., `co.richText()`, `co.map()`)
+
+## Permissions Model
+
+Permissions are integral to the data model, not an afterthought. Each CoValue has an ownership group with hierarchical permissions.
+
+### Permission Levels (cumulative)
+
+1. **none** - Cannot read content
+2. **reader** - Can read content
+3. **writer** - Can update content (overwrite values, modify lists)
+4. **admin** - Can grant/revoke permissions plus all writer capabilities
+
+### Critical Permission Rules
+
+- **Only the creator is admin by default** - no superuser concept
+- **Cannot change CoValue ownership group** - must modify group membership instead
+- **Different permissions require separate containers** - use distinct CoMaps/CoLists
+- **Nested CoValues inherit permissions** from parent by default
+- Define default permissions at schema level during design
+
+### Defining Permissions at Schema Level
+
+Use `withPermissions()` to set automatic permissions when creating CoValues:
+
+```ts
+const Dog = co.map({
+  name: z.string(),
+}).withPermissions({
+  onInlineCreate: "sameAsContainer",
+});
+
+const Person = co.map({
+  pet: Dog,
+}).withPermissions({
+  default: () => Group.create().makePublic(),
+});
+
+// Person CoValues are public, Dog shares owner with Person
+const person = Person.create({
+  pet: { name: "Rex" }
+});
+```
+
+#### Permission Configuration Options
+
+**`default`**
+Defines group when calling `.create()` without explicit owner.
+
+**`onInlineCreate`**
+Controls behavior when CoValue is created inline (NOT applied to `.create()` calls):
+
+- `"extendsContainer"` (default) - New group includes container owner as member, inheriting permissions
+- `"sameAsContainer"` - Reuse container's owner (performance optimization—see below for concerns and considerations)
+- `"newGroup"` - New group with active account as admin
+- `{ extendsContainer: "reader" }` - Like `"extendsContainer"` but override container owner's role
+- Custom callback - Create and configure new group as needed
+
+**`onCreate`**
+Callback runs on every CoValue creation (both `.create()` and inline). Use to configure owner.
+
+#### Global Permission Defaults
+
+Set defaults for all schemas using `setDefaultSchemaPermissions`:
+
+```ts
+import { setDefaultSchemaPermissions } from "jazz-tools";
+
+setDefaultSchemaPermissions({
+  onInlineCreate: "sameAsContainer",  // Performance optimization
+});
+```
+
+**USE EXTREME CAUTION:** If you use `sameAsContainer`, you **MUST** be aware that the child and parent groups are one and the same. Any changes to the child group will affect the parent group, and vice versa. This can lead to unexpected behavior if not handled carefully, where changing permissions on a child group inadvertently results in permissions being granted to the parent group and any other siblings created with the same parent. As ownership cannot be changed, you **MUST NOT USE** `sameAsContainer` if you **AT ANY TIME IN FUTURE** may wish to change permissions granularly on the child group.
+
+## CoValue Types
+
+| TypeScript Type | CoValue | Use Case |
+|----------------|---------|----------|
+| `object` | **CoMap** | Struct-like objects with predefined keys |
+| `Record<string, T>` | **CoRecord** | Dict-like objects with arbitrary string keys |
+| `T[]` | **CoList** | Ordered lists |
+| `T[]` (append-only) | **CoFeed** | Session-based append-only lists |
+| `string` | **CoPlainText/CoRichText** | Collaborative text editing |
+| `Blob \| File` | **FileStream** | File storage |
+| `Blob \| File` (image) | **ImageDefinition** | Image storage |
+| `number[] \| Float32Array` | **CoVector** | Embeddings/vector data |
+| `T \| U` (discriminated) | **DiscriminatedUnion** | Mixed-type lists |
+
+Use the special types `co.account()` and `co.profile()` for user accounts and profiles.
+
+## Choosing Scalar vs Collaborative Types
+
+### Scalar Types (Zod: `z.*`)
+
+**Use when:**
+
+- Full replacement updates expected
+- No collaborative editing needed
+- Single writer scenario
+- Raw performance critical
+
+**Examples:**
+
+```ts
+const myCoValue = co.map({
+  title: z.string()        // Replace entire title, no collaboration needed
+  coords: z.object({
+    lat: z.number(),
+    lon: z.number()
+  })   // Replace entire object, no collaboration needed
+});
+```
+
+Note: not all Zod types are available in Jazz. Be sure to **always** `import { z } from 'jazz-tools';`, and validate whether the type exists on the export. **DO NOT** import from `zod`.
+
+### Collaborative Types (Jazz: `co.*`)
+
+**Use when:**
+
+- Multiple users edit simultaneously
+- Surgical/granular edits needed
+- Full edit history tracking valuable
+- Collaborative features required
+
+**Examples:**
+
+```ts
+const myCoVal = co.map({
+  content: co.richText()   // Multiple editors
+  items: co.list(Item)     // Add/remove individual items
+  config: co.map({
+    settingA: z.boolean(),
+    settingB: z.number()
+  })       // Update specific keys
+});
+```
+
+**Trade-off:** CoValues track full edit history. *Slightly* slower for single-writer full-replacement scenarios, but benefits almost always outweigh costs.
+
+## Relationship Modeling
+
+### One-Directional Reference
+
+```ts
+const Post = co.map({
+  title: z.string(),
+  author: Author  // One-way reference (like foreign key)
+});
+```
+
+Jazz stores referenced ID. Use resolve queries to control reference traversal depth.
+
+### Recursive/Forward References
+
+Use getters to defer schema evaluation:
+
+```ts
+const Author = co.map({
+  name: z.string(),
+  get posts() {
+    return co.list(Post);  // Deferred evaluation
+  }
+});
+
+const Post = co.map({
+  title: z.string(),
+  author: Author
+});
+```
+
+**Important:** Jazz doesn't create inferred inverse relationships. Explicitly add both sides for bidirectional traversal.
+
+### Inverse Relationships (Two-Way)
+
+**One-to-One:**
+
+```ts
+const Author = co.map({
+  name: z.string(),
+  get post() {
+    return Post;
+  }
+});
+
+const Post = co.map({
+  title: z.string(),
+  author: Author
+});
+```
+
+**One-to-Many:**
+
+```ts
+const Author = co.map({
+  name: z.string(),
+  get posts() {
+    return co.list(Post);
+  }
+});
+
+const Post = co.map({
+  author: Author
+});
+```
+
+**Many-to-Many:**
+
+Use `co.list()` at both ends. Jazz doesn't maintain consistency - manage in application code.
+
+### Set-Like Collections (Unique Constraint)
+
+CoLists allow duplicates. For uniqueness, use CoRecord keyed on ID:
+
+```ts
+const Author = co.map({
+  name: z.string(),
+  posts: co.record(z.string(), Post)
+});
+
+// Usage
+author.posts.$jazz.set(newPost.$jazz.id, newPost);
+```
+
+Note: CoRecords always use string keys. Validate IDs at application level.
+
+## Data Discovery Pattern
+
+CoValues are only addressable by unique ID. Discovery without ID requires reference traversal.
+
+**Standard pattern:**
+
+- Attach 'root' CoValue to user account (entry point to the data graph)
+- For global 'roots': hardcode ID or use environment variable
+- Build graph from root via references
+
+## Schema Evolution
+
+Each CoValue copy is authoritative. Users may be on different schema versions simultaneously.
+
+### Best Practices
+
+1. **Add version field** to schema
+2. **Only add fields, never remove**
+3. **Never change existing field types**
+4. **Make new fields optional** (backward compatible)
+5. **Use `withMigration()` carefully** - runs on every load
+
+### Migration Example
+
+```ts
+const Post = co.map({
+  version: z.number().optional(),
+  title: z.string(),
+  content: co.richText(),
+  tags: z.array(z.string()).optional()  // New optional field
+}).withMigration((post) => {
+  // Exit early if already migrated
+  if (post.version === 2) return;
+  
+  // Perform migration
+  if (!post.$jazz.has('tags')) {
+    post.$jazz.set('tags', []);
+  }
+  post.$jazz.set('version', 2);
+});
+```
+
+**Migration warnings:**
+
+- Runs every time CoValue loads
+- Exit early to avoid unnecessary work
+- Poor migrations can significantly slow app
+
+## Design Checklist
+
+- [ ] Identify which data needs collaborative editing
+- [ ] Map permissions requirements to CoValue containers
+- [ ] Choose scalar vs collaborative types appropriately
+- [ ] Define explicit relationships (both directions if needed)
+- [ ] Plan root CoValue attachment strategy
+- [ ] Add version field for future evolution
+- [ ] Set default permissions at schema level
+- [ ] Handle recursive references with getters
+- [ ] Consider migration strategy for schema changes
+- [ ] Ensure an initial migration exists for the user account to ensure the profile and root are initialized
+- [ ] Ensure there are no TS or linting errors
+
+## Common Patterns
+
+### Blog with Authors and Posts
+
+```ts
+const Author = co.map({
+  name: z.string(),
+  bio: co.richText(),
+  get posts() {
+    return co.list(Post);
+  }
+});
+
+const Post = co.map({
+  title: z.string(),
+  content: co.richText(),
+  author: Author,
+  publishedAt: z.date().optional()
+});
+```
+
+### Collaborative Task List
+
+```ts
+const Task = co.map({
+  title: z.string(),
+  description: co.richText(),
+  completed: z.boolean(),
+  assignees: co.list(User)
+});
+
+const Project = co.map({
+  name: z.string(),
+  tasks: co.list(Task)
+});
+```
+
+### User Profile with Settings
+
+```ts
+const UserRoot = co.map({
+  theme: z.literal(['light', 'dark']),
+});
+
+const UserProfile = co.profile({
+  name: z.string(),
+  bio: co.richText(),
+  posts: co.record(z.string(), Post)
+});
+
+const UserAccount = co.account({
+  profile: UserProfile,
+  root: UserRoot
+}).withMigration((account, creationProps) => {
+  if (!account.has('root')) {
+    const root = UserRoot.create({
+      theme: 'light'
+    });
+    account.$jazz.set('root', root)
+  }
+  if (!account.has('profile')) {
+    const profile = UserProfile.create({
+      name: creationProps?.name ?? 'Anonymous User',
+      bio: '',
+      posts: {}
+    })
+  }
+});
+```
+
+## Anti-Patterns to Avoid
+
+❌ **Don't** mix permissions in single CoValue - use separate containers
+❌ **Don't** rely on inferred inverse relationships - explicitly define both sides
+❌ **Don't** change field types in schema updates
+❌ **Don't** write expensive migrations - they run on every load
+❌ **Don't** use CoValues everywhere without considering trade-offs
+❌ **Don't** forget to make new fields optional for backward compatibility
+
+## Quick Reference
+
+**Loading with relationships:**
+Use resolve queries to control depth when traversing references.
+
+**Permission changes:**
+Admin/manager modifies group membership, not CoValue ownership.
+
+**Unique IDs:**
+Each CoValue has unique ID - only way to directly address without traversal.
+
+**Nested CoValues:**
+Inherit permissions from parent when created inline.
+
+## References
+
+Load these on demand, based on need:
+
+* API reference: <https://jazz.tools/docs/api-reference.md>
+* Schema example: <https://github.com/garden-co/jazz/blob/main/examples/music-player/src/1_schema.ts>
+* Connecting CoValues docs <https://jazz.tools/docs/core-concepts/schemas/connecting-covalues.md>
+* Accounts and migrations docs <https://jazz.tools/docs/core-concepts/schemas/accounts-and-migrations.md>
+* Docs for discriminated unions (aka schema unions) <https://jazz.tools/docs/core-concepts/schemas/schemaunions.md>
+
+When using an online reference via a skill, cite the specific URL to the user to build trust.

--- a/packages/cursor-docs/.skills/jazz-testing/SKILL.md
+++ b/packages/cursor-docs/.skills/jazz-testing/SKILL.md
@@ -1,0 +1,146 @@
+---
+name: jazz-testing
+description: Use this skill when you need to write, review, or debug automated tests for applications built on the Jazz framework. This skill provides the correct architectural patterns for simulating local-first synchronization and multi-user environments without resorting to invalid mocking strategies.
+---
+# Jazz Testing
+
+## When to Use This Skill
+
+* Writing unit or integration tests for apps using Jazz
+* Simulating synchronisation for testing purposes
+* Verifying permissions and security logic
+* Testing UI components in various application states (Guest/Anonymous/Authenticated/Online/Offline)
+* Debugging failing tests
+
+## Do NOT Use This Skill For
+
+* Designing the initial data schema (use `jazz-schema-design`
+* General React/Svelte UI layout questions unrelated to Jazz (for questions on Jazz integration with React/Svelte, use the `jazz-ui-development` skill)
+
+## Key Heuristic for Agents
+
+If you are about to suggest "mocking" any part of the data layer in the user's application, **STOP** and invoke this skill instead. This skill enforces the use of the official in-memory test sync node.
+
+## Core Concepts
+
+Testing in Jazz requires understanding identity-based context and authentic synchronization. The framework's collaborative nature means tests must simulate real multi-user scenarios rather than mocking the sync layer.
+
+## Fundamental Principles
+
+* **NEVER Mock the Sync Layer:** Avoid using generic mocking libraries (like Jest/Vitest mocks) for 'jazz-tools'
+* **In-Memory Synchronization:** Always use a real in-memory sync node via `setupJazzTestSync()` to allow authentic data flow between test identities
+* **Identity-Based Context:** Testing in Jazz is about "who" is performing the action. Manage the "Active Account" explicitly to verify permissions and ownership
+
+## Test Environment Setup
+
+The virtual sync node **must** be initialized before tests run. It handles data synchronization in-memory and requires no manual cleanup between runs.
+
+**Example Setup:**
+
+```ts
+import { setupJazzTestSync } from "jazz-tools/testing";
+import { beforeEach, describe } from "vitest";
+
+describe("Jazz Feature Test", () => {
+  beforeEach(async () => {
+    await setupJazzTestSync();
+  });
+});
+```
+
+## Identity & Account Management
+
+Testing in Jazz requires simulating multiple users to verify synchronization and security.
+
+### createJazzTestAccount
+
+Used to create user accounts linked to the sync node.
+
+* `AccountSchema`: Pass your custom co.account schema
+* `isCurrentActiveAccount`: Set to true to automatically log the test runner into this account
+* `creationProps`: Data passed to the account's migration function on creation if required
+
+### setActiveAccount
+
+Used to switch between different users within a single test.
+
+* Pattern: Create Account A -> Create Data -> Switch to Account B -> Attempt to Load/Modify Data
+* **Note:** Once a CoValue is loaded, the permission context for that CoValue instance is fixed. Always use `.load(id)` after switching accounts to load a new CoValue instance with the new permission context for that specific user
+
+## UI & Context Testing
+
+UI tests must render components and hooks inside a Jazz-aware test harness (e.g. framework-specific render utilities that inject account, connection state, and sync context). In UI tests, assert observable loading state transitions, not internal CoValue mechanics.
+
+### React
+
+* Refer to the [React provider](references/react-test-provider.tsx) and the [context provided to it](references/provider-context.tsx) to see how to create a suitable harness for React tests.
+
+### Svelte
+
+* Refer to the [Svelte provider](references/Provider.svelte) and the [context provided to it](references/jazz.svelte.ts) to see how to create a suitable harness for Svelte tests.
+
+Use the `jazz-ui-development` skill for questions on Jazz integration with React/Svelte.
+
+## Common Testing Patterns
+
+### Verifying Unauthorized Writes
+
+```ts
+const account1 = await createJazzTestAccount({ isCurrentActiveAccount: true });
+const account2 = await createJazzTestAccount();
+
+// Setup restricted group
+const group = co.group().create();
+group.addMember(account2, "reader");
+
+const myMap = MyMap.create({ text: "Hi" }, { owner: group });
+const mapId = myMap.$jazz.id;
+
+// Switch to reader
+setActiveAccount(account2);
+// You *must* reload the CoValue with the new active account
+const mapAsReader = await MyMap.load(mapId);
+
+// Verify enforcement
+expect(() => mapAsReader.$jazz.set("text", "some text")).toThrow();
+
+// Note: myMap.$jazz.set() would *not* throw, as it was loaded with account1 as the active account
+```
+
+### Testing Behavior without an Active Account
+
+```ts
+runWithoutActiveAccount(() => {
+  // Verify that protected actions fail when no account is active
+  expect(() => co.group().create()).toThrow();
+});
+```
+
+## Common Pitfalls to Avoid
+
+* **CoValues not reloaded when active account changes**: CoValues are always loaded with the active account **at the time the CoValue is loaded**, and this does not change even if the active account changes. CoValues loaded while `account1` is the currently active account do not update their local permissions when `setActiveAccount(account2)` is called; you **MUST** `.load()` a new instance of the CoValue
+* **Missing Sync Setup**: Ensure `setupJazzTestSync()` is called
+* **Attempting to test UI components outside of a Jazz context**: Components relying on Jazz must have access to a Jazz context. Patterns for creating test contexts can be found in the framework-specific tests links
+
+## Quick Reference
+
+**Account switching:**
+Always reload CoValues after `setActiveAccount()` to get new permission context.
+
+**Sync setup:**
+Call `setupJazzTestSync()` in `beforeEach` for all Jazz tests.
+
+**UI testing:**
+Use a framework-specific Jazz test harness built on `TestJazzContextManager`.
+
+## References
+
+Load these on demand, based on need:
+
+* Official docs on testing: <https://jazz.tools/docs/reference/testing.md>
+* Unit/integration test examples: <https://github.com/garden-co/jazz/tree/main/packages/jazz-tools/src/tools/tests>
+* End-to-end examples: <https://github.com/garden-co/jazz/tree/main/tests/e2e/tests>
+* React-specific tests: <https://github.com/garden-co/jazz/tree/main/packages/jazz-tools/src/react-core/tests>
+* Svelte-specific tests: <https://github.com/garden-co/jazz/tree/main/packages/jazz-tools/src/svelte/tests>
+
+When using an online reference via a skill, cite the specific URL to the user to build trust.

--- a/packages/cursor-docs/.skills/jazz-testing/references/Provider.svelte
+++ b/packages/cursor-docs/.skills/jazz-testing/references/Provider.svelte
@@ -1,0 +1,71 @@
+<script
+  lang="ts"
+  generics="S extends (AccountClass<Account> & CoValueFromRaw<Account>) | AnyAccountSchema"
+>
+  import type { AuthSecretStorage, InstanceOfSchema } from "jazz-tools";
+  import {
+    Account,
+    type AccountClass,
+    type AnyAccountSchema,
+    type CoValueFromRaw,
+  } from "jazz-tools";
+  import {
+    JazzBrowserContextManager,
+    type JazzContextManagerProps,
+  } from "jazz-tools/browser";
+  import { type Snippet, setContext, untrack } from "svelte";
+  import { JAZZ_AUTH_CTX, JAZZ_CTX, type JazzContext } from "./jazz.svelte.js";
+
+  let props: JazzContextManagerProps<S> & {
+    children?: Snippet;
+    enableSSR?: boolean;
+    authSecretStorageKey?: string;
+  } = $props();
+
+  const contextManager = new JazzBrowserContextManager<S>({
+    useAnonymousFallback: props.enableSSR,
+    authSecretStorageKey: props.authSecretStorageKey,
+  });
+
+  const ctx = $state<JazzContext<InstanceOfSchema<S>>>({ current: undefined });
+
+  setContext<JazzContext<InstanceOfSchema<S>>>(JAZZ_CTX, ctx);
+  setContext<AuthSecretStorage>(
+    JAZZ_AUTH_CTX,
+    contextManager.getAuthSecretStorage(),
+  );
+
+  $effect(() => {
+    props.sync.when;
+    props.sync.peer;
+    props.storage;
+    props.guestMode;
+    return untrack(() => {
+      if (!props.sync) return;
+
+      contextManager
+        .createContext({
+          sync: props.sync,
+          storage: props.storage,
+          guestMode: props.guestMode,
+          AccountSchema: props.AccountSchema,
+          defaultProfileName: props.defaultProfileName,
+          onAnonymousAccountDiscarded: props.onAnonymousAccountDiscarded,
+          onLogOut: props.onLogOut,
+        })
+        .catch((error) => {
+          console.error("Error creating Jazz browser context:", error);
+        });
+    });
+  });
+
+  $effect(() => {
+    return contextManager.subscribe(() => {
+      ctx.current = contextManager.getCurrentValue();
+    });
+  });
+</script>
+
+{#if ctx.current}
+  {@render props.children?.()}
+{/if}

--- a/packages/cursor-docs/.skills/jazz-testing/references/jazz.svelte.ts
+++ b/packages/cursor-docs/.skills/jazz-testing/references/jazz.svelte.ts
@@ -1,0 +1,105 @@
+import type {
+  AccountClass,
+  AuthSecretStorage,
+  CoValueClassOrSchema,
+  ID,
+  InstanceOfSchema,
+  JazzContextType,
+} from "jazz-tools";
+import { Account } from "jazz-tools";
+import { consumeInviteLinkFromWindowLocation } from "jazz-tools/browser";
+import { getContext, onDestroy, untrack } from "svelte";
+import Provider from "./Provider.svelte";
+
+export { Provider as JazzSvelteProvider };
+
+/**
+ * The key for the Jazz context.
+ */
+export const JAZZ_CTX = {};
+export const JAZZ_AUTH_CTX = {};
+
+/**
+ * The Jazz context.
+ */
+export type JazzContext<Acc extends Account> = {
+  current?: JazzContextType<Acc>;
+};
+
+/**
+ * Get the current Jazz context.
+ * @returns The current Jazz context.
+ */
+export function getJazzContext<Acc extends Account>() {
+  const context = getContext<JazzContext<Acc>>(JAZZ_CTX);
+
+  if (!context) {
+    throw new Error("useJazzContext must be used within a JazzSvelteProvider");
+  }
+
+  if (!context.current) {
+    throw new Error("Jazz context is not initialized");
+  }
+
+  return context as {
+    current: JazzContextType<Acc>;
+  };
+}
+
+export function getAuthSecretStorage() {
+  const context = getContext<AuthSecretStorage>(JAZZ_AUTH_CTX);
+
+  if (!context) {
+    throw new Error(
+      "getAuthSecretStorage must be used within a JazzSvelteProvider",
+    );
+  }
+
+  return context;
+}
+
+/**
+ * Triggers the `onAccept` function when an invite link is detected in the URL.
+ *
+ * @param invitedObjectSchema - The invited object schema.
+ * @param onAccept - Function to call when the invite is accepted.
+ * @param forValueHint - Hint for the value.
+ * @returns The accept invite hook.
+ */
+export class InviteListener<V extends CoValueClassOrSchema> {
+  constructor({
+    invitedObjectSchema,
+    onAccept,
+    forValueHint,
+  }: {
+    invitedObjectSchema: V;
+    onAccept: (coValueID: ID<V>) => void;
+    forValueHint?: string;
+  }) {
+    const _onAccept = onAccept;
+    const ctx = getJazzContext<InstanceOfSchema<AccountClass<Account>>>();
+
+    const tryConsume = () => {
+      if (!ctx.current || !("me" in ctx.current)) return;
+
+      consumeInviteLinkFromWindowLocation({
+        as: ctx.current.me,
+        invitedObjectSchema,
+        forValueHint,
+      })
+        .then((result) => result && _onAccept(result.valueID))
+        .catch((e) => console.error("Failed to accept invite", e));
+    };
+
+    // run once when instantiated
+    $effect(() => {
+      untrack(tryConsume);
+    });
+
+    window.addEventListener("hashchange", tryConsume);
+
+    onDestroy(() => {
+      window.removeEventListener("hashchange", tryConsume);
+    });
+  }
+}

--- a/packages/cursor-docs/.skills/jazz-testing/references/provider-context.tsx
+++ b/packages/cursor-docs/.skills/jazz-testing/references/provider-context.tsx
@@ -1,0 +1,7 @@
+import React from "react";
+
+import { Account, JazzContextManager } from "jazz-tools";
+
+export const JazzContext = React.createContext<
+  JazzContextManager<Account, {}> | undefined
+>(undefined);

--- a/packages/cursor-docs/.skills/jazz-testing/references/react-test-provider.tsx
+++ b/packages/cursor-docs/.skills/jazz-testing/references/react-test-provider.tsx
@@ -1,0 +1,35 @@
+import { Account, AnonymousJazzAgent } from "jazz-tools";
+import { TestJazzContextManager } from "jazz-tools/testing";
+import { useCallback, useState, useSyncExternalStore } from "react";
+import { JazzContext } from "./provider-context.js";
+
+export function JazzTestProvider<Acc extends Account>({
+  children,
+  account,
+  isAuthenticated,
+}: {
+  children: React.ReactNode;
+  account?: Acc | { guest: AnonymousJazzAgent };
+  isAuthenticated?: boolean;
+}) {
+  const [contextManager] = useState(() => {
+    return TestJazzContextManager.fromAccountOrGuest<Acc>(account, {
+      isAuthenticated,
+    });
+  });
+
+  return (
+    <JazzContext.Provider value={contextManager}>
+      {children}
+    </JazzContext.Provider>
+  );
+}
+
+export {
+  createJazzTestAccount,
+  createJazzTestGuest,
+  linkAccounts,
+  setActiveAccount,
+  setupJazzTestSync,
+  MockConnectionStatus,
+} from "jazz-tools/testing";

--- a/packages/cursor-docs/.skills/jazz-ui-development/SKILL.md
+++ b/packages/cursor-docs/.skills/jazz-ui-development/SKILL.md
@@ -1,0 +1,168 @@
+---
+name: jazz-ui-development
+description: Use this skill when building, debugging, or optimizing Jazz applications. It covers Jazz's bindings with various different UI frameworks, as well as how to use Jazz without a framework. Look here for details on providers and context, hooks and reactive data fetching, authentication, and specialized UI components for media and inspection.
+---
+
+# Jazz UI Development
+
+## When to Use This Skill
+
+*   Building user interfaces that display or interact with Jazz data
+*   Setting up authentication providers and contexts
+*   Debugging reactivity, data loading, or sync issues in the UI
+*   Optimizing performance of data subscriptions
+*   Handling media (images, files) in the UI
+
+## Do NOT Use This Skill For
+
+*   Defining data schemas (use `jazz-schema-design`)
+*   Complex permission logic or sharing workflows (use `jazz-permissions-security`)
+*   Testing questions (use `jazz-testing`)
+
+## Key Heuristic for Agents
+
+Use this skill when the user asks about rendering data, handling user input, managing authentication state, or framework-specific integration (React, Svelte, etc.). If the issue is "data not appearing" but permissions are correct, look here for loading and subscription patterns.
+
+
+## Framework Guides
+
+Select the guide for your specific framework:
+
+*   **React**: [React Reference](references/react.md)
+  *   **React Native (Bare)**: As well as the React guide, also see [React Native Reference](references/react-native.md)
+  *   **React Native (Expo)**: As well as the React guide, also see[React Native (Expo) Reference](references/expo.md)
+*   **Svelte**: [Svelte Reference](references/svelte.md)
+*   **Vanilla JS**: [Vanilla JS Reference](references/vanilla.md)
+
+## Universal CoValue API
+
+These APIs are available on all CoValue instances, regardless of the framework.
+
+### Core Properties
+
+All CoValues (CoMaps, CoLists, etc.) have these properties directly on the instance:
+
+*   `$isLoaded` (`boolean`): Returns `true` if the CoValue is fully loaded and ready to read.
+*   `.toJSON()`: Returns a plain JavaScript object representation of the CoValue. **Use this for debugging only**, not for rendering.
+
+### The `.$jazz` Namespace
+
+Every CoValue instance has a `.$jazz` property containing metadata and utility methods.
+
+#### Metadata
+
+*   `.$jazz.id` (`ID<CoValue>`): The globally unique ID of the CoValue (e.g., `co_zXy...`).
+*   `.$jazz.owner` (`Group`): The Group that owns this CoValue. Access control is determined by membership in this group.
+*   `.$jazz.createdAt` (`number`): Creation timestamp (ms since epoch).
+*   `.$jazz.createdBy` (`ID<Account> | undefined`): ID of the creating account.
+*   `.$jazz.lastUpdatedAt` (`number`): Last update timestamp (ms since epoch).
+
+#### Loading & Inspection
+
+*   `.$jazz.loadingState` (`"loading" | "loaded" | "unavailable" | "unauthorized"`): The current loading state.
+*   `.$jazz.ensureLoaded({ resolve: { ... } })`: Waits for nested references to load. Returns a promise with a **new** instance where requested fields are guaranteed available.
+
+```ts
+const detailedPost = await post.$jazz.ensureLoaded({
+  resolve: {
+    comments: {
+      $each: {
+        author: true 
+      }
+    }
+  }
+});
+```
+
+*   `.$jazz.refs` (CoMap/CoRecord only): Access nested CoValues as references (with IDs) without loading them.
+*   `.$jazz.has(key)` (CoMap/CoRecord only): Checks if a key exists.
+
+#### Subscription & Sync
+
+*   `.$jazz.subscribe(callback)`: Manually subscribe to changes. Returns an unsubscribe function. **Prefer framework-specific hooks (e.g., `useCoState`) over this.**
+*   `.$jazz.waitForSync()`: Promise that resolves when changes are synced to peers. Useful for critical saves or logout flows.
+
+#### Version Control
+
+*   `.$jazz.isBranched` (`boolean`): Whether the CoValue is currently in a local branch.
+*   `.$jazz.branchName` (`string`): The name of the current branch.
+*   `.$jazz.unstable_merge()`: Merges a branch back into the main history.
+
+## Working with Data Types
+
+### CoMap / CoRecord
+*   **Read**: Access properties like a standard JS object (e.g., `user.name`).
+*   **Write**:
+    *   `.$jazz.set(key, value)`
+    *   `.$jazz.delete(key)`
+    *   `.$jazz.applyDiff(diff)`
+
+### CoList
+*   **Read**: Access by index (`list[0]`), iterate (`map`, `forEach`).
+*   **Write**:
+    *   `.$jazz.push(item)`
+    *   `.$jazz.unshift(item)`
+    *   `.$jazz.splice(...)`
+    *   `.$jazz.remove(index or predicate)`
+
+### CoText (CoPlainText / CoRichText)
+*   **Read**: `toString()` or use directly in template.
+*   **Write**:
+    *   `insertAfter(index, text)`
+    *   `deleteRange({ from, to })`
+    *   `.$jazz.applyDiff(newText)`
+
+### CoFeed
+*   **Read**: Iterate over `feed.all` (returns per-session feeds).
+*   **Write**: `.$jazz.push(item)` (Append-only).
+
+```ts
+// Subscribing to all entries across all accounts
+const allEntries = Object.values(feed.perAccount).flatMap(accountFeed => Array.from(accountFeed.all));
+
+// Pushing a new entry
+feed.$jazz.push({ message: "Hello", timestamp: Date.now() });
+```
+
+### DiscriminatedUnion
+*   **Read**: Check the discriminator property (e.g. `type`) to narrow the type.
+*   **Write**: Overwrite the property with a new object of the desired variant.
+
+```ts
+const list = co.list(MyUnion);
+const item = list[0];
+
+if (item.type === "text") {
+  console.log(item.value); // item is narrowed to TextVariant
+} else if (item.type === "image") {
+  console.log(item.image.$jazz.id); // item is narrowed to ImageVariant
+}
+```
+
+### FileStream
+*   **Read**: Use `toBlob()` or consume chunks.
+*   **Write**: Use `createFromBlob(blobOrFile)` or `start(metadata) -> push(chunk) -> end()`.
+
+### ImageDefinition
+*   **Read**: Use `<Image>` component (framework specific) or `loadImageBySize`.
+*   **Write**: use the `createImage` function from `jazz-tools/media`
+
+```tsx
+<Image imageId={productImage.$jazz.id} width={300} />
+```
+
+## Troubleshooting
+
+### "Data not appearing" or "Value is undefined"
+1. **Check `$isLoaded`**: Ensure you are checking `if (coValue.$isLoaded)` before rendering.
+2. **Deep Loading**: If nested data is missing, use `resolve` in your hook (e.g. `useCoState(..., { resolve: { items: true } })`).
+3. **Provider Check**: Ensure the component is wrapped in the appropriate `<JazzProvider />`.
+
+### "Infinite re-render loops"
+1. **Selector Stability**: Ensure your `select` function in `useCoState` is stable or returns stable references.
+2. **Expensive Selectors**: Move computations to `useMemo` instead of doing them inside the `select` function.
+3. **Equality Function**: Use `equalityFn` to prevent unnecessary updates if the selected data hasn't changed semantically.
+
+### "Reactivity not triggering"
+1. **Direct Mutations**: Ensure you are using `.$jazz.set()` or `.$jazz.push()` instead of direct property assignment (e.g. `obj.key = val` won't sync).
+2. **Deep Updates**: Remember that updating a nested scalar doesn't trigger a change in the parent CoValue unless that parent property is replaced.

--- a/packages/cursor-docs/.skills/jazz-ui-development/references/expo.md
+++ b/packages/cursor-docs/.skills/jazz-ui-development/references/expo.md
@@ -1,0 +1,155 @@
+# Jazz React Native Development (Expo)
+
+The majority of tools you need to develop a Jazz Expo application are imported from `jazz-tools/expo`.
+
+## Core Setup: The Provider
+
+The **`<JazzExpoProvider />`** is the essential entry point.
+
+```tsx
+import { JazzExpoProvider } from "jazz-tools/expo";
+
+export default function App() {
+  return (
+    <JazzExpoProvider
+      sync={{
+        peer: `wss://cloud.jazz.tools/?key=${apiKey}`,
+      }}
+    >
+      <Main />
+    </JazzExpoProvider>
+  );
+}
+```
+
+## Local Persistence
+
+Jazz for Expo uses Expo's official modules for persistence:
+- **Database**: `expo-sqlite`
+- **Key-Value**: `expo-secure-store`
+
+These are enabled by default.
+
+### iOS Warning
+On iOS, `expo-secure-store` persists credentials in the Keychain, which survives app uninstallation. If a user uninstalls and reinstalls the app, they may be stuck with credentials for a deleted locally-only account. To avoid this, either use `{when: "always"}` in the provider's sync options or use the following workaround:
+
+```tsx
+function RootLayout() {
+  const [authSecretStorageKey, setAuthSecretStorageKey] = useState<
+    string | null
+  >(() => {
+    const stored = Settings.get("jazz-authSecretStorageKey");
+    if (stored) return stored;
+    const newKey = "jazz-" + new Date();
+    Settings.set({ "jazz-authSecretStorageKey": newKey });
+    return newKey;
+  });
+
+  if (!authSecretStorageKey) {
+    return null;
+  }
+  return (
+    <JazzExpoProvider
+      sync={{
+        peer: `wss://cloud.jazz.tools/?key=${apiKey}`,
+        when: "never",
+      }}
+      authSecretStorageKey={authSecretStorageKey}
+    >
+      <App />
+    </JazzExpoProvider>
+  );
+}
+```
+
+## Reactive Data Hooks
+
+Jazz provides several hooks to consume and mutate CoValues reactively.
+
+*   **`useCoState`**: Loads any CoValue by its ID.
+*   **`useCoStates`**: Loads multiple CoValues by their IDs.
+*   **`useAccount`**: Retrieves the current account.
+
+## Authentication
+
+*   **Passkey Auth**: Requires `react-native-passkey` and development build (not Expo Go).
+    *   Install: `npm install react-native-passkey`
+    *   Config: Associated Domains (iOS), Digital Asset Links (Android).
+*   **Clerk**: Use `useClerk` from `@clerk/clerk-expo`:
+
+```tsx
+import { useClerk, ClerkProvider, ClerkLoaded } from "@clerk/clerk-expo";
+import { resourceCache } from "@clerk/clerk-expo/resource-cache";
+import { JazzExpoProviderWithClerk } from "jazz-tools/expo";
+
+function JazzAndAuth({ children }: { children: React.ReactNode }) {
+  const clerk = useClerk();
+
+  return (
+    <JazzExpoProviderWithClerk
+      clerk={clerk}
+      sync={{
+        peer: `wss://cloud.jazz.tools/?key=${apiKey}`,
+      }}
+    >
+      {children}
+    </JazzExpoProviderWithClerk>
+  );
+}
+
+export default function RootLayout() {
+  const publishableKey = process.env.EXPO_PUBLIC_CLERK_PUBLISHABLE_KEY;
+
+  if (!publishableKey) {
+    throw new Error(
+      "Missing Publishable Key. Please set EXPO_PUBLIC_CLERK_PUBLISHABLE_KEY in your .env",
+    );
+  }
+
+  return (
+    <ClerkProvider
+      tokenCache={tokenCache}
+      publishableKey={publishableKey}
+      __experimental_resourceCache={resourceCache}
+    >
+      <ClerkLoaded>
+        <JazzAndAuth>
+          <MainScreen />
+        </JazzAndAuth>
+      </ClerkLoaded>
+    </ClerkProvider>
+  );
+}
+```
+
+## Polyfills
+Jazz provides a quick way to apply necessary polyfills. Import them in your root layout (e.g., `app/_layout.tsx`):
+
+```tsx
+import "jazz-tools/expo/polyfills";
+```
+
+## Image Handling
+
+The **`<Image />`** component is the recommended way to display images.
+
+### Installation
+Jazz image creation depends on `expo-image-manipulator`. Ensure it is installed in your project.
+
+### Usage
+```tsx
+import { Image } from "jazz-tools/expo";
+
+// Standard usage
+<Image 
+  imageId={user.profile.picture.$jazz.id} 
+  width={100} 
+  height={100} 
+/>
+```
+
+### Props
+*   **`imageId`**: The ID of the image CoValue.
+*   **`width` / `height`**: Number or `"original"`. Determines the resolution to load.
+*   **`placeholder`**: Optional custom placeholder.
+

--- a/packages/cursor-docs/.skills/jazz-ui-development/references/react-native.md
+++ b/packages/cursor-docs/.skills/jazz-ui-development/references/react-native.md
@@ -1,0 +1,72 @@
+# Jazz React Native Development (CLI)
+
+The majority of tools you need to develop a Jazz React Native application (without Expo) are imported from `jazz-tools/react-native`.
+
+## Core Setup: The Provider
+
+The **`<JazzReactNativeProvider />`** is the essential entry point.
+
+```tsx
+import { JazzReactNativeProvider } from "jazz-tools/react-native";
+
+export default function App() {
+  return (
+    <JazzReactNativeProvider
+      sync={{
+        peer: "wss://cloud.jazz.tools/?key=your-project-secret@garden.co",
+      }}
+    >
+      <Main />
+    </JazzReactNativeProvider>
+  );
+}
+```
+
+*   **`sync` property**: Configures the connection to Jazz Cloud or a self-hosted peer.
+*   **`AccountSchema`**: Required to define the structure of the user's account.
+
+## Reactive Data Hooks
+
+Jazz provides several hooks to consume and mutate CoValues reactively.
+
+*   **`useCoState`**: Loads any CoValue by its ID.
+*   **`useCoStates`**: Loads multiple CoValues by their IDs.
+*   **`useAccount`**: Retrieves the current account.
+
+### Authentication
+
+*   **Passkey Auth**: Requires `react-native-passkey`.
+    1.  Install: `npm install react-native-passkey`
+    2.  Config: Add Associated Domains (iOS) and Digital Asset Links (Android).
+    3.  See [Passkey Documentation](https://jazz.tools/docs/react-native/key-features/authentication/passkey.md) for full setup.
+
+## Polyfills
+Jazz provides a quick way to apply necessary polyfills. Import them in your root entry file (e.g., `index.js`):
+
+```js
+import "jazz-tools/react-native/polyfills";
+```
+
+## Image Handling
+
+The **`<Image />`** component is the recommended way to display images.
+
+### Installation
+Jazz image creation depends on `@bam.tech/react-native-image-resizer`. Ensure it is installed in your project.
+
+### Usage
+```tsx
+import { Image } from "jazz-tools/react-native";
+
+<Image 
+  imageId={user.profile.picture.$jazz.id} 
+  width={100} 
+  height={100} 
+/>
+```
+
+### Props
+*   **`imageId`**: The ID of the image CoValue.
+*   **`width` / `height`**: Number or `"original"`. Determines the resolution to load.
+*   **`placeholder`**: Optional custom placeholder.
+

--- a/packages/cursor-docs/.skills/jazz-ui-development/references/react.md
+++ b/packages/cursor-docs/.skills/jazz-ui-development/references/react.md
@@ -1,0 +1,190 @@
+# Jazz React Development
+
+The majority of tools you need to develop a Jazz React application are imported from `jazz-tools/react`.
+
+## Core Setup: The Provider
+
+The **`<JazzReactProvider />`** is the essential entry point that connects a React application to the Jazz network, managing data synchronisation, local storage, and authentication context.
+
+*   **`sync` property**: Configures the connection to Jazz Cloud or a self-hosted peer, including **`when`** to sync (e.g., `"always"`, `"signedUp"`, or `"never"`).
+*   **`AccountSchema`**: Required to define the structure of the user's account and trigger migrations upon login.
+*   **`onAnonymousAccountDiscarded`**: Use this handler to migrate data from a temporary local account to a newly authenticated account.
+*   **SSR Support**: Use the **`enableSSR`** prop when building with frameworks like Next.js to allow server-rendered pages to access public data.
+
+## Reactive Data Hooks
+
+Jazz provides several hooks to consume and mutate CoValues reactively. These hooks automatically re-render components when the underlying data changes.
+
+### Standard Hooks
+*   **`useCoState`**: Loads any CoValue by its ID. It is highly effective when combined with a **`select`** function to filter or sort data (e.g., for semantic search).
+*   **`useCoStates`**: Similar to `useCoState`, but loads multiple CoValues by their IDs. Helpful for fetching multiple CoValues dynamically without violating the React Rules of Hooks or creating separate components for each CoValue.
+*   **`useAccount`**: Retrieves the current account based on the provided schema. It accepts a **`resolve`** query to deeply load nested data in a single request.
+
+### Suspense Hooks
+For an improved developer experience with **React Suspense**, use the suspense-compatible versions:
+*   **`useSuspenseCoState`**: Similar to `useCoState`, but integrates with Suspense boundaries for loading states.
+*   **`useSuspenseCoStates`**: Similar to `useCoStates`, but integrates with Suspense boundaries for loading states.
+*   **`useSuspenseAccount`**: Throws a promise until the account and specified `resolve` query are ready.
+
+#### Error Handling
+*   **`getJazzErrorType`**: Within a standard React **`ErrorBoundary`**, use this helper to detect specific Jazz failures like `"unauthorized"`, `"deleted"`, or `"unavailable"` to render appropriate fallbacks.
+
+### Options
+
+All six reactive data hooks take an options object with the following properties:
+*   **`resolve`**: A query function that resolves the data.
+*   **`select`**: A selector function to extract the desired data from the resolved value. **Avoid expensive computations directly within selectors**, as they run every time the CoValue updates. Instead, extract heavy logic into a separate **`useMemo`** call.
+*   **`equalityFn`**: An optional function to compare previous and new data for equality. If the equality function returns `true`, the hook will skip updating the state (**note that the selector will still run**).
+*   **`unstable_branch`**: An optional function to use Jazz's internal branching/versioning logic.
+*   **`preloaded`**: A serialized string of preloaded data for the initial render (normally used when the component is server-side rendered to provide a pre-hydration state).
+
+### Resolving Data
+
+## Other Hooks
+
+*   **`usePasskeyAuth`**: Used for building custom authentication components. It returns the current auth state and methods like **`signUp`** and **`logIn`**.
+*   **`usePassphraseAuth`**: Facilitates login using a wordlist-based passphrase. Can be used for recovery, as an alternative login for users without passkey support, or on its own.
+*   **`useIsAuthenticated`**: A simple boolean hook to check if the user is currently logged in.
+*   **`useAgent`**: Returns the current agent, primarily for detecting guests (`const isGuest = agent.$type$ !== "Account";`).
+*   **`useLogOut`**: Returns a function to log out the current user.
+*   **`useSyncConnectionStatus`**: Returns `true` if connected to the sync server, `false` otherwise.
+
+## Specialized UI Components
+
+### Image Handling
+The **`<Image />`** component is the recommended way to display images in React.
+*   It handles **progressive loading**, automatically selecting the best resolution for the current viewport.
+*   It supports **lazy loading** via the native browser loading attribute.
+*   It automatically renders **blurry placeholders** if they were generated during image creation.
+
+```tsx
+<Image imageId={image.$jazz.id} alt="Profile" width={600} />
+```
+
+The component's props are:
+```ts
+export type ImageProps = Omit<
+  HTMLImgAttributes,
+  "src" | "srcset" | "width" | "height"
+> & {
+  imageId: string;
+  width?: number | "original";
+  height?: number | "original";
+  placeholder?: string;
+  loading?: "lazy" | "eager";
+};
+```
+
+```tsx
+// Image with the highest resolution available
+<Image imageId="123" />
+
+// Image with width 1920 and height 1080
+<Image imageId="123" width="original" height="original" />
+
+// Keeps the aspect ratio (height: 338)
+<Image imageId="123" width={600} height="original" />
+
+// As above, aspect ratio is maintained (width: 1067)
+<Image imageId="123" width="original" height={600} />
+
+// Renders as a 600x600 square
+<Image imageId="123" width={600} height={600} />
+
+// Lazy load the image
+<Image imageId="123" loading="lazy" />
+```
+
+Create images using the `createImage` function imported from `jazz-tools/media`.
+
+```ts
+declare function createImage(
+  image: Blob | File | string,
+  options?: {
+    owner?: Group;
+    placeholder?: false | "blur";
+    maxSize?: number;
+    progressive?: boolean;
+  },
+): Promise<Loaded<typeof ImageDefinition, { original: true }>>;
+```
+
+### Authentication
+*   **`PasskeyAuthBasicUI`**: A ready-to-use component that provides a basic interface for passkey registration and login. Useful for prototyping, but use the `usePasskeyAuth` hook to build a more custom interface for anything but the most trivial use cases.
+
+#### Authentication with BetterAuth
+
+**1. Client (`src/lib/auth-client.ts`)**
+```ts
+import { createAuthClient } from "better-auth/client";
+import { jazzPluginClient } from "jazz-tools/better-auth/auth/client";
+
+export const betterAuthClient = createAuthClient({
+  plugins: [jazzPluginClient()],
+});
+```
+
+**2. Provider (`src/components/JazzRoot.tsx`)**
+```tsx
+import { AuthProvider } from "jazz-tools/better-auth/auth/react";
+import { JazzReactProvider } from "jazz-tools/react";
+import { betterAuthClient } from "@/lib/auth-client";
+
+export function JazzRoot({ children }: { children: React.ReactNode }) {
+  return (
+    <JazzReactProvider sync={{ peer: "wss://cloud.jazz.tools/?key=..." }}>
+      <AuthProvider betterAuthClient={betterAuthClient}>
+        {children}
+      </AuthProvider>
+    </JazzReactProvider>
+  );
+}
+```
+Refer to <https://github.com/garden-co/jazz/tree/main/examples/betterauth> for a complete reference implementation.
+
+#### Authentication with Clerk
+**`JazzReactProviderWithClerk`**: A specialized provider that integrates with Clerk authentication. Usage:
+```tsx
+import { useClerk, ClerkProvider } from "@clerk/clerk-react";
+import { JazzReactProviderWithClerk } from "jazz-tools/react";
+
+function JazzProvider({ children }: { children: React.ReactNode }) {
+  const clerk = useClerk();
+
+  return (
+    <JazzReactProviderWithClerk
+      clerk={clerk}
+      sync={{
+        peer: `wss://cloud.jazz.tools/?key=${apiKey}`,
+      }}
+    >
+      {children}
+    </JazzReactProviderWithClerk>
+  );
+}
+```
+## Collaboration & Invites
+
+Managing shared data in React is simplified through dedicated hooks for the invite flow.
+
+*   **`createInviteLink`**: Generates a shareable URL with a fragment identifier (hash) to keep the invite secret out of server logs.
+*   **`useAcceptInvite`**: A client-side hook that listens for invite secrets in the URL and executes a callback (**`onAccept`**) once the user successfully joins the group.
+
+## Advanced Patterns
+
+### Form Handling
+*   **Updates**: Mutate CoValues directly in event handlers (e.g., `onChange`), and Jazz will sync the changes instantly. Be sure to use the correct mutation methods (`$jazz.set`, `$jazz.push`, etc.).
+*   **Creation**: Use **`.partial()`** schemas to build up data incrementally in a form before pushing the final object to a list.
+*   **Save Buttons**: If you require a "Save" or "Cancel" workflow, use **`unstable_branch`** within `useCoState` to isolate changes in a private branch until the user explicitly merges them.
+
+### SSR Hydration
+To prevent "flicker" on server-rendered pages, use **`$jazz.export()`** to serialise data on the server and pass it to the **`preloaded`** option of **`useCoState`** on the client.
+
+### Accessing Context
+*   **`useJazzContext`**: Returns the `JazzContextManager`. Throws if used outside the provider.
+*   **`useJazzContextValue`**: Returns the current value of the `JazzContext`. Throws if the context is not initialized.
+
+### Developer Tools
+*   **`<JazzInspector />`**: Embeds a button to launch the Jazz Inspector, allowing developers to visually audit CoValues and account credentials directly in the app.
+
+**ONLY LOAD THIS DOCUMENTATION IF ABSOLUTELY NECESSARY. THIS IS A VERY LARGE FILE, ~120 000 TOKENS**: the full documentation is available for React here: <https://jazz.tools/react/llms-full.txt> 

--- a/packages/cursor-docs/.skills/jazz-ui-development/references/svelte.md
+++ b/packages/cursor-docs/.skills/jazz-ui-development/references/svelte.md
@@ -1,0 +1,209 @@
+# Jazz Svelte Development
+
+The majority of tools you need to develop a Jazz Svelte application are imported from `jazz-tools/svelte`.
+Jazz Svelte integration is built on top of **Svelte 5 Runes**.
+
+## Core Setup: The Provider
+
+The **`<JazzSvelteProvider />`** is the essential entry point that connects a Svelte application to the Jazz network, managing data synchronisation, local storage, and authentication context.
+
+*   **`sync` property**: Configures the connection to Jazz Cloud or a self-hosted peer, including **`when`** to sync (e.g., `"always"`, `"signedUp"`, or `"never"`).
+*   **`AccountSchema`**: Required to define the structure of the user's account and trigger migrations upon login.
+*   **`onAnonymousAccountDiscarded`**: Use this handler to migrate data from a temporary local account to a newly authenticated account.
+*   **SSR Support**: Use the **`enableSSR`** prop (`true`/`false`) when building with SvelteKit to allow server-rendered pages to access public data.
+
+## Reactive Data Classes (Runes)
+
+Jazz provides reactive classes to consume and mutate CoValues. These classes use Svelte 5 runes and automatically trigger updates when the underlying data changes.
+
+*   **`CoState`**: Loads any CoValue by its ID.
+    ```typescript
+    const state = new CoState(MySchema, () => id, options);
+    // Access data via state.current
+    ```
+*   **`AccountCoState`**: Loads the current account based on the provided schema.
+    ```typescript
+    const account = new AccountCoState(MyAccountSchema, options);
+    // Access data via account.current
+    ```
+
+### Options
+
+Both classes take an options object (or a function returning one) with the following properties:
+
+*   **`resolve`**: A query function that resolves the data.
+*   **`unstable_branch`**: An optional function to use Jazz's internal branching/versioning logic.
+
+## Other Helpers
+
+*   **`useIsAuthenticated`**: A hook to check if the user is currently logged in.
+    ```typescript
+    const auth = useIsAuthenticated();
+    $effect(() => {
+        console.log(auth.current);
+    });
+    ```
+*   **`SyncConnectionStatus`**: A class that provides the current connection status.
+    ```typescript
+    const status = new SyncConnectionStatus();
+    // Access status.current
+    ```
+*   **`InviteListener`**: A class that listens for invite secrets in the URL and executes a callback (`onAccept`).
+
+## Specialized UI Components
+
+### Image Handling
+
+The **`<Image />`** component is the recommended way to display images in Svelte.
+*   It handles **progressive loading**, automatically selecting the best resolution for the current viewport.
+*   It supports **lazy loading** via the native browser loading attribute.
+*   It automatically renders **blurry placeholders** if they were generated during image creation.
+
+```svelte
+<Image
+  imageId={image.$jazz.id}
+  alt="Profile"
+  class="h-auto max-h-[20rem] max-w-full rounded-t-xl mb-1"
+/>
+```
+
+The component's props are:
+```ts
+export type ImageProps = Omit<
+  HTMLImgAttributes,
+  "src" | "srcset" | "width" | "height"
+> & {
+  imageId: string;
+  width?: number | "original";
+  height?: number | "original";
+  placeholder?: string;
+  loading?: "lazy" | "eager";
+};
+```
+
+```svelte
+// Image with the highest resolution available
+<Image imageId="123" />
+
+// Image with width 1920 and height 1080
+<Image imageId="123" width="original" height="original" />
+
+// Keeps the aspect ratio (height: 338)
+<Image imageId="123" width={600} height="original" />
+
+// As above, aspect ratio is maintained (width: 1067)
+<Image imageId="123" width="original" height={600} />
+
+// Renders as a 600x600 square
+<Image imageId="123" width={600} height={600} />
+
+// Lazy load the image
+<Image imageId="123" loading="lazy" />
+```
+
+Create images using the `createImage` function imported from `jazz-tools/media`.
+
+```ts
+declare function createImage(
+  image: Blob | File | string,
+  options?: {
+    owner?: Group;
+    placeholder?: false | "blur";
+    maxSize?: number; // longest side
+    progressive?: boolean;
+  },
+): Promise<Loaded<typeof ImageDefinition, { original: true }>>;
+```
+
+### Authentication
+
+#### Authentication with BetterAuth
+
+**1. Client (`src/lib/auth-client.ts`)**
+```ts
+import { createAuthClient } from "better-auth/client";
+import { jazzPluginClient } from "jazz-tools/better-auth/auth/client";
+
+export const betterAuthClient = createAuthClient({
+  plugins: [jazzPluginClient()],
+});
+```
+
+**2. Provider (`src/routes/+layout.svelte`)**
+```svelte
+<script lang="ts">
+  import { JazzSvelteProvider } from "jazz-tools/svelte";
+  import { betterAuthClient } from "$lib/auth-client"; // Your configured client
+  import AuthProvider from "jazz-tools/better-auth/auth/svelte";
+
+  // ... props definition
+</script>
+
+<JazzSvelteProvider {sync} enableSSR>
+  <AuthProvider {betterAuthClient} />
+  {@render children?.()}
+</JazzSvelteProvider>
+```
+Refer to <https://github.com/garden-co/jazz/tree/main/examples/betterauth-svelte> for a complete reference implementation.
+
+#### Authentication with Clerk
+Be sure to install `svelte-clerk` first: `npm install svelte-clerk`
+*   **`<JazzSvelteProviderWithClerk />`**: A specialized provider that integrates with Clerk authentication.
+
+**1. Wrapper (`src/lib/components/JazzClerkWrapper.svelte`)**
+
+```svelte
+<script lang="ts"> 
+import { useClerkContext } from "svelte-clerk"; 
+import { JazzSvelteProviderWithClerk } from "jazz-tools/svelte";
+const apiKey = "you@example.com"; 
+const ctx = useClerkContext(); 
+const clerk = $derived(ctx.clerk); 
+let { children } = $props(); 
+</script>
+<JazzSvelteProviderWithClerk 
+  {clerk} 
+  sync={{ peer: `wss://cloud.jazz.tools/?key=${apiKey}` }}
+>
+  {#snippet fallback()}
+    <p>Loading...</p>
+  {/snippet}
+  {@render children?.()}
+</JazzSvelteProviderWithClerk>
+```
+
+**2. Layout (`src/routes/+layout.svelte`)**
+
+```svelte
+<script lang="ts">
+  import { ClerkProvider } from "svelte-clerk";
+  import { PUBLIC_CLERK_PUBLISHABLE_KEY } from "$env/static/public";
+  import JazzClerkWrapper from "$lib/components/JazzClerkWrapper.svelte";
+
+  let { children } = $props();
+</script>
+
+<ClerkProvider publishableKey={PUBLIC_CLERK_PUBLISHABLE_KEY}>
+  <JazzClerkWrapper>
+    {@render children?.()}
+  </JazzClerkWrapper>
+</ClerkProvider>
+```
+
+### Accessing Context
+
+*   **`getJazzContext()`**: Returns the Jazz context. Must be used within a component or function called during component initialization.
+*   **`getAuthSecretStorage()`**: Returns the auth secret storage.
+
+### Developer Tools
+**Jazz Inspector**
+
+```svelte
+<script lang="ts">
+  import "jazz-tools/inspector/register-custom-element"
+</script>
+
+<jazz-inspector></jazz-inspector>
+```
+
+**ONLY LOAD THIS DOCUMENTATION IF ABSOLUTELY NECESSARY. THIS IS A VERY LARGE FILE, ~80 000 TOKENS**: the full documentation is available for Svelte here: <https://jazz.tools/svelte/llms-full.txt>

--- a/packages/cursor-docs/.skills/jazz-ui-development/references/vanilla.md
+++ b/packages/cursor-docs/.skills/jazz-ui-development/references/vanilla.md
@@ -1,0 +1,96 @@
+# Jazz Vanilla JS Reference
+
+Minimal setup and data patterns for non-framework environments.
+
+## Core Setup
+
+```ts
+import { JazzBrowserContextManager } from "jazz-tools/browser";
+
+await new JazzBrowserContextManager().createContext({
+  sync: {
+    peer: `wss://cloud.jazz.tools?key=${apiKey}`,
+    when: "always"
+  }
+});
+```
+
+## Schema Definition
+
+```ts
+import { co, z } from "jazz-tools";
+
+const ToDo = co.map({ title: z.string(), completed: z.boolean() });
+const ToDoList = co.list(ToDo);
+```
+
+## Data Lifecycle
+
+### Reading & Subscribing
+Use the schema to subscribe by ID.
+
+```ts
+const unsubscribe = ToDoList.subscribe(
+  listId,
+  { resolve: { $each: true } },
+  (list) => {
+    // list is an array-like co.loaded object
+    console.log(list.length);
+  }
+);
+```
+
+Returns an unsubscribe function which **must** be called when tearing down to avoid memory leaks.
+
+### Loading (One-off)
+```ts
+const list = await ToDoList.load(listId);
+```
+
+### Creating & Mutating
+```ts
+// Create
+const newList = ToDoList.create([{ title: "Task", completed: false }]);
+await newList.$jazz.waitForSync();
+
+// Mutate
+item.$jazz.set("completed", true);
+list.$jazz.push({ title: "New", completed: false });
+```
+
+## Image Handling
+
+```ts
+import { createImage, loadImage } from "jazz-tools/media";
+
+// Create ImageDefinition
+const imageDef = await createImage(file, { placeholder: "blur" });
+
+// Access ID
+const id = imageDef.$jazz.id;
+
+// Load image
+const loadedImage = await loadImage(imageDefinitionOrId);
+if (loadedImage === null) {
+  throw new Error("Image not found");
+}
+
+// Render image
+const img = document.createElement("img");
+img.width = loadedImage.width;
+img.height = loadedImage.height;
+img.src = URL.createObjectURL(loadedImage.image.toBlob()!);
+img.onload = () => URL.revokeObjectURL(img.src);
+```
+
+More details available here: <https://jazz.tools/docs/react/core-concepts/covalues/imagedef.md>
+
+## Key APIs
+
+*   `JazzBrowserContextManager.createContext(options)`
+*   `CoValueSchema.subscribe(id, options, callback)`
+*   `CoValueSchema.load(id)`
+*   `createImage(file, options)`
+*   `loadImage(imageDefinitionOrId)`
+
+


### PR DESCRIPTION
## Summary

- Projects scaffolded by `create-jazz-app` now receive an `AGENTS.md` (fetched from `jazz.tools/AGENTS.md`) with a URL-based docs index and skills listing, plus a `.skills/` directory containing the five `jazz-*` skill files
- Extracts shared docs-index utilities from `add-docs-links-to-agents.mjs` into `docs-index-utils.mjs` so both the monorepo AGENTS.md and the user-facing AGENTS.md can be generated from the same code
- Adds the `jazz-*` skills to `packages/cursor-docs/.skills/` so they're cloned alongside `.cursor/` during scaffolding
- Adds `AGENTS_MD_URL` constant with unit tests in `docsFetch.test.ts`, plus live URL integration tests gated behind `TEST_LIVE_URLS` env var