### PR TITLE
Fix InvalidSignature errors from storage when concurrent writer is active

### DIFF
--- a/.changeset/concurrent-writer-fix.md
+++ b/.changeset/concurrent-writer-fix.md
@@ -1,0 +1,15 @@
+---
+"cojson": patch
+---
+
+Fix InvalidSignature errors when loading from storage with a concurrent writer
+
+The storage load path read session metadata and transaction rows in separate
+non-transactional queries. The transaction query used `idx <= lastIdx` where
+`lastIdx` is a count, not an index. When a concurrent writer committed a new
+transaction at that index between the two reads, the query picked up the extra
+row and paired it with a signature that didn't cover it.
+
+Convert `lastIdx` to an index (`lastIdx - 1`) so the query matches the
+convention used by `signatureAfter` entries. This ensures a stale session read
+never overshoots the signature boundary, even under concurrent writes.

--- a/packages/cojson/src/storage/storageAsync.ts
+++ b/packages/cojson/src/storage/storageAsync.ts
@@ -182,7 +182,7 @@ export class StorageApiAsync implements StorageAPI {
 
       if (lastSignature?.signature !== sessionRow.lastSignature) {
         signatures.push({
-          idx: sessionRow.lastIdx,
+          idx: sessionRow.lastIdx - 1,
           signature: sessionRow.lastSignature,
         });
       }

--- a/packages/cojson/src/storage/storageSync.ts
+++ b/packages/cojson/src/storage/storageSync.ts
@@ -154,7 +154,7 @@ export class StorageApiSync implements StorageAPI {
 
       if (lastSignature?.signature !== sessionRow.lastSignature) {
         signatures.push({
-          idx: sessionRow.lastIdx,
+          idx: sessionRow.lastIdx - 1,
           signature: sessionRow.lastSignature,
         });
       }

--- a/packages/cojson/src/tests/sync.storageAsync.test.ts
+++ b/packages/cojson/src/tests/sync.storageAsync.test.ts
@@ -1,4 +1,5 @@
 import { assert, beforeEach, describe, expect, test, vi } from "vitest";
+import Database from "libsql";
 
 import { emptyKnownState } from "../exports";
 import {
@@ -747,5 +748,176 @@ describe("client syncs with a server with storage", () => {
         "bob -> server | KNOWN Map sessions: header/1",
       ]
     `);
+  });
+
+  test("TOCTOU: extra transaction at idx=lastIdx does not cause InvalidSignature", async () => {
+    // loadCoValue reads session metadata (lastIdx, lastSignature) and
+    // transaction rows in separate non-transactional queries. The
+    // transaction query uses `idx <= lastIdx` where lastIdx is a COUNT.
+    // If a concurrent writer inserts a transaction at idx=lastIdx
+    // between the two reads, the query picks up the extra row and
+    // pairs it with a signature that doesn't cover it.
+
+    const dbPath = getDbPath();
+
+    const node1 = setupTestNode();
+    node1.connectToSyncServer();
+    await node1.addAsyncStorage({ ourName: "node1", filename: dbPath });
+
+    const group = jazzCloud.node.createGroup();
+    const map = group.createMap();
+    map.set("a", "1", "trusting");
+    map.set("b", "2", "trusting");
+    map.set("c", "3", "trusting");
+
+    const mapOnNode1 = await loadCoValueOrFail(node1.node, map.id);
+    await mapOnNode1.core.waitForSync();
+    await node1.node.gracefulShutdown();
+
+    // Inject a transaction at idx = lastIdx via raw SQL, simulating
+    // what the concurrent writer would have committed between the
+    // two non-transactional reads in loadCoValue.
+    const rawDb = new Database(dbPath);
+    rawDb.pragma("journal_mode = WAL");
+
+    const coValueRow = rawDb
+      .prepare("SELECT rowID FROM coValues WHERE id = ?")
+      .get(map.id) as { rowID: number };
+    assert(coValueRow, "CoValue not found in storage");
+
+    const sessions = rawDb
+      .prepare(
+        "SELECT rowID, lastIdx FROM sessions WHERE coValue = ?",
+      )
+      .all(coValueRow.rowID) as { rowID: number; lastIdx: number }[];
+
+    const targetSession = sessions.find((s) => s.lastIdx > 0);
+    assert(targetSession, "No session with transactions");
+
+    const existingTx = rawDb
+      .prepare("SELECT tx FROM transactions WHERE ses = ? AND idx = 0")
+      .get(targetSession.rowID) as { tx: string };
+
+    // Insert at idx = lastIdx (the off-by-one the <= query exposes)
+    rawDb
+      .prepare("INSERT INTO transactions (ses, idx, tx) VALUES (?, ?, ?)")
+      .run(targetSession.rowID, targetSession.lastIdx, existingTx.tx);
+    rawDb.close();
+
+    const consoleErrorSpy = vi.spyOn(console, "error");
+
+    const node2 = setupTestNode();
+    node2.connectToSyncServer();
+    await node2.addAsyncStorage({ ourName: "node2", filename: dbPath });
+
+    await loadCoValueOrFail(node2.node, map.id);
+
+    const signatureErrors = consoleErrorSpy.mock.calls.filter(
+      ([msg]) =>
+        typeof msg === "string" &&
+        msg.includes("Failed to add transactions"),
+    );
+
+    expect(signatureErrors).toEqual([]);
+    consoleErrorSpy.mockRestore();
+  });
+
+  test("TOCTOU: concurrent write between getCoValueSessions and getNewTransactionInSession does not cause InvalidSignature", async () => {
+    // Simulates the async gap in expo-sqlite by intercepting the
+    // storage client: after getCoValueSessions returns session
+    // metadata, a concurrent writer inserts a new transaction at
+    // idx=lastIdx before getNewTransactionInSession runs.
+
+    const dbPath = getDbPath();
+
+    const node1 = setupTestNode();
+    node1.connectToSyncServer();
+    await node1.addAsyncStorage({ ourName: "node1", filename: dbPath });
+
+    const group = jazzCloud.node.createGroup();
+    const map = group.createMap();
+    map.set("a", "1", "trusting");
+    map.set("b", "2", "trusting");
+
+    const mapOnNode1 = await loadCoValueOrFail(node1.node, map.id);
+    await mapOnNode1.core.waitForSync();
+    await node1.node.gracefulShutdown();
+
+    // Prepare the concurrent write payload: read the session state
+    // so we know what index to insert at.
+    const rawDb = new Database(dbPath);
+    rawDb.pragma("journal_mode = WAL");
+
+    const coValueRow = rawDb
+      .prepare("SELECT rowID FROM coValues WHERE id = ?")
+      .get(map.id) as { rowID: number };
+    assert(coValueRow, "CoValue not found");
+
+    const sessions = rawDb
+      .prepare(
+        "SELECT rowID, lastIdx FROM sessions WHERE coValue = ?",
+      )
+      .all(coValueRow.rowID) as { rowID: number; lastIdx: number }[];
+
+    const targetSession = sessions.find((s) => s.lastIdx > 0);
+    assert(targetSession, "No session with transactions");
+
+    // Grab an existing transaction as a template
+    const existingTx = rawDb
+      .prepare("SELECT tx FROM transactions WHERE ses = ? AND idx = 0")
+      .get(targetSession.rowID) as { tx: string };
+    rawDb.close();
+
+    // Create the loading node with a patched storage client
+    const consoleErrorSpy = vi.spyOn(console, "error");
+
+    const node2 = setupTestNode();
+    node2.connectToSyncServer();
+    const { storage } = await node2.addAsyncStorage({
+      ourName: "node2",
+      filename: dbPath,
+    });
+
+    // Patch getNewTransactionInSession to inject a concurrent write
+    // in the gap — this is exactly what happens with expo-sqlite's
+    // truly async native bridge between the two non-transactional reads.
+    const dbClient = (storage as any).dbClient;
+    const original = dbClient.getNewTransactionInSession.bind(dbClient);
+    let injected = false;
+
+    dbClient.getNewTransactionInSession = async (
+      sessionRowId: number,
+      fromIdx: number,
+      toIdx: number,
+    ) => {
+      if (!injected && sessionRowId === targetSession.rowID) {
+        injected = true;
+
+        // Simulate concurrent writer committing a new transaction
+        // at idx = lastIdx (the session count). The session metadata
+        // was already read by getCoValueSessions with the old lastIdx,
+        // but this INSERT lands before the transaction query runs.
+        const writer = new Database(dbPath);
+        writer.pragma("journal_mode = WAL");
+        writer
+          .prepare(
+            "INSERT INTO transactions (ses, idx, tx) VALUES (?, ?, ?)",
+          )
+          .run(targetSession.rowID, targetSession.lastIdx, existingTx.tx);
+        writer.close();
+      }
+      return original(sessionRowId, fromIdx, toIdx);
+    };
+
+    await loadCoValueOrFail(node2.node, map.id);
+
+    const signatureErrors = consoleErrorSpy.mock.calls.filter(
+      ([msg]) =>
+        typeof msg === "string" &&
+        msg.includes("Failed to add transactions"),
+    );
+
+    expect(signatureErrors).toEqual([]);
+    consoleErrorSpy.mockRestore();
   });
 });

--- a/packages/cojson/src/tests/sync.storageAsync.test.ts
+++ b/packages/cojson/src/tests/sync.storageAsync.test.ts
@@ -786,9 +786,7 @@ describe("client syncs with a server with storage", () => {
     assert(coValueRow, "CoValue not found in storage");
 
     const sessions = rawDb
-      .prepare(
-        "SELECT rowID, lastIdx FROM sessions WHERE coValue = ?",
-      )
+      .prepare("SELECT rowID, lastIdx FROM sessions WHERE coValue = ?")
       .all(coValueRow.rowID) as { rowID: number; lastIdx: number }[];
 
     const targetSession = sessions.find((s) => s.lastIdx > 0);
@@ -814,8 +812,7 @@ describe("client syncs with a server with storage", () => {
 
     const signatureErrors = consoleErrorSpy.mock.calls.filter(
       ([msg]) =>
-        typeof msg === "string" &&
-        msg.includes("Failed to add transactions"),
+        typeof msg === "string" && msg.includes("Failed to add transactions"),
     );
 
     expect(signatureErrors).toEqual([]);
@@ -854,9 +851,7 @@ describe("client syncs with a server with storage", () => {
     assert(coValueRow, "CoValue not found");
 
     const sessions = rawDb
-      .prepare(
-        "SELECT rowID, lastIdx FROM sessions WHERE coValue = ?",
-      )
+      .prepare("SELECT rowID, lastIdx FROM sessions WHERE coValue = ?")
       .all(coValueRow.rowID) as { rowID: number; lastIdx: number }[];
 
     const targetSession = sessions.find((s) => s.lastIdx > 0);
@@ -900,9 +895,7 @@ describe("client syncs with a server with storage", () => {
         const writer = new Database(dbPath);
         writer.pragma("journal_mode = WAL");
         writer
-          .prepare(
-            "INSERT INTO transactions (ses, idx, tx) VALUES (?, ?, ?)",
-          )
+          .prepare("INSERT INTO transactions (ses, idx, tx) VALUES (?, ?, ?)")
           .run(targetSession.rowID, targetSession.lastIdx, existingTx.tx);
         writer.close();
       }
@@ -913,8 +906,7 @@ describe("client syncs with a server with storage", () => {
 
     const signatureErrors = consoleErrorSpy.mock.calls.filter(
       ([msg]) =>
-        typeof msg === "string" &&
-        msg.includes("Failed to add transactions"),
+        typeof msg === "string" && msg.includes("Failed to add transactions"),
     );
 
     expect(signatureErrors).toEqual([]);


### PR DESCRIPTION
## Summary

- Fixes `"Failed to add transactions from storage: invalid signature"` errors observed on Expo/Android with Clerk auth
- Root cause: `loadCoValue` reads session metadata and transaction rows in separate non-transactional queries, and the transaction query uses `idx <= lastIdx` where `lastIdx` is a count (not an index) — a concurrent writer inserting at that index between the two reads causes the query to pick up an extra transaction not covered by the signature
- Fix: convert `lastIdx` to an index (`lastIdx - 1`) when building the final signatures array entry, matching the convention already used by `signatureAfter` entries

## How the bug manifests

On Expo/Android with Clerk auth, a race condition creates two `LocalNode`s sharing the same SQLite database. With expo-sqlite's truly async native bridge, each `await` in `loadCoValue` yields the JS event loop, giving the first node's sync writes a chance to commit between the second node's reads:

1. `getCoValueSessions` reads `lastIdx=3, lastSignature=S₃`
2. Concurrent writer commits: `lastIdx=5, lastSignature=S₅`, inserts T₃ and T₄
3. `getNewTransactionInSession(ses, 0, 3)` queries `idx <= 3` → returns 4 transactions (T₀–T₃)
4. Content message pairs 4 transactions with S₃ (which covers 3) → `InvalidSignature`

## Why we fix the storage layer, not the Clerk race

The two-`LocalNode` situation is triggered by the Clerk auth listener firing before the initial context creation completes. Suppressing that listener isn't viable — Clerk is an external auth provider and the listener is the mechanism by which Jazz learns about authentication state changes. We can't know whether a session is authenticated until the token is validated, so we can't safely skip the listener's first call.

Instead, this PR makes the storage layer resilient to concurrent writers regardless of what creates them. Stale session metadata now produces a consistent (if slightly behind) read rather than an invalid one — the excluded transactions are picked up shortly after via the sync server or a subsequent storage load.

## Test plan

- [ ] Two regression tests in `sync.storageAsync.test.ts` that reproduce the TOCTOU state — both by injecting a rogue row at `idx=lastIdx` and by patching `getNewTransactionInSession` to simulate a concurrent write in the async gap
- [ ] Full cojson test suite passes (1352 tests), including existing "storing stale data should not compromise the signatures" tests
- [ ] Verify on Android emulator with Clerk auth that the signature errors no longer appear