### PR TITLE
Unify createInviteLink signature across core and browser

### DIFF
--- a/.changeset/unify-create-invite-link-signature.md
+++ b/.changeset/unify-create-invite-link-signature.md
@@ -1,0 +1,5 @@
+---
+"jazz-tools": patch
+---
+
+Accept an options object `{ baseURL, valueHint? }` as the third argument to `createInviteLink`, matching the signature already used by the browser and React Native wrappers. The positional form `(value, role, baseURL, valueHint?)` is deprecated but still supported.

--- a/packages/jazz-tools/src/browser/createBrowserContext.ts
+++ b/packages/jazz-tools/src/browser/createBrowserContext.ts
@@ -13,11 +13,9 @@ import {
   CoValueFromRaw,
   CryptoProvider,
   ID,
-  InviteSecret,
   NewAccountProps,
   SessionID,
   SyncConfig,
-  cojsonInternals,
   createAnonymousJazzContext,
 } from "jazz-tools";
 import { createJazzContext } from "jazz-tools";
@@ -243,68 +241,3 @@ export async function createJazzBrowserContext<
 export type SessionProvider = (
   accountID: ID<Account> | AgentID,
 ) => Promise<SessionID>;
-
-/** @category Invite Links */
-export function createInviteLink<C extends CoValue>(
-  value: C,
-  role: "reader" | "writer" | "admin" | "writeOnly",
-  // default to same address as window.location, but without hash
-  {
-    baseURL = window.location.href.replace(/#.*$/, ""),
-    valueHint,
-  }: { baseURL?: string; valueHint?: string } = {},
-): string {
-  const coValueCore = value.$jazz.raw.core;
-  let currentCoValue = coValueCore;
-
-  while (currentCoValue.verified.header.ruleset.type === "ownedByGroup") {
-    currentCoValue = currentCoValue.getGroup().core;
-  }
-
-  const { ruleset, meta } = currentCoValue.verified.header;
-
-  if (ruleset.type !== "group" || meta?.type === "account") {
-    throw new Error("Can't create invite link for object without group");
-  }
-
-  const group = cojsonInternals.expectGroup(currentCoValue.getCurrentContent());
-  const inviteSecret = group.createInvite(role);
-
-  return `${baseURL}#/invite/${valueHint ? valueHint + "/" : ""}${
-    value.$jazz.id
-  }/${inviteSecret}`;
-}
-
-/** @category Invite Links */
-export function parseInviteLink<C extends CoValue>(
-  inviteURL: string,
-):
-  | {
-      valueID: ID<C>;
-      valueHint?: string;
-      inviteSecret: InviteSecret;
-    }
-  | undefined {
-  const url = new URL(inviteURL);
-  const parts = url.hash.split("/");
-
-  let valueHint: string | undefined;
-  let valueID: ID<C> | undefined;
-  let inviteSecret: InviteSecret | undefined;
-
-  if (parts[0] === "#" && parts[1] === "invite") {
-    if (parts.length === 5) {
-      valueHint = parts[2];
-      valueID = parts[3] as ID<C>;
-      inviteSecret = parts[4] as InviteSecret;
-    } else if (parts.length === 4) {
-      valueID = parts[2] as ID<C>;
-      inviteSecret = parts[3] as InviteSecret;
-    }
-
-    if (!valueID || !inviteSecret) {
-      return undefined;
-    }
-    return { valueID, inviteSecret, valueHint };
-  }
-}

--- a/packages/jazz-tools/src/browser/index.ts
+++ b/packages/jazz-tools/src/browser/index.ts
@@ -27,7 +27,7 @@ export function createInviteLink<C extends CoValue>(
     valueHint,
   }: { baseURL?: string; valueHint?: string } = {},
 ): string {
-  return baseCreateInviteLink(value, role, baseURL, valueHint);
+  return baseCreateInviteLink(value, role, { baseURL, valueHint });
 }
 
 /** @category Invite Links */

