### PR TITLE
fix(mcp): prevent bundler from stripping "node:" prefix on sqlite import

### DIFF
--- a/packages/jazz-tools/src/mcp/backend-sqlite.ts
+++ b/packages/jazz-tools/src/mcp/backend-sqlite.ts
@@ -33,7 +33,10 @@ export async function createSqliteBackend(
   dbPath: string,
 ): Promise<DocsBackend> {
   // Dynamic import keeps node:sqlite off the top-level parse graph
-  const { DatabaseSync } = await import("node:sqlite");
+  // Use a variable so esbuild cannot statically analyse and strip the "node:" prefix.
+  // eslint-disable-next-line @typescript-eslint/no-implied-eval
+  const sqliteMod = "node:sqlite";
+  const { DatabaseSync } = await import(sqliteMod);
   const db = new DatabaseSync(dbPath, { readOnly: true });
 
   // ------------------------------------------------------------------

--- a/packages/jazz-tools/src/mcp/server.ts
+++ b/packages/jazz-tools/src/mcp/server.ts
@@ -28,7 +28,10 @@ async function selectBackend(
 ): Promise<DocsBackend> {
   try {
     // Step 1: confirm node:sqlite is importable
-    const { DatabaseSync } = await import("node:sqlite");
+    // Use a variable so esbuild cannot statically analyse and strip the "node:" prefix.
+    // eslint-disable-next-line @typescript-eslint/no-implied-eval
+    const sqliteMod = "node:sqlite";
+    const { DatabaseSync } = await import(sqliteMod);
 
     // Step 2: FTS5 probe on an in-memory DB
     const probe = new DatabaseSync(":memory:");


### PR DESCRIPTION
Taking this pattern https://github.com/garden-co/jazz/blob/cbf3b0faa5e601711f2ac4f25dd1108cfbefd2c6/packages/jazz-tools/src/mcp/build-index.ts#L271-L274

And applying it to other `node:sqlite` imports to fix this error even on recent Node versions
```
$ npx jazz-run@latest mcp
node:sqlite not available — using basic text search. Upgrade to Node >=22.13 (current LTS) for better results.
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this only changes how `node:sqlite` is dynamically imported to avoid bundler rewriting, without altering query logic or request handling.
> 
> **Overview**
> Ensures the MCP docs server reliably selects the SQLite/FTS5 backend when available by preventing bundlers (e.g. esbuild) from stripping the `node:` prefix.
> 
> Replaces direct `await import("node:sqlite")` calls in `backend-sqlite.ts` and `server.ts` with a variable-based dynamic import (`const sqliteMod = "node:sqlite"; await import(sqliteMod)`), keeping the rest of the backend selection and DB usage unchanged.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0c57f30f5baa7e19e11f3e37557a1af76c5a8415. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->