### PR TITLE
feat: add ability to create cursors and load by cursor

### DIFF
--- a/.changeset/cursor-time-travel.md
+++ b/.changeset/cursor-time-travel.md
@@ -1,0 +1,14 @@
+---
+"cojson": patch
+"jazz-tools": patch
+---
+
+Add cursor-based time travel for CoValues
+
+Introduces the ability to create cursors (frontier snapshots) on loaded CoValues and later reload them at that exact point in time. Cursors encode the full frontier state of a CoValue and its resolved children, enabling read-only historical views.
+
+- Add `createCursor()` and `cursor` getter to CoValue instances
+- Support loading CoValues by cursor via `load()` and `ensureLoaded()`
+- Add `useCurrentCursor` option to capture the current state as a cursor
+- Prevent mutations on cursor-loaded (time-travel) CoValues
+- Validate cursor root ID and resolve query compatibility (subset check)

--- a/packages/cojson/src/coValue.ts
+++ b/packages/cojson/src/coValue.ts
@@ -8,6 +8,7 @@ import { RawCoStream } from "./coValues/coStream.js";
 import { RawGroup } from "./coValues/group.js";
 import { RawCoID } from "./ids.js";
 import { JsonObject, JsonValue } from "./jsonValue.js";
+import { CoValueFrontier } from "./knownState.js";
 
 export type CoID<T extends RawCoValue> = RawCoID & {
   readonly __type: T;
@@ -26,6 +27,8 @@ export interface RawCoValue {
   /** Returns an immutable JSON presentation of this `CoValue` */
   toJSON(): JsonValue;
   atTime(time: number): this;
+  /** Returns a view of this `CoValue` at the given frontier */
+  atFrontier(frontier: CoValueFrontier): this;
   /** Lets you subscribe to future updates to this CoValue (whether made locally or by other users).
    *
    * Takes a listener function that will be called with the current state for each update.
@@ -77,6 +80,10 @@ export class RawUnknownCoValue implements RawCoValue {
   }
 
   atTime() {
+    return this;
+  }
+
+  atFrontier() {
     return this;
   }
 

--- a/packages/cojson/src/coValueCore/coValueCore.ts
+++ b/packages/cojson/src/coValueCore/coValueCore.ts
@@ -2,10 +2,7 @@ import { UpDownCounter, ValueType, metrics } from "@opentelemetry/api";
 import type { PeerState } from "../PeerState.js";
 import type { RawCoValue } from "../coValue.js";
 import type { LoadMode } from "../queue/OutgoingLoadQueue.js";
-import {
-  RawAccount,
-  type ControlledAccountOrAgent,
-} from "../coValues/account.js";
+import { type ControlledAccountOrAgent } from "../coValues/account.js";
 import type { RawGroup } from "../coValues/group.js";
 import { CO_VALUE_LOADING_CONFIG } from "../config.js";
 import { coreToCoValue } from "../coreToCoValue.js";
@@ -53,6 +50,7 @@ import { decryptTransactionChangesAndMeta } from "./decryptTransactionChangesAnd
 import {
   cloneKnownState,
   combineKnownStateSessions,
+  CoValueFrontier,
   CoValueKnownState,
   emptyKnownState,
   KnownStateSessions,
@@ -669,6 +667,13 @@ export class CoValueCore {
 
     // 3. Fallback to empty state (truly unknown CoValue)
     return emptyKnownState(this.id);
+  }
+
+  /**
+   * Returns a new frontier object from the CoValue's known state
+   */
+  frontier(): CoValueFrontier {
+    return { ...this.knownState().sessions };
   }
 
   /**

--- a/packages/cojson/src/coValues/account.ts
+++ b/packages/cojson/src/coValues/account.ts
@@ -11,7 +11,6 @@ import {
 import { AgentID, isAgentID } from "../ids.js";
 import { JsonObject } from "../jsonValue.js";
 import { LocalNode } from "../localNode.js";
-import { logger } from "../logger.js";
 import type { AccountRole, Role } from "../permissions.js";
 import { RawCoMap } from "./coMap.js";
 import { Everyone, EVERYONE, InviteSecret, RawGroup } from "./group.js";

--- a/packages/cojson/src/coValues/binaryCoStream.ts
+++ b/packages/cojson/src/coValues/binaryCoStream.ts
@@ -59,12 +59,18 @@ export class RawBinaryCoStreamView<
     this.totalValidTransactions = 0;
   }
 
-  constructor(core: AvailableCoValueCore) {
+  constructor(
+    core: AvailableCoValueCore,
+    options?: {
+      atFrontierFilter?: CoValueFrontier;
+    },
+  ) {
     this.id = core.id as CoID<this>;
     this.core = core;
     this.ended = false;
     this.chunks = [];
     this.knownTransactions = { [core.id]: 0 };
+    this.atFrontierFilter = options?.atFrontierFilter;
     this.processNewTransactions();
   }
 
@@ -89,11 +95,9 @@ export class RawBinaryCoStreamView<
   }
 
   atFrontier(frontier: CoValueFrontier): this {
-    const clone = Object.create(this) as RawBinaryCoStreamView<Meta>;
-    clone.atFrontierFilter = frontier;
-    clone.resetInternalState();
-    clone.processNewTransactions();
-    return clone as this;
+    return new RawBinaryCoStreamView(this.core, {
+      atFrontierFilter: frontier,
+    }) as this;
   }
 
   isTimeTravelEntity(): boolean {
@@ -112,7 +116,7 @@ export class RawBinaryCoStreamView<
       return;
     }
 
-    for (const { txID, madeAt, changes } of newValidTransactions) {
+    for (const { txID, changes } of newValidTransactions) {
       if (
         this.atFrontierFilter &&
         txID.txIndex >= (this.atFrontierFilter[txID.sessionID] ?? -1)
@@ -189,6 +193,12 @@ export class RawBinaryCoStream<
   extends RawBinaryCoStreamView<Meta>
   implements RawCoValue
 {
+  override atFrontier(frontier: CoValueFrontier): this {
+    return new RawBinaryCoStream(this.core, {
+      atFrontierFilter: frontier,
+    }) as this;
+  }
+
   /** @internal */
   push(
     item: BinaryStreamItem,

--- a/packages/cojson/src/coValues/binaryCoStream.ts
+++ b/packages/cojson/src/coValues/binaryCoStream.ts
@@ -4,6 +4,7 @@ import type { AvailableCoValueCore } from "../coValueCore/coValueCore.js";
 import type { RawCoID } from "../ids.js";
 import type { JsonObject } from "../jsonValue.js";
 import type { RawGroup } from "./group.js";
+import { CoValueFrontier } from "../knownState.js";
 
 export type BinaryStreamInfo = {
   mimeType: string;
@@ -47,6 +48,9 @@ export class RawBinaryCoStreamView<
   private start: BinaryStreamStart | undefined;
   private ended: boolean;
 
+  /** @internal */
+  atFrontierFilter?: CoValueFrontier = undefined;
+
   private resetInternalState() {
     this.chunks = [];
     this.start = undefined;
@@ -84,6 +88,18 @@ export class RawBinaryCoStreamView<
     throw new Error("Not yet implemented");
   }
 
+  atFrontier(frontier: CoValueFrontier): this {
+    const clone = Object.create(this) as RawBinaryCoStreamView<Meta>;
+    clone.atFrontierFilter = frontier;
+    clone.resetInternalState();
+    clone.processNewTransactions();
+    return clone as this;
+  }
+
+  isTimeTravelEntity(): boolean {
+    return Boolean(this.atFrontierFilter);
+  }
+
   processNewTransactions() {
     if (this.ended) return;
 
@@ -97,6 +113,13 @@ export class RawBinaryCoStreamView<
     }
 
     for (const { txID, madeAt, changes } of newValidTransactions) {
+      if (
+        this.atFrontierFilter &&
+        txID.txIndex >= (this.atFrontierFilter[txID.sessionID] ?? -1)
+      ) {
+        continue;
+      }
+
       for (const changeUntyped of changes) {
         const change = changeUntyped as BinaryStreamItem;
 
@@ -172,6 +195,10 @@ export class RawBinaryCoStream<
     privacy: "private" | "trusting" = "private",
     updateView: boolean = true,
   ): void {
+    if (this.isTimeTravelEntity()) {
+      throw new Error("Cannot mutate a time travel entity");
+    }
+
     this.core.makeTransaction([item], privacy);
     if (updateView) {
       this.processNewTransactions();

--- a/packages/cojson/src/coValues/coList.ts
+++ b/packages/cojson/src/coValues/coList.ts
@@ -1,11 +1,15 @@
 import { CoID, RawCoValue } from "../coValue.js";
-import { AvailableCoValueCore } from "../coValueCore/coValueCore.js";
+import {
+  AvailableCoValueCore,
+  DecryptedTransaction,
+} from "../coValueCore/coValueCore.js";
 import { AgentID, SessionID, TransactionID, RawCoID } from "../ids.js";
 import { JsonObject, JsonValue } from "../jsonValue.js";
 import { accountOrAgentIDfromSessionID } from "../typeUtils/accountOrAgentIDfromSessionID.js";
 import { isCoValue } from "../typeUtils/isCoValue.js";
 import { RawAccountID } from "./account.js";
 import { RawGroup } from "./group.js";
+import { CoValueFrontier } from "../knownState.js";
 
 export type OpID = TransactionID & { changeIdx: number };
 
@@ -78,6 +82,9 @@ export class RawCoList<
   /** @internal */
   atTimeFilter?: number = undefined;
 
+  /** @internal */
+  atFrontierFilter?: CoValueFrontier = undefined;
+
   /** @category 6. Meta */
   readonly _item!: Item;
 
@@ -106,7 +113,13 @@ export class RawCoList<
   }
 
   /** @internal */
-  constructor(core: AvailableCoValueCore, atTimeFilter?: number) {
+  constructor(
+    core: AvailableCoValueCore,
+    options?: {
+      atTimeFilter?: number;
+      atFrontierFilter?: CoValueFrontier;
+    },
+  ) {
     this.id = core.id as CoID<this>;
     this.core = core;
 
@@ -115,13 +128,14 @@ export class RawCoList<
     this.afterStart = [];
     this.beforeEnd = [];
     this.knownTransactions = { [core.id]: 0 };
-    this.atTimeFilter = atTimeFilter;
+    this.atTimeFilter = options?.atTimeFilter;
+    this.atFrontierFilter = options?.atFrontierFilter;
 
     const ruleset = this.core.verified.header.ruleset;
     this.#isDeletionRestricted =
       ruleset.type === "ownedByGroup" && ruleset.restrictDeletion === true;
 
-    this._processNewTransactions();
+    this.processNewTransactions();
   }
 
   private getInsertionsEntry(opID: OpID) {
@@ -208,17 +222,6 @@ export class RawCoList<
   }
 
   processNewTransactions() {
-    if (this.isTimeTravelEntity()) {
-      throw new Error("Cannot process transactions on a time travel entity");
-    }
-    this._processNewTransactions();
-  }
-
-  private transactionContainsDeletion(changes: ListOpPayload<Item>[]) {
-    return changes.some((change) => change.op === "del");
-  }
-
-  private _processNewTransactions() {
     // Get all transactions including invalid ones, so that items referencing
     // entries from invalid init transactions can still find their references.
     const transactions = this.core.getValidSortedTransactions({
@@ -235,10 +238,12 @@ export class RawCoList<
     let oldestValidTransaction: number | undefined = undefined;
     this._cachedEntries = undefined;
 
-    for (const { txID, changes, madeAt, isValid } of transactions) {
-      if (this.isFilteredOut(madeAt)) {
+    for (const tx of transactions) {
+      if (this.isFilteredOut(tx)) {
         continue;
       }
+
+      const { txID, changes, madeAt, isValid } = tx;
 
       if (
         isValid &&
@@ -338,6 +343,10 @@ export class RawCoList<
     this.totalValidTransactions += transactions.length;
   }
 
+  private transactionContainsDeletion(changes: ListOpPayload<Item>[]) {
+    return changes.some((change) => change.op === "del");
+  }
+
   rebuildFromCore() {
     this.version += 1;
 
@@ -346,14 +355,22 @@ export class RawCoList<
   }
 
   isTimeTravelEntity() {
-    return Boolean(this.atTimeFilter);
+    return Boolean(this.atTimeFilter) || Boolean(this.atFrontierFilter);
   }
 
-  private isFilteredOut(time: number): boolean {
-    if (this.atTimeFilter === undefined) {
-      return false;
+  private isFilteredOut(tx: DecryptedTransaction): boolean {
+    if (this.atTimeFilter !== undefined && tx.madeAt > this.atTimeFilter) {
+      return true;
     }
-    return time > this.atTimeFilter;
+
+    if (
+      this.atFrontierFilter !== undefined &&
+      tx.txID.txIndex >= (this.atFrontierFilter[tx.txID.sessionID] ?? -1)
+    ) {
+      return true;
+    }
+
+    return false;
   }
 
   /** @category 6. Meta */
@@ -366,13 +383,18 @@ export class RawCoList<
     return this.core.getGroup();
   }
 
-  /**
-   * Not yet implemented
-   *
-   * @category 4. Time travel
-   */
+  /** @category 4. Time travel */
   atTime(time: number): this {
-    return new RawCoList(this.core, time) as this;
+    return new RawCoList(this.core, {
+      atTimeFilter: time,
+    }) as this;
+  }
+
+  /** @category 4. Time travel */
+  atFrontier(frontier: CoValueFrontier): this {
+    return new RawCoList(this.core, {
+      atFrontierFilter: frontier,
+    }) as this;
   }
 
   /**
@@ -600,6 +622,10 @@ export class RawCoList<
     privacy: "private" | "trusting" = "private",
     meta?: JsonObject,
   ) {
+    if (this.isTimeTravelEntity()) {
+      throw new Error("Cannot mutate a time travel entity");
+    }
+
     const entries = this.entries();
     after =
       after === undefined
@@ -651,6 +677,10 @@ export class RawCoList<
     before?: number,
     privacy: "private" | "trusting" = "private",
   ) {
+    if (this.isTimeTravelEntity()) {
+      throw new Error("Cannot mutate a time travel entity");
+    }
+
     const entries = this.entries();
     before = before === undefined ? 0 : before;
     let opIDAfter;
@@ -693,6 +723,10 @@ export class RawCoList<
    * @category 2. Editing
    **/
   delete(at: number, privacy: "private" | "trusting" = "private") {
+    if (this.isTimeTravelEntity()) {
+      throw new Error("Cannot mutate a time travel entity");
+    }
+
     const entries = this.entries();
     const entry = entries[at];
     if (!entry) {
@@ -716,6 +750,10 @@ export class RawCoList<
     newItem: Item,
     privacy: "private" | "trusting" = "private",
   ) {
+    if (this.isTimeTravelEntity()) {
+      throw new Error("Cannot mutate a time travel entity");
+    }
+
     const entries = this.entries();
     const entry = entries[at];
     if (!entry) {

--- a/packages/cojson/src/coValues/coMap.ts
+++ b/packages/cojson/src/coValues/coMap.ts
@@ -9,6 +9,7 @@ import { accountOrAgentIDfromSessionID } from "../typeUtils/accountOrAgentIDfrom
 import { isCoValue } from "../typeUtils/isCoValue.js";
 import { RawAccountID } from "./account.js";
 import type { RawGroup } from "./group.js";
+import { CoValueFrontier } from "../knownState.js";
 
 type MapOp<K extends string, V extends JsonValue | undefined> = {
   txID: TransactionID;
@@ -78,6 +79,8 @@ export class RawCoMap<
   ignorePrivateTransactions: boolean;
   /** @internal */
   atTimeFilter?: number = undefined;
+  /** @internal */
+  atFrontierFilter?: CoValueFrontier = undefined;
   /** @category 6. Meta */
   readonly _shape!: Shape;
 
@@ -169,7 +172,7 @@ export class RawCoMap<
   }
 
   isTimeTravelEntity() {
-    return Boolean(this.atTimeFilter);
+    return Boolean(this.atTimeFilter) || Boolean(this.atFrontierFilter);
   }
 
   /** @category 6. Meta */
@@ -192,21 +195,12 @@ export class RawCoMap<
     return clone as this;
   }
 
-  /** @internal */
-  timeFilteredOps<K extends keyof Shape & string>(
-    key: K,
-  ): MapOp<K, Shape[K]>[] | undefined {
-    if (key === "constructor") {
-      return undefined;
-    }
-
-    const atTimeFilter = this.atTimeFilter;
-
-    if (atTimeFilter) {
-      return this.ops[key]?.filter((op) => op.madeAt <= atTimeFilter);
-    } else {
-      return this.ops[key];
-    }
+  /** @category 4. Time travel */
+  atFrontier(frontier: CoValueFrontier): this {
+    const clone = Object.create(this) as RawCoMap<Shape, Meta>;
+    clone.atFrontierFilter = frontier;
+    clone.latest = {};
+    return clone as this;
   }
 
   /**
@@ -237,13 +231,14 @@ export class RawCoMap<
 
       // Time travel values are lazily computed
       if (entries && !(key in this.latest)) {
-        const atTimeFilter = this.atTimeFilter;
-
-        if (!atTimeFilter) {
-          latestChange = entries[entries.length - 1];
-        } else {
-          latestChange = entries.findLast((op) => op.madeAt <= atTimeFilter);
-        }
+        latestChange = entries.findLast(
+          (op) =>
+            (this.atTimeFilter === undefined ||
+              op.madeAt <= this.atTimeFilter) &&
+            (this.atFrontierFilter === undefined ||
+              op.txID.txIndex <
+                (this.atFrontierFilter[op.txID.sessionID] ?? -1)),
+        );
 
         this.latest[key] = latestChange;
       }
@@ -306,14 +301,20 @@ export class RawCoMap<
   nthEditAt<K extends keyof Shape & string>(key: K, n: number) {
     const ops = this.ops[key];
 
-    const atTimeFilter = this.atTimeFilter;
     const entry = ops?.[n];
 
     if (!entry) {
       return undefined;
     }
 
-    if (atTimeFilter && entry.madeAt > atTimeFilter) {
+    if (this.atTimeFilter && entry.madeAt > this.atTimeFilter) {
+      return undefined;
+    }
+
+    if (
+      this.atFrontierFilter &&
+      entry.txID.txIndex >= (this.atFrontierFilter[entry.txID.sessionID] ?? -1)
+    ) {
       return undefined;
     }
 
@@ -348,11 +349,17 @@ export class RawCoMap<
       return;
     }
 
-    const atTimeFilter = this.atTimeFilter;
-
     for (const entry of entries) {
       // Entries are sorted by madeAt
-      if (atTimeFilter && entry.madeAt > atTimeFilter) {
+      if (this.atTimeFilter && entry.madeAt > this.atTimeFilter) {
+        return;
+      }
+
+      if (
+        this.atFrontierFilter &&
+        entry.txID.txIndex >=
+          (this.atFrontierFilter[entry.txID.sessionID] ?? -1)
+      ) {
         return;
       }
 

--- a/packages/cojson/src/coValues/coPlainText.ts
+++ b/packages/cojson/src/coValues/coPlainText.ts
@@ -3,6 +3,7 @@ import { AvailableCoValueCore } from "../coValueCore/coValueCore.js";
 import { TRANSACTION_CONFIG } from "../config.js";
 import { JsonObject } from "../jsonValue.js";
 import { DeletionOpPayload, OpID, RawCoList } from "./coList.js";
+import { CoValueFrontier } from "../knownState.js";
 
 export type StringifiedOpID = string & { __stringifiedOpID: true };
 
@@ -55,8 +56,14 @@ export class RawCoPlainText<
     PlaintextIdxMapping
   >;
 
-  constructor(core: AvailableCoValueCore, atTimeFilter?: number) {
-    super(core, atTimeFilter);
+  constructor(
+    core: AvailableCoValueCore,
+    options?: {
+      atTimeFilter?: number;
+      atFrontierFilter?: CoValueFrontier;
+    },
+  ) {
+    super(core, options);
     this._cachedMapping = new WeakMap();
   }
 
@@ -98,7 +105,15 @@ export class RawCoPlainText<
   }
 
   atTime(time: number): this {
-    return new RawCoPlainText(this.core, time) as this;
+    return new RawCoPlainText(this.core, {
+      atTimeFilter: time,
+    }) as this;
+  }
+
+  atFrontier(frontier: CoValueFrontier): this {
+    return new RawCoPlainText(this.core, {
+      atFrontierFilter: frontier,
+    }) as this;
   }
 
   /**

--- a/packages/cojson/src/coValues/coPlainText.ts
+++ b/packages/cojson/src/coValues/coPlainText.ts
@@ -104,13 +104,13 @@ export class RawCoPlainText<
       .join("");
   }
 
-  atTime(time: number): this {
+  override atTime(time: number): this {
     return new RawCoPlainText(this.core, {
       atTimeFilter: time,
     }) as this;
   }
 
-  atFrontier(frontier: CoValueFrontier): this {
+  override atFrontier(frontier: CoValueFrontier): this {
     return new RawCoPlainText(this.core, {
       atFrontierFilter: frontier,
     }) as this;

--- a/packages/cojson/src/coValues/coStream.ts
+++ b/packages/cojson/src/coValues/coStream.ts
@@ -42,11 +42,17 @@ export class RawCoStreamView<
     this.totalValidTransactions = 0;
   }
 
-  constructor(core: AvailableCoValueCore) {
+  constructor(
+    core: AvailableCoValueCore,
+    options?: {
+      atFrontierFilter?: CoValueFrontier;
+    },
+  ) {
     this.id = core.id as CoID<this>;
     this.core = core;
     this.items = {};
     this.knownTransactions = { [core.id]: 0 };
+    this.atFrontierFilter = options?.atFrontierFilter;
     this.processNewTransactions();
   }
 
@@ -71,11 +77,9 @@ export class RawCoStreamView<
   }
 
   atFrontier(frontier: CoValueFrontier): this {
-    const clone = Object.create(this) as RawCoStreamView<Item, Meta>;
-    clone.atFrontierFilter = frontier;
-    clone.resetInternalState();
-    clone.processNewTransactions();
-    return clone as this;
+    return new RawCoStreamView(this.core, {
+      atFrontierFilter: frontier,
+    }) as this;
   }
 
   isTimeTravelEntity() {
@@ -253,16 +257,14 @@ export class RawCoStreamView<
 
   *itemsBy(account: RawAccountID | AgentID) {
     // TODO: this can be made more lazy without a huge collect and sort
-    const items = [
-      ...Object.keys(this.items).flatMap((sessionID) =>
-        sessionID.startsWith(account)
-          ? [...this.itemsIn(sessionID as SessionID)].map((item) => ({
-              in: sessionID as SessionID,
-              ...item,
-            }))
-          : [],
-      ),
-    ];
+    const items = Object.keys(this.items).flatMap((sessionID) =>
+      sessionID.startsWith(account)
+        ? [...this.itemsIn(sessionID as SessionID)].map((item) => ({
+            in: sessionID as SessionID,
+            ...item,
+          }))
+        : [],
+    );
 
     items.sort((a, b) => a.at.getTime() - b.at.getTime());
 
@@ -296,6 +298,12 @@ export class RawCoStream<
   extends RawCoStreamView<Item, Meta>
   implements RawCoValue
 {
+  override atFrontier(frontier: CoValueFrontier): this {
+    return new RawCoStream(this.core, {
+      atFrontierFilter: frontier,
+    }) as this;
+  }
+
   push(item: Item, privacy: "private" | "trusting" = "private"): void {
     if (this.isTimeTravelEntity()) {
       throw new Error("Cannot mutate a time travel entity");

--- a/packages/cojson/src/coValues/coStream.ts
+++ b/packages/cojson/src/coValues/coStream.ts
@@ -8,6 +8,7 @@ import { isCoValue } from "../typeUtils/isCoValue.js";
 import { RawAccountID } from "./account.js";
 import { RawGroup } from "./group.js";
 import { RawCoID } from "../ids.js";
+import { CoValueFrontier } from "../knownState.js";
 
 export type CoStreamItem<Item extends JsonValue> = {
   value: Item;
@@ -31,6 +32,9 @@ export class RawCoStreamView<
   knownTransactions: Record<RawCoID, number>;
   totalValidTransactions: number = 0;
   version: number = 0;
+
+  /** @internal */
+  atFrontierFilter?: CoValueFrontier = undefined;
 
   private resetInternalState() {
     this.items = {};
@@ -66,6 +70,18 @@ export class RawCoStreamView<
     throw new Error("Not yet implemented");
   }
 
+  atFrontier(frontier: CoValueFrontier): this {
+    const clone = Object.create(this) as RawCoStreamView<Item, Meta>;
+    clone.atFrontierFilter = frontier;
+    clone.resetInternalState();
+    clone.processNewTransactions();
+    return clone as this;
+  }
+
+  isTimeTravelEntity() {
+    return Boolean(this.atFrontierFilter);
+  }
+
   /** @internal */
   protected compareStreamItems(
     a: CoStreamItem<Item>,
@@ -96,6 +112,13 @@ export class RawCoStreamView<
     }
 
     for (const { txID, madeAt, changes } of newValidTransactions) {
+      if (
+        this.atFrontierFilter &&
+        txID.txIndex >= (this.atFrontierFilter[txID.sessionID] ?? -1)
+      ) {
+        continue;
+      }
+
       for (const changeUntyped of changes) {
         const change = changeUntyped as Item;
         let entries = this.items[txID.sessionID];
@@ -274,6 +297,10 @@ export class RawCoStream<
   implements RawCoValue
 {
   push(item: Item, privacy: "private" | "trusting" = "private"): void {
+    if (this.isTimeTravelEntity()) {
+      throw new Error("Cannot mutate a time travel entity");
+    }
+
     this.core.makeTransaction([isCoValue(item) ? item.id : item], privacy);
     this.processNewTransactions();
   }

--- a/packages/cojson/src/cursor.ts
+++ b/packages/cojson/src/cursor.ts
@@ -1,0 +1,7 @@
+import { RawCoID } from "./ids.js";
+import { CoValueFrontier } from "./knownState.js";
+
+export type RawCoValueCursor = {
+  rootId: RawCoID;
+  frontiers: Record<RawCoID, CoValueFrontier>;
+};

--- a/packages/cojson/src/exports.ts
+++ b/packages/cojson/src/exports.ts
@@ -76,7 +76,8 @@ import {
 } from "./sync.js";
 import { setSyncStateTrackingBatchDelay } from "./UnsyncedCoValuesTracker.js";
 import { emptyKnownState } from "./knownState.js";
-
+import type { CoValueFrontier } from "./knownState.js";
+import type { RawCoValueCursor } from "./cursor.js";
 import {
   getContentMessageSize,
   getTransactionSize,
@@ -217,6 +218,8 @@ export type {
   PeerState,
   SyncWhen,
   CoValueHeader,
+  CoValueFrontier,
+  RawCoValueCursor,
 };
 
 export * from "./storage/index.js";

--- a/packages/cojson/src/knownState.ts
+++ b/packages/cojson/src/knownState.ts
@@ -2,6 +2,8 @@ import type { RawCoID, SessionID } from "./exports.js";
 
 export type KnownStateSessions = { [sessionID: SessionID]: number };
 
+export type CoValueFrontier = KnownStateSessions;
+
 export type CoValueKnownState = {
   id: RawCoID;
   header: boolean;

--- a/packages/jazz-tools/src/react-core/hooks.ts
+++ b/packages/jazz-tools/src/react-core/hooks.ts
@@ -30,6 +30,7 @@ import {
   captureStack,
   getUnloadedCoValueWithoutId,
   type BranchDefinition,
+  type CoValueCursor,
 } from "jazz-tools";
 import { JazzContext } from "./provider.js";
 import { getCurrentAccountFromContextManager } from "./utils.js";
@@ -100,6 +101,7 @@ export function useCoValueSubscription<
   options?: {
     resolve?: ResolveQueryStrict<S, R>;
     unstable_branch?: BranchDefinition;
+    cursor?: CoValueCursor;
   },
   source?: string,
 ): CoValueSubscription<S, R> | null {
@@ -109,6 +111,7 @@ export function useCoValueSubscription<
     [id],
     resolve,
     options?.unstable_branch,
+    options?.cursor,
     source,
   );
   return (subscriptions[0] ?? null) as CoValueSubscription<S, R> | null;
@@ -127,6 +130,7 @@ interface SubscriptionsState {
   agent: AnonymousJazzAgent | Loaded<any, true>;
   branchName?: string;
   branchOwnerId?: string;
+  cursor?: CoValueCursor;
 }
 
 /**
@@ -142,6 +146,7 @@ function useCoValueSubscriptions(
   ids: readonly (string | undefined | null)[],
   resolve: ResolveQuery<any>,
   branch?: BranchDefinition,
+  cursor?: CoValueCursor,
   source?: string,
 ): (SubscriptionScope<CoValue> | null)[] {
   const contextManager = useJazzContext();
@@ -166,6 +171,7 @@ function useCoValueSubscriptions(
         false,
         false,
         branch,
+        cursor,
       );
 
       if (callerStack) {
@@ -187,6 +193,7 @@ function useCoValueSubscriptions(
       agent,
       branchName: branch?.name,
       branchOwnerId: branch?.owner?.$jazz.id,
+      cursor,
     };
   };
 
@@ -430,6 +437,12 @@ export function useCoState<
      * For more info see the [branching](https://jazz.tools/docs/react/using-covalues/version-control) documentation.
      */
     unstable_branch?: BranchDefinition;
+    /**
+     * Load the CoValue at a specific cursor.
+     *
+     * Cursors let you take a "snapshot" of a CoValue at the time of cursor creations.
+     */
+    cursor?: CoValueCursor;
     preloaded?: ExportedCoValue<Loaded<S, R>>;
   },
 ): TSelectorReturn {
@@ -477,6 +490,12 @@ export function useSuspenseCoState<
      * For more info see the [branching](https://jazz.tools/docs/react/using-covalues/version-control) documentation.
      */
     unstable_branch?: BranchDefinition;
+    /**
+     * Load the CoValue at a specific cursor.
+     *
+     * Cursors let you take a "snapshot" of a CoValue at the time of cursor creations.
+     */
+    cursor?: CoValueCursor;
     preloaded?: ExportedCoValue<Loaded<S, R>>;
   },
 ): TSelectorReturn {
@@ -549,6 +568,7 @@ export function useAccountSubscription<
   options?: {
     resolve?: ResolveQueryStrict<S, R>;
     unstable_branch?: BranchDefinition;
+    cursor?: CoValueCursor;
   },
   source?: string,
 ) {
@@ -580,6 +600,7 @@ export function useAccountSubscription<
       false,
       false,
       options?.unstable_branch,
+      options?.cursor,
     );
 
     // Set callerStack on returned subscription after retrieval
@@ -596,6 +617,7 @@ export function useAccountSubscription<
       Schema,
       branchName: options?.unstable_branch?.name,
       branchOwnerId: options?.unstable_branch?.owner?.$jazz.id,
+      cursor: options?.cursor,
     };
   };
 
@@ -609,7 +631,9 @@ export function useAccountSubscription<
       subscription.contextManager !== contextManager ||
       subscription.Schema !== Schema ||
       subscription.branchName !== options?.unstable_branch?.name ||
-      subscription.branchOwnerId !== options?.unstable_branch?.owner?.$jazz.id
+      subscription.branchOwnerId !==
+        options?.unstable_branch?.owner?.$jazz.id ||
+      subscription.cursor !== options?.cursor
     ) {
       // No need to manually destroy - cache handles cleanup via SubscriptionScope lifecycle
       setSubscription(createSubscription());
@@ -745,6 +769,12 @@ export function useAccount<
      * For more info see the [branching](https://jazz.tools/docs/react/using-covalues/version-control) documentation.
      */
     unstable_branch?: BranchDefinition;
+    /**
+     * Load the CoValue at a specific cursor.
+     *
+     * Cursors let you take a "snapshot" of a CoValue at the time of cursor creations.
+     */
+    cursor?: CoValueCursor;
   },
 ): TSelectorReturn {
   const subscription = useAccountSubscription(
@@ -787,6 +817,12 @@ export function useSuspenseAccount<
      * For more info see the [branching](https://jazz.tools/docs/react/using-covalues/version-control) documentation.
      */
     unstable_branch?: BranchDefinition;
+    /**
+     * Load the CoValue at a specific cursor.
+     *
+     * Cursors let you take a "snapshot" of a CoValue at the time of cursor creations.
+     */
+    cursor?: CoValueCursor;
   },
 ): TSelectorReturn {
   const subscription = useAccountSubscription(
@@ -1074,6 +1110,12 @@ export function useSuspenseCoStates<
      * For more info see the [branching](https://jazz.tools/docs/react/using-covalues/version-control) documentation.
      */
     unstable_branch?: BranchDefinition;
+    /**
+     * Load the CoValue at a specific cursor.
+     *
+     * Cursors let you take a "snapshot" of a CoValue at the time of cursor creations.
+     */
+    cursor?: CoValueCursor;
   },
 ): TSelectorReturn[] {
   const resolve = getResolveQuery(Schema, options?.resolve);
@@ -1082,6 +1124,7 @@ export function useSuspenseCoStates<
     ids,
     resolve,
     options?.unstable_branch,
+    options?.cursor,
     "useSuspenseCoStates",
   ) as SubscriptionScope<CoValue>[];
   useSuspendUntilLoaded(subscriptionScopes);
@@ -1144,6 +1187,12 @@ export function useCoStates<
      * For more info see the [branching](https://jazz.tools/docs/react/using-covalues/version-control) documentation.
      */
     unstable_branch?: BranchDefinition;
+    /**
+     * Load the CoValue at a specific cursor.
+     *
+     * Cursors let you take a "snapshot" of a CoValue at the time of cursor creations.
+     */
+    cursor?: CoValueCursor;
   },
 ): TSelectorReturn[] {
   const resolve = getResolveQuery(Schema, options?.resolve);
@@ -1152,6 +1201,7 @@ export function useCoStates<
     ids,
     resolve,
     options?.unstable_branch,
+    options?.cursor,
     "useCoStates",
   ) as SubscriptionScope<CoValue>[];
   return useSubscriptionsSelector(subscriptionScopes, options);

--- a/packages/jazz-tools/src/svelte/jazz.class.svelte.ts
+++ b/packages/jazz-tools/src/svelte/jazz.class.svelte.ts
@@ -11,9 +11,9 @@ import type {
   InstanceOfSchema,
   Loaded,
   MaybeLoaded,
-  NotLoaded,
   ResolveQuery,
   ResolveQueryStrict,
+  CoValueCursor,
 } from "jazz-tools";
 import {
   captureStack,
@@ -48,6 +48,12 @@ type CoStateOptions<
    * For more info see the [branching](https://jazz.tools/docs/svelte/using-covalues/version-control) documentation.
    */
   unstable_branch?: BranchDefinition;
+  /**
+   * Load the CoValue at a specific cursor.
+   *
+   * Cursors let you take a "snapshot" of a CoValue at the time of cursor creations.
+   */
+  cursor?: CoValueCursor;
 };
 
 type CoStateId = string | undefined | null;
@@ -106,6 +112,7 @@ export class CoState<
           false, // skipRetry
           false, // bestEffortResolution
           options?.unstable_branch,
+          options?.cursor,
         );
 
         subscriptionScope.callerStack = callerStack;
@@ -193,6 +200,7 @@ export class AccountCoState<
           false, // skipRetry
           false, // bestEffortResolution
           options?.unstable_branch,
+          options?.cursor,
         );
 
         subscriptionScope.callerStack = callerStack;

--- a/packages/jazz-tools/src/tools/coValues/CoValueBase.ts
+++ b/packages/jazz-tools/src/tools/coValues/CoValueBase.ts
@@ -13,6 +13,8 @@ import {
   getSubscriptionScope,
   inspect,
   unstable_mergeBranch,
+  CoValueCursor,
+  RefsToResolve,
 } from "../internal.js";
 import { Group, TypeSym } from "../internal.js";
 
@@ -167,6 +169,18 @@ export abstract class CoValueJazzApi<V extends CoValue> {
     const subscriptionScope = this._subscriptionScope;
 
     return Boolean(subscriptionScope?.unstable_branch);
+  }
+
+  get cursor(): CoValueCursor | undefined {
+    const subscriptionScope = this._subscriptionScope;
+
+    return subscriptionScope?.cursor;
+  }
+
+  createCursor(): CoValueCursor {
+    const subscriptionScope = getSubscriptionScope(this.coValue);
+
+    return subscriptionScope.cursor ?? subscriptionScope.createCursor();
   }
 
   /**

--- a/packages/jazz-tools/src/tools/coValues/account.ts
+++ b/packages/jazz-tools/src/tools/coValues/account.ts
@@ -59,6 +59,8 @@ import {
   subscribeToExistingCoValue,
   InstanceOfSchemaCoValuesMaybeLoaded,
   LoadedAndRequired,
+  CoValueCursor,
+  LoadCoValueCursorOption,
 } from "../internal.js";
 import type { CoreAccountSchema } from "../implementation/zodSchema/schemaTypes/AccountSchema.js";
 import type { AccountSchema as HydratedAccountSchema } from "../implementation/zodSchema/schemaTypes/AccountSchema.js";
@@ -571,6 +573,7 @@ class AccountJazzApi<A extends Account> extends CoValueJazzApi<A> {
     options: {
       resolve: RefsToResolveStrict<A, R>;
       unstable_branch?: BranchDefinition;
+      cursor?: LoadCoValueCursorOption;
     },
   ): Promise<Resolved<A, R>> {
     return ensureCoValueLoaded(this.account as unknown as A, options);
@@ -586,6 +589,7 @@ class AccountJazzApi<A extends Account> extends CoValueJazzApi<A> {
     options: {
       resolve?: RefsToResolveStrict<A, R>;
       unstable_branch?: BranchDefinition;
+      cursor?: CoValueCursor;
     },
     listener: (value: Resolved<A, R>, unsubscribe: () => void) => void,
   ): () => void;

--- a/packages/jazz-tools/src/tools/coValues/coFeed.ts
+++ b/packages/jazz-tools/src/tools/coValues/coFeed.ts
@@ -51,6 +51,8 @@ import {
   subscribeToExistingCoValue,
   CoreFileStreamSchema,
   CoValueCreateOptionsInternal,
+  CoValueCursor,
+  LoadCoValueCursorOption,
 } from "../internal.js";
 import { z } from "../implementation/zodSchema/zodReExport.js";
 import {
@@ -559,6 +561,7 @@ export class CoFeedJazzApi<F extends CoFeed> extends CoValueJazzApi<F> {
     options?: {
       resolve?: RefsToResolveStrict<F, R>;
       unstable_branch?: BranchDefinition;
+      cursor?: LoadCoValueCursorOption;
     },
   ): Promise<Resolved<F, R>> {
     return ensureCoValueLoaded(this.coFeed, options);
@@ -579,6 +582,7 @@ export class CoFeedJazzApi<F extends CoFeed> extends CoValueJazzApi<F> {
     options: {
       resolve?: RefsToResolveStrict<F, R>;
       unstable_branch?: BranchDefinition;
+      cursor?: CoValueCursor;
     },
     listener: (value: Resolved<F, R>, unsubscribe: () => void) => void,
   ): () => void;

--- a/packages/jazz-tools/src/tools/coValues/coList.ts
+++ b/packages/jazz-tools/src/tools/coValues/coList.ts
@@ -38,6 +38,8 @@ import {
   subscribeToCoValueWithoutMe,
   subscribeToExistingCoValue,
   CoValueCreateOptionsInternal,
+  CoValueCursor,
+  LoadCoValueCursorOption,
 } from "../internal.js";
 import { z } from "../implementation/zodSchema/zodReExport.js";
 import { CoreCoListSchema } from "../implementation/zodSchema/schemaTypes/CoListSchema.js";
@@ -912,6 +914,7 @@ export class CoListJazzApi<L extends CoList> extends CoValueJazzApi<L> {
     options: {
       resolve: RefsToResolveStrict<L, R>;
       unstable_branch?: BranchDefinition;
+      cursor?: LoadCoValueCursorOption;
     },
   ): Promise<Resolved<L, R>> {
     return ensureCoValueLoaded(this.coList, options);
@@ -935,6 +938,7 @@ export class CoListJazzApi<L extends CoList> extends CoValueJazzApi<L> {
     options: {
       resolve?: RefsToResolveStrict<L, R>;
       unstable_branch?: BranchDefinition;
+      cursor?: CoValueCursor;
     },
     listener: (value: Resolved<L, R>, unsubscribe: () => void) => void,
   ): () => void;

--- a/packages/jazz-tools/src/tools/coValues/coMap.ts
+++ b/packages/jazz-tools/src/tools/coValues/coMap.ts
@@ -53,6 +53,8 @@ import {
   subscribeToExistingCoValue,
   CoreCoMapSchema,
   CoValueCreateOptionsInternal,
+  CoValueCursor,
+  LoadCoValueCursorOption,
 } from "../internal.js";
 import { z } from "../implementation/zodSchema/zodReExport.js";
 import {
@@ -779,6 +781,7 @@ class CoMapJazzApi<M extends CoMap> extends CoValueJazzApi<M> {
     options: {
       resolve: RefsToResolveStrict<Map, R>;
       unstable_branch?: BranchDefinition;
+      cursor?: LoadCoValueCursorOption;
     },
   ): Promise<Resolved<Map, R>> {
     return ensureCoValueLoaded(this.coMap, options);
@@ -802,6 +805,7 @@ class CoMapJazzApi<M extends CoMap> extends CoValueJazzApi<M> {
     options: {
       resolve?: RefsToResolveStrict<Map, R>;
       unstable_branch?: BranchDefinition;
+      cursor?: CoValueCursor;
     },
     listener: (value: Resolved<Map, R>, unsubscribe: () => void) => void,
   ): () => void;

--- a/packages/jazz-tools/src/tools/coValues/interfaces.ts
+++ b/packages/jazz-tools/src/tools/coValues/interfaces.ts
@@ -31,6 +31,8 @@ import {
   coValueClassFromCoValueClassOrSchema,
   inspect,
   LocalValidationMode,
+  CoValueCursor,
+  LoadCoValueCursorOption,
 } from "../internal.js";
 import type {
   BranchDefinition,
@@ -78,6 +80,8 @@ export interface CoValue {
     isBranched: boolean;
     branchName: string | undefined;
     unstable_merge: () => void;
+    cursor: CoValueCursor | undefined;
+    createCursor: () => CoValueCursor;
   };
   /**
    * Whether the CoValue is loaded. Can be used to distinguish between loaded and {@link NotLoaded} CoValues.
@@ -167,16 +171,18 @@ export function loadCoValueWithoutMe<
     loadAs?: Account | AnonymousJazzAgent;
     skipRetry?: boolean;
     unstable_branch?: BranchDefinition;
+    cursor?: LoadCoValueCursorOption;
   },
 ): Promise<Settled<Resolved<V, R>>> {
   return loadCoValue(cls, id, {
     ...options,
     loadAs: options?.loadAs ?? activeAccountContext.get(),
     unstable_branch: options?.unstable_branch,
+    cursor: options?.cursor,
   });
 }
 
-export function loadCoValue<
+export async function loadCoValue<
   V extends CoValue,
   const R extends RefsToResolve<V>,
 >(
@@ -187,8 +193,46 @@ export function loadCoValue<
     loadAs: Account | AnonymousJazzAgent;
     skipRetry?: boolean;
     unstable_branch?: BranchDefinition;
+    cursor?: LoadCoValueCursorOption;
   },
 ): Promise<Settled<Resolved<V, R>>> {
+  let cursor: CoValueCursor | undefined;
+
+  if (options.cursor) {
+    if (typeof options.cursor === "string") {
+      cursor = options.cursor;
+    } else if (options.cursor.useCurrentCursor) {
+      const loadAs = options.loadAs ?? activeAccountContext.get();
+      const node = "node" in loadAs ? loadAs.node : loadAs.$jazz.localNode;
+
+      const resolve = options.resolve ?? true;
+
+      const rootNode = new SubscriptionScope<CoValue>(
+        node,
+        resolve as any,
+        id,
+        {
+          ref: coValueClassFromCoValueClassOrSchema(cls),
+          optional: false,
+        },
+        options.skipRetry,
+        false,
+        options.unstable_branch,
+        undefined,
+      );
+
+      try {
+        await rootNode.getPromise();
+        rootNode.destroy();
+      } catch (error) {
+        rootNode.destroy();
+        throw error;
+      }
+
+      cursor = rootNode.createCursor();
+    }
+  }
+
   return new Promise((resolve) => {
     subscribeToCoValue<V, R>(
       cls,
@@ -200,6 +244,7 @@ export function loadCoValue<
         skipRetry: options.skipRetry,
         onError: resolve,
         unstable_branch: options.unstable_branch,
+        cursor,
       },
       (value, unsubscribe) => {
         resolve(value);
@@ -218,6 +263,7 @@ export async function ensureCoValueLoaded<
     | {
         resolve?: RefsToResolveStrict<V, R>;
         unstable_branch?: BranchDefinition;
+        cursor?: LoadCoValueCursorOption;
       }
     | undefined,
 ): Promise<Resolved<V, R>> {
@@ -228,6 +274,7 @@ export async function ensureCoValueLoaded<
       loadAs: existing.$jazz.loadedAs,
       resolve: options?.resolve,
       unstable_branch: options?.unstable_branch,
+      cursor: options?.cursor,
     },
   );
 
@@ -261,6 +308,7 @@ export type SubscribeListenerOptions<
    */
   onUnavailable?: (value: NotLoaded<V>) => void;
   unstable_branch?: BranchDefinition;
+  cursor?: CoValueCursor;
 };
 
 export type SubscribeRestArgs<V extends CoValue, R extends RefsToResolve<V>> =
@@ -290,6 +338,7 @@ export function parseSubscribeRestArgs<
           onUnauthorized: args[0].onUnauthorized,
           onUnavailable: args[0].onUnavailable,
           unstable_branch: args[0].unstable_branch,
+          cursor: args[0].cursor,
         },
         listener: args[1],
       };
@@ -346,6 +395,7 @@ export function subscribeToCoValue<
     syncResolution?: boolean;
     skipRetry?: boolean;
     unstable_branch?: BranchDefinition;
+    cursor?: CoValueCursor;
   },
   listener: SubscribeListener<V, R>,
 ): () => void {
@@ -367,6 +417,7 @@ export function subscribeToCoValue<
     options.skipRetry,
     false,
     options.unstable_branch,
+    options.cursor,
   );
 
   // Track performance for API subscriptions
@@ -434,6 +485,7 @@ export function subscribeToExistingCoValue<
          */
         onUnauthorized?: (value: NotLoaded<V>) => void;
         unstable_branch?: BranchDefinition;
+        cursor?: CoValueCursor;
       }
     | undefined,
   listener: SubscribeListener<V, R>,
@@ -448,6 +500,7 @@ export function subscribeToExistingCoValue<
       onUnavailable: options?.onUnavailable,
       onUnauthorized: options?.onUnauthorized,
       unstable_branch: options?.unstable_branch,
+      cursor: options?.cursor,
     },
     listener,
   );
@@ -831,6 +884,7 @@ export async function exportCoValue<
     skipRetry?: boolean;
     bestEffortResolution?: boolean;
     unstable_branch?: BranchDefinition;
+    cursor?: CoValueCursor;
   },
 ) {
   const loadAs = options.loadAs ?? activeAccountContext.get();

--- a/packages/jazz-tools/src/tools/exports.ts
+++ b/packages/jazz-tools/src/tools/exports.ts
@@ -128,6 +128,8 @@ export {
   type CoreAccountSchema as AnyAccountSchema,
   type ResolveQuery,
   type ResolveQueryStrict,
+  type CoValueCursor,
+  type LoadCoValueCursorOption,
 } from "./internal.js";
 
 export {

--- a/packages/jazz-tools/src/tools/implementation/zodSchema/schemaTypes/CoDiscriminatedUnionSchema.ts
+++ b/packages/jazz-tools/src/tools/implementation/zodSchema/schemaTypes/CoDiscriminatedUnionSchema.ts
@@ -14,6 +14,8 @@ import {
   SubscribeCallback,
   SubscribeListenerOptions,
   coOptionalDefiner,
+  CoValueCursor,
+  LoadCoValueCursorOption,
 } from "../../../internal.js";
 import { z } from "../zodReExport.js";
 import { CoOptionalSchema } from "./CoOptionalSchema.js";
@@ -107,6 +109,7 @@ export class CoDiscriminatedUnionSchema<
       loadAs?: Account | AnonymousJazzAgent;
       skipRetry?: boolean;
       unstable_branch?: BranchDefinition;
+      cursor?: LoadCoValueCursorOption;
     },
   ): Promise<
     Settled<

--- a/packages/jazz-tools/src/tools/implementation/zodSchema/schemaTypes/CoFeedSchema.ts
+++ b/packages/jazz-tools/src/tools/implementation/zodSchema/schemaTypes/CoFeedSchema.ts
@@ -17,6 +17,7 @@ import {
   withSchemaPermissions,
   type Schema,
   CoValueCreateOptions,
+  LoadCoValueCursorOption,
 } from "../../../internal.js";
 import { AnonymousJazzAgent } from "../../anonymousJazzAgent.js";
 import { CoFeedSchemaInit } from "../typeConverters/CoFieldSchemaInit.js";
@@ -124,6 +125,7 @@ export class CoFeedSchema<
       resolve?: RefsToResolveStrict<CoFeedInstanceCoValuesMaybeLoaded<T>, R>;
       loadAs?: Account | AnonymousJazzAgent;
       unstable_branch?: BranchDefinition;
+      cursor?: LoadCoValueCursorOption;
     },
   ): Promise<Settled<Resolved<CoFeedInstanceCoValuesMaybeLoaded<T>, R>>> {
     // @ts-expect-error

--- a/packages/jazz-tools/src/tools/implementation/zodSchema/schemaTypes/CoListSchema.ts
+++ b/packages/jazz-tools/src/tools/implementation/zodSchema/schemaTypes/CoListSchema.ts
@@ -16,6 +16,7 @@ import {
   withSchemaPermissions,
   type Schema,
   CoValueCreateOptions,
+  LoadCoValueCursorOption,
 } from "../../../internal.js";
 import { CoValueUniqueness } from "cojson";
 import { AnonymousJazzAgent } from "../../anonymousJazzAgent.js";
@@ -121,6 +122,7 @@ export class CoListSchema<
       resolve?: RefsToResolveStrict<CoListInstanceCoValuesMaybeLoaded<T>, R>;
       loadAs?: Account | AnonymousJazzAgent;
       unstable_branch?: BranchDefinition;
+      cursor?: LoadCoValueCursorOption;
     },
   ): Promise<Settled<Resolved<CoListInstanceCoValuesMaybeLoaded<T>, R>>> {
     // @ts-expect-error

--- a/packages/jazz-tools/src/tools/implementation/zodSchema/schemaTypes/CoMapSchema.ts
+++ b/packages/jazz-tools/src/tools/implementation/zodSchema/schemaTypes/CoMapSchema.ts
@@ -21,6 +21,8 @@ import {
   isCoValueSchema,
   type Schema,
   CoValueCreateOptions,
+  CoValueCursor,
+  LoadCoValueCursorOption,
 } from "../../../internal.js";
 import { AnonymousJazzAgent } from "../../anonymousJazzAgent.js";
 import { removeGetters, withSchemaResolveQuery } from "../../schemaUtils.js";
@@ -178,6 +180,7 @@ export class CoMapSchema<
       loadAs?: Account | AnonymousJazzAgent;
       skipRetry?: boolean;
       unstable_branch?: BranchDefinition;
+      cursor?: LoadCoValueCursorOption;
     },
   ): Promise<
     Settled<

--- a/packages/jazz-tools/src/tools/implementation/zodSchema/schemaTypes/CoRecordSchema.ts
+++ b/packages/jazz-tools/src/tools/implementation/zodSchema/schemaTypes/CoRecordSchema.ts
@@ -13,6 +13,7 @@ import {
   Simplify,
   SubscribeListenerOptions,
   LocalValidationMode,
+  LoadCoValueCursorOption,
 } from "../../../internal.js";
 import { AnonymousJazzAgent } from "../../anonymousJazzAgent.js";
 import { CoFieldSchemaInit } from "../typeConverters/CoFieldSchemaInit.js";
@@ -75,6 +76,7 @@ export interface CoRecordSchema<
       >;
       loadAs?: Account | AnonymousJazzAgent;
       unstable_branch?: BranchDefinition;
+      cursor?: LoadCoValueCursorOption;
     },
   ): Promise<Settled<Resolved<CoRecordInstanceCoValuesMaybeLoaded<K, V>, R>>>;
 

