### PR TITLE
feat(cojson): track incoming sync message counts by type

### DIFF
--- a/.changeset/add-incoming-message-type-metric.md
+++ b/.changeset/add-incoming-message-type-metric.md
@@ -1,0 +1,5 @@
+---
+"cojson": patch
+---
+
+Add a new incoming queue metric that tracks pushed sync messages by type (`messageType`).

--- a/packages/cojson/src/queue/IncomingMessagesQueue.ts
+++ b/packages/cojson/src/queue/IncomingMessagesQueue.ts
@@ -14,6 +14,7 @@ import { LinkedList } from "./LinkedList.js";
 export class IncomingMessagesQueue {
   private pullCounter: Counter;
   private pushCounter: Counter;
+  private pushByTypeCounter: Counter;
 
   queues: [LinkedList<SyncMessage>, PeerState][];
   peerToQueue: WeakMap<PeerState, LinkedList<SyncMessage>>;
@@ -31,6 +32,13 @@ export class IncomingMessagesQueue {
       .getMeter("cojson")
       .createCounter(`jazz.messagequeue.incoming.pushed`, {
         description: "Number of messages pushed to the queue",
+        valueType: ValueType.INT,
+        unit: "1",
+      });
+    this.pushByTypeCounter = metrics
+      .getMeter("cojson")
+      .createCounter(`jazz.messagequeue.incoming.pushed.by_type`, {
+        description: "Number of messages pushed to the queue by message type",
         valueType: ValueType.INT,
         unit: "1",
       });
@@ -71,6 +79,10 @@ export class IncomingMessagesQueue {
 
     this.pushCounter.add(1, {
       peerRole: peer.role,
+    });
+    this.pushByTypeCounter.add(1, {
+      peerRole: peer.role,
+      messageType: msg.action,
     });
 
     this.processQueues();

--- a/packages/cojson/src/tests/IncomingMessagesQueue.test.ts
+++ b/packages/cojson/src/tests/IncomingMessagesQueue.test.ts
@@ -279,6 +279,38 @@ describe("IncomingMessagesQueue", () => {
       expect(pushValue).toBe(1);
     });
 
+    test("should track pushed message count by incoming message type", async () => {
+      const { queue, peer1, metricReader } = setup();
+
+      queue.push(createMockSyncMessage("load-1", "load"), peer1);
+      queue.push(createMockSyncMessage("known-1", "known"), peer1);
+      queue.push(createMockSyncMessage("known-2", "known"), peer1);
+      queue.push(createMockSyncMessage("content-1", "content"), peer1);
+      queue.push(createMockSyncMessage("done-1", "done"), peer1);
+
+      const loadValue = await metricReader.getMetricValue(
+        "jazz.messagequeue.incoming.pushed.by_type",
+        { peerRole: "client", messageType: "load" },
+      );
+      const knownValue = await metricReader.getMetricValue(
+        "jazz.messagequeue.incoming.pushed.by_type",
+        { peerRole: "client", messageType: "known" },
+      );
+      const contentValue = await metricReader.getMetricValue(
+        "jazz.messagequeue.incoming.pushed.by_type",
+        { peerRole: "client", messageType: "content" },
+      );
+      const doneValue = await metricReader.getMetricValue(
+        "jazz.messagequeue.incoming.pushed.by_type",
+        { peerRole: "client", messageType: "done" },
+      );
+
+      expect(loadValue).toBe(1);
+      expect(knownValue).toBe(2);
+      expect(contentValue).toBe(1);
+      expect(doneValue).toBe(1);
+    });
+
     test("should increment pull counter when pulling messages", async () => {
       const { queue, peer1, metricReader } = setup();
       const msg = createMockSyncMessage("test");


### PR DESCRIPTION
## Summary
- add `jazz.messagequeue.incoming.pushed.by_type` in `IncomingMessagesQueue`
- record incoming push counts by `peerRole` and `messageType`
- add queue metrics tests to verify per-type counts for `load`, `known`, `content`, and `done`
- include a changeset for `cojson` (patch)

## Testing
- `pnpm test --watch=false IncomingMessagesQueue.test.ts`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: instrumentation-only change that adds a new counter and a focused test, without altering queue behavior. Main concern is metric label cardinality via `messageType`, but it’s derived from the bounded `SyncMessage.action` set.
> 
> **Overview**
> **Adds per-message-type incoming queue telemetry.** `IncomingMessagesQueue` now increments a new counter, `jazz.messagequeue.incoming.pushed.by_type`, on every `push`, labeled by `peerRole` and `messageType` (from `msg.action`).
> 
> **Tests and release metadata updated.** `IncomingMessagesQueue.test.ts` adds coverage asserting per-type counts for `load`, `known`, `content`, and `done`, and a changeset bumps `cojson` as a patch release.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9877c6155e254aa4900650218ed46b9ea2372321. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->