### PR TITLE
feat: introduce `omit`, `extend`, and `safeExtend` methods to CoMapSchema

### DIFF
--- a/.changeset/shiny-donuts-scream.md
+++ b/.changeset/shiny-donuts-scream.md
@@ -1,0 +1,5 @@
+---
+"jazz-tools": patch
+---
+
+Introduce `omit`, `extend`, and `safeExtend` methods to CoMap schemas

--- a/homepage/homepage/content/docs/code-snippets/core-concepts/covalues/comaps/extend.ts
+++ b/homepage/homepage/content/docs/code-snippets/core-concepts/covalues/comaps/extend.ts
@@ -1,0 +1,17 @@
+// [!code hide]
+import { co, z } from "jazz-tools";
+
+const Project = co.map({
+  name: z.string(),
+  startDate: z.date(),
+});
+
+const ProjectWithStatus = Project.extend({
+  status: z.literal(["planning", "active", "completed"]),
+});
+
+const project = ProjectWithStatus.create({
+  name: "My project",
+  startDate: new Date("2025-04-01"),
+  status: "planning",
+});

--- a/homepage/homepage/content/docs/code-snippets/core-concepts/covalues/comaps/omit.ts
+++ b/homepage/homepage/content/docs/code-snippets/core-concepts/covalues/comaps/omit.ts
@@ -1,0 +1,17 @@
+// [!code hide]
+import { co, z } from "jazz-tools";
+
+const Project = co.map({
+  name: z.string(),
+  startDate: z.date(),
+  status: z.literal(["planning", "active", "completed"]),
+});
+
+const ProjectWithoutStatus = Project.omit({
+  status: true,
+});
+
+const project = ProjectWithoutStatus.create({
+  name: "My project",
+  startDate: new Date("2025-04-01"),
+});

--- a/homepage/homepage/content/docs/code-snippets/core-concepts/covalues/comaps/safe-extend.ts
+++ b/homepage/homepage/content/docs/code-snippets/core-concepts/covalues/comaps/safe-extend.ts
@@ -1,0 +1,16 @@
+// [!code hide]
+import { co, z } from "jazz-tools";
+
+const Project = co.map({
+  name: z.string(),
+  startDate: z.date(),
+});
+
+const ProjectWithFixedName = Project.safeExtend({
+  name: z.literal("My project"),
+});
+
+const project = ProjectWithFixedName.create({
+  name: "My project",
+  startDate: new Date("2025-04-01"),
+});