--- a/packages/jazz-tools/src/tools/implementation/zodSchema/schemaTypes/PlainTextSchema.ts
+++ b/packages/jazz-tools/src/tools/implementation/zodSchema/schemaTypes/PlainTextSchema.ts
@@ -8,6 +8,8 @@ import {
   coOptionalDefiner,
   unstable_mergeBranchWithResolve,
   withSchemaPermissions,
+  CoValueCursor,
+  LoadCoValueCursorOption,
 } from "../../../internal.js";
 import { AnonymousJazzAgent } from "../../anonymousJazzAgent.js";
 import { CoOptionalSchema } from "./CoOptionalSchema.js";
@@ -85,6 +87,7 @@ export class PlainTextSchema implements CorePlainTextSchema {
     options: {
       loadAs: Account | AnonymousJazzAgent;
       unstable_branch?: BranchDefinition;
+      cursor?: LoadCoValueCursorOption;
     },
   ): Promise<Settled<CoPlainText>> {
     return this.coValueClass.load(id, options);
@@ -95,6 +98,7 @@ export class PlainTextSchema implements CorePlainTextSchema {
     options: {
       loadAs: Account | AnonymousJazzAgent;
       unstable_branch?: BranchDefinition;
+      cursor?: CoValueCursor;
     },
     listener: (value: CoPlainText, unsubscribe: () => void) => void,
   ): () => void;

--- a/packages/jazz-tools/src/tools/implementation/zodSchema/schemaTypes/RichTextSchema.ts
+++ b/packages/jazz-tools/src/tools/implementation/zodSchema/schemaTypes/RichTextSchema.ts
@@ -7,6 +7,8 @@ import {
   coOptionalDefiner,
   unstable_mergeBranchWithResolve,
   withSchemaPermissions,
+  CoValueCursor,
+  LoadCoValueCursorOption,
 } from "../../../internal.js";
 import { AnonymousJazzAgent } from "../../anonymousJazzAgent.js";
 import { CoOptionalSchema } from "./CoOptionalSchema.js";
@@ -84,6 +86,7 @@ export class RichTextSchema implements CoreRichTextSchema {
     options: {
       loadAs: Account | AnonymousJazzAgent;
       unstable_branch?: BranchDefinition;
+      cursor?: LoadCoValueCursorOption;
     },
   ): Promise<Settled<CoRichText>> {
     return this.coValueClass.load(id, options);
@@ -94,6 +97,7 @@ export class RichTextSchema implements CoreRichTextSchema {
     options: {
       loadAs: Account | AnonymousJazzAgent;
       unstable_branch?: BranchDefinition;
+      cursor?: CoValueCursor;
     },
     listener: (value: CoRichText, unsubscribe: () => void) => void,
   ): () => void;

--- a/packages/jazz-tools/src/tools/subscribe/CoValueCoreSubscription.ts
+++ b/packages/jazz-tools/src/tools/subscribe/CoValueCoreSubscription.ts
@@ -1,12 +1,13 @@
 import {
   cojsonInternals,
   CoValueCore,
+  CoValueFrontier,
   isRawCoID,
   LocalNode,
   RawCoID,
   RawCoValue,
 } from "cojson";
-import type { BranchDefinition } from "./types.js";
+import type { BranchDefinition, DecodedCoValueCursor } from "./types.js";
 import { CoValueLoadingState } from "./types.js";
 
 /**
@@ -27,6 +28,7 @@ export class CoValueCoreSubscription {
     value: RawCoValue | typeof CoValueLoadingState.UNAVAILABLE,
   ) => void;
   private skipRetry?: boolean;
+  private frontier?: CoValueFrontier;
 
   constructor(
     localNode: LocalNode,
@@ -36,6 +38,7 @@ export class CoValueCoreSubscription {
     ) => void,
     skipRetry?: boolean,
     branch?: BranchDefinition,
+    decodedCursor?: DecodedCoValueCursor,
   ) {
     this.localNode = localNode;
     this.listener = listener;
@@ -43,6 +46,10 @@ export class CoValueCoreSubscription {
     this.branchName = branch?.name;
     this.branchOwnerId = branch?.owner?.$jazz.raw.id;
     this.source = localNode.getCoValue(id as RawCoID);
+
+    if (decodedCursor) {
+      this.frontier = decodedCursor.frontiers[id as RawCoID];
+    }
 
     this.initializeSubscription();
   }
@@ -188,7 +195,13 @@ export class CoValueCoreSubscription {
     if (value === CoValueLoadingState.UNAVAILABLE) {
       this.listener(CoValueLoadingState.UNAVAILABLE);
     } else if (isCompletelyDownloaded(value)) {
-      this.listener(value.getCurrentContent());
+      const currentContent = value.getCurrentContent();
+
+      this.listener(
+        this.frontier
+          ? currentContent.atFrontier(this.frontier)
+          : currentContent,
+      );
     }
   }
 

--- a/packages/jazz-tools/src/tools/subscribe/CoValueCoreSubscription.ts
+++ b/packages/jazz-tools/src/tools/subscribe/CoValueCoreSubscription.ts
@@ -28,7 +28,7 @@ export class CoValueCoreSubscription {
     value: RawCoValue | typeof CoValueLoadingState.UNAVAILABLE,
   ) => void;
   private skipRetry?: boolean;
-  private frontier?: CoValueFrontier;
+  private frontier?: CoValueFrontier | typeof CoValueLoadingState.UNAVAILABLE;
 
   constructor(
     localNode: LocalNode,
@@ -48,7 +48,9 @@ export class CoValueCoreSubscription {
     this.source = localNode.getCoValue(id as RawCoID);
 
     if (decodedCursor) {
-      this.frontier = decodedCursor.frontiers[id as RawCoID];
+      this.frontier =
+        decodedCursor.frontiers[id as RawCoID] ??
+        CoValueLoadingState.UNAVAILABLE;
     }
 
     this.initializeSubscription();
@@ -197,11 +199,15 @@ export class CoValueCoreSubscription {
     } else if (isCompletelyDownloaded(value)) {
       const currentContent = value.getCurrentContent();
 
-      this.listener(
-        this.frontier
-          ? currentContent.atFrontier(this.frontier)
-          : currentContent,
-      );
+      if (this.frontier) {
+        this.listener(
+          this.frontier === CoValueLoadingState.UNAVAILABLE
+            ? CoValueLoadingState.UNAVAILABLE
+            : currentContent.atFrontier(this.frontier),
+        );
+      } else {
+        this.listener(currentContent);
+      }
     }
   }
 

--- a/packages/jazz-tools/src/tools/subscribe/SubscriptionCache.ts
+++ b/packages/jazz-tools/src/tools/subscribe/SubscriptionCache.ts
@@ -2,6 +2,7 @@ import { LocalNode } from "cojson";
 import type {
   CoValue,
   CoValueClassOrSchema,
+  CoValueCursor,
   Loaded,
   RefEncoded,
   RefsToResolve,
@@ -25,6 +26,7 @@ interface CacheEntry {
   schema: CoValueClassOrSchema;
   resolve: RefsToResolve<any>;
   branch?: BranchDefinition;
+  cursor?: CoValueCursor;
   subscriberCount: number;
   cleanupTimeoutId?: ReturnType<typeof setTimeout>;
   unsubscribeFromScope: () => void;
@@ -67,6 +69,7 @@ export class SubscriptionCache {
     schema: CoValueClassOrSchema,
     resolve: RefsToResolve<any>,
     branch?: BranchDefinition,
+    cursor?: CoValueCursor,
   ): boolean {
     // Compare schema by object identity
     if (entry.schema !== schema) {
@@ -90,6 +93,10 @@ export class SubscriptionCache {
       return false;
     }
 
+    if (entry.cursor !== cursor) {
+      return false;
+    }
+
     return true;
   }
 
@@ -102,6 +109,7 @@ export class SubscriptionCache {
     id: string,
     resolve: RefsToResolve<any>,
     branch?: BranchDefinition,
+    cursor?: CoValueCursor,
   ): CacheEntry | undefined {
     // Get the inner set for this id (quick filter)
     const idSet = this.getIdSet(id);
@@ -111,7 +119,7 @@ export class SubscriptionCache {
 
     // Search only within entries for this id
     for (const entry of idSet) {
-      if (this.matchesEntry(entry, schema, resolve, branch)) {
+      if (this.matchesEntry(entry, schema, resolve, branch, cursor)) {
         return entry;
       }
     }
@@ -197,6 +205,7 @@ export class SubscriptionCache {
     skipRetry?: boolean,
     bestEffortResolution?: boolean,
     branch?: BranchDefinition,
+    cursor?: CoValueCursor,
   ): SubscriptionScope<Loaded<S, ResolveQuery<S>>> {
     // Handle undefined/null id case
     if (!id) {
@@ -204,7 +213,13 @@ export class SubscriptionCache {
     }
 
     // Search for matching entry
-    const matchingEntry = this.findMatchingEntry(schema, id, resolve, branch);
+    const matchingEntry = this.findMatchingEntry(
+      schema,
+      id,
+      resolve,
+      branch,
+      cursor,
+    );
 
     if (matchingEntry) {
       // Found existing entry - cancel any pending cleanup since we're reusing it
@@ -231,6 +246,7 @@ export class SubscriptionCache {
       skipRetry ?? false,
       bestEffortResolution ?? false,
       branch,
+      cursor,
     );
 
     const handleSubscriberChange = (count: number) => {
@@ -247,6 +263,7 @@ export class SubscriptionCache {
       schema,
       resolve: copyResolve(resolve),
       branch,
+      cursor,
       subscriberCount: subscriptionScope.subscribers.size,
       unsubscribeFromScope: subscriptionScope.onSubscriberChange(
         handleSubscriberChange,

--- a/packages/jazz-tools/src/tools/subscribe/SubscriptionScope.ts
+++ b/packages/jazz-tools/src/tools/subscribe/SubscriptionScope.ts
@@ -14,7 +14,6 @@ import {
   isRefEncoded,
   CoValueCursor,
   DecodedCoValueCursor,
-  CoValueErrorState,
 } from "../internal.js";
 import { applyCoValueMigrations } from "../lib/migration.js";
 import { CoValueCoreSubscription } from "./CoValueCoreSubscription.js";
@@ -312,17 +311,8 @@ export class SubscriptionScope<D extends CoValue> {
   private handleUpdate(
     update: RawCoValue | typeof CoValueLoadingState.UNAVAILABLE,
   ) {
-    const cursorReplayedError =
-      this._cursor?.decoded?.valueErrors?.[this.id as RawCoID];
-
-    if (
-      update === CoValueLoadingState.UNAVAILABLE ||
-      cursorReplayedError === CoValueLoadingState.UNAVAILABLE
-    ) {
-      if (
-        this.value.type === CoValueLoadingState.LOADING ||
-        cursorReplayedError === CoValueLoadingState.UNAVAILABLE
-      ) {
+    if (update === CoValueLoadingState.UNAVAILABLE) {
+      if (this.value.type === CoValueLoadingState.LOADING) {
         const error = new JazzError(this.id, CoValueLoadingState.UNAVAILABLE, [
           {
             code: CoValueLoadingState.UNAVAILABLE,
@@ -341,14 +331,8 @@ export class SubscriptionScope<D extends CoValue> {
       return;
     }
 
-    if (
-      update.core.isDeleted ||
-      cursorReplayedError === CoValueLoadingState.DELETED
-    ) {
-      if (
-        this.value.type !== CoValueLoadingState.DELETED ||
-        cursorReplayedError === CoValueLoadingState.DELETED
-      ) {
+    if (update.core.isDeleted) {
+      if (this.value.type !== CoValueLoadingState.DELETED) {
         const error = new JazzError(this.id, CoValueLoadingState.DELETED, [
           {
             code: CoValueLoadingState.DELETED,
@@ -366,14 +350,8 @@ export class SubscriptionScope<D extends CoValue> {
       return;
     }
 
-    if (
-      !hasAccessToCoValue(update) ||
-      cursorReplayedError === CoValueLoadingState.UNAUTHORIZED
-    ) {
-      if (
-        this.value.type !== CoValueLoadingState.UNAUTHORIZED ||
-        cursorReplayedError === CoValueLoadingState.UNAUTHORIZED
-      ) {
+    if (!hasAccessToCoValue(update)) {
+      if (this.value.type !== CoValueLoadingState.UNAUTHORIZED) {
         const message = `Jazz Authorization Error: The current user (${this.node.getCurrentAgent().id}) is not authorized to access ${this.id}`;
 
         const error = new JazzError(this.id, CoValueLoadingState.UNAUTHORIZED, [
@@ -903,7 +881,6 @@ export class SubscriptionScope<D extends CoValue> {
       this.skipRetry,
       this.bestEffortResolution,
       this.unstable_branch,
-      this._cursor,
     );
     this.childNodes.set(id, child);
     child.setListener((value) => this.handleChildUpdate(id, value));
@@ -1166,7 +1143,7 @@ export class SubscriptionScope<D extends CoValue> {
       this.skipRetry,
       this.bestEffortResolution,
       this.unstable_branch,
-      this._cursor,
+      isAutoloaded ? undefined : this._cursor,
     );
     this.childNodes.set(id, child);
     child.setListener((value) => this.handleChildUpdate(id, value, key));
@@ -1181,14 +1158,9 @@ export class SubscriptionScope<D extends CoValue> {
   }
 
   private *selfAndChildrenFrontiers(): IterableIterator<
-    [RawCoID, CoValueFrontier | CoValueErrorState]
+    [RawCoID, CoValueFrontier]
   > {
-    if (this.value.type === CoValueLoadingState.LOADING) {
-      return;
-    }
-
     if (this.value.type !== CoValueLoadingState.LOADED) {
-      yield [this.id as RawCoID, this.value.type];
       return;
     }
 
@@ -1209,31 +1181,12 @@ export class SubscriptionScope<D extends CoValue> {
   }
 
   createCursor() {
-    const { frontiers, valueErrors } = Array.from(
-      this.selfAndChildrenFrontiers(),
-    ).reduce(
-      (acc, [id, value]) => {
-        if (typeof value === "string") {
-          acc.valueErrors[id] = value;
-        } else {
-          acc.frontiers[id] = value;
-        }
-
-        return acc;
-      },
-      {
-        frontiers: {} as Record<RawCoID, CoValueFrontier>,
-        valueErrors: {} as Record<RawCoID, CoValueErrorState>,
-      },
-    );
-
     return encodeCursor({
       version: 1,
       rootId: this.id as RawCoID,
       // we pass the initial resolve, and not the actual resolve as it may have changed due to autoloading
       resolveFingerprint: this.initialResolve,
-      frontiers,
-      valueErrors,
+      frontiers: Object.fromEntries(this.selfAndChildrenFrontiers()),
     });
   }
 

--- a/packages/jazz-tools/src/tools/subscribe/SubscriptionScope.ts
+++ b/packages/jazz-tools/src/tools/subscribe/SubscriptionScope.ts
@@ -1,4 +1,4 @@
-import { LocalNode, RawCoValue } from "cojson";
+import { LocalNode, RawCoValue, RawCoID, CoValueFrontier } from "cojson";
 import {
   CoFeed,
   CoList,
@@ -12,6 +12,9 @@ import {
   createUnloadedCoValue,
   instantiateRefEncodedFromRaw,
   isRefEncoded,
+  CoValueCursor,
+  DecodedCoValueCursor,
+  CoValueErrorState,
 } from "../internal.js";
 import { applyCoValueMigrations } from "../lib/migration.js";
 import { CoValueCoreSubscription } from "./CoValueCoreSubscription.js";
@@ -39,6 +42,7 @@ import {
   rejectedPromise,
   resolvedPromise,
 } from "./utils.js";
+import { decodeAndValidateCursor, encodeCursor } from "./cursor.js";
 
 export class SubscriptionScope<D extends CoValue> {
   static isProfilingEnabled = isDev;
@@ -71,6 +75,7 @@ export class SubscriptionScope<D extends CoValue> {
   private subscription: CoValueCoreSubscription;
   private dirty = false;
   private resolve: RefsToResolve<any>;
+  private initialResolve: RefsToResolve<any>;
   private idsSubscribed = new Set<string>();
   private autoloaded = new Set<string>();
   private autoloadedKeys = new Set<string>();
@@ -81,6 +86,13 @@ export class SubscriptionScope<D extends CoValue> {
   private migrating = false;
   private migrationFailed = false;
   closed = false;
+
+  private _cursor:
+    | {
+        encoded: CoValueCursor;
+        decoded: DecodedCoValueCursor;
+      }
+    | undefined;
 
   private silenceUpdates = false;
 
@@ -99,12 +111,31 @@ export class SubscriptionScope<D extends CoValue> {
     public skipRetry = false,
     public bestEffortResolution = false,
     public unstable_branch?: BranchDefinition,
-    callerStack?: Error | undefined,
+    cursor?:
+      | CoValueCursor
+      | {
+          encoded: CoValueCursor;
+          decoded: DecodedCoValueCursor;
+        },
   ) {
-    // Use caller stack if provided, otherwise capture here (less useful but better than nothing)
-    this.callerStack = callerStack;
     this.resolve = resolve;
+    this.initialResolve = resolve;
     this.value = { type: CoValueLoadingState.LOADING, id };
+
+    if (cursor) {
+      if (typeof cursor === "object") {
+        this._cursor = cursor;
+      } else {
+        this._cursor = {
+          encoded: cursor,
+          decoded: decodeAndValidateCursor({
+            rootId: id,
+            cursor,
+            resolve,
+          }),
+        };
+      }
+    }
 
     let lastUpdate:
       | RawCoValue
@@ -164,6 +195,7 @@ export class SubscriptionScope<D extends CoValue> {
       },
       skipRetry,
       this.unstable_branch,
+      this._cursor?.decoded,
     );
   }
 
@@ -280,8 +312,17 @@ export class SubscriptionScope<D extends CoValue> {
   private handleUpdate(
     update: RawCoValue | typeof CoValueLoadingState.UNAVAILABLE,
   ) {
-    if (update === CoValueLoadingState.UNAVAILABLE) {
-      if (this.value.type === CoValueLoadingState.LOADING) {
+    const cursorReplayedError =
+      this._cursor?.decoded?.valueErrors?.[this.id as RawCoID];
+
+    if (
+      update === CoValueLoadingState.UNAVAILABLE ||
+      cursorReplayedError === CoValueLoadingState.UNAVAILABLE
+    ) {
+      if (
+        this.value.type === CoValueLoadingState.LOADING ||
+        cursorReplayedError === CoValueLoadingState.UNAVAILABLE
+      ) {
         const error = new JazzError(this.id, CoValueLoadingState.UNAVAILABLE, [
           {
             code: CoValueLoadingState.UNAVAILABLE,
@@ -300,8 +341,14 @@ export class SubscriptionScope<D extends CoValue> {
       return;
     }
 
-    if (update.core.isDeleted) {
-      if (this.value.type !== CoValueLoadingState.DELETED) {
+    if (
+      update.core.isDeleted ||
+      cursorReplayedError === CoValueLoadingState.DELETED
+    ) {
+      if (
+        this.value.type !== CoValueLoadingState.DELETED ||
+        cursorReplayedError === CoValueLoadingState.DELETED
+      ) {
         const error = new JazzError(this.id, CoValueLoadingState.DELETED, [
           {
             code: CoValueLoadingState.DELETED,
@@ -319,8 +366,14 @@ export class SubscriptionScope<D extends CoValue> {
       return;
     }
 
-    if (!hasAccessToCoValue(update)) {
-      if (this.value.type !== CoValueLoadingState.UNAUTHORIZED) {
+    if (
+      !hasAccessToCoValue(update) ||
+      cursorReplayedError === CoValueLoadingState.UNAUTHORIZED
+    ) {
+      if (
+        this.value.type !== CoValueLoadingState.UNAUTHORIZED ||
+        cursorReplayedError === CoValueLoadingState.UNAUTHORIZED
+      ) {
         const message = `Jazz Authorization Error: The current user (${this.node.getCurrentAgent().id}) is not authorized to access ${this.id}`;
 
         const error = new JazzError(this.id, CoValueLoadingState.UNAUTHORIZED, [
@@ -738,6 +791,11 @@ export class SubscriptionScope<D extends CoValue> {
 
     const resolve: Record<string, any> = this.resolve;
     if (!resolve.$each && !(key in resolve)) {
+      // do not autoload any descendants if we're loading using a cursor
+      if (this.cursor) {
+        return;
+      }
+
       // Adding the key to the resolve object to resolve the key when calling loadChildren
       resolve[key] = true;
       // Track the keys that are autoloaded to flag any id on that key as autoloaded
@@ -845,6 +903,7 @@ export class SubscriptionScope<D extends CoValue> {
       this.skipRetry,
       this.bestEffortResolution,
       this.unstable_branch,
+      this._cursor,
     );
     this.childNodes.set(id, child);
     child.setListener((value) => this.handleChildUpdate(id, value));
@@ -1107,6 +1166,7 @@ export class SubscriptionScope<D extends CoValue> {
       this.skipRetry,
       this.bestEffortResolution,
       this.unstable_branch,
+      this._cursor,
     );
     this.childNodes.set(id, child);
     child.setListener((value) => this.handleChildUpdate(id, value, key));
@@ -1118,6 +1178,63 @@ export class SubscriptionScope<D extends CoValue> {
     if (this.closed) {
       child.destroy();
     }
+  }
+
+  private *selfAndChildrenFrontiers(): IterableIterator<
+    [RawCoID, CoValueFrontier | CoValueErrorState]
+  > {
+    if (this.value.type === CoValueLoadingState.LOADING) {
+      return;
+    }
+
+    if (this.value.type !== CoValueLoadingState.LOADED) {
+      yield [this.id as RawCoID, this.value.type];
+      return;
+    }
+
+    yield [this.id as RawCoID, this.value.value.$jazz.raw.core.frontier()];
+
+    for (const child of this.childNodes.values()) {
+      // do not add autoloaded children to frontiers
+      if (this.autoloaded.has(child.id)) {
+        continue;
+      }
+
+      yield* child.selfAndChildrenFrontiers();
+    }
+  }
+
+  get cursor() {
+    return this._cursor?.encoded;
+  }
+
+  createCursor() {
+    const { frontiers, valueErrors } = Array.from(
+      this.selfAndChildrenFrontiers(),
+    ).reduce(
+      (acc, [id, value]) => {
+        if (typeof value === "string") {
+          acc.valueErrors[id] = value;
+        } else {
+          acc.frontiers[id] = value;
+        }
+
+        return acc;
+      },
+      {
+        frontiers: {} as Record<RawCoID, CoValueFrontier>,
+        valueErrors: {} as Record<RawCoID, CoValueErrorState>,
+      },
+    );
+
+    return encodeCursor({
+      version: 1,
+      rootId: this.id as RawCoID,
+      // we pass the initial resolve, and not the actual resolve as it may have changed due to autoloading
+      resolveFingerprint: this.initialResolve,
+      frontiers,
+      valueErrors,
+    });
   }
 
   destroy() {

--- a/packages/jazz-tools/src/tools/subscribe/cursor.ts
+++ b/packages/jazz-tools/src/tools/subscribe/cursor.ts
@@ -1,11 +1,6 @@
 import { base58 } from "@scure/base";
 import { cojsonInternals, RawCoID, Stringified } from "cojson";
-import {
-  CoValueCursor,
-  CoValueErrorState,
-  CoValueLoadingState,
-  DecodedCoValueCursor,
-} from "./types.js";
+import { CoValueCursor, DecodedCoValueCursor } from "./types.js";
 import { z } from "zod/v4";
 import type { RefsToResolve } from "../coValues/deepLoading.js";
 
@@ -14,16 +9,6 @@ const cursorSchema = z.object({
   rootId: z.string<RawCoID>(),
   resolveFingerprint: z.record(z.string(), z.any()),
   frontiers: z.record(z.string<RawCoID>(), z.record(z.string(), z.number())),
-  valueErrors: z
-    .record(
-      z.string<RawCoID>(),
-      z.enum([
-        CoValueLoadingState.UNAVAILABLE,
-        CoValueLoadingState.UNAUTHORIZED,
-        CoValueLoadingState.DELETED,
-      ]) satisfies z.ZodEnum<Record<CoValueErrorState, CoValueErrorState>>,
-    )
-    .optional(),
 }) satisfies z.ZodType<DecodedCoValueCursor>;
 
 export class CursorError extends Error {
@@ -48,12 +33,6 @@ export const encodeCursor = (
           !decodedCursor.resolveFingerprint
             ? {}
             : decodedCursor.resolveFingerprint,
-
-        // remove empty valueErrors to reduce the cursor size
-        ...(decodedCursor.valueErrors &&
-        Object.keys(decodedCursor.valueErrors).length === 0
-          ? { valueErrors: undefined }
-          : {}),
       }),
     ),
   )}`;

--- a/packages/jazz-tools/src/tools/subscribe/cursor.ts
+++ b/packages/jazz-tools/src/tools/subscribe/cursor.ts
@@ -19,6 +19,27 @@ export class CursorError extends Error {
   }
 }
 
+export const normalizeResolveForFingerprint = (
+  resolve: RefsToResolve<any>,
+): RefsToResolve<any> => {
+  if (resolve === true) {
+    return {};
+  }
+
+  if (typeof resolve === "object") {
+    return Object.fromEntries(
+      Object.entries(resolve)
+        .filter(([k]) => k !== "$onError")
+        .map(([k, v]) => [
+          k,
+          normalizeResolveForFingerprint(v as RefsToResolve<any>),
+        ]),
+    );
+  }
+
+  return resolve;
+};
+
 export const encodeCursor = (
   decodedCursor: Omit<DecodedCoValueCursor, "resolveFingerprint"> & {
     resolveFingerprint: DecodedCoValueCursor["resolveFingerprint"] | boolean;
@@ -29,11 +50,9 @@ export const encodeCursor = (
     textEncoder.encode(
       cojsonInternals.stableStringify({
         ...decodedCursor,
-        resolveFingerprint:
-          decodedCursor.resolveFingerprint === true ||
-          !decodedCursor.resolveFingerprint
-            ? {}
-            : decodedCursor.resolveFingerprint,
+        resolveFingerprint: normalizeResolveForFingerprint(
+          decodedCursor.resolveFingerprint,
+        ),
       }),
     ),
   )}`;
@@ -73,7 +92,7 @@ export const decodeAndValidateCursor = ({
     throw new CursorError("Invalid cursor: root CoValue ID mismatch");
   }
 
-  const normalizedResolve = resolve === true ? {} : resolve;
+  const normalizedResolve = normalizeResolveForFingerprint(resolve);
 
   if (
     !isSubsetOfRefsToResolve(

--- a/packages/jazz-tools/src/tools/subscribe/cursor.ts
+++ b/packages/jazz-tools/src/tools/subscribe/cursor.ts
@@ -3,6 +3,7 @@ import { cojsonInternals, RawCoID, Stringified } from "cojson";
 import { CoValueCursor, DecodedCoValueCursor } from "./types.js";
 import { z } from "zod/v4";
 import type { RefsToResolve } from "../coValues/deepLoading.js";
+import { isSubsetOfRefsToResolve } from "./utils.js";
 
 const cursorSchema = z.object({
   version: z.literal(1),
@@ -72,16 +73,16 @@ export const decodeAndValidateCursor = ({
     throw new CursorError("Invalid cursor: root CoValue ID mismatch");
   }
 
-  const normalizedResolveFingerprint = cojsonInternals.stableStringify(
-    decodedCursor.resolveFingerprint,
-  );
-  const normalizedResolve = cojsonInternals.stableStringify(
-    resolve === true ? {} : resolve,
-  );
+  const normalizedResolve = resolve === true ? {} : resolve;
 
-  if (normalizedResolveFingerprint !== normalizedResolve) {
+  if (
+    !isSubsetOfRefsToResolve(
+      normalizedResolve,
+      decodedCursor.resolveFingerprint,
+    )
+  ) {
     throw new CursorError(
-      `Invalid cursor: resolve query mismatch. Expected ${normalizedResolve}, got cursor with ${normalizedResolveFingerprint}`,
+      `Invalid cursor: resolve query mismatch. Expected ${JSON.stringify(normalizedResolve)} to be a subset of ${JSON.stringify(decodedCursor.resolveFingerprint)}`,
     );
   }
 

--- a/packages/jazz-tools/src/tools/subscribe/cursor.ts
+++ b/packages/jazz-tools/src/tools/subscribe/cursor.ts
@@ -1,0 +1,110 @@
+import { base58 } from "@scure/base";
+import { cojsonInternals, RawCoID, Stringified } from "cojson";
+import {
+  CoValueCursor,
+  CoValueErrorState,
+  CoValueLoadingState,
+  DecodedCoValueCursor,
+} from "./types.js";
+import { z } from "zod/v4";
+import type { RefsToResolve } from "../coValues/deepLoading.js";
+
+const cursorSchema = z.object({
+  version: z.literal(1),
+  rootId: z.string<RawCoID>(),
+  resolveFingerprint: z.record(z.string(), z.any()),
+  frontiers: z.record(z.string<RawCoID>(), z.record(z.string(), z.number())),
+  valueErrors: z
+    .record(
+      z.string<RawCoID>(),
+      z.enum([
+        CoValueLoadingState.UNAVAILABLE,
+        CoValueLoadingState.UNAUTHORIZED,
+        CoValueLoadingState.DELETED,
+      ]) satisfies z.ZodEnum<Record<CoValueErrorState, CoValueErrorState>>,
+    )
+    .optional(),
+}) satisfies z.ZodType<DecodedCoValueCursor>;
+
+export class CursorError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "CursorError";
+  }
+}
+
+export const encodeCursor = (
+  decodedCursor: Omit<DecodedCoValueCursor, "resolveFingerprint"> & {
+    resolveFingerprint: DecodedCoValueCursor["resolveFingerprint"] | boolean;
+  },
+): CoValueCursor => {
+  const textEncoder = new TextEncoder();
+  return `cursor_z${base58.encode(
+    textEncoder.encode(
+      cojsonInternals.stableStringify({
+        ...decodedCursor,
+        resolveFingerprint:
+          decodedCursor.resolveFingerprint === true ||
+          !decodedCursor.resolveFingerprint
+            ? {}
+            : decodedCursor.resolveFingerprint,
+
+        // remove empty valueErrors to reduce the cursor size
+        ...(decodedCursor.valueErrors &&
+        Object.keys(decodedCursor.valueErrors).length === 0
+          ? { valueErrors: undefined }
+          : {}),
+      }),
+    ),
+  )}`;
+};
+
+export const decodeAndValidateCursor = ({
+  rootId,
+  resolve,
+  cursor,
+}: {
+  cursor: CoValueCursor;
+  rootId: string;
+  resolve: RefsToResolve<any>;
+}): DecodedCoValueCursor => {
+  const textDecoder = new TextDecoder();
+
+  let maybeDecodedCursor: DecodedCoValueCursor;
+  try {
+    maybeDecodedCursor = cojsonInternals.parseJSON(
+      textDecoder.decode(
+        base58.decode(cursor.replace(/^cursor_z/, "")),
+      ) as Stringified<DecodedCoValueCursor>,
+    );
+  } catch {
+    throw new CursorError("Invalid cursor string");
+  }
+
+  const parseResult = cursorSchema.safeParse(maybeDecodedCursor);
+
+  if (!parseResult.success) {
+    throw new CursorError("Invalid cursor string");
+  }
+
+  const decodedCursor = parseResult.data;
+
+  if (decodedCursor.rootId !== rootId) {
+    throw new CursorError("Invalid cursor: root CoValue ID mismatch");
+  }
+
+  const normalizedResolveFingerprint = cojsonInternals.stableStringify(
+    decodedCursor.resolveFingerprint,
+  );
+  const normalizedResolve = cojsonInternals.stableStringify(
+    resolve === true ? {} : resolve,
+  );
+
+  if (normalizedResolveFingerprint !== normalizedResolve) {
+    throw new CursorError(
+      `Invalid cursor: resolve query mismatch. Expected ${normalizedResolve}, got cursor with ${normalizedResolveFingerprint}`,
+    );
+  }
+
+  return decodedCursor;
+};

--- a/packages/jazz-tools/src/tools/subscribe/types.ts
+++ b/packages/jazz-tools/src/tools/subscribe/types.ts
@@ -1,5 +1,6 @@
 import type { Account, CoValue, Group, Resolved } from "../internal.js";
 import type { JazzError } from "./JazzError.js";
+import { RawCoID, RawCoValueCursor } from "cojson";
 
 export const CoValueLoadingState = {
   /**
@@ -49,6 +50,18 @@ export type SubscriptionValueLoading = {
 };
 
 export type BranchDefinition = { name: string; owner?: Group | Account };
+
+export type DecodedCoValueCursor = RawCoValueCursor & {
+  version: 1;
+  resolveFingerprint: Record<string, any>;
+  valueErrors?: Record<RawCoID, CoValueErrorState>;
+};
+
+export type CoValueCursor = `cursor_z${string}`;
+
+export type LoadCoValueCursorOption =
+  | CoValueCursor
+  | { useCurrentCursor: true };
 
 /**
  * Detail structure for subscription performance marks and measures.

--- a/packages/jazz-tools/src/tools/subscribe/types.ts
+++ b/packages/jazz-tools/src/tools/subscribe/types.ts
@@ -1,6 +1,6 @@
 import type { Account, CoValue, Group, Resolved } from "../internal.js";
 import type { JazzError } from "./JazzError.js";
-import { RawCoID, RawCoValueCursor } from "cojson";
+import { RawCoValueCursor } from "cojson";
 
 export const CoValueLoadingState = {
   /**
@@ -54,7 +54,6 @@ export type BranchDefinition = { name: string; owner?: Group | Account };
 export type DecodedCoValueCursor = RawCoValueCursor & {
   version: 1;
   resolveFingerprint: Record<string, any>;
-  valueErrors?: Record<RawCoID, CoValueErrorState>;
 };
 
 export type CoValueCursor = `cursor_z${string}`;

--- a/packages/jazz-tools/src/tools/subscribe/utils.ts
+++ b/packages/jazz-tools/src/tools/subscribe/utils.ts
@@ -64,9 +64,10 @@ export function rejectedPromise<T>(reason: unknown): PromiseWithStatus<T> {
   return promise;
 }
 
-export function isEqualRefsToResolve(
+function compareRefsToResolve(
   a: RefsToResolve<any>,
   b: RefsToResolve<any>,
+  mode: "equality" | "subset",
 ) {
   // Fast path: same reference
   if (a === b) {
@@ -98,7 +99,7 @@ export function isEqualRefsToResolve(
   const keysB = Object.keys(b);
 
   // Different number of keys means not equal
-  if (keysA.length !== keysB.length) {
+  if (mode === "equality" && keysA.length !== keysB.length) {
     return false;
   }
 
@@ -112,10 +113,24 @@ export function isEqualRefsToResolve(
     const valueB = (b as any)[key];
 
     // Recursively compare nested RefsToResolve values
-    if (!isEqualRefsToResolve(valueA, valueB)) {
+    if (!compareRefsToResolve(valueA, valueB, mode)) {
       return false;
     }
   }
 
   return true;
+}
+
+export function isEqualRefsToResolve(
+  a: RefsToResolve<any>,
+  b: RefsToResolve<any>,
+) {
+  return compareRefsToResolve(a, b, "equality");
+}
+
+export function isSubsetOfRefsToResolve(
+  a: RefsToResolve<any>,
+  b: RefsToResolve<any>,
+) {
+  return compareRefsToResolve(a, b, "subset");
 }

--- a/packages/jazz-tools/src/tools/tests/coValue.cursor.test.ts
+++ b/packages/jazz-tools/src/tools/tests/coValue.cursor.test.ts
@@ -704,7 +704,7 @@ describe("Creating and loading CoValues with cursors", () => {
       assertLoaded(snapshot);
 
       expect(snapshot.secret?.$jazz.loadingState).toBe(
-        CoValueLoadingState.UNAUTHORIZED,
+        CoValueLoadingState.UNAVAILABLE,
       );
     });
 
@@ -748,7 +748,7 @@ describe("Creating and loading CoValues with cursors", () => {
       assertLoaded(snapshot);
 
       expect(snapshot.secret?.$jazz.loadingState).toBe(
-        CoValueLoadingState.UNAUTHORIZED,
+        CoValueLoadingState.UNAVAILABLE,
       );
 
       const latest = await Document.load(original.$jazz.id, {

--- a/packages/jazz-tools/src/tools/tests/coValue.cursor.test.ts
+++ b/packages/jazz-tools/src/tools/tests/coValue.cursor.test.ts
@@ -1,0 +1,817 @@
+import { cojsonInternals } from "cojson";
+import { beforeEach, describe, expect, test } from "vitest";
+import { Group, co, z, ResolveQuery } from "../exports.js";
+import { CoValueLoadingState } from "../internal.js";
+import { createJazzTestAccount, setupJazzTestSync } from "../testing.js";
+import { assertLoaded } from "./utils.js";
+import { decodeAndValidateCursor } from "../subscribe/cursor";
+
+describe("Creating and loading CoValues with cursors", () => {
+  let me: Awaited<ReturnType<typeof createJazzTestAccount>>;
+
+  beforeEach(async () => {
+    cojsonInternals.CO_VALUE_LOADING_CONFIG.RETRY_DELAY = 1000;
+
+    await setupJazzTestSync();
+
+    me = await createJazzTestAccount({
+      isCurrentActiveAccount: true,
+      creationProps: { name: "Hermes Puggington" },
+    });
+  });
+
+  describe("createCursor", () => {
+    test("returns a non-empty opaque string for a loaded root", async () => {
+      const cursor = me.$jazz.createCursor();
+      expect(cursor).toBeTypeOf("string");
+      expect(cursor).toMatch(/^cursor_z/);
+    });
+
+    test("root with resolved descendants encodes frontiers", async () => {
+      const Person = co.map({
+        name: z.string(),
+        get friends() {
+          return co.list(Person);
+        },
+      });
+
+      const john = Person.create({
+        name: "John",
+        friends: [
+          {
+            name: "Jane",
+            friends: [
+              {
+                name: "Bob",
+                friends: [],
+              },
+            ],
+          },
+        ],
+      });
+
+      const resolve = {
+        friends: {
+          $each: {
+            friends: {
+              $each: true,
+            },
+          },
+        },
+      } satisfies ResolveQuery<typeof Person>;
+
+      const loadedJohn = await john.$jazz.ensureLoaded({
+        resolve,
+      });
+
+      const cursor = loadedJohn.$jazz.createCursor();
+      const decodedCursor = decodeAndValidateCursor({
+        cursor,
+        rootId: loadedJohn.$jazz.id,
+        resolve,
+      });
+
+      expect(decodedCursor.frontiers).toEqual({
+        [john.$jazz.id]: expect.anything(),
+        [john.friends.$jazz.id]: expect.anything(),
+        [john.friends[0]!.$jazz.id]: expect.anything(),
+        [john.friends[0]!.friends.$jazz.id]: expect.anything(),
+        [john.friends[0]!.friends[0]!.$jazz.id]: expect.anything(),
+      });
+    });
+
+    test("CoList with no `resolve` encodes only the root frontier", async () => {
+      const TodoList = co.list(co.map({ title: z.string() }));
+      const todos = TodoList.create([{ title: "Todo 1" }]);
+      const loadedTodos = await todos.$jazz.ensureLoaded({
+        resolve: true,
+      });
+      const cursor = loadedTodos.$jazz.createCursor();
+      const decodedCursor = decodeAndValidateCursor({
+        cursor,
+        rootId: todos.$jazz.id,
+        resolve: {},
+      });
+
+      expect(decodedCursor.frontiers).toEqual({
+        [todos.$jazz.id]: expect.anything(),
+      });
+    });
+
+    test("CoMap with no `resolve` encodes only the root frontier", async () => {
+      const Person = co.map({
+        name: z.string(),
+        age: z.number(),
+        pet: co.map({ name: z.string() }),
+      });
+
+      const person = Person.create({
+        name: "John",
+        age: 30,
+        pet: { name: "Rex" },
+      });
+
+      const loadedPerson = await person.$jazz.ensureLoaded({
+        resolve: true,
+      });
+
+      // triggering load on `.owner` so  trigger a child subscription
+      // and then ensure it does not get added to frontier
+      expect(loadedPerson.$jazz.owner).toBeDefined();
+
+      const cursor = loadedPerson.$jazz.createCursor();
+      const decodedCursor = decodeAndValidateCursor({
+        cursor,
+        rootId: person.$jazz.id,
+        resolve: {},
+      });
+
+      expect(decodedCursor.frontiers).toEqual({
+        [person.$jazz.id]: expect.anything(),
+      });
+    });
+
+    test("CoFeed with `resolve` encodes frontiers for all entries", async () => {
+      const EventFeed = co.feed(co.map({ name: z.string() }));
+
+      const eventFeed = EventFeed.create([{ name: "event-1" }]);
+      const loadedEventFeed = await eventFeed.$jazz.ensureLoaded({
+        resolve: { $each: true },
+      });
+      const cursor = loadedEventFeed.$jazz.createCursor();
+
+      const decodedCursor = decodeAndValidateCursor({
+        cursor,
+        rootId: eventFeed.$jazz.id,
+        resolve: { $each: true },
+      });
+
+      expect(decodedCursor.frontiers).toEqual({
+        [loadedEventFeed.$jazz.id]: expect.anything(),
+        [loadedEventFeed.byMe!.value.$jazz.id]: expect.anything(),
+      });
+    });
+
+    test("CoMap with no `resolve` does not encode autoloaded children frontiers", async () => {
+      const Person = co.map({
+        name: z.string(),
+        age: z.number(),
+        pet: co.map({ name: z.string() }),
+      });
+
+      const person = Person.create({
+        name: "John",
+        age: 30,
+        pet: { name: "Rex" },
+      });
+
+      const loadedPerson = await person.$jazz.ensureLoaded({
+        resolve: true,
+      });
+
+      // trigger autoload on pet
+      const petLoadingState = loadedPerson.pet.$jazz.loadingState;
+      expect(petLoadingState).toBeOneOf([
+        CoValueLoadingState.LOADING,
+        CoValueLoadingState.LOADED,
+      ]);
+
+      const cursor = loadedPerson.$jazz.createCursor();
+
+      const decodedCursor = decodeAndValidateCursor({
+        cursor,
+        rootId: person.$jazz.id,
+        resolve: true,
+      });
+
+      expect(decodedCursor.frontiers).toEqual({
+        [person.$jazz.id]: expect.anything(),
+      });
+    });
+
+    test("CoFeed returns a valid cursor", async () => {
+      const EventFeed = co.feed(z.string());
+      const eventFeed = EventFeed.create(["event-1", "event-2"]);
+      const cursor = eventFeed.$jazz.createCursor();
+      expect(cursor).toMatch(/^cursor_z/);
+    });
+
+    test("CoPlainText returns a valid cursor", async () => {
+      const text = co.plainText().create("Hello world");
+      const cursor = text.$jazz.createCursor();
+      expect(cursor).toMatch(/^cursor_z/);
+    });
+
+    test("multi-level `resolve` (root → list → map → text) encodes all frontiers", async () => {
+      const Project = co.map({
+        name: z.string(),
+        tasks: co.list(
+          co.map({
+            title: z.string(),
+            description: co.plainText(),
+          }),
+        ),
+      });
+
+      const project = Project.create({
+        name: "Project 1",
+        tasks: [
+          {
+            title: "Task 1",
+            description: "A task",
+          },
+        ],
+      });
+
+      const resolve = {
+        tasks: {
+          $each: {
+            description: true,
+          },
+        },
+      } satisfies ResolveQuery<typeof Project>;
+
+      const loadedProject = await project.$jazz.ensureLoaded({
+        resolve,
+      });
+
+      const cursor = loadedProject.$jazz.createCursor();
+      const decodedCursor = decodeAndValidateCursor({
+        cursor,
+        rootId: project.$jazz.id,
+        resolve,
+      });
+
+      expect(decodedCursor.frontiers).toEqual({
+        [project.$jazz.id]: expect.anything(),
+        [project.tasks.$jazz.id]: expect.anything(),
+        [project.tasks[0]!.$jazz.id]: expect.anything(),
+        [project.tasks[0]!.description.$jazz.id]: expect.anything(),
+      });
+    });
+
+    test("returns the same cursor when called multiple times without mutations", () => {
+      const Person = co.map({
+        name: z.string(),
+        age: z.number(),
+      });
+
+      const person = Person.create({ name: "John", age: 30 });
+
+      const cursor1 = person.$jazz.createCursor();
+      const cursor2 = person.$jazz.createCursor();
+      expect(cursor1).toBe(cursor2);
+    });
+
+    test("returns a different cursor after a mutation", () => {
+      const Person = co.map({
+        name: z.string(),
+        age: z.number(),
+      });
+
+      const person = Person.create({ name: "John", age: 30 });
+
+      const cursor1 = person.$jazz.createCursor();
+      person.$jazz.set("name", "Jane");
+      const cursor2 = person.$jazz.createCursor();
+      expect(cursor1).not.toBe(cursor2);
+    });
+  });
+
+  describe("load() with cursor", () => {
+    test("loads original snapshot of CoMap after mutation", async () => {
+      const Person = co.map({
+        name: z.string(),
+        age: z.number(),
+      });
+
+      const person = Person.create({ name: "John", age: 30 });
+      const personSnapshot = await person.$jazz.ensureLoaded({
+        resolve: true,
+        cursor: {
+          useCurrentCursor: true,
+        },
+      });
+
+      person.$jazz.set("name", "Jane");
+
+      expect(personSnapshot.name).toBe("John");
+
+      const loadedSnapshot = await Person.load(person.$jazz.id, {
+        cursor: personSnapshot.$jazz.cursor,
+      });
+      assertLoaded(loadedSnapshot);
+      expect(loadedSnapshot.name).toBe("John");
+    });
+
+    test("loads original snapshot of CoList after mutation", async () => {
+      const TodoList = co.list(z.string());
+
+      const todoList = TodoList.create(["Buy groceries", "Walk the dog"]);
+      const todoListSnapshot = await todoList.$jazz.ensureLoaded({
+        resolve: true,
+        cursor: {
+          useCurrentCursor: true,
+        },
+      });
+
+      todoList.$jazz.push("Call mom");
+
+      const loadedSnapshot = await TodoList.load(todoList.$jazz.id, {
+        cursor: todoListSnapshot.$jazz.cursor,
+      });
+      assertLoaded(loadedSnapshot);
+      expect(loadedSnapshot).toEqual(["Buy groceries", "Walk the dog"]);
+    });
+
+    test("loads original snapshot of CoFeed after mutation", async () => {
+      const EventFeed = co.feed(z.string());
+
+      const eventFeed = EventFeed.create(["event-1", "event-2"]);
+      const eventFeedSnapshot = await eventFeed.$jazz.ensureLoaded({
+        resolve: true,
+        cursor: {
+          useCurrentCursor: true,
+        },
+      });
+
+      eventFeed.$jazz.push("event-3");
+
+      const loadedSnapshot = await EventFeed.load(eventFeed.$jazz.id, {
+        cursor: eventFeedSnapshot.$jazz.cursor,
+      });
+      assertLoaded(loadedSnapshot);
+      expect(loadedSnapshot.perAccount[me.$jazz.id]?.value).toBe("event-2");
+    });
+
+    test("loads original snapshot of CoPlainText after mutation", async () => {
+      const text = co.plainText().create("Hello world");
+      const textSnapshot = await co.plainText().load(text.$jazz.id, {
+        loadAs: me,
+        cursor: {
+          useCurrentCursor: true,
+        },
+      });
+      assertLoaded(textSnapshot);
+
+      text.$jazz.applyDiff("Hello Jazz");
+
+      const loadedSnapshot = await co.plainText().load(text.$jazz.id, {
+        loadAs: me,
+        cursor: textSnapshot.$jazz.cursor,
+      });
+      assertLoaded(loadedSnapshot);
+      expect(loadedSnapshot.toString()).toBe("Hello world");
+    });
+
+    test("loads original snapshot of branched CoMap after mutation", async () => {
+      const Person = co.map({
+        name: z.string(),
+        age: z.number(),
+      });
+
+      const person = Person.create({ name: "John", age: 30 });
+      const branchName = "cursor-branch";
+      const branchedPerson = await Person.load(person.$jazz.id, {
+        unstable_branch: { name: branchName },
+      });
+      assertLoaded(branchedPerson);
+
+      branchedPerson.$jazz.applyDiff({ name: "Jane", age: 31 });
+
+      const branchedPersonSnapshot = await branchedPerson.$jazz.ensureLoaded({
+        resolve: true,
+        unstable_branch: { name: branchName },
+        cursor: {
+          useCurrentCursor: true,
+        },
+      });
+
+      branchedPerson.$jazz.applyDiff({ name: "Bob", age: 32 });
+
+      const loadedSnapshot = await Person.load(person.$jazz.id, {
+        unstable_branch: { name: branchName },
+        cursor: branchedPersonSnapshot.$jazz.cursor,
+      });
+      assertLoaded(loadedSnapshot);
+      expect(loadedSnapshot.name).toBe("Jane");
+      expect(loadedSnapshot.age).toBe(31);
+    });
+
+    test("loads original snapshot of multi-level value with mutations at all levels", async () => {
+      const Organization = co.map({
+        name: z.string(),
+        description: co.plainText(),
+        teams: co.list(
+          co.map({
+            name: z.string(),
+            members: co.list(
+              co.map({
+                name: z.string(),
+                role: z.string(),
+              }),
+            ),
+          }),
+        ),
+        projects: co.list(
+          co.map({
+            name: z.string(),
+            tasks: co.list(
+              co.map({
+                title: z.string(),
+                description: z.string(),
+                status: z.string(),
+                comments: co.feed(
+                  co.map({
+                    text: z.string(),
+                    author: z.string(),
+                  }),
+                ),
+              }),
+            ),
+          }),
+        ),
+      });
+
+      const original = Organization.create({
+        name: "Acme Corporation",
+        description: "A company that makes things.",
+        teams: [
+          {
+            name: "Engineering",
+            members: [
+              { name: "John", role: "Lead" },
+              { name: "Jane", role: "Developer" },
+            ],
+          },
+        ],
+        projects: [
+          {
+            name: "Project 1",
+            tasks: [
+              {
+                title: "Task 1",
+                description: "A task",
+                status: "todo",
+                comments: [
+                  { text: "A comment", author: "John" },
+                  { text: "Another comment", author: "Jane" },
+                ],
+              },
+            ],
+          },
+        ],
+      });
+
+      const originalJson = original.toJSON();
+
+      const resolve = {
+        description: true,
+        teams: { $each: { members: { $each: true } } },
+        projects: {
+          $each: { tasks: { $each: { comments: { $each: true } } } },
+        },
+      } satisfies ResolveQuery<typeof Organization>;
+
+      const originalSnapshot = await Organization.load(original.$jazz.id, {
+        resolve,
+        cursor: {
+          useCurrentCursor: true,
+        },
+      });
+      assertLoaded(originalSnapshot);
+
+      original.$jazz.applyDiff({
+        name: "Acme + Garden",
+        description: "A company that makes things and gardens.",
+      });
+
+      original.teams[0]?.$jazz.set("name", "Engineering + Design");
+      original.teams.$jazz.push({
+        name: "Marketing",
+        members: [],
+      });
+      original.projects[0]?.$jazz.set("name", "Project 1 + Marketing");
+      original.projects[0]?.tasks[0]?.$jazz.set("title", "Task 1 + Marketing");
+      original.projects[0]?.tasks[0]?.comments.$jazz.push({
+        text: "A comment",
+        author: "Wile E. Coyote",
+      });
+      original.projects[0]?.tasks.$jazz.push({
+        title: "Task 2",
+        description: "A task",
+        status: "todo",
+        comments: [],
+      });
+
+      const loadedSnapshot = await Organization.load(original.$jazz.id, {
+        resolve,
+        cursor: originalSnapshot.$jazz.cursor,
+      });
+      assertLoaded(loadedSnapshot);
+
+      expect(loadedSnapshot.toJSON()).toEqual(originalJson);
+    });
+
+    test("snapshot loaded with cursor does not autoload non-resolved children", async () => {
+      const Person = co.map({
+        name: z.string(),
+        age: z.number(),
+        pet: co.map({ name: z.string() }),
+      });
+
+      const person = Person.create({
+        name: "John",
+        age: 30,
+        pet: { name: "Rex" },
+      });
+
+      const personSnapshot = await Person.load(person.$jazz.id, {
+        cursor: {
+          useCurrentCursor: true,
+        },
+      });
+
+      assertLoaded(personSnapshot);
+
+      expect(personSnapshot.pet.$jazz.loadingState).toBe(
+        CoValueLoadingState.UNAVAILABLE,
+      );
+    });
+
+    test("CoMap loaded with cursor cannot be mutated", async () => {
+      const Person = co.map({
+        name: z.string(),
+        age: z.number(),
+      });
+
+      const person = Person.create({
+        name: "John",
+        age: 30,
+      });
+
+      const personSnapshot = await person.$jazz.ensureLoaded({
+        resolve: true,
+        cursor: {
+          useCurrentCursor: true,
+        },
+      });
+
+      expect(() => {
+        personSnapshot.$jazz.set("name", "Jane");
+      }).toThrowError("Cannot set value on a time travel entity");
+    });
+
+    test("CoList loaded with cursor cannot be mutated", async () => {
+      const TodoList = co.list(z.string());
+
+      const todoList = TodoList.create(["Buy groceries", "Walk the dog"]);
+
+      const todoListSnapshot = await todoList.$jazz.ensureLoaded({
+        resolve: true,
+        cursor: {
+          useCurrentCursor: true,
+        },
+      });
+
+      expect(() => {
+        todoListSnapshot.$jazz.push("Call mom");
+      }).toThrowError("Cannot mutate a time travel entity");
+    });
+
+    test("CoFeed loaded with cursor cannot be mutated", async () => {
+      const EventFeed = co.feed(z.string());
+
+      const eventFeed = EventFeed.create(["event-1", "event-2"]);
+
+      const eventFeedSnapshot = await eventFeed.$jazz.ensureLoaded({
+        resolve: true,
+        cursor: {
+          useCurrentCursor: true,
+        },
+      });
+
+      expect(() => {
+        eventFeedSnapshot.$jazz.push("event-3");
+      }).toThrowError("Cannot mutate a time travel entity");
+    });
+  });
+
+  test("ensureLoaded() with cursor", async () => {
+    const Person = co.map({
+      name: z.string(),
+      age: z.number(),
+      pet: co.map({ name: z.string() }),
+    });
+
+    const person = Person.create({
+      name: "John",
+      age: 30,
+      pet: { name: "Rex" },
+    });
+
+    const personSnapshot = await person.$jazz.ensureLoaded({
+      resolve: { pet: true },
+      cursor: {
+        useCurrentCursor: true,
+      },
+    });
+
+    person.$jazz.set("name", "Jane");
+    person.pet.$jazz.set("name", "Fido");
+
+    const loadedSnapshot = await person.$jazz.ensureLoaded({
+      resolve: { pet: true },
+      cursor: personSnapshot.$jazz.cursor,
+    });
+
+    expect(loadedSnapshot.name).toBe("John");
+    expect(loadedSnapshot.pet.name).toBe("Rex");
+  });
+
+  describe("load() with cursor and errored descendants", () => {
+    test("keeps missing nested optional values with cursor", async () => {
+      const Pet = co.map({ name: z.string() });
+      const Person = co.map({
+        name: z.string(),
+        pet: co.optional(Pet),
+      });
+
+      const original = Person.create({ name: "John" });
+
+      const loadedOriginal = await Person.load(original.$jazz.id, {
+        resolve: { pet: true },
+      });
+      assertLoaded(loadedOriginal);
+
+      const cursor = loadedOriginal.$jazz.createCursor();
+
+      original.$jazz.applyDiff({
+        name: "John Smith",
+        pet: Pet.create({ name: "Rex" }),
+      });
+
+      const snapshot = await Person.load(original.$jazz.id, {
+        resolve: { pet: true },
+        cursor: cursor,
+      });
+      assertLoaded(snapshot);
+
+      expect(snapshot.pet).toBeUndefined();
+
+      const latest = await Person.load(original.$jazz.id, {
+        resolve: { pet: true },
+      });
+      assertLoaded(latest);
+      expect(latest.pet?.name).toBe("Rex");
+    });
+
+    test("handles nested values without access permissions", async () => {
+      const Secret = co.map({ value: z.string() });
+      const Document = co.map({
+        title: z.string(),
+        secret: co.optional(Secret),
+      });
+
+      const alice = await createJazzTestAccount({
+        creationProps: { name: "Alice" },
+      });
+
+      const secretGroup = Group.create({ owner: alice });
+      const secret = Secret.create(
+        { value: "classified" },
+        { owner: secretGroup },
+      );
+      const original = Document.create({
+        title: "Doc",
+        secret,
+      });
+
+      const loadedOriginal = await Document.load(original.$jazz.id, {
+        resolve: { secret: { $onError: "catch" } },
+      });
+      assertLoaded(loadedOriginal);
+      expect(loadedOriginal.secret?.$jazz.loadingState).toBe(
+        CoValueLoadingState.UNAUTHORIZED,
+      );
+
+      const cursor = loadedOriginal.$jazz.createCursor();
+
+      const snapshot = await Document.load(original.$jazz.id, {
+        resolve: { secret: { $onError: "catch" } },
+        cursor: cursor,
+      });
+      assertLoaded(snapshot);
+
+      expect(snapshot.secret?.$jazz.loadingState).toBe(
+        CoValueLoadingState.UNAUTHORIZED,
+      );
+    });
+
+    test("handles nested values when access is granted after cursor creation", async () => {
+      const Secret = co.map({ value: z.string() });
+      const Document = co.map({
+        title: z.string(),
+        secret: co.optional(Secret),
+      });
+
+      const alice = await createJazzTestAccount({
+        creationProps: { name: "Alice" },
+      });
+
+      const secretGroup = Group.create({ owner: alice });
+      const secret = Secret.create(
+        { value: "classified" },
+        { owner: secretGroup },
+      );
+      const original = Document.create({
+        title: "Doc",
+        secret,
+      });
+
+      const loadedOriginal = await Document.load(original.$jazz.id, {
+        resolve: { secret: { $onError: "catch" } },
+      });
+      assertLoaded(loadedOriginal);
+      expect(loadedOriginal.secret?.$jazz.loadingState).toBe(
+        CoValueLoadingState.UNAUTHORIZED,
+      );
+
+      const cursor = loadedOriginal.$jazz.createCursor();
+
+      secretGroup.addMember(me, "reader");
+
+      const snapshot = await Document.load(original.$jazz.id, {
+        resolve: { secret: { $onError: "catch" } },
+        cursor: cursor,
+      });
+      assertLoaded(snapshot);
+
+      expect(snapshot.secret?.$jazz.loadingState).toBe(
+        CoValueLoadingState.UNAUTHORIZED,
+      );
+
+      const latest = await Document.load(original.$jazz.id, {
+        resolve: { secret: { $onError: "catch" } },
+      });
+      assertLoaded(latest);
+      expect(latest.secret?.$jazz.loadingState).toBe(
+        CoValueLoadingState.LOADED,
+      );
+    });
+
+    test("handles nested values when access is removed after cursor creation", async () => {
+      const Secret = co.map({ value: z.string() });
+      const Document = co.map({
+        title: z.string(),
+        secret: co.optional(Secret),
+      });
+
+      const alice = await createJazzTestAccount({
+        creationProps: { name: "Alice" },
+      });
+
+      const secretGroup = Group.create({ owner: alice });
+      secretGroup.addMember(me, "reader");
+
+      const secret = Secret.create(
+        { value: "classified" },
+        { owner: secretGroup },
+      );
+      const original = Document.create({
+        title: "Doc",
+        secret,
+      });
+
+      const loadedOriginal = await Document.load(original.$jazz.id, {
+        resolve: { secret: { $onError: "catch" } },
+      });
+      assertLoaded(loadedOriginal);
+      expect(loadedOriginal.secret?.$jazz.loadingState).toBe(
+        CoValueLoadingState.LOADED,
+      );
+
+      const cursor = loadedOriginal.$jazz.createCursor();
+
+      secretGroup.removeMember(me);
+
+      const snapshot = await Document.load(original.$jazz.id, {
+        resolve: { secret: { $onError: "catch" } },
+        cursor: cursor,
+      });
+      assertLoaded(snapshot);
+
+      expect(snapshot.secret?.$jazz.loadingState).toBe(
+        CoValueLoadingState.LOADED,
+      );
+
+      const latest = await Document.load(original.$jazz.id, {
+        resolve: { secret: { $onError: "catch" } },
+      });
+      assertLoaded(latest);
+      expect(latest.secret?.$jazz.loadingState).toBe(
+        CoValueLoadingState.UNAUTHORIZED,
+      );
+    });
+  });
+});

--- a/packages/jazz-tools/src/tools/tests/cursor.test.ts
+++ b/packages/jazz-tools/src/tools/tests/cursor.test.ts
@@ -1,0 +1,206 @@
+import { describe, expect, it } from "vitest";
+import {
+  CursorError,
+  decodeAndValidateCursor,
+  encodeCursor,
+} from "../subscribe/cursor.js";
+import type {
+  CoValueCursor,
+  DecodedCoValueCursor,
+} from "../subscribe/types.js";
+import { type SessionID } from "cojson";
+
+const rootId = "co_zRoot";
+const sessionA = "sessionA" as SessionID;
+const sessionB = "sessionB" as SessionID;
+
+const buildCursor = (
+  overrides: Partial<DecodedCoValueCursor> = {},
+): DecodedCoValueCursor => ({
+  version: 1,
+  rootId,
+  resolveFingerprint: {},
+  frontiers: {
+    co_zRoot: {
+      [sessionA]: 1,
+    },
+  },
+  ...overrides,
+});
+
+describe("`encodeCursor` and `decodeAndValidateCursor`", () => {
+  it("encodes with the cursor_z prefix", () => {
+    const encoded = encodeCursor(buildCursor());
+
+    expect(encoded.startsWith("cursor_z")).toBe(true);
+  });
+
+  it("roundtrips a valid cursor", () => {
+    const decodedCursor = buildCursor({
+      resolveFingerprint: { profile: { name: true }, friends: { $each: true } },
+      frontiers: {
+        co_zRoot: { [sessionA]: 3, [sessionB]: 9 },
+        co_zChild: { [sessionA]: 1 },
+      },
+    });
+    const encoded = encodeCursor(decodedCursor);
+
+    const decoded = decodeAndValidateCursor({
+      cursor: encoded,
+      rootId,
+      resolve: decodedCursor.resolveFingerprint,
+    });
+
+    expect(decoded).toEqual(decodedCursor);
+  });
+
+  it("produces identical cursors for equivalent resolve/frontier data regardless of key ordering", () => {
+    const firstCursor = buildCursor({
+      resolveFingerprint: {
+        profile: { name: true, email: true },
+        friends: { $each: true },
+      },
+      frontiers: {
+        co_zRoot: { [sessionA]: 3, [sessionB]: 9 },
+        co_zChild: { [sessionA]: 1, [sessionB]: 2 },
+      },
+    });
+
+    const sameDataDifferentOrder = buildCursor({
+      resolveFingerprint: {
+        friends: { $each: true },
+        profile: { email: true, name: true },
+      },
+      frontiers: {
+        co_zChild: { [sessionB]: 2, [sessionA]: 1 },
+        co_zRoot: { [sessionB]: 9, [sessionA]: 3 },
+      },
+    });
+
+    expect(encodeCursor(firstCursor)).toBe(
+      encodeCursor(sameDataDifferentOrder),
+    );
+  });
+
+  it("normalizes cursor payloads with extra top-level properties when decoded and re-encoded", () => {
+    const cursorWithExtraProperty: DecodedCoValueCursor & {
+      extraMetadata: string;
+    } = {
+      version: 1,
+      rootId,
+      resolveFingerprint: {
+        profile: { name: true, email: true },
+        friends: { $each: true },
+      },
+      frontiers: {
+        co_zChild: { [sessionB]: 2, [sessionA]: 1 },
+        co_zRoot: { [sessionB]: 9, [sessionA]: 3 },
+      },
+      extraMetadata: "should-be-stripped",
+    };
+
+    const encodedWithExtraProperty = encodeCursor(cursorWithExtraProperty);
+
+    const decoded = decodeAndValidateCursor({
+      cursor: encodedWithExtraProperty,
+      rootId,
+      resolve: {
+        friends: { $each: true },
+        profile: { email: true, name: true },
+      },
+    });
+
+    const canonicalExpected = buildCursor({
+      resolveFingerprint: {
+        profile: { name: true, email: true },
+        friends: { $each: true },
+      },
+      frontiers: {
+        co_zRoot: { [sessionA]: 3, [sessionB]: 9 },
+        co_zChild: { [sessionA]: 1, [sessionB]: 2 },
+      },
+    });
+
+    expect(decoded).toEqual(canonicalExpected);
+    expect(encodeCursor(decoded)).toBe(encodeCursor(canonicalExpected));
+  });
+
+  it("accepts resolve=true when cursor resolveFingerprint is {}", () => {
+    const decodedCursor = buildCursor({ resolveFingerprint: {} });
+    const encoded = encodeCursor(decodedCursor);
+
+    const decoded = decodeAndValidateCursor({
+      cursor: encoded,
+      rootId,
+      resolve: true,
+    });
+
+    expect(decoded).toEqual(decodedCursor);
+  });
+
+  it("throws CursorError when root CoValue ID does not match", () => {
+    const encoded = encodeCursor(buildCursor());
+
+    expect(() =>
+      decodeAndValidateCursor({
+        cursor: encoded,
+        rootId: "co_zDifferentRoot",
+        resolve: {},
+      }),
+    ).toThrowError(CursorError);
+    expect(() =>
+      decodeAndValidateCursor({
+        cursor: encoded,
+        rootId: "co_zDifferentRoot",
+        resolve: {},
+      }),
+    ).toThrowError("Invalid cursor: root CoValue ID mismatch");
+  });
+
+  it("throws CursorError when resolve query does not match", () => {
+    const decodedCursor = buildCursor({
+      resolveFingerprint: { profile: { name: true } },
+    });
+    const encoded = encodeCursor(decodedCursor);
+
+    expect(() =>
+      decodeAndValidateCursor({
+        cursor: encoded,
+        rootId,
+        resolve: { profile: { email: true } },
+      }),
+    ).toThrowError(
+      new CursorError(
+        'Invalid cursor: resolve query mismatch. Expected {"profile":{"email":true}}, got cursor with {"profile":{"name":true}}',
+      ),
+    );
+  });
+
+  it("throws CursorError when decoded payload does not match schema", () => {
+    const invalidCursor: CoValueCursor = encodeCursor({
+      // @ts-expect-error invalid version
+      version: 2,
+      rootId,
+      resolveFingerprint: {},
+      frontiers: {},
+    });
+
+    expect(() =>
+      decodeAndValidateCursor({
+        cursor: invalidCursor,
+        rootId,
+        resolve: {},
+      }),
+    ).toThrowError(new CursorError("Invalid cursor string"));
+  });
+
+  it("throws when cursor cannot be decoded as JSON", () => {
+    expect(() =>
+      decodeAndValidateCursor({
+        cursor: "cursor_z3",
+        rootId,
+        resolve: {},
+      }),
+    ).toThrowError(new CursorError("Invalid cursor string"));
+  });
+});

--- a/packages/jazz-tools/src/tools/tests/cursor.test.ts
+++ b/packages/jazz-tools/src/tools/tests/cursor.test.ts
@@ -37,7 +37,7 @@ describe("`encodeCursor` and `decodeAndValidateCursor`", () => {
 
   it("roundtrips a valid cursor", () => {
     const decodedCursor = buildCursor({
-      resolveFingerprint: { profile: { name: true }, friends: { $each: true } },
+      resolveFingerprint: { profile: { name: {} }, friends: { $each: {} } },
       frontiers: {
         co_zRoot: { [sessionA]: 3, [sessionB]: 9 },
         co_zChild: { [sessionA]: 1 },
@@ -112,8 +112,8 @@ describe("`encodeCursor` and `decodeAndValidateCursor`", () => {
 
     const canonicalExpected = buildCursor({
       resolveFingerprint: {
-        profile: { name: true, email: true },
-        friends: { $each: true },
+        profile: { name: {}, email: {} },
+        friends: { $each: {} },
       },
       frontiers: {
         co_zRoot: { [sessionA]: 3, [sessionB]: 9 },
@@ -140,7 +140,22 @@ describe("`encodeCursor` and `decodeAndValidateCursor`", () => {
 
   it("accepts resolve as subset of cursor resolveFingerprint", () => {
     const decodedCursor = buildCursor({
-      resolveFingerprint: { pet: true, friends: true },
+      resolveFingerprint: { pet: {}, friends: {} },
+    });
+    const encoded = encodeCursor(decodedCursor);
+
+    const decoded = decodeAndValidateCursor({
+      cursor: encoded,
+      rootId,
+      resolve: { pet: true },
+    });
+
+    expect(decoded).toEqual(decodedCursor);
+  });
+
+  it("accepts deep `true` in resolve as subset of cursor resolveFingerprint", () => {
+    const decodedCursor = buildCursor({
+      resolveFingerprint: { pet: { animalFriends: {} }, friends: {} },
     });
     const encoded = encodeCursor(decodedCursor);
 
@@ -186,7 +201,7 @@ describe("`encodeCursor` and `decodeAndValidateCursor`", () => {
       }),
     ).toThrowError(
       new CursorError(
-        'Invalid cursor: resolve query mismatch. Expected {"profile":{"email":true}} to be a subset of {"profile":{"name":true}}',
+        'Invalid cursor: resolve query mismatch. Expected {"profile":{"email":{}}} to be a subset of {"profile":{"name":{}}}',
       ),
     );
   });
@@ -205,7 +220,7 @@ describe("`encodeCursor` and `decodeAndValidateCursor`", () => {
       }),
     ).toThrowError(
       new CursorError(
-        'Invalid cursor: resolve query mismatch. Expected {"profile":{"name":true,"email":true}} to be a subset of {"profile":{"name":true}}',
+        'Invalid cursor: resolve query mismatch. Expected {"profile":{"name":{},"email":{}}} to be a subset of {"profile":{"name":{}}}',
       ),
     );
   });

--- a/packages/jazz-tools/src/tools/tests/cursor.test.ts
+++ b/packages/jazz-tools/src/tools/tests/cursor.test.ts
@@ -138,6 +138,21 @@ describe("`encodeCursor` and `decodeAndValidateCursor`", () => {
     expect(decoded).toEqual(decodedCursor);
   });
 
+  it("accepts resolve as subset of cursor resolveFingerprint", () => {
+    const decodedCursor = buildCursor({
+      resolveFingerprint: { pet: true, friends: true },
+    });
+    const encoded = encodeCursor(decodedCursor);
+
+    const decoded = decodeAndValidateCursor({
+      cursor: encoded,
+      rootId,
+      resolve: { pet: true },
+    });
+
+    expect(decoded).toEqual(decodedCursor);
+  });
+
   it("throws CursorError when root CoValue ID does not match", () => {
     const encoded = encodeCursor(buildCursor());
 
@@ -171,7 +186,26 @@ describe("`encodeCursor` and `decodeAndValidateCursor`", () => {
       }),
     ).toThrowError(
       new CursorError(
-        'Invalid cursor: resolve query mismatch. Expected {"profile":{"email":true}}, got cursor with {"profile":{"name":true}}',
+        'Invalid cursor: resolve query mismatch. Expected {"profile":{"email":true}} to be a subset of {"profile":{"name":true}}',
+      ),
+    );
+  });
+
+  it("throws CursorError when resolve query is a superset of the cursor resolveFingerprint", () => {
+    const decodedCursor = buildCursor({
+      resolveFingerprint: { profile: { name: true } },
+    });
+    const encoded = encodeCursor(decodedCursor);
+
+    expect(() =>
+      decodeAndValidateCursor({
+        cursor: encoded,
+        rootId,
+        resolve: { profile: { name: true, email: true } },
+      }),
+    ).toThrowError(
+      new CursorError(
+        'Invalid cursor: resolve query mismatch. Expected {"profile":{"name":true,"email":true}} to be a subset of {"profile":{"name":true}}',
       ),
     );
   });


### PR DESCRIPTION
A couple of divergences from from spec in #3504 

- Children error loading states are stored in the cursor to ensure we can replay the same exact state at the time of cursor creation.
- The recommended method to create a cursor for a CoValue is to load it with `{ cursor: { useCurrentCursor: true } }`. This will load the current state of the value, create a cursor, and then return the same value loaded (and as a result frozen) with that same cursor. This ensures we do not encounter any race conditions if a CoValue is changed after the cursor is created.

From the spec:
```ts
const tasks = await TaskList.load(listId, { resolve: { $each: true } });
for (const task of tasks ?? []) {
  const id = await insert(db, {
    title: task.title ?? "",
    body: task.body ?? "",
  });
  oramaIds.set(task.id, id);
}

// if anything changes between the above and below lines, these changes would not be captured by the index

// Snapshot the current frontier so incremental indexing
// only replays changes made after this point.
const cursor = await currentCursor(TaskList, listId, {
  resolve: { $each: true },
});
```

A more serious case:
```ts
const product = await Product.load(productId);
const price = product.price * (1 + product.taxes);

const cursor = await currentCursor(Product, productId, {
  resolve: true,
});

// at a later time
const product = await Product.load(productId, {
  cursor,
});

// not guaranteed to match the above price
const price = product.price * (1 + product.taxes);
```

With the change:
```ts
const tasks = await TaskList.load(listId, {
  resolve: { $each: true },
  cursor: { useCurrentCursor: true },
});

for (const task of tasks ?? []) {
  const id = await insert(db, {
    title: task.title ?? "",
    body: task.body ?? "",
  });
  oramaIds.set(task.id, id);
}

// this cursor is guaranteed to be consistent with the state of `tasks`
const cursor = tasks.$jazz.cursor;
```

A cursor can still be created using `.$jazz.createCursor()` in case this consistency is not needed