### PR TITLE
fix(cojson-storage-indexeddb): handle IndexedDB shutdown races

### DIFF
--- a/.changeset/handle-indexeddb-shutdown-races.md
+++ b/.changeset/handle-indexeddb-shutdown-races.md
@@ -1,0 +1,5 @@
+"cojson": patch
+"cojson-storage-indexeddb": patch
+---
+
+Avoid unhandled IndexedDB shutdown race errors by treating close-time transactions as safe no-ops and guarding finished transaction cleanup.

--- a/packages/cojson-storage-indexeddb/src/CoJsonIDBTransaction.ts
+++ b/packages/cojson-storage-indexeddb/src/CoJsonIDBTransaction.ts
@@ -15,6 +15,27 @@ const DEFAULT_TX_STORES: StoreName[] = [
   "deletedCoValues",
 ];
 
+export function isStorageConnectionClosingError(error: unknown): boolean {
+  const message = error instanceof Error ? error.message.toLowerCase() : "";
+
+  return (
+    message.includes("database connection is closing") ||
+    message.includes("database connection is closed") ||
+    message.includes("connection is closing") ||
+    message.includes("connection is closed")
+  );
+}
+
+export function isStorageTransactionFinishedError(error: unknown): boolean {
+  const message = error instanceof Error ? error.message.toLowerCase() : "";
+
+  return (
+    message.includes("transaction has finished") ||
+    message.includes("transaction is inactive") ||
+    message.includes("transaction is already committing or done")
+  );
+}
+
 /**
  * An access unit for the IndexedDB Jazz database.
  * It's a wrapper around the IDBTransaction object that helps on batching multiple operations
@@ -36,12 +57,22 @@ export class CoJsonIDBTransaction {
     public db: IDBDatabase,
     // The object stores this transaction will operate on
     private storeNames: StoreName[] = DEFAULT_TX_STORES,
+    private onDatabaseClosing?: () => void,
   ) {
     this.refresh();
   }
 
   refresh() {
-    this.tx = this.db.transaction(this.storeNames, "readwrite");
+    try {
+      this.tx = this.db.transaction(this.storeNames, "readwrite");
+    } catch (error) {
+      if (isStorageConnectionClosingError(error)) {
+        this.failed = true;
+        this.done = true;
+        this.onDatabaseClosing?.();
+      }
+      throw error;
+    }
 
     this.tx.oncomplete = () => {
       this.done = true;
@@ -52,13 +83,41 @@ export class CoJsonIDBTransaction {
   }
 
   rollback() {
-    this.tx.abort();
+    this.abortIfActive();
+  }
+
+  private abortIfActive() {
+    if (this.done) {
+      return;
+    }
+
+    try {
+      this.tx.abort();
+    } catch (error) {
+      if (isStorageConnectionClosingError(error)) {
+        this.failed = true;
+        this.done = true;
+        this.onDatabaseClosing?.();
+        return;
+      }
+
+      if (!isStorageTransactionFinishedError(error)) {
+        throw error;
+      }
+    }
   }
 
   getObjectStore(name: StoreName) {
     try {
       return this.tx.objectStore(name);
     } catch (error) {
+      if (isStorageConnectionClosingError(error)) {
+        this.failed = true;
+        this.done = true;
+        this.onDatabaseClosing?.();
+        throw error;
+      }
+
       this.refresh();
       return this.tx.objectStore(name);
     }
@@ -103,8 +162,14 @@ export class CoJsonIDBTransaction {
 
         request.onerror = () => {
           this.failed = true;
-          this.tx.abort();
-          console.error(request.error);
+          this.abortIfActive();
+
+          if (isStorageConnectionClosingError(request.error)) {
+            this.onDatabaseClosing?.();
+          } else {
+            console.error(request.error);
+          }
+
           reject(request.error);
 
           // Don't leave any pending promise
@@ -123,7 +188,33 @@ export class CoJsonIDBTransaction {
 
   commit() {
     if (!this.done) {
-      this.tx.commit();
+      try {
+        this.tx.commit();
+      } catch (error) {
+        if (isStorageConnectionClosingError(error)) {
+          this.failed = true;
+          this.done = true;
+          this.onDatabaseClosing?.();
+          return;
+        }
+
+        if (!isStorageTransactionFinishedError(error)) {
+          throw error;
+        }
+      }
+    }
+  }
+}
+
+function commitTransaction(tx: IDBTransaction) {
+  try {
+    tx.commit();
+  } catch (error) {
+    if (
+      !isStorageConnectionClosingError(error) &&
+      !isStorageTransactionFinishedError(error)
+    ) {
+      throw error;
     }
   }
 }
@@ -134,7 +225,15 @@ export function queryIndexedDbStore<T>(
   callback: (store: IDBObjectStore) => IDBRequest<T>,
 ) {
   return new Promise<T>((resolve, reject) => {
-    const tx = db.transaction(storeName, "readonly");
+    let tx: IDBTransaction;
+
+    try {
+      tx = db.transaction(storeName, "readonly");
+    } catch (error) {
+      reject(error);
+      return;
+    }
+
     const request = callback(tx.objectStore(storeName));
 
     request.onerror = () => {
@@ -142,8 +241,12 @@ export function queryIndexedDbStore<T>(
     };
 
     request.onsuccess = () => {
-      resolve(request.result as T);
-      tx.commit();
+      try {
+        commitTransaction(tx);
+        resolve(request.result as T);
+      } catch (error) {
+        reject(error);
+      }
     };
   });
 }
@@ -154,7 +257,15 @@ export function putIndexedDbStore<T, O extends IDBValidKey>(
   value: T,
 ) {
   return new Promise<O>((resolve, reject) => {
-    const tx = db.transaction(storeName, "readwrite");
+    let tx: IDBTransaction;
+
+    try {
+      tx = db.transaction(storeName, "readwrite");
+    } catch (error) {
+      reject(error);
+      return;
+    }
+
     const request = tx.objectStore(storeName).put(value);
 
     request.onerror = () => {
@@ -162,8 +273,12 @@ export function putIndexedDbStore<T, O extends IDBValidKey>(
     };
 
     request.onsuccess = () => {
-      resolve(request.result as O);
-      tx.commit();
+      try {
+        commitTransaction(tx);
+        resolve(request.result as O);
+      } catch (error) {
+        reject(error);
+      }
     };
   });
 }

--- a/packages/cojson-storage-indexeddb/src/idbClient.ts
+++ b/packages/cojson-storage-indexeddb/src/idbClient.ts
@@ -18,6 +18,7 @@ import type {
 import { cojsonInternals } from "cojson";
 import {
   CoJsonIDBTransaction,
+  isStorageConnectionClosingError,
   putIndexedDbStore,
   queryIndexedDbStore,
   StoreName,
@@ -239,17 +240,77 @@ export class IDBTransaction implements DBTransactionInterfaceAsync {
 
 export class IDBClient implements DBClientInterfaceAsync {
   private db;
+  private closed = false;
 
   activeTransaction: CoJsonIDBTransaction | undefined;
   autoBatchingTransaction: CoJsonIDBTransaction | undefined;
 
   constructor(db: IDBDatabase) {
     this.db = db;
+
+    this.db.onversionchange = () => {
+      this.close();
+    };
+
+    this.db.onclose = () => {
+      this.closed = true;
+    };
+  }
+
+  close() {
+    if (this.closed) {
+      return;
+    }
+
+    this.closed = true;
+
+    try {
+      this.db.close();
+    } catch (error) {
+      if (!isStorageConnectionClosingError(error)) {
+        throw error;
+      }
+    }
+  }
+
+  isClosed() {
+    return this.closed;
+  }
+
+  private handleConnectionClosingError(error: unknown): boolean {
+    if (!isStorageConnectionClosingError(error)) {
+      return false;
+    }
+
+    this.close();
+
+    return true;
+  }
+
+  private async runWithFallback<T>(
+    fallback: T,
+    operation: () => Promise<T>,
+  ): Promise<T> {
+    if (this.closed) {
+      return fallback;
+    }
+
+    try {
+      return await operation();
+    } catch (error) {
+      if (this.handleConnectionClosingError(error)) {
+        return fallback;
+      }
+
+      throw error;
+    }
   }
 
   async getCoValue(coValueId: RawCoID): Promise<StoredCoValueRow | undefined> {
-    return queryIndexedDbStore(this.db, "coValues", (store) =>
-      store.index("coValuesById").get(coValueId),
+    return this.runWithFallback(undefined, () =>
+      queryIndexedDbStore(this.db, "coValues", (store) =>
+        store.index("coValuesById").get(coValueId),
+      ),
     );
   }
 
@@ -258,8 +319,10 @@ export class IDBClient implements DBClientInterfaceAsync {
   }
 
   async getCoValueSessions(coValueRowId: number): Promise<StoredSessionRow[]> {
-    return queryIndexedDbStore(this.db, "sessions", (store) =>
-      store.index("sessionsByCoValue").getAll(coValueRowId),
+    return this.runWithFallback([], () =>
+      queryIndexedDbStore(this.db, "sessions", (store) =>
+        store.index("sessionsByCoValue").getAll(coValueRowId),
+      ),
     );
   }
 
@@ -268,9 +331,11 @@ export class IDBClient implements DBClientInterfaceAsync {
     fromIdx: number,
     toIdx: number,
   ): Promise<TransactionRow[]> {
-    return queryIndexedDbStore(this.db, "transactions", (store) =>
-      store.getAll(
-        IDBKeyRange.bound([sessionRowId, fromIdx], [sessionRowId, toIdx]),
+    return this.runWithFallback([], () =>
+      queryIndexedDbStore(this.db, "transactions", (store) =>
+        store.getAll(
+          IDBKeyRange.bound([sessionRowId, fromIdx], [sessionRowId, toIdx]),
+        ),
       ),
     );
   }
@@ -279,11 +344,13 @@ export class IDBClient implements DBClientInterfaceAsync {
     sessionRowId: number,
     firstNewTxIdx: number,
   ): Promise<SignatureAfterRow[]> {
-    return queryIndexedDbStore(this.db, "signatureAfter", (store) =>
-      store.getAll(
-        IDBKeyRange.bound(
-          [sessionRowId, firstNewTxIdx],
-          [sessionRowId, Number.POSITIVE_INFINITY],
+    return this.runWithFallback([], () =>
+      queryIndexedDbStore(this.db, "signatureAfter", (store) =>
+        store.getAll(
+          IDBKeyRange.bound(
+            [sessionRowId, firstNewTxIdx],
+            [sessionRowId, Number.POSITIVE_INFINITY],
+          ),
         ),
       ),
     );
@@ -297,20 +364,32 @@ export class IDBClient implements DBClientInterfaceAsync {
       return this.getCoValueRowID(id);
     }
 
-    return putIndexedDbStore<CoValueRow, number>(this.db, "coValues", {
-      id,
-      header,
-    }).catch(() => this.getCoValueRowID(id));
+    try {
+      return await putIndexedDbStore<CoValueRow, number>(this.db, "coValues", {
+        id,
+        header,
+      });
+    } catch (error) {
+      if (this.handleConnectionClosingError(error)) {
+        return undefined;
+      }
+
+      return this.getCoValueRowID(id);
+    }
   }
 
   async getAllCoValuesWaitingForDelete(): Promise<RawCoID[]> {
-    const entries = await queryIndexedDbStore<DeletedCoValueQueueEntry[]>(
-      this.db,
-      "deletedCoValues",
-      (store) =>
-        store.index("deletedCoValuesByStatus").getAll("pending") as IDBRequest<
-          DeletedCoValueQueueEntry[]
-        >,
+    const entries = await this.runWithFallback(
+      [] as DeletedCoValueQueueEntry[],
+      () =>
+        queryIndexedDbStore<DeletedCoValueQueueEntry[]>(
+          this.db,
+          "deletedCoValues",
+          (store) =>
+            store
+              .index("deletedCoValuesByStatus")
+              .getAll("pending") as IDBRequest<DeletedCoValueQueueEntry[]>,
+        ),
     );
     return entries.map((e) => e.coValueID);
   }
@@ -319,14 +398,18 @@ export class IDBClient implements DBClientInterfaceAsync {
     operationsCallback: (tx: IDBTransaction) => Promise<unknown>,
     storeNames?: StoreName[],
   ) {
-    const tx = new CoJsonIDBTransaction(this.db, storeNames);
+    await this.runWithFallback(undefined, async () => {
+      const tx = new CoJsonIDBTransaction(this.db, storeNames, () =>
+        this.close(),
+      );
 
-    try {
-      await operationsCallback(new IDBTransaction(tx));
-      tx.commit(); // Tells the browser to not wait for another possible request and commit the transaction immediately
-    } catch (error) {
-      tx.rollback();
-    }
+      try {
+        await operationsCallback(new IDBTransaction(tx));
+        tx.commit(); // Tells the browser to not wait for another possible request and commit the transaction immediately
+      } catch (error) {
+        tx.rollback();
+      }
+    });
   }
 
   async trackCoValuesSyncState(
@@ -375,6 +458,10 @@ export class IDBClient implements DBClientInterfaceAsync {
     const coValue = await this.getCoValue(coValueID);
 
     if (!coValue) {
+      if (this.closed) {
+        return;
+      }
+
       console.warn(`CoValue ${coValueID} not found, skipping deletion`);
       return;
     }
@@ -386,24 +473,29 @@ export class IDBClient implements DBClientInterfaceAsync {
     limit: number,
     offset: number,
   ): Promise<{ id: RawCoID }[]> {
-    const rows = await queryIndexedDbStore<StoredCoValueRow[]>(
-      this.db,
-      "coValues",
-      (store) =>
+    const rows = await this.runWithFallback([] as StoredCoValueRow[], () =>
+      queryIndexedDbStore<StoredCoValueRow[]>(this.db, "coValues", (store) =>
         // Include upper bound but not lower bound (offset starts at 0)
         store.getAll(IDBKeyRange.bound(offset, offset + limit, true, false)),
+      ),
     );
     return rows.map((row) => ({ id: row.id }));
   }
 
   async getCoValueCount(): Promise<number> {
-    return queryIndexedDbStore(this.db, "coValues", (store) => store.count());
+    return this.runWithFallback(0, () =>
+      queryIndexedDbStore(this.db, "coValues", (store) => store.count()),
+    );
   }
 
   async getUnsyncedCoValueIDs(): Promise<RawCoID[]> {
-    const records = await queryIndexedDbStore<
-      { rowID: number; coValueId: RawCoID; peerId: string }[]
-    >(this.db, "unsyncedCoValues", (store) => store.getAll());
+    const records = await this.runWithFallback(
+      [] as { rowID: number; coValueId: RawCoID; peerId: string }[],
+      () =>
+        queryIndexedDbStore<
+          { rowID: number; coValueId: RawCoID; peerId: string }[]
+        >(this.db, "unsyncedCoValues", (store) => store.getAll()),
+    );
     const uniqueIds = new Set<RawCoID>();
     for (const record of records) {
       uniqueIds.add(record.coValueId);
@@ -435,7 +527,10 @@ export class IDBClient implements DBClientInterfaceAsync {
     const { LOCK_TTL_MS, RECONCILIATION_INTERVAL_MS } =
       cojsonInternals.STORAGE_RECONCILIATION_CONFIG;
 
-    let result: StorageReconciliationAcquireResult;
+    let result: StorageReconciliationAcquireResult = {
+      acquired: false,
+      reason: "not_due",
+    };
     await this.transaction(
       async (tx) => {
         const lock = await tx.getStorageReconciliationLock(lockKey);
@@ -469,7 +564,7 @@ export class IDBClient implements DBClientInterfaceAsync {
       },
       ["storageReconciliationLocks"],
     );
-    return result!;
+    return result;
   }
 
   async renewStorageReconciliationLock(
@@ -526,6 +621,10 @@ export class IDBClient implements DBClientInterfaceAsync {
 
     // Get all session counters without loading transactions
     const sessions = await this.getCoValueSessions(coValueRow.rowID);
+
+    if (this.closed) {
+      return undefined;
+    }
 
     const knownState: CojsonInternalTypes.CoValueKnownState = {
       id: coValueId as RawCoID,

--- a/packages/cojson-storage-indexeddb/src/tests/CoJsonIDBTransaction.test.ts
+++ b/packages/cojson-storage-indexeddb/src/tests/CoJsonIDBTransaction.test.ts
@@ -1,5 +1,7 @@
 import { afterEach, beforeEach, describe, expect, test } from "vitest";
+import type { SessionID } from "cojson";
 import { CoJsonIDBTransaction } from "../CoJsonIDBTransaction";
+import { IDBClient } from "../idbClient";
 
 const TEST_DB_NAME = "test-cojson-idb-transaction";
 
@@ -40,6 +42,9 @@ describe("CoJsonIDBTransaction", () => {
             unique: true,
           },
         );
+        db.createObjectStore("storageReconciliationLocks", {
+          keyPath: "key",
+        });
       };
 
       request.onsuccess = () => {
@@ -259,5 +264,72 @@ describe("CoJsonIDBTransaction", () => {
     ).rejects.toThrow(
       "Failed to execute 'objectStore' on 'IDBTransaction': The specified object store was not found.",
     );
+  });
+
+  test("rollback ignores finished transactions", async () => {
+    const tx = new CoJsonIDBTransaction(db);
+
+    await tx.handleRequest((tx) =>
+      tx.getObjectStore("coValues").put({
+        id: "test1",
+        value: "hello",
+      }),
+    );
+
+    const completed = new Promise<void>((resolve) => {
+      tx.tx.addEventListener("complete", () => resolve(), { once: true });
+    });
+
+    tx.commit();
+    await completed;
+
+    expect(() => tx.rollback()).not.toThrow();
+  });
+
+  test("returns safe fallbacks once the database starts closing", async () => {
+    const seedTx = db.transaction("unsyncedCoValues", "readwrite");
+    seedTx.objectStore("unsyncedCoValues").put({
+      rowID: 1,
+      coValueId: "co_zseed",
+      peerId: "peer",
+    });
+    await new Promise<void>((resolve) => {
+      seedTx.addEventListener("complete", () => resolve(), { once: true });
+    });
+
+    const client = new IDBClient(db);
+    const versionChange = new Promise<void>((resolve) => {
+      db.addEventListener("versionchange", () => resolve(), { once: true });
+    });
+    const deleteRequest = new Promise<void>((resolve, reject) => {
+      const request = indexedDB.deleteDatabase(TEST_DB_NAME);
+      request.onerror = () => reject(request.error);
+      request.onsuccess = () => resolve();
+    });
+
+    await versionChange;
+
+    expect(client.isClosed()).toBe(true);
+    await expect(client.getUnsyncedCoValueIDs()).resolves.toEqual([]);
+    await expect(
+      client.tryAcquireStorageReconciliationLock(
+        "session" as SessionID,
+        "peer",
+      ),
+    ).resolves.toEqual({
+      acquired: false,
+      reason: "not_due",
+    });
+    await expect(
+      client.trackCoValuesSyncState([
+        {
+          id: "co_zseed",
+          peerId: "peer",
+          synced: false,
+        },
+      ]),
+    ).resolves.toBeUndefined();
+
+    await deleteRequest;
   });
 });

--- a/packages/cojson/src/localNode.ts
+++ b/packages/cojson/src/localNode.ts
@@ -101,9 +101,10 @@ export class LocalNode {
   }
 
   removeStorage() {
-    this.storage?.close();
-    this.storage = undefined;
     this.syncManager.removeStorage();
+    const storage = this.storage;
+    this.storage = undefined;
+    storage?.close();
   }
 
   /**

--- a/packages/cojson/src/storage/storageAsync.ts
+++ b/packages/cojson/src/storage/storageAsync.ts
@@ -36,6 +36,7 @@ import { isDeleteSessionID } from "../ids.js";
 
 export class StorageApiAsync implements StorageAPI {
   private readonly dbClient: DBClientInterfaceAsync;
+  private closePromise: Promise<unknown> | undefined;
 
   private deletedCoValuesEraserScheduler:
     | DeletedCoValuesEraserScheduler
@@ -96,7 +97,9 @@ export class StorageApiAsync implements StorageAPI {
         // Error handling contract:
         // - Log warning
         // - Behave like "not found" so callers can fall back (full load / load from peers)
-        logger.warn("Failed to load knownState from storage", { id, err });
+        if (!this.dbClient.isClosed?.()) {
+          logger.warn("Failed to load knownState from storage", { id, err });
+        }
         return undefined;
       })
       .finally(() => {
@@ -124,6 +127,11 @@ export class StorageApiAsync implements StorageAPI {
     this.interruptEraser("load");
     const coValueRow = await this.dbClient.getCoValue(id);
 
+    if (this.dbClient.isClosed?.()) {
+      done?.(false);
+      return;
+    }
+
     if (!coValueRow) {
       done?.(false);
       return;
@@ -132,6 +140,11 @@ export class StorageApiAsync implements StorageAPI {
     const allCoValueSessions = await this.dbClient.getCoValueSessions(
       coValueRow.rowID,
     );
+
+    if (this.dbClient.isClosed?.()) {
+      done?.(false);
+      return;
+    }
 
     const signaturesBySession = new Map<
       SessionID,
@@ -153,6 +166,11 @@ export class StorageApiAsync implements StorageAPI {
         }
       }),
     );
+
+    if (this.dbClient.isClosed?.()) {
+      done?.(false);
+      return;
+    }
 
     const knownState = this.knownStates.getKnownState(coValueRow.id);
     knownState.header = true;
@@ -193,6 +211,11 @@ export class StorageApiAsync implements StorageAPI {
           idx,
           signature.idx,
         );
+
+        if (this.dbClient.isClosed?.()) {
+          done?.(false);
+          return;
+        }
 
         collectNewTxs({
           newTxsInSession,
@@ -241,6 +264,10 @@ export class StorageApiAsync implements StorageAPI {
     contentMessage: NewContentMessage,
     pushCallback: (data: NewContentMessage) => void,
   ) {
+    if (this.dbClient.isClosed?.()) {
+      return;
+    }
+
     const dependedOnCoValuesList = getDependedOnCoValues(
       coValueRow.header,
       contentMessage,
@@ -358,6 +385,10 @@ export class StorageApiAsync implements StorageAPI {
     );
 
     if (!storedCoValueRowID) {
+      if (this.dbClient.isClosed?.()) {
+        return false;
+      }
+
       const knownState = emptyKnownState(id as RawCoID);
       this.knownStates.setKnownState(id, knownState);
 
@@ -404,6 +435,10 @@ export class StorageApiAsync implements StorageAPI {
           setSessionCounter(knownState.sessions, sessionID, newLastIdx);
         }
       });
+    }
+
+    if (this.dbClient.isClosed?.()) {
+      return false;
     }
 
     this.inMemoryCoValues.add(id);
@@ -511,11 +546,30 @@ export class StorageApiAsync implements StorageAPI {
     return this.knownStates.waitForSync(id, coValue);
   }
 
+  private handleAsyncStorageError(error: unknown, message: string): void {
+    if (this.dbClient.isClosed?.()) {
+      return;
+    }
+
+    logger.warn(message, {
+      err: error,
+    });
+  }
+
   trackCoValuesSyncState(
     updates: { id: RawCoID; peerId: PeerID; synced: boolean }[],
     done?: () => void,
   ): void {
-    this.dbClient.trackCoValuesSyncState(updates).then(() => done?.());
+    this.dbClient
+      .trackCoValuesSyncState(updates)
+      .then(() => done?.())
+      .catch((error) => {
+        this.handleAsyncStorageError(
+          error,
+          "Failed to persist CoValue sync state to storage",
+        );
+        done?.();
+      });
   }
 
   getCoValueIDs(
@@ -523,11 +577,29 @@ export class StorageApiAsync implements StorageAPI {
     offset: number,
     callback: (batch: { id: RawCoID }[]) => void,
   ): void {
-    this.dbClient.getCoValueIDs(limit, offset).then(callback);
+    this.dbClient
+      .getCoValueIDs(limit, offset)
+      .then(callback)
+      .catch((error) => {
+        this.handleAsyncStorageError(
+          error,
+          "Failed to load CoValue IDs from storage",
+        );
+        callback([]);
+      });
   }
 
   getCoValueCount(callback: (count: number) => void): void {
-    this.dbClient.getCoValueCount().then(callback);
+    this.dbClient
+      .getCoValueCount()
+      .then(callback)
+      .catch((error) => {
+        this.handleAsyncStorageError(
+          error,
+          "Failed to load CoValue count from storage",
+        );
+        callback(0);
+      });
   }
 
   tryAcquireStorageReconciliationLock(
@@ -537,7 +609,14 @@ export class StorageApiAsync implements StorageAPI {
   ): void {
     this.dbClient
       .tryAcquireStorageReconciliationLock(sessionId, peerId)
-      .then(callback);
+      .then(callback)
+      .catch((error) => {
+        this.handleAsyncStorageError(
+          error,
+          "Failed to acquire storage reconciliation lock",
+        );
+        callback({ acquired: false, reason: "not_due" });
+      });
   }
 
   renewStorageReconciliationLock(
@@ -545,21 +624,49 @@ export class StorageApiAsync implements StorageAPI {
     peerId: PeerID,
     offset: number,
   ): void {
-    this.dbClient.renewStorageReconciliationLock(sessionId, peerId, offset);
+    this.dbClient
+      .renewStorageReconciliationLock(sessionId, peerId, offset)
+      .catch((error) => {
+        this.handleAsyncStorageError(
+          error,
+          "Failed to renew storage reconciliation lock",
+        );
+      });
   }
 
   releaseStorageReconciliationLock(sessionId: SessionID, peerId: PeerID): void {
-    this.dbClient.releaseStorageReconciliationLock(sessionId, peerId);
+    this.dbClient
+      .releaseStorageReconciliationLock(sessionId, peerId)
+      .catch((error) => {
+        this.handleAsyncStorageError(
+          error,
+          "Failed to release storage reconciliation lock",
+        );
+      });
   }
 
   getUnsyncedCoValueIDs(
     callback: (unsyncedCoValueIDs: RawCoID[]) => void,
   ): void {
-    this.dbClient.getUnsyncedCoValueIDs().then(callback);
+    this.dbClient
+      .getUnsyncedCoValueIDs()
+      .then(callback)
+      .catch((error) => {
+        this.handleAsyncStorageError(
+          error,
+          "Failed to load unsynced CoValue IDs from storage",
+        );
+        callback([]);
+      });
   }
 
   stopTrackingSyncState(id: RawCoID): void {
-    this.dbClient.stopTrackingSyncState(id);
+    this.dbClient.stopTrackingSyncState(id).catch((error) => {
+      this.handleAsyncStorageError(
+        error,
+        "Failed to stop tracking CoValue sync state in storage",
+      );
+    });
   }
 
   onCoValueUnmounted(id: RawCoID): void {
@@ -568,9 +675,30 @@ export class StorageApiAsync implements StorageAPI {
   }
 
   close() {
+    if (this.closePromise) {
+      return this.closePromise;
+    }
+
+    this.interruptEraser("close");
     this.deletedCoValuesEraserScheduler?.dispose();
     this.inMemoryCoValues.clear();
     this.knownStates.clear();
-    return this.storeQueue.close();
+    this.pendingKnownStateLoads.clear();
+
+    const pendingStore = this.storeQueue.close();
+
+    this.closePromise = (async () => {
+      await pendingStore;
+
+      try {
+        return await this.dbClient.close?.();
+      } catch (error) {
+        if (!this.dbClient.isClosed?.()) {
+          throw error;
+        }
+      }
+    })();
+
+    return this.closePromise;
   }
 }

--- a/packages/cojson/src/storage/types.ts
+++ b/packages/cojson/src/storage/types.ts
@@ -319,6 +319,10 @@ export interface DBClientInterfaceAsync {
     sessionId: SessionID,
     peerId: PeerID,
   ): Promise<void>;
+
+  close?(): Promise<unknown> | unknown;
+
+  isClosed?(): boolean;
 }
 
 export interface DBTransactionInterfaceSync {

--- a/packages/cojson/src/tests/storageAsync.shutdown.test.ts
+++ b/packages/cojson/src/tests/storageAsync.shutdown.test.ts
@@ -1,0 +1,115 @@
+import { afterEach, describe, expect, test, vi } from "vitest";
+import type { RawCoID, SessionID } from "../exports.js";
+import { logger } from "../exports.js";
+import { StorageApiAsync } from "../storage/storageAsync.js";
+import type {
+  DBClientInterfaceAsync,
+  StorageReconciliationAcquireResult,
+} from "../storage/types.js";
+
+function createClosingError() {
+  return new DOMException(
+    "Failed to execute 'transaction' on 'IDBDatabase': The database connection is closing.",
+    "InvalidStateError",
+  );
+}
+
+function createMockDbClient(
+  overrides: Partial<DBClientInterfaceAsync> = {},
+): DBClientInterfaceAsync {
+  return {
+    getCoValue: vi.fn().mockResolvedValue(undefined),
+    upsertCoValue: vi.fn().mockResolvedValue(undefined),
+    getAllCoValuesWaitingForDelete: vi.fn().mockResolvedValue([]),
+    getCoValueSessions: vi.fn().mockResolvedValue([]),
+    getNewTransactionInSession: vi.fn().mockResolvedValue([]),
+    getSignatures: vi.fn().mockResolvedValue([]),
+    transaction: vi.fn().mockResolvedValue(undefined),
+    trackCoValuesSyncState: vi.fn().mockResolvedValue(undefined),
+    getUnsyncedCoValueIDs: vi.fn().mockResolvedValue([]),
+    stopTrackingSyncState: vi.fn().mockResolvedValue(undefined),
+    eraseCoValueButKeepTombstone: vi.fn().mockResolvedValue(undefined),
+    getCoValueKnownState: vi.fn().mockResolvedValue(undefined),
+    getCoValueIDs: vi.fn().mockResolvedValue([]),
+    getCoValueCount: vi.fn().mockResolvedValue(0),
+    tryAcquireStorageReconciliationLock: vi.fn().mockResolvedValue({
+      acquired: false,
+      reason: "not_due",
+    } satisfies StorageReconciliationAcquireResult),
+    renewStorageReconciliationLock: vi.fn().mockResolvedValue(undefined),
+    releaseStorageReconciliationLock: vi.fn().mockResolvedValue(undefined),
+    close: vi.fn().mockResolvedValue(undefined),
+    isClosed: vi.fn().mockReturnValue(false),
+    ...overrides,
+  };
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("StorageApiAsync shutdown handling", () => {
+  test("uses safe fallbacks for callback-based async storage methods", async () => {
+    const closingError = createClosingError();
+    let closed = true;
+    const dbClient = createMockDbClient({
+      trackCoValuesSyncState: vi.fn().mockRejectedValue(closingError),
+      getCoValueIDs: vi.fn().mockRejectedValue(closingError),
+      getCoValueCount: vi.fn().mockRejectedValue(closingError),
+      tryAcquireStorageReconciliationLock: vi
+        .fn()
+        .mockRejectedValue(closingError),
+      getUnsyncedCoValueIDs: vi.fn().mockRejectedValue(closingError),
+      stopTrackingSyncState: vi.fn().mockRejectedValue(closingError),
+      renewStorageReconciliationLock: vi.fn().mockRejectedValue(closingError),
+      releaseStorageReconciliationLock: vi.fn().mockRejectedValue(closingError),
+      isClosed: vi.fn(() => closed),
+    });
+    const storage = new StorageApiAsync(dbClient);
+    const warnSpy = vi.spyOn(logger, "warn");
+
+    await new Promise<void>((resolve) => {
+      storage.trackCoValuesSyncState(
+        [{ id: "co_zclosing" as RawCoID, peerId: "peer", synced: false }],
+        resolve,
+      );
+    });
+
+    const ids = await new Promise<{ id: RawCoID }[]>((resolve) => {
+      storage.getCoValueIDs(10, 0, resolve);
+    });
+    expect(ids).toEqual([]);
+
+    const count = await new Promise<number>((resolve) => {
+      storage.getCoValueCount(resolve);
+    });
+    expect(count).toBe(0);
+
+    const lock = await new Promise<StorageReconciliationAcquireResult>(
+      (resolve) => {
+        storage.tryAcquireStorageReconciliationLock(
+          "session" as SessionID,
+          "peer",
+          resolve,
+        );
+      },
+    );
+    expect(lock).toEqual({
+      acquired: false,
+      reason: "not_due",
+    });
+
+    const unsyncedIds = await new Promise<RawCoID[]>((resolve) => {
+      storage.getUnsyncedCoValueIDs(resolve);
+    });
+    expect(unsyncedIds).toEqual([]);
+
+    storage.stopTrackingSyncState("co_zclosing" as RawCoID);
+    storage.renewStorageReconciliationLock("session" as SessionID, "peer", 5);
+    storage.releaseStorageReconciliationLock("session" as SessionID, "peer");
+
+    await new Promise<void>(queueMicrotask);
+
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- harden the IndexedDB adapter against close-time `transaction()` failures and keep shutdown-specific handling local to that backend
- make `StorageApiAsync` resolve callback-based operations safely during shutdown instead of surfacing unhandled DOMExceptions
- guard transaction cleanup paths so `abort()`/`commit()` on already-finished transactions do not create secondary noise, and add regression tests plus a changeset

## Testing
- `pnpm exec vitest --run --root . --project cojson packages/cojson/src/tests/storageAsync.shutdown.test.ts`
- `pnpm exec vitest --run --root . --project cojson-storage-indexeddb packages/cojson-storage-indexeddb/src/tests/CoJsonIDBTransaction.test.ts`
- `pnpm exec tsc -p packages/cojson-storage-indexeddb/tsconfig.json --noEmit`
