### PR TITLE
fix(cojson-storage-indexeddb): stop IDB transactions after DB close

### DIFF
--- a/.changeset/stop-idb-transactions-after-close.md
+++ b/.changeset/stop-idb-transactions-after-close.md
@@ -1,0 +1,5 @@
+"cojson": patch
+"cojson-storage-indexeddb": patch
+---
+
+Stop attempting IndexedDB transactions after the database connection is closed

--- a/packages/cojson-storage-indexeddb/src/idbClient.ts
+++ b/packages/cojson-storage-indexeddb/src/idbClient.ts
@@ -239,12 +239,31 @@ export class IDBTransaction implements DBTransactionInterfaceAsync {
 
 export class IDBClient implements DBClientInterfaceAsync {
   private db;
+  private closed = false;
 
   activeTransaction: CoJsonIDBTransaction | undefined;
   autoBatchingTransaction: CoJsonIDBTransaction | undefined;
 
   constructor(db: IDBDatabase) {
     this.db = db;
+
+    this.db.onclose = () => {
+      this.closed = true;
+    };
+  }
+
+  close() {
+    if (this.closed) return;
+    this.closed = true;
+    try {
+      this.db.close();
+    } catch {
+      // Already closing
+    }
+  }
+
+  isClosed() {
+    return this.closed;
   }
 
   async getCoValue(coValueId: RawCoID): Promise<StoredCoValueRow | undefined> {
@@ -319,6 +338,8 @@ export class IDBClient implements DBClientInterfaceAsync {
     operationsCallback: (tx: IDBTransaction) => Promise<unknown>,
     storeNames?: StoreName[],
   ) {
+    if (this.closed) return;
+
     const tx = new CoJsonIDBTransaction(this.db, storeNames);
 
     try {

--- a/packages/cojson-storage-indexeddb/src/tests/CoJsonIDBTransaction.test.ts
+++ b/packages/cojson-storage-indexeddb/src/tests/CoJsonIDBTransaction.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, test } from "vitest";
 import { CoJsonIDBTransaction } from "../CoJsonIDBTransaction";
+import { IDBClient } from "../idbClient";
 
 const TEST_DB_NAME = "test-cojson-idb-transaction";
 
@@ -40,6 +41,9 @@ describe("CoJsonIDBTransaction", () => {
             unique: true,
           },
         );
+        db.createObjectStore("storageReconciliationLocks", {
+          keyPath: "key",
+        });
       };
 
       request.onsuccess = () => {
@@ -259,5 +263,147 @@ describe("CoJsonIDBTransaction", () => {
     ).rejects.toThrow(
       "Failed to execute 'objectStore' on 'IDBTransaction': The specified object store was not found.",
     );
+  });
+});
+
+describe("IDBClient", () => {
+  let db: IDBDatabase;
+
+  beforeEach(async () => {
+    await new Promise<void>((resolve, reject) => {
+      const request = indexedDB.open(TEST_DB_NAME, 1);
+
+      request.onerror = () => reject(request.error);
+
+      request.onupgradeneeded = () => {
+        const db = request.result;
+        const coValues = db.createObjectStore("coValues", {
+          keyPath: "rowID",
+          autoIncrement: true,
+        });
+        coValues.createIndex("coValuesById", "id", { unique: true });
+        const sessions = db.createObjectStore("sessions", {
+          keyPath: "rowID",
+          autoIncrement: true,
+        });
+        sessions.createIndex("uniqueSessions", ["coValue", "sessionID"], {
+          unique: true,
+        });
+        sessions.createIndex("sessionsByCoValue", "coValue");
+        db.createObjectStore("transactions", {
+          keyPath: ["ses", "idx"],
+        });
+        db.createObjectStore("signatureAfter", {
+          keyPath: ["ses", "idx"],
+        });
+        const deletedCoValues = db.createObjectStore("deletedCoValues", {
+          keyPath: "coValueID",
+        });
+        deletedCoValues.createIndex("deletedCoValuesByStatus", "status", {
+          unique: false,
+        });
+        const unsyncedCoValues = db.createObjectStore("unsyncedCoValues", {
+          keyPath: "rowID",
+          autoIncrement: true,
+        });
+        unsyncedCoValues.createIndex("byCoValueId", "coValueId");
+        unsyncedCoValues.createIndex(
+          "uniqueUnsyncedCoValues",
+          ["coValueId", "peerId"],
+          { unique: true },
+        );
+        db.createObjectStore("storageReconciliationLocks", {
+          keyPath: "key",
+        });
+      };
+
+      request.onsuccess = () => {
+        db = request.result;
+        resolve();
+      };
+    });
+  });
+
+  afterEach(async () => {
+    db.close();
+    await new Promise<void>((resolve, reject) => {
+      const request = indexedDB.deleteDatabase(TEST_DB_NAME);
+      request.onerror = () => reject(request.error);
+      request.onsuccess = () => resolve();
+    });
+  });
+
+  test("close() marks the client as closed", () => {
+    const client = new IDBClient(db);
+    expect(client.isClosed()).toBe(false);
+    client.close();
+    expect(client.isClosed()).toBe(true);
+  });
+
+  test("close() is idempotent", () => {
+    const client = new IDBClient(db);
+    client.close();
+    client.close();
+    expect(client.isClosed()).toBe(true);
+  });
+
+  test("transaction() is a no-op after close", async () => {
+    const client = new IDBClient(db);
+
+    await client.transaction(
+      async (tx) => {
+        await tx.putUnsyncedCoValueRecord({
+          coValueId: "co_zBefore" as any,
+          peerId: "peer",
+        });
+      },
+      ["unsyncedCoValues"],
+    );
+
+    client.close();
+
+    let callbackRan = false;
+    await client.transaction(async () => {
+      callbackRan = true;
+    });
+    expect(callbackRan).toBe(false);
+
+    const freshDb = await new Promise<IDBDatabase>((resolve, reject) => {
+      const req = indexedDB.open(TEST_DB_NAME);
+      req.onerror = () => reject(req.error);
+      req.onsuccess = () => resolve(req.result);
+    });
+    const readTx = freshDb.transaction("unsyncedCoValues", "readonly");
+    const all = await new Promise<any[]>((resolve) => {
+      const req = readTx.objectStore("unsyncedCoValues").getAll();
+      req.onsuccess = () => resolve(req.result);
+    });
+    freshDb.close();
+
+    expect(all).toHaveLength(1);
+    expect(all[0].coValueId).toBe("co_zBefore");
+  });
+
+  test("trackCoValuesSyncState is a no-op after close", async () => {
+    const client = new IDBClient(db);
+    client.close();
+
+    await client.trackCoValuesSyncState([
+      { id: "co_zTest" as any, peerId: "peer", synced: false },
+    ]);
+
+    const freshDb = await new Promise<IDBDatabase>((resolve, reject) => {
+      const req = indexedDB.open(TEST_DB_NAME);
+      req.onerror = () => reject(req.error);
+      req.onsuccess = () => resolve(req.result);
+    });
+    const readTx = freshDb.transaction("unsyncedCoValues", "readonly");
+    const all = await new Promise<any[]>((resolve) => {
+      const req = readTx.objectStore("unsyncedCoValues").getAll();
+      req.onsuccess = () => resolve(req.result);
+    });
+    freshDb.close();
+
+    expect(all).toHaveLength(0);
   });
 });

--- a/packages/cojson/src/localNode.ts
+++ b/packages/cojson/src/localNode.ts
@@ -101,9 +101,10 @@ export class LocalNode {
   }
 
   removeStorage() {
-    this.storage?.close();
-    this.storage = undefined;
     this.syncManager.removeStorage();
+    const storage = this.storage;
+    this.storage = undefined;
+    storage?.close();
   }
 
   /**

--- a/packages/cojson/src/storage/storageAsync.ts
+++ b/packages/cojson/src/storage/storageAsync.ts
@@ -571,6 +571,16 @@ export class StorageApiAsync implements StorageAPI {
     this.deletedCoValuesEraserScheduler?.dispose();
     this.inMemoryCoValues.clear();
     this.knownStates.clear();
-    return this.storeQueue.close();
+
+    const pendingStore = this.storeQueue.close();
+
+    return (async () => {
+      await pendingStore;
+      try {
+        await this.dbClient.close?.();
+      } catch {
+        // Closing errors are non-actionable
+      }
+    })();
   }
 }

--- a/packages/cojson/src/storage/types.ts
+++ b/packages/cojson/src/storage/types.ts
@@ -319,6 +319,10 @@ export interface DBClientInterfaceAsync {
     sessionId: SessionID,
     peerId: PeerID,
   ): Promise<void>;
+
+  close?(): Promise<unknown> | unknown;
+
+  isClosed?(): boolean;
 }
 
 export interface DBTransactionInterfaceSync {


### PR DESCRIPTION
- Adds a `closed` flag to `IDBClient` that gates `transaction()` calls, so once the browser or app closes the IndexedDB connection no further transactions are attempted
- `StorageApiAsync.close()` now calls `dbClient.close()` after draining the store queue
- `LocalNode.removeStorage()` reordered to stop sync work before closing storage

Fixes the cascade of `InvalidStateError: Failed to execute 'transaction' on 'IDBDatabase': The database connection is closing` seen in production.