### PR TITLE
fix(jazz-tools/better-auth): Email OTP case insensitive

### DIFF
--- a/.changeset/email-otp-case-insensitive.md
+++ b/.changeset/email-otp-case-insensitive.md
@@ -1,0 +1,5 @@
+---
+"jazz-tools": patch
+---
+
+Fixed Better Auth email OTP sign-in to handle email addresses case-insensitively.

--- a/packages/jazz-tools/src/better-auth/auth/server.ts
+++ b/packages/jazz-tools/src/better-auth/auth/server.ts
@@ -216,7 +216,8 @@ export const jazzPlugin: () => JazzPlugin = () => {
             return context.path?.startsWith("/sign-in/email-otp") || false;
           },
           handler: createAuthMiddleware(async (ctx) => {
-            const email = ctx.body.email;
+            // lowercase the email as done in https://github.com/better-auth/better-auth/blob/40a80b070bbabf2d6886e8a3ad1bc068c8d570cb/packages/better-auth/src/plugins/email-otp/routes.ts#L641
+            const email = ctx.body.email.toLowerCase();
             const identifier = `jazz-auth-sign-in-otp-${email}`;
 
             const data =

--- a/packages/jazz-tools/src/better-auth/auth/tests/server.test.ts
+++ b/packages/jazz-tools/src/better-auth/auth/tests/server.test.ts
@@ -453,6 +453,51 @@ describe("Better-Auth server plugin", async () => {
       );
     });
 
+    it("should be case-insensitive for email", async () => {
+      let OTP: string = "";
+
+      sendVerificationOTPSpy.mockImplementationOnce(({ otp }) => {
+        OTP = otp;
+      });
+
+      await auth.api.sendVerificationOTP({
+        headers: {
+          "x-jazz-auth": JSON.stringify({
+            accountID: "123",
+            secretSeed: [1, 2, 3],
+            accountSecret: "123",
+          }),
+        },
+        body: {
+          email: "EMAIL@email.it",
+          type: "sign-in",
+        },
+      });
+
+      expect(accountCreationSpy).toHaveBeenCalledTimes(0);
+      expect(sendVerificationOTPSpy).toHaveBeenCalledTimes(1);
+      expect(verificationCreationSpy).toHaveBeenCalledTimes(2);
+      expect(verificationCreationSpy.mock.calls[0]?.[0]).toMatchObject(
+        expect.objectContaining({
+          identifier: "jazz-auth-sign-in-otp-email@email.it",
+          value: expect.stringContaining('"accountID":"123"'),
+        }),
+      );
+
+      await auth.api.signInEmailOTP({
+        body: {
+          email: "EMAIL@email.it",
+          otp: OTP,
+        },
+      });
+
+      expect(accountCreationSpy).toHaveBeenCalledTimes(1);
+      expect(accountCreationSpy).toHaveBeenCalledWith(
+        expect.objectContaining({ accountID: "123" }),
+        expect.any(Object),
+      );
+    });
+
     it("should not expect Jazz's credentials using Email OTP for sign-in an already registered user", async () => {
       // 1. User registration
       const userData = {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: a small normalization change (lowercasing email) in the email-OTP sign-in middleware plus a targeted test; no auth flow restructuring or new data access patterns.
> 
> **Overview**
> Fixes a mismatch in Email OTP sign-in where verification lookups could fail when the provided email casing differed.
> 
> The `/sign-in/email-otp` middleware now lowercases `ctx.body.email` before building the `jazz-auth-sign-in-otp-...` verification identifier, and a new test asserts OTP sign-in works with uppercase/mixed-case emails. Includes a `changeset` for a patch release.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9a43096c957c0ba69aeaf38d6e0ba60e45e3d7c0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->