### PR TITLE
docs: fix Auth component import path in quickstart guide

### DIFF
--- a/homepage/homepage/content/docs/code-snippets/key-features/authentication/quickstart/+layout-with-auth.svelte
+++ b/homepage/homepage/content/docs/code-snippets/key-features/authentication/quickstart/+layout-with-auth.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   // [!code ++:2]
   import { JazzSvelteProvider } from "jazz-tools/svelte";
-  import Auth from '$lib/Auth.svelte';
+  import Auth from '$lib/components/Auth.svelte';
   import { JazzFestAccount } from "$lib/schema";
   // @ts-expect-error Will be there in a real app
   import { PUBLIC_JAZZ_API_KEY } from "$env/static/public";


### PR DESCRIPTION
## Description
This PR fixes a typo in the Svelte authentication quickstart documentation.

The Auth component is created in `src/lib/components/Auth.svelte` according to the guide, so the import statement in the layout file should be:
```svelte
import Auth from '$lib/components/Auth.svelte';
```

instead of:
```svelte
import Auth from '$lib/Auth.svelte';
```

## Related Issue
Fixes #3474

## Changes Made
- Updated import path in `+layout-with-auth.svelte` to correctly reference the Auth component location

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change to a code snippet import path; no runtime or production logic is affected.
> 
> **Overview**
> Fixes the Svelte authentication quickstart snippet by updating the `Auth` component import from `$lib/Auth.svelte` to `$lib/components/Auth.svelte`, matching where the guide has users create the component.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3dfdc45e7646a5b497ea4ec166abb52fc21982d7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->