--- a/homepage/homepage/content/docs/core-concepts/covalues/comaps.mdx
+++ b/homepage/homepage/content/docs/core-concepts/covalues/comaps.mdx
@@ -75,16 +75,16 @@ When the recursive references involve more complex types, it is sometimes requir
 ```
 </CodeGroup>
 
-### Partial
+### `.partial()`
 
-For convenience Jazz provies a dedicated API for making all the properties of a CoMap optional:
+For convenience Jazz provides a dedicated API for making all the properties of a CoMap optional:
 
 <CodeGroup>
 ```ts partial.ts
 ```
 </CodeGroup>
 
-### Pick
+### `.pick()`
 
 You can also pick specific fields from a CoMap:
 
@@ -92,6 +92,37 @@ You can also pick specific fields from a CoMap:
 ```ts pick.ts
 ```
 </CodeGroup>
+
+### `.omit()`
+
+To omit specific fields:
+
+<CodeGroup>
+```ts omit.ts
+```
+</CodeGroup>
+
+### `.extend()`
+
+You can extend an existing CoMap by adding fields or overriding existing ones:
+
+<CodeGroup>
+```ts extend.ts
+```
+</CodeGroup>
+
+`.extend()` preserves all of the CoMap's defined configurations, such as those defined using `withMigration()`, `withPermissions()`, and `resolved()`.
+
+### `.safeExtend()`
+
+Use `.safeExtend()` when you want to extend a CoMap while type-checking ensures that new fields cannot override existing fields with incompatible types:
+
+<CodeGroup>
+```ts safe-extend.ts
+```
+</CodeGroup>
+
+Like `.extend()`, `.safeExtend()` preserves all of the CoMap's defined configurations.
 
 ### Working with Record CoMaps
 

--- a/packages/jazz-tools/src/tools/implementation/zodSchema/schemaTypes/CoMapSchema.ts
+++ b/packages/jazz-tools/src/tools/implementation/zodSchema/schemaTypes/CoMapSchema.ts
@@ -13,7 +13,6 @@ import {
   Simplify,
   SubscribeCallback,
   SubscribeListenerOptions,
-  coMapDefiner,
   coOptionalDefiner,
   hydrateCoreCoValueSchema,
   isAnyCoValueSchema,
@@ -394,14 +393,7 @@ export class CoMapSchema<
     return hydrateCoreCoValueSchema(schemaWithCatchAll);
   }
 
-  withMigration(
-    migration: (
-      value: Resolved<
-        Simplify<CoMapInstanceCoValuesMaybeLoaded<Shape>> & CoMap,
-        true
-      >,
-    ) => undefined,
-  ): this {
+  withMigration(migration: CoMapMigration<Shape>): this {
     // @ts-expect-error avoid exposing 'migrate' at the type level
     this.coValueClass.prototype.migrate = migration;
     return this;
@@ -417,6 +409,7 @@ export class CoMapSchema<
 
   /**
    * Creates a new CoMap schema by picking the specified keys from the original schema.
+   * The new CoMap will **not** inherit any configurations (migration, catchall, permissions, default resolve query)
    *
    * @param keys - The keys to pick from the original schema.
    * @returns A new CoMap schema with the picked keys.
@@ -433,12 +426,51 @@ export class CoMapSchema<
       }
     }
 
-    // @ts-expect-error the picked shape contains all required keys
-    return coMapDefiner(pickedShape);
+    return this.copy(
+      {
+        shape: pickedShape as Pick<Shape, Keys>,
+        permissions: DEFAULT_SCHEMA_PERMISSIONS,
+        resolveQuery: true,
+      },
+      {
+        shouldCopyCatchAll: false,
+        shouldCopyMigration: false,
+      },
+    );
+  }
+
+  /**
+   * Creates a new CoMap schema by omitting the specified keys from the original schema.
+   * The new CoMap will **not** inherit any configurations (migration, catchall, permissions, default resolve query)
+   *
+   * @param keys - The keys to omit from the original schema.
+   * @returns A new CoMap schema with the omitted keys.
+   */
+  omit<Keys extends keyof Shape>(
+    keys: { [key in Keys]: true },
+  ): CoMapSchema<Simplify<Omit<Shape, Keys>>, unknown, Owner> {
+    const newShape: Record<string, AnyZodOrCoValueSchema> = { ...this.shape };
+
+    for (const key in keys) {
+      delete newShape[key];
+    }
+
+    return this.copy(
+      {
+        shape: newShape as Omit<Shape, Keys>,
+        permissions: DEFAULT_SCHEMA_PERMISSIONS,
+        resolveQuery: true,
+      },
+      {
+        shouldCopyCatchAll: false,
+        shouldCopyMigration: false,
+      },
+    );
   }
 
   /**
    * Creates a new CoMap schema by making all fields optional.
+   * The new CoMap will **not** inherit any configurations (migration, permissions, default resolve query) except catchall
    *
    * @returns A new CoMap schema with all fields optional.
    */
@@ -462,15 +494,64 @@ export class CoMapSchema<
       }
     }
 
-    const partialCoMapSchema = coMapDefiner(partialShape);
-    if (this.catchAll) {
-      // @ts-expect-error the partial shape contains all required keys
-      return partialCoMapSchema.catchall(
-        this.catchAll as unknown as AnyZodOrCoValueSchema,
-      );
-    }
-    // @ts-expect-error the partial shape contains all required keys
-    return partialCoMapSchema;
+    return this.copy(
+      {
+        shape: partialShape as PartialShape<Shape, Keys>,
+        permissions: DEFAULT_SCHEMA_PERMISSIONS,
+        resolveQuery: true,
+      },
+      {
+        shouldCopyMigration: false,
+      },
+    );
+  }
+
+  /**
+   * Creates a new CoMap schema by extending the current schema with additional fields.
+   * The new CoMap **will** inherit all configurations (migration, catchall, permissions, default resolve query)
+   *
+   * @param shape - The shape object with additional fields to add to the schema.
+   * @returns A new CoMap schema with the additional fields.
+   */
+  extend<ExtendShape extends z.core.$ZodLooseShape>(
+    shape: ExtendShape,
+  ): CoMapSchema<
+    z.core.util.Extend<Shape, ExtendShape>,
+    CatchAll,
+    Owner,
+    DefaultResolveQuery
+  > {
+    return this.copy({
+      shape: {
+        ...this.shape,
+        ...shape,
+      } as z.core.util.Extend<Shape, ExtendShape>,
+    });
+  }
+
+  /**
+   * Creates a new CoMap schema by extending the current schema with additional fields,
+   * while also making sure that no existing fields are accidentally overridden.
+   * The new CoMap **will** inherit all configurations (migration, catchall, permissions, default resolve query)
+   *
+   * @param shape - The shape object with additional fields to add to the schema.
+   * @returns A new CoMap schema with the additional fields.
+   */
+  safeExtend<ExtendShape extends z.core.$ZodLooseShape>(
+    shape: SafeExtendShape<Shape, ExtendShape> &
+      Partial<Record<keyof Shape, AnyZodOrCoValueSchema>>,
+  ): CoMapSchema<
+    z.core.util.Extend<Shape, ExtendShape>,
+    CatchAll,
+    Owner,
+    DefaultResolveQuery
+  > {
+    return this.copy({
+      shape: {
+        ...this.shape,
+        ...shape,
+      } as z.core.util.Extend<Shape, ExtendShape>,
+    });
   }
 
   /**
@@ -502,22 +583,45 @@ export class CoMapSchema<
   /**
    * Creates a copy of this schema, preserving all previous configuration
    */
-  private copy<ResolveQuery extends CoreResolveQuery = DefaultResolveQuery>({
-    permissions,
-    resolveQuery,
-  }: {
-    permissions?: SchemaPermissions;
-    resolveQuery?: ResolveQuery;
-  }): CoMapSchema<Shape, CatchAll, Owner, ResolveQuery> {
-    const coreSchema = createCoreCoMapSchema(this.shape, this.catchAll);
-    // @ts-expect-error
-    const copy: CoMapSchema<Shape, CatchAll, Owner, ResolveQuery> =
-      hydrateCoreCoValueSchema(coreSchema);
-    // @ts-expect-error avoid exposing 'migrate' at the type level
-    copy.coValueClass.prototype.migrate = this.coValueClass.prototype.migrate;
-    // @ts-expect-error TS cannot infer that the resolveQuery type is valid
-    copy.resolveQuery = resolveQuery ?? this.resolveQuery;
+  private copy<
+    ShapeOverride extends z.core.$ZodLooseShape = Shape,
+    ResolveQuery extends CoreResolveQuery = DefaultResolveQuery,
+  >(
+    {
+      shape,
+      permissions,
+      resolveQuery,
+    }: {
+      shape?: ShapeOverride;
+      permissions?: SchemaPermissions;
+      resolveQuery?: ResolveQuery;
+    },
+    options: {
+      shouldCopyCatchAll?: boolean;
+      shouldCopyMigration?: boolean;
+    } = {},
+  ): CoMapSchema<ShapeOverride, CatchAll, Owner, ResolveQuery> {
+    const { shouldCopyCatchAll = true, shouldCopyMigration = true } = options;
+
+    const coreSchema = createCoreCoMapSchema(
+      shape ?? this.shape,
+      shouldCopyCatchAll ? this.catchAll : (undefined as unknown),
+    );
+
+    const copy = hydrateCoreCoValueSchema(coreSchema) as CoMapSchema<
+      ShapeOverride,
+      CatchAll,
+      Owner,
+      ResolveQuery
+    >;
+
+    if (shouldCopyMigration) {
+      // @ts-expect-error avoid exposing 'migrate' at the type level
+      copy.coValueClass.prototype.migrate = this.coValueClass.prototype.migrate;
+    }
+
     copy.#permissions = permissions ?? this.#permissions;
+    copy.resolveQuery = (resolveQuery ?? this.resolveQuery) as ResolveQuery;
     return copy;
   }
 }
@@ -611,6 +715,13 @@ export interface CoreCoMapSchema<
   getDefinition: () => CoMapSchemaDefinition;
 }
 
+type CoMapMigration<Shape extends z.core.$ZodLooseShape> = (
+  value: Resolved<
+    Simplify<CoMapInstanceCoValuesMaybeLoaded<Shape>> & CoMap,
+    true
+  >,
+) => undefined;
+
 export type CoMapInstanceShape<
   Shape extends z.core.$ZodLooseShape,
   CatchAll extends AnyZodOrCoValueSchema | unknown = unknown,
@@ -642,3 +753,29 @@ export type PartialShape<
         : never
     : Shape[key];
 }>;
+
+export type SafeExtendShape<
+  Base extends z.core.$ZodLooseShape,
+  Ext extends z.core.$ZodLooseShape,
+> = {
+  [K in keyof Ext]: K extends keyof Base
+    ? Base[K] extends z.core.SomeType
+      ? Ext[K] extends z.core.SomeType
+        ? InstanceOrPrimitiveOfSchema<
+            Ext[K]
+          > extends InstanceOrPrimitiveOfSchema<Base[K]>
+          ? z.core.input<Ext[K]> extends z.core.input<Base[K]>
+            ? Ext[K]
+            : never
+          : never
+        : never
+      : Ext[K] extends z.core.SomeType
+        ? never
+        : // both are CoValue schemas
+          InstanceOrPrimitiveOfSchema<
+              Ext[K]
+            > extends InstanceOrPrimitiveOfSchema<Base[K]>
+          ? Ext[K]
+          : never
+    : Ext[K];
+};

--- a/packages/jazz-tools/src/tools/tests/coMap.test-d.ts
+++ b/packages/jazz-tools/src/tools/tests/coMap.test-d.ts
@@ -491,6 +491,70 @@ describe("CoMap", async () => {
     matches(Person);
   });
 
+  test("CoMap.omit()", () => {
+    const Person = co.map({
+      name: z.string(),
+      age: z.number(),
+      dog: co.map({
+        name: z.string(),
+        breed: z.string(),
+      }),
+    });
+
+    const PersonWithoutDog = Person.omit({
+      dog: true,
+    });
+
+    type ExpectedType = co.Map<{
+      name: ZodString;
+      age: ZodNumber;
+    }>;
+
+    function matches(value: ExpectedType) {
+      return value;
+    }
+
+    matches(PersonWithoutDog);
+  });
+
+  test("CoMap.omit() with a recursive reference", () => {
+    const Person = co.map({
+      name: z.string(),
+      age: z.number(),
+      dog: co.map({
+        name: z.string(),
+        breed: z.string(),
+      }),
+      get friend() {
+        return Person.omit({
+          dog: true,
+          friend: true,
+        }).optional();
+      },
+    });
+
+    type ExpectedType = co.Map<{
+      name: ZodString;
+      age: ZodNumber;
+      dog: co.Map<{
+        name: ZodString;
+        breed: ZodString;
+      }>;
+      friend: co.Optional<
+        co.Map<{
+          name: ZodString;
+          age: ZodNumber;
+        }>
+      >;
+    }>;
+
+    function matches(value: ExpectedType) {
+      return value;
+    }
+
+    matches(Person);
+  });
+
   test("CoMap.partial()", () => {
     const Person = co.map({
       name: z.string(),
@@ -566,6 +630,202 @@ describe("CoMap", async () => {
     }
 
     matches(Person);
+  });
+
+  test("CoMap.extend()", () => {
+    const Person = co.map({
+      name: z.string(),
+      age: z.number(),
+    });
+
+    const PersonWithDog = Person.extend({
+      address: z.string(),
+      dog: co.map({
+        name: z.string(),
+        breed: z.string(),
+      }),
+    });
+
+    type ExpectedType = co.Map<{
+      name: ZodString;
+      age: ZodNumber;
+      address: ZodString;
+      dog: co.Map<{
+        name: ZodString;
+        breed: ZodString;
+      }>;
+    }>;
+
+    function matches(value: ExpectedType) {
+      return value;
+    }
+
+    matches(PersonWithDog);
+  });
+
+  test("CoMap.extend() with a recursive reference", () => {
+    const Person = co.map({
+      name: z.string(),
+      age: z.number(),
+    });
+
+    const PersonWithDog = Person.extend({
+      dog: co.map({
+        name: z.string(),
+        breed: z.string(),
+      }),
+      get friend() {
+        return PersonWithDog.optional();
+      },
+    });
+
+    type ExpectedType = co.Map<{
+      name: ZodString;
+      age: ZodNumber;
+      dog: co.Map<{
+        name: ZodString;
+        breed: ZodString;
+      }>;
+      friend: co.Optional<
+        co.Map<{
+          name: ZodString;
+          age: ZodNumber;
+          dog: co.Map<{
+            name: ZodString;
+            breed: ZodString;
+          }>;
+          friend: co.Optional<ExpectedType>;
+        }>
+      >;
+    }>;
+
+    function matches(value: ExpectedType) {
+      return value;
+    }
+
+    matches(PersonWithDog);
+  });
+
+  test("CoMap.safeExtend()", () => {
+    const Person = co.map({
+      name: z.string(),
+      age: z.number(),
+    });
+
+    const PersonWithDog = Person.safeExtend({
+      address: z.string(),
+      dog: co.map({
+        name: z.string(),
+        breed: z.string(),
+      }),
+    });
+
+    type ExpectedType = co.Map<{
+      name: ZodString;
+      age: ZodNumber;
+      address: ZodString;
+      dog: co.Map<{
+        name: ZodString;
+        breed: ZodString;
+      }>;
+    }>;
+
+    function matches(value: ExpectedType) {
+      return value;
+    }
+
+    matches(PersonWithDog);
+  });
+
+  test("CoMap.safeExtend() works with compatible existing keys", () => {
+    const PersonWithDog = co.map({
+      name: z.string(),
+      age: z.number(),
+      dog: co.map({
+        name: z.string(),
+        breed: z.string(),
+      }),
+    });
+
+    const PersonWithDogAndAddress = PersonWithDog.safeExtend({
+      name: z.string().min(1),
+      address: z.string(),
+      dog: co.map({
+        name: z.string(),
+        breed: z.string(),
+      }),
+    });
+
+    type ExpectedType = co.Map<{
+      name: ZodString;
+      age: ZodNumber;
+      address: ZodString;
+      dog: co.Map<{
+        name: ZodString;
+        breed: ZodString;
+      }>;
+    }>;
+
+    function matches(value: ExpectedType) {
+      return value;
+    }
+
+    matches(PersonWithDogAndAddress);
+  });
+
+  test("CoMap.safeExtend() rejects incompatible Zod type overrides", () => {
+    const Person = co.map({
+      name: z.string(),
+      age: z.number(),
+    });
+
+    Person.safeExtend({
+      // @ts-expect-error - cannot override with an incompatible Zod type
+      name: z.number(),
+    });
+  });
+
+  test("CoMap.safeExtend() rejects incompatible CoValue overrides", () => {
+    const PersonWithDog = co.map({
+      name: z.string(),
+      age: z.number(),
+      dog: co.map({
+        name: z.string(),
+        breed: z.string(),
+      }),
+    });
+
+    PersonWithDog.safeExtend({
+      // @ts-expect-error - cannot override with an incompatible CoValue schema
+      dog: co.map({
+        name: z.string(),
+      }),
+    });
+  });
+
+  test("CoMap.safeExtend() rejects deep incompatible CoValue overrides", () => {
+    const PersonWithDog = co.map({
+      name: z.string(),
+      age: z.number(),
+      dog: co.map({
+        name: z.string(),
+        breed: z.string(),
+        home: co.map({
+          address: z.string(),
+        }),
+      }),
+    });
+
+    PersonWithDog.safeExtend({
+      // @ts-expect-error - cannot override with an incompatible CoValue schema
+      dog: co.map({
+        name: z.string(),
+        breed: z.string(),
+        home: co.map({
+          street: z.string(),
+        }),
+      }),
+    });
   });
 });
 

--- a/packages/jazz-tools/src/tools/tests/coMap.test.ts
+++ b/packages/jazz-tools/src/tools/tests/coMap.test.ts
@@ -2967,6 +2967,280 @@ describe("co.map schema", () => {
     });
   });
 
+  describe("omit()", () => {
+    test("creates a new CoMap schema by omitting fields of another CoMap schema", () => {
+      const Person = co.map({
+        name: z.string(),
+        age: z.number(),
+        city: z.string(),
+      });
+
+      const PersonWithoutCity = Person.omit({
+        city: true,
+      });
+
+      const person = PersonWithoutCity.create({
+        name: "John",
+        age: 20,
+      });
+
+      expect(person.name).toEqual("John");
+      expect(person.age).toEqual(20);
+      // @ts-expect-error - property `city` does not exist in person
+      expect(person.city).toBeUndefined();
+    });
+
+    test("the new schema does not include catchall properties", () => {
+      const Person = co
+        .map({
+          name: z.string(),
+          age: z.number(),
+          city: z.string(),
+        })
+        .catchall(z.string());
+
+      const PersonWithoutCity = Person.omit({
+        city: true,
+      });
+
+      expect(PersonWithoutCity.catchAll).toBeUndefined();
+
+      const person = PersonWithoutCity.create({
+        name: "John",
+        age: 20,
+      });
+
+      // @ts-expect-error - property `extraField` does not exist in person
+      expect(person.extraField).toBeUndefined();
+    });
+  });
+
+  describe("extend()", () => {
+    test("creates a new CoMap schema by extending another CoMap schema", () => {
+      const Person = co.map({
+        name: z.string(),
+        age: z.number(),
+      });
+
+      const PersonWithAddress = Person.extend({
+        address: z.string(),
+      });
+
+      const person = PersonWithAddress.create({
+        name: "John",
+        age: 20,
+        address: "Earth",
+      });
+
+      expect(person.name).toEqual("John");
+      expect(person.age).toEqual(20);
+      expect(person.address).toEqual("Earth");
+    });
+
+    test("the new schema keeps catchall properties", () => {
+      const Person = co
+        .map({
+          name: z.string(),
+        })
+        .catchall(z.string());
+
+      const PersonWithAddress = Person.extend({
+        address: z.string(),
+      });
+
+      const person = PersonWithAddress.create({
+        name: "John",
+        address: "Earth",
+      });
+
+      person.$jazz.set("extraField", "extra");
+
+      expect(person.extraField).toEqual("extra");
+    });
+  });
+
+  describe("safeExtend()", () => {
+    test("creates a new CoMap schema by safely extending fields", () => {
+      const Person = co.map({
+        name: z.string(),
+        age: z.number(),
+      });
+
+      const PersonWithAddress = Person.safeExtend({
+        name: z.literal("John"),
+        address: z.string(),
+      });
+
+      const person = PersonWithAddress.create({
+        name: "John",
+        age: 20,
+        address: "Earth",
+      });
+
+      expect(person.name).toEqual("John");
+      expect(person.address).toEqual("Earth");
+    });
+
+    test("the new schema keeps catchall properties", () => {
+      const Person = co
+        .map({
+          name: z.string(),
+        })
+        .catchall(z.string());
+
+      const PersonWithAddress = Person.safeExtend({
+        address: z.string(),
+      });
+
+      const person = PersonWithAddress.create({
+        name: "John",
+        address: "Earth",
+      });
+
+      person.$jazz.set("extraField", "extra");
+
+      expect(person.extraField).toEqual("extra");
+    });
+  });
+
+  describe("schema configuration inheritance", () => {
+    test("pick/omit/partial do not inherit migration", async () => {
+      const withMigration = co
+        .map({
+          name: z.string(),
+          version: z.literal([1, 2]),
+        })
+        .withMigration((person) => {
+          if (person.version === 1) {
+            person.$jazz.set("version", 2);
+          }
+        });
+
+      const Picked = withMigration.pick({ version: true });
+      const Omitted = withMigration.omit({ name: true });
+      const Partial = withMigration.partial();
+
+      const picked = Picked.create({ version: 1 });
+      const omitted = Omitted.create({ version: 1 });
+      const partial = Partial.create({ version: 1 });
+
+      const loadedPicked = await Picked.load(picked.$jazz.id);
+      const loadedOmitted = await Omitted.load(omitted.$jazz.id);
+      const loadedPartial = await Partial.load(partial.$jazz.id);
+
+      assertLoaded(loadedPicked);
+      assertLoaded(loadedOmitted);
+      assertLoaded(loadedPartial);
+
+      expect(loadedPicked.version).toEqual(1);
+      expect(loadedOmitted.version).toEqual(1);
+      expect(loadedPartial.version).toEqual(1);
+    });
+
+    test("extend/safeExtend inherit migration", async () => {
+      const withMigration = co
+        .map({
+          name: z.string(),
+          version: z.literal([1, 2]),
+        })
+        .withMigration((person) => {
+          if (person.version === 1) {
+            person.$jazz.set("version", 2);
+          }
+        });
+
+      const Extended = withMigration.extend({
+        city: z.string(),
+      });
+      const SafeExtended = withMigration.safeExtend({
+        name: z.literal("John"),
+      });
+
+      const extended = Extended.create({
+        name: "John",
+        version: 1,
+        city: "Paris",
+      });
+      const safeExtended = SafeExtended.create({
+        name: "John",
+        version: 1,
+      });
+
+      const loadedExtended = await Extended.load(extended.$jazz.id);
+      const loadedSafeExtended = await SafeExtended.load(safeExtended.$jazz.id);
+
+      assertLoaded(loadedExtended);
+      assertLoaded(loadedSafeExtended);
+
+      expect(loadedExtended.version).toEqual(2);
+      expect(loadedSafeExtended.version).toEqual(2);
+    });
+
+    test("pick/omit/partial reset default schema permissions", () => {
+      const customOwner = Group.create();
+      const base = co
+        .map({
+          name: z.string(),
+          age: z.number(),
+        })
+        .withPermissions({
+          default: () => customOwner,
+        });
+
+      const picked = base.pick({ name: true }).create({ name: "John" });
+      const omitted = base.omit({ age: true }).create({ name: "John" });
+      const partial = base.partial().create({});
+
+      expect(picked.$jazz.owner.$jazz.id).not.toEqual(customOwner.$jazz.id);
+      expect(omitted.$jazz.owner.$jazz.id).not.toEqual(customOwner.$jazz.id);
+      expect(partial.$jazz.owner.$jazz.id).not.toEqual(customOwner.$jazz.id);
+    });
+
+    test("extend/safeExtend inherit resolved query and default schema permissions", () => {
+      const customOwner = Group.create();
+      const Dog = co.map({
+        name: z.string(),
+      });
+      const base = co
+        .map({
+          name: z.string(),
+          dog1: Dog,
+          dog2: Dog,
+        })
+        .resolved({ dog1: true })
+        .withPermissions({
+          default: () => customOwner,
+        });
+
+      const extended = base.extend({
+        city: z.string(),
+      });
+      const safeExtended = base.safeExtend({
+        name: z.literal("John"),
+      });
+
+      expect(extended.resolveQuery).toEqual({ dog1: true });
+      expect(safeExtended.resolveQuery).toEqual({ dog1: true });
+
+      const extendedValue = extended.create({
+        name: "John",
+        dog1: Dog.create({ name: "Rex" }),
+        dog2: Dog.create({ name: "Fido" }),
+        city: "Paris",
+      });
+      const safeExtendedValue = safeExtended.create({
+        name: "John",
+        dog1: Dog.create({ name: "Rex" }),
+        dog2: Dog.create({ name: "Fido" }),
+      });
+
+      expect(extendedValue.$jazz.owner.$jazz.id).toEqual(customOwner.$jazz.id);
+      expect(safeExtendedValue.$jazz.owner.$jazz.id).toEqual(
+        customOwner.$jazz.id,
+      );
+    });
+  });
+
   test("co.map() should throw an error if passed a CoValue schema", () => {
     expect(() => co.map(co.map({}))).toThrow(
       "co.map() expects an object as its argument, not a CoValue schema",


### PR DESCRIPTION
I've refactored the existing `partial()` and `pick()` methods to use the existing private `copy()` method and added some options to make sure they function exactly the same as before, which is not inheriting migrations, permissions, `resolveQuery`, and `catchall` for `pick()`. 

In my opinion though, all these derived schemas should inherit `permissions`, and `partial()` should also technically be able to inherit the `resolveQuery` just based on the average user's expectation of behavior if they chain calls like this `schema.withPermissions(...).partial()`.

I didn't want to introduce any behavioral changes to existing methods — especially inheriting permissions, this could potentially be a breaking change for some users, but I think making `partial()` inherit `resolveQuery` should be mostly fine though.

Closes #2288 