--- a/packages/jazz-tools/src/react-native-core/platform.ts
+++ b/packages/jazz-tools/src/react-native-core/platform.ts
@@ -240,7 +240,10 @@ export function createInviteLink<C extends CoValue>(
   role: "reader" | "writer" | "admin",
   { baseURL, valueHint }: { baseURL?: string; valueHint?: string } = {},
 ): string {
-  return baseCreateInviteLink(value, role, baseURL ?? "", valueHint);
+  return baseCreateInviteLink(value, role, {
+    baseURL: baseURL ?? "",
+    valueHint,
+  });
 }
 
 export function setupKvStore(

--- a/packages/jazz-tools/src/tools/implementation/invites.ts
+++ b/packages/jazz-tools/src/tools/implementation/invites.ts
@@ -2,8 +2,10 @@ import { AccountRole, type InviteSecret, cojsonInternals } from "cojson";
 import { Account } from "../coValues/account.js";
 import type { CoValue, CoValueClassOrSchema } from "../internal.js";
 
-/** @category Invite Links */
-/** @deprecated Use the options object form: `createInviteLink(value, role, { baseURL, valueHint? })` */
+/**
+ * @category Invite Links
+ * @deprecated Use the options object form: `createInviteLink(value, role, { baseURL, valueHint? })`
+ */
 export function createInviteLink<C extends CoValue>(
   value: C,
   role: AccountRole,

--- a/packages/jazz-tools/src/tools/implementation/invites.ts
+++ b/packages/jazz-tools/src/tools/implementation/invites.ts
@@ -3,12 +3,34 @@ import { Account } from "../coValues/account.js";
 import type { CoValue, CoValueClassOrSchema } from "../internal.js";
 
 /** @category Invite Links */
+/** @deprecated Use the options object form: `createInviteLink(value, role, { baseURL, valueHint? })` */
 export function createInviteLink<C extends CoValue>(
   value: C,
   role: AccountRole,
   baseURL: string,
   valueHint?: string,
+): string;
+/** @category Invite Links */
+export function createInviteLink<C extends CoValue>(
+  value: C,
+  role: AccountRole,
+  options: { baseURL: string; valueHint?: string },
+): string;
+export function createInviteLink<C extends CoValue>(
+  value: C,
+  role: AccountRole,
+  baseURLOrOptions: string | { baseURL: string; valueHint?: string },
+  valueHint?: string,
 ): string {
+  const baseURL =
+    typeof baseURLOrOptions === "string"
+      ? baseURLOrOptions
+      : baseURLOrOptions.baseURL;
+  const hint =
+    typeof baseURLOrOptions === "string"
+      ? valueHint
+      : baseURLOrOptions.valueHint;
+
   const coValueCore = value.$jazz.raw.core;
   let currentCoValue = coValueCore;
 
@@ -25,7 +47,7 @@ export function createInviteLink<C extends CoValue>(
   const group = cojsonInternals.expectGroup(currentCoValue.getCurrentContent());
   const inviteSecret = group.createInvite(role);
 
-  return `${baseURL}#/invite/${valueHint ? valueHint + "/" : ""}${
+  return `${baseURL}#/invite/${hint ? hint + "/" : ""}${
     value.$jazz.id
   }/${inviteSecret}`;
 }

--- a/packages/jazz-tools/src/tools/tests/invites.test.ts
+++ b/packages/jazz-tools/src/tools/tests/invites.test.ts
@@ -38,6 +38,19 @@ describe("Invite Links", () => {
     );
   });
 
+  test("createInviteLink accepts options object", () => {
+    const inviteLink = createInviteLink(group, "writer", {
+      baseURL,
+      valueHint: "myGroup",
+    });
+
+    expect(inviteLink).toMatch(
+      new RegExp(
+        `^${baseURL}#/invite/myGroup/${group.$jazz.id}/[A-Za-z0-9_-]+$`,
+      ),
+    );
+  });
+
   test("parseInviteLink correctly parses valid link", () => {
     const inviteLink = createInviteLink(group, "writer", baseURL, "myGroup");
     const result = parseInviteLink(inviteLink);


### PR DESCRIPTION
## Summary

- Add an options object overload `{ baseURL, valueHint? }` to the core `createInviteLink`, matching the signature already used by browser and React Native wrappers
- Deprecate the positional form `(value, role, baseURL, valueHint?)`
- Update browser and RN wrappers to forward via the object form
- Remove duplicate `createInviteLink` and `parseInviteLink` implementations from `createBrowserContext.ts` (dead code, shadowed by `browser/index.ts`)

## Context

Raised by @legowhales — the signature mismatch between `jazz-tools` (positional) and `jazz-tools/browser` (options object) was causing AI assistants to generate incorrect call sites. Now both forms work at every import path.

## Test plan

- [x] New test verifying the object form works at the core level
- [x] Existing tests for positional form still pass
- [x] Browser invite link test passes
- [x] Full jazz-tools suite: 2033 tests pass, no type errors