### PR TITLE
fix: SQLite transaction errors during storage reconciliation on expo-sqlite

### DIFF
--- a/.changeset/heavy-moons-repair.md
+++ b/.changeset/heavy-moons-repair.md
@@ -1,0 +1,5 @@
+---
+"cojson": patch
+---
+
+Recover from partially-written storage rows in async SQLite storage. Interrupted write transactions could leave orphan `transactions`/`signatureAfter` rows that made every subsequent store of the same session fail with "UNIQUE constraint failed: transactions.ses, transactions.idx"; those rows are now overwritten instead.

--- a/.changeset/spicy-pandas-refuse.md
+++ b/.changeset/spicy-pandas-refuse.md
@@ -1,0 +1,5 @@
+---
+"jazz-tools": patch
+---
+
+Serialize Expo SQLite transactions at the connection level. The adapter is shared across providers/contexts, so concurrent storage clients could nest `BEGIN` statements on the same connection, causing "cannot start a transaction within a transaction" and "cannot rollback - no transaction is active" errors during storage reconciliation.

--- a/packages/cojson/src/storage/sqliteAsync/client.ts
+++ b/packages/cojson/src/storage/sqliteAsync/client.ts
@@ -96,10 +96,12 @@ export class SQLiteTransactionAsync implements DBTransactionInterfaceAsync {
     newTransaction: Transaction,
   ): Promise<void> {
     // An interrupted write transaction (e.g. a concurrent ROLLBACK on a shared
-    // connection) can leave orphan rows with idx >= the session's lastIdx.
-    // A session's transaction at a given idx is canonical, so overwriting is
-    // safe and lets the session recover instead of failing on the primary key
-    // forever.
+    // connection) can leave orphan rows at idx >= the session's lastIdx, which
+    // would otherwise block the session on this primary key forever.
+    // Overwriting is safe: writes always start at the committed lastIdx (see
+    // putNewTxs), so a conflicting row is never covered by any stored
+    // signature, and the verified replacement commits atomically with the
+    // session row and signature that cover it.
     await this.tx.run(
       `INSERT INTO transactions (ses, idx, tx) VALUES (?, ?, ?)
        ON CONFLICT(ses, idx) DO UPDATE SET tx=excluded.tx`,
@@ -116,9 +118,12 @@ export class SQLiteTransactionAsync implements DBTransactionInterfaceAsync {
     idx: number;
     signature: Signature;
   }): Promise<void> {
-    // Same recovery rationale as addTransaction: the signature at a given
-    // (ses, idx) is canonical, so overwrite orphan rows left by interrupted
-    // write transactions.
+    // Same recovery rationale as addTransaction: a conflict can only be an
+    // orphan row left by an interrupted write transaction, and the verified
+    // replacement commits atomically with the matching session update.
+    // Orphan signature rows are worse than orphan transactions: loadCoValue
+    // reads all signatureAfter rows unbounded by lastIdx, so an orphan here
+    // is served to readers until it is overwritten.
     await this.tx.run(
       `INSERT INTO signatureAfter (ses, idx, signature) VALUES (?, ?, ?)
        ON CONFLICT(ses, idx) DO UPDATE SET signature=excluded.signature`,

--- a/packages/cojson/src/storage/sqliteAsync/client.ts
+++ b/packages/cojson/src/storage/sqliteAsync/client.ts
@@ -95,8 +95,14 @@ export class SQLiteTransactionAsync implements DBTransactionInterfaceAsync {
     nextIdx: number,
     newTransaction: Transaction,
   ): Promise<void> {
+    // An interrupted write transaction (e.g. a concurrent ROLLBACK on a shared
+    // connection) can leave orphan rows with idx >= the session's lastIdx.
+    // A session's transaction at a given idx is canonical, so overwriting is
+    // safe and lets the session recover instead of failing on the primary key
+    // forever.
     await this.tx.run(
-      "INSERT INTO transactions (ses, idx, tx) VALUES (?, ?, ?)",
+      `INSERT INTO transactions (ses, idx, tx) VALUES (?, ?, ?)
+       ON CONFLICT(ses, idx) DO UPDATE SET tx=excluded.tx`,
       [sessionRowID, nextIdx, JSON.stringify(newTransaction)],
     );
   }
@@ -110,8 +116,12 @@ export class SQLiteTransactionAsync implements DBTransactionInterfaceAsync {
     idx: number;
     signature: Signature;
   }): Promise<void> {
+    // Same recovery rationale as addTransaction: the signature at a given
+    // (ses, idx) is canonical, so overwrite orphan rows left by interrupted
+    // write transactions.
     await this.tx.run(
-      "INSERT INTO signatureAfter (ses, idx, signature) VALUES (?, ?, ?)",
+      `INSERT INTO signatureAfter (ses, idx, signature) VALUES (?, ?, ?)
+       ON CONFLICT(ses, idx) DO UPDATE SET signature=excluded.signature`,
       [sessionRowID, idx, signature],
     );
   }

--- a/packages/cojson/src/tests/SQLiteClientAsync.test.ts
+++ b/packages/cojson/src/tests/SQLiteClientAsync.test.ts
@@ -2,6 +2,15 @@ import { beforeEach, describe, expect, test } from "vitest";
 import { getDbPath } from "./testStorage.js";
 import { setupTestNode } from "./testUtils.js";
 import { DBClientInterfaceAsync } from "../exports.js";
+import type { Transaction } from "../coValueCore/verifiedState.js";
+
+function makeTrustingTransaction(changes: string) {
+  return {
+    privacy: "trusting",
+    madeAt: 0,
+    changes,
+  } as unknown as Transaction;
+}
 
 describe("SQLiteClientAsync", () => {
   describe("transaction", () => {
@@ -50,18 +59,12 @@ describe("SQLiteClientAsync", () => {
           signature: `signature_z0`,
         });
       });
-      // Second transaction fails (duplicate primary key)
+      // Second transaction fails
       await expect(
-        dbClient.transaction(async (tx) => {
-          return tx.addSignatureAfter({
-            sessionRowID: 0,
-            idx: 0,
-            signature: `signature_z0`,
-          });
+        dbClient.transaction(async () => {
+          throw new Error("transaction failed");
         }),
-      ).rejects.toThrow(
-        /UNIQUE constraint failed: signatureAfter\.ses, signatureAfter\.idx/,
-      );
+      ).rejects.toThrow("transaction failed");
       // Third transaction succeeds
       await dbClient.transaction(async (tx) => {
         return tx.addSignatureAfter({
@@ -70,6 +73,48 @@ describe("SQLiteClientAsync", () => {
           signature: `signature_z1`,
         });
       });
+    });
+
+    test("addTransaction overwrites an orphan row at the same (ses, idx)", async () => {
+      // Simulates a row left behind by an interrupted write transaction:
+      // the session row was rolled back but the transaction row persisted.
+      await dbClient.transaction(async (tx) => {
+        return tx.addTransaction(1, 0, makeTrustingTransaction("orphan"));
+      });
+
+      await expect(
+        dbClient.transaction(async (tx) => {
+          return tx.addTransaction(1, 0, makeTrustingTransaction("recovered"));
+        }),
+      ).resolves.not.toThrow();
+
+      const txs = await dbClient.getNewTransactionInSession(1, 0, 0);
+      expect(txs).toHaveLength(1);
+      expect(txs[0]?.tx).toEqual(makeTrustingTransaction("recovered"));
+    });
+
+    test("addSignatureAfter overwrites an orphan row at the same (ses, idx)", async () => {
+      await dbClient.transaction(async (tx) => {
+        return tx.addSignatureAfter({
+          sessionRowID: 1,
+          idx: 0,
+          signature: "signature_zorphan",
+        });
+      });
+
+      await expect(
+        dbClient.transaction(async (tx) => {
+          return tx.addSignatureAfter({
+            sessionRowID: 1,
+            idx: 0,
+            signature: "signature_zrecovered",
+          });
+        }),
+      ).resolves.not.toThrow();
+
+      const signatures = await dbClient.getSignatures(1, 0);
+      expect(signatures).toHaveLength(1);
+      expect(signatures[0]?.signature).toBe("signature_zrecovered");
     });
   });
 });

--- a/packages/jazz-tools/src/expo/storage/expo-sqlite-adapter.ts
+++ b/packages/jazz-tools/src/expo/storage/expo-sqlite-adapter.ts
@@ -7,6 +7,15 @@ export class ExpoSQLiteAdapter implements SQLiteDatabaseDriverAsync {
   private db: SQLiteDatabase | null = null;
   private initializing: Promise<SQLiteDatabase> | null = null;
   private dbName: string;
+  /**
+   * Serializes transactions at the connection level. The adapter is shared
+   * across providers/contexts (see `getInstance`), each with its own storage
+   * client and transaction queue, and `withTransactionAsync` is not exclusive:
+   * without serialization here, a second BEGIN on the same connection fails
+   * with "cannot start a transaction within a transaction" and its ROLLBACK
+   * aborts the other caller's active transaction.
+   */
+  private txQueue: Promise<unknown> = Promise.resolve();
 
   static withDB(db: SQLiteDatabase): ExpoSQLiteAdapter {
     const adapter = new ExpoSQLiteAdapter();
@@ -89,14 +98,22 @@ export class ExpoSQLiteAdapter implements SQLiteDatabaseDriverAsync {
     await this.db.runAsync(sql, params?.map((p) => p as SQLiteBindValue) ?? []);
   }
 
-  public async transaction(callback: (tx: ExpoSQLiteAdapter) => unknown) {
-    if (!this.db) {
-      throw new Error("Database not initialized");
-    }
+  public transaction(callback: (tx: ExpoSQLiteAdapter) => unknown) {
+    const run = () => {
+      const db = this.db;
 
-    await this.db.withTransactionAsync(async () => {
-      await callback(ExpoSQLiteAdapter.withDB(this.db!));
-    });
+      if (!db) {
+        throw new Error("Database not initialized");
+      }
+
+      return db.withTransactionAsync(async () => {
+        await callback(ExpoSQLiteAdapter.withDB(db));
+      });
+    };
+
+    const next = this.txQueue.then(run, run);
+    this.txQueue = next;
+    return next;
   }
 
   /**

--- a/packages/jazz-tools/src/expo/tests/expo-sqlite-adapter.test.ts
+++ b/packages/jazz-tools/src/expo/tests/expo-sqlite-adapter.test.ts
@@ -9,6 +9,48 @@ vi.mock("expo-sqlite", () => ({
 
 import { ExpoSQLiteAdapter } from "../storage/expo-sqlite-adapter.js";
 
+/**
+ * Reproduces expo-sqlite's `withTransactionAsync` semantics: transactions are
+ * not exclusive, a nested BEGIN throws, and a failed BEGIN still triggers a
+ * ROLLBACK that aborts whichever transaction is currently active.
+ */
+function createFakeTransactionalDb() {
+  let inTransaction = false;
+
+  const execAsync = vi.fn(async (sql: string) => {
+    if (sql === "BEGIN") {
+      if (inTransaction) {
+        throw new Error("cannot start a transaction within a transaction");
+      }
+      inTransaction = true;
+    } else if (sql === "COMMIT") {
+      if (!inTransaction) {
+        throw new Error("cannot commit - no transaction is active");
+      }
+      inTransaction = false;
+    } else if (sql === "ROLLBACK") {
+      if (!inTransaction) {
+        throw new Error("cannot rollback - no transaction is active");
+      }
+      inTransaction = false;
+    }
+  });
+
+  return {
+    execAsync,
+    async withTransactionAsync(task: () => Promise<void>) {
+      try {
+        await execAsync("BEGIN");
+        await task();
+        await execAsync("COMMIT");
+      } catch (e) {
+        await execAsync("ROLLBACK");
+        throw e;
+      }
+    },
+  };
+}
+
 describe("ExpoSQLiteAdapter", () => {
   describe("getInstance", () => {
     it("returns the same instance for the same database name", async () => {
@@ -36,6 +78,58 @@ describe("ExpoSQLiteAdapter", () => {
 
       // @ts-expect-error - db is private
       expect(adapter1.db?.execAsync).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe("transaction", () => {
+    it("serializes concurrent transactions on the same connection", async () => {
+      const db = createFakeTransactionalDb();
+      const adapter = ExpoSQLiteAdapter.withDB(
+        db as unknown as Parameters<typeof ExpoSQLiteAdapter.withDB>[0],
+      );
+
+      const order: string[] = [];
+
+      // Without serialization, the interleaved BEGINs throw
+      // "cannot start a transaction within a transaction" and the resulting
+      // ROLLBACK aborts the other transaction.
+      await Promise.all(
+        Array.from({ length: 5 }, (_, i) =>
+          adapter.transaction(async () => {
+            order.push(`start-${i}`);
+            // Yield so a concurrent transaction would interleave here
+            await new Promise((resolve) => setTimeout(resolve, (5 - i) * 2));
+            order.push(`end-${i}`);
+          }),
+        ),
+      );
+
+      for (let i = 0; i < 5; i++) {
+        expect(order[i * 2]).toBe(`start-${i}`);
+        expect(order[i * 2 + 1]).toBe(`end-${i}`);
+      }
+    });
+
+    it("keeps processing transactions after one fails", async () => {
+      const db = createFakeTransactionalDb();
+      const adapter = ExpoSQLiteAdapter.withDB(
+        db as unknown as Parameters<typeof ExpoSQLiteAdapter.withDB>[0],
+      );
+
+      const failing = adapter.transaction(async () => {
+        throw new Error("boom");
+      });
+      const succeeding = adapter.transaction(async () => {});
+
+      await expect(failing).rejects.toThrow("boom");
+      await expect(succeeding).resolves.not.toThrow();
+
+      // The failed transaction rolled back exactly once, without touching
+      // the following transaction.
+      const rollbacks = db.execAsync.mock.calls.filter(
+        ([sql]) => sql === "ROLLBACK",
+      );
+      expect(rollbacks).toHaveLength(1);
     });
   });
 });


### PR DESCRIPTION
Fixes https://github.com/garden-co/jazz/issues/1046

## Problem

expo-sqlite's `withTransactionAsync` is not exclusive, and Jazz was serializing transactions per storage client rather than per connection. Since the shared `ExpoSQLiteAdapter` (via `getInstance`) is reused across multiple contexts on the same device — auth transitions, anonymous account migration, multiple providers — several of these contexts can end up issuing transactions on the same underlying connection at once.

When that happens, a second `BEGIN` fails with "cannot start a transaction within a transaction", and expo-sqlite's own catch handler then issues a `ROLLBACK` — which aborts the *other* caller's active transaction ("cannot rollback - no transaction is active"). That mid-flight rollback breaks the atomicity of `storeSingle`, leaving orphan rows with `idx >= ` the session's `lastIdx`. From that point on, every subsequent store for that session fails permanently with `UNIQUE constraint failed: transactions.ses, transactions.idx`.

## Fix

- **Connection-level transaction queue in `ExpoSQLiteAdapter`**: transactions issued against the shared adapter are now serialized at the connection level instead of relying on each storage client to serialize its own calls, so concurrent callers can no longer interleave `BEGIN`/`ROLLBACK` on the same connection.
- **`ON CONFLICT(ses, idx) DO UPDATE` upserts** in `addTransaction` and `addSignatureAfter` of the async SQLite client, so databases that were already corrupted by this bug self-heal instead of failing forever.

### Why the upserts cannot break signature consistency

Session logs are signed, so overwriting rows would be dangerous if it could touch content a stored signature covers. It can't, structurally:

1. **A conflict can only happen outside the signed range.** `putNewTxs` computes its write range inside the same DB transaction from the committed session row: it slices off everything below `lastIdx` and starts inserting exactly at `idx = lastIdx`. Rows at `idx < lastIdx` — the ones covered by `sessions.lastSignature` and `signatureAfter` — are never written at all (this also means a divergent fork of a session is sliced away, as before). A conflict at `idx >= lastIdx` means the row exists but the committed session state says it shouldn't — by definition an orphan no stored signature accounts for.
2. **The signature state commits atomically with the overwritten rows.** `storeSingle` writes the session row (`lastIdx` + `lastSignature`), `signatureAfter`, and the transaction rows in one driver transaction, so there is no window where an overwritten row coexists with a signature computed over the old orphan content.
3. **The replacement content is already signature-verified.** Storage is only fed from the sync manager after per-session verification, so what overwrites the orphan is the verified chain, not raw peer input.

Overwriting orphan `signatureAfter` rows is additionally load-bearing: `loadCoValue` reads *all* signature rows for a session unbounded by `lastIdx`, so an orphan signature row is actually served to readers on load until it is repaired.

The one case the self-heal deliberately does not touch: a hypothetical mismatched row *below* `lastIdx`. That still surfaces as a verification failure at load and gets corrected from peers, exactly as before.

## Testing

- New adapter tests reproduce expo-sqlite's exact `withTransactionAsync` semantics and fail without the connection-level serialization fix.
- New `SQLiteClientAsync` tests cover orphan-row recovery for both `addTransaction` and `addSignatureAfter`.
- Full async storage/reconciliation test suites pass (106 tests).
