### PR TITLE
feat: implement migration error handling in jazz-tools

### DIFF
--- a/.changeset/migration-errors-unavailable.md
+++ b/.changeset/migration-errors-unavailable.md
@@ -1,0 +1,7 @@
+---
+"jazz-tools": patch
+---
+
+Mark CoValue migration failures as unavailable instead of throwing behavior.
+
+When a migration throws (for example, async migrations or write attempts without permissions), loading now resolves to a CoValue with `$jazz.loadingState === "unavailable"`.

--- a/packages/jazz-tools/src/tools/subscribe/SubscriptionScope.ts
+++ b/packages/jazz-tools/src/tools/subscribe/SubscriptionScope.ts
@@ -143,10 +143,9 @@ export class SubscriptionScope<D extends CoValue> {
           }
 
           this.migrating = true;
+          const instance = instantiateRefEncodedFromRaw(this.schema, value);
           try {
-            applyCoValueMigrations(
-              instantiateRefEncodedFromRaw(this.schema, value),
-            );
+            applyCoValueMigrations(instance);
           } catch (error) {
             const reason =
               error instanceof Error ? error.message : String(error);

--- a/packages/jazz-tools/src/tools/subscribe/SubscriptionScope.ts
+++ b/packages/jazz-tools/src/tools/subscribe/SubscriptionScope.ts
@@ -79,6 +79,7 @@ export class SubscriptionScope<D extends CoValue> {
   private version = 0;
   private migrated = false;
   private migrating = false;
+  private migrationFailed = false;
   closed = false;
 
   private silenceUpdates = false;
@@ -116,6 +117,11 @@ export class SubscriptionScope<D extends CoValue> {
       (value) => {
         lastUpdate = value;
 
+        if (this.migrationFailed) {
+          this.handleUpdate(CoValueLoadingState.UNAVAILABLE);
+          return;
+        }
+
         if (skipRetry && value === CoValueLoadingState.UNAVAILABLE) {
           this.handleUpdate(value);
           return;
@@ -137,9 +143,19 @@ export class SubscriptionScope<D extends CoValue> {
           }
 
           this.migrating = true;
-          applyCoValueMigrations(
-            instantiateRefEncodedFromRaw(this.schema, value),
-          );
+          try {
+            applyCoValueMigrations(
+              instantiateRefEncodedFromRaw(this.schema, value),
+            );
+          } catch (error) {
+            const reason =
+              error instanceof Error ? error.message : String(error);
+            this.migrationFailed = true;
+            this.migrated = true;
+            console.error(`Migration failed for ${this.id}: ${reason}`);
+            this.handleUpdate(CoValueLoadingState.UNAVAILABLE);
+            return;
+          }
           this.migrated = true;
           this.handleUpdate(lastUpdate);
           return;


### PR DESCRIPTION

Mark CoValue migration failures as unavailable instead of throwing behavior.

When a migration throws (for example, async migrations or write attempts without permissions), loading now resolves to a CoValue with `$jazz.loadingState === "unavailable"`.