### PR TITLE
fix(jazz-tools/better-auth): import createAuthMiddleware from better-auth/api

### DIFF
--- a/.changeset/fix-ba-createauthmiddleware-import.md
+++ b/.changeset/fix-ba-createauthmiddleware-import.md
@@ -1,0 +1,5 @@
+---
+"jazz-tools": patch
+---
+
+fix(better-auth): import createAuthMiddleware from better-auth/api for compatibility with better-auth 1.5.3

--- a/packages/jazz-tools/src/better-auth/auth/server.ts
+++ b/packages/jazz-tools/src/better-auth/auth/server.ts
@@ -4,9 +4,8 @@ import {
   MiddlewareContext,
   MiddlewareOptions,
 } from "better-auth";
-import { APIError } from "better-auth/api";
+import { APIError, createAuthMiddleware } from "better-auth/api";
 import { symmetricDecrypt, symmetricEncrypt } from "better-auth/crypto";
-import { createAuthMiddleware } from "better-auth/plugins";
 import type { Account, AuthCredentials, ID } from "jazz-tools";
 
 // Define a type to have user fields mapped in the better-auth instance


### PR DESCRIPTION
## Summary

- `createAuthMiddleware` was removed from `better-auth/plugins` re-exports in better-auth 1.5.3, causing a build error
- Importing from `better-auth/api` is the canonical location and is compatible with older versions too
- All tests passing

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk change limited to an import path update plus a patch changeset; behavior should remain the same but build compatibility depends on the target `better-auth` version.
> 
> **Overview**
> Fixes compatibility with `better-auth` 1.5.3 by switching `createAuthMiddleware` to be imported from `better-auth/api` (alongside `APIError`) instead of `better-auth/plugins`.
> 
> Adds a patch changeset for `jazz-tools` to release this import-path fix.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 307b11d6309b64a820e5c1ff92fbfaa9277f4524. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->