### PR TITLE
fix: recover when the browser closes the IndexedDB connection

### DIFF
--- a/.changeset/idb-connection-recovery.md
+++ b/.changeset/idb-connection-recovery.md
@@ -1,0 +1,5 @@
+---
+"cojson-storage-indexeddb": patch
+---
+
+Recover when the browser closes the IndexedDB connection behind our back (tab suspension on iOS/Safari, storage pressure, IndexedDB backend restarts). The connection is now managed by a connection manager that listens for `close`/`versionchange` events and lazily reopens the database, and every storage operation retries once on `InvalidStateError` instead of failing forever. Fixes the cascade of "InvalidStateError: Failed to execute 'transaction' on 'IDBDatabase': The database connection is closing" errors seen in production, after which storage silently stopped persisting for the rest of the session.

--- a/packages/cojson-storage-indexeddb/src/CoJsonIDBTransaction.ts
+++ b/packages/cojson-storage-indexeddb/src/CoJsonIDBTransaction.ts
@@ -24,7 +24,7 @@ export class CoJsonIDBTransaction {
   declare tx: IDBTransaction;
 
   pendingRequests: ((txEntry: this) => void)[] = [];
-  rejectHandlers: (() => void)[] = [];
+  rejectHandlers: ((error: unknown) => void)[] = [];
 
   id = Math.random();
 
@@ -52,7 +52,27 @@ export class CoJsonIDBTransaction {
   }
 
   rollback() {
-    this.tx.abort();
+    try {
+      this.tx.abort();
+    } catch (error) {
+      // The transaction already finished or the connection is gone; aborting
+      // again would throw and mask the error that triggered the rollback
+    }
+  }
+
+  /**
+   * Rejects every queued request so no promise is left pending when the
+   * transaction can't make progress anymore (e.g. the connection was closed).
+   */
+  private failPendingRequests(error: unknown) {
+    this.failed = true;
+    this.pendingRequests = [];
+
+    const handlers = this.rejectHandlers;
+    this.rejectHandlers = [];
+    for (const handler of handlers) {
+      handler(error);
+    }
   }
 
   getObjectStore(name: StoreName) {
@@ -87,13 +107,17 @@ export class CoJsonIDBTransaction {
             resolve(result);
           } catch (error) {
             reject(error);
+            this.failPendingRequests(error);
           }
         });
       });
     }
 
     this.running = true;
-    return handler(this, next);
+    return handler(this, next).catch((error) => {
+      this.failPendingRequests(error);
+      throw error;
+    });
   }
 
   handleRequest<T>(handler: (txEntry: this) => IDBRequest<T>) {
@@ -102,15 +126,10 @@ export class CoJsonIDBTransaction {
         const request = handler(txEntry);
 
         request.onerror = () => {
-          this.failed = true;
-          this.tx.abort();
-          console.error(request.error);
+          // pushRequest fails the queued requests when this rejection
+          // reaches it; transaction() logs the error if the retry fails too
           reject(request.error);
-
-          // Don't leave any pending promise
-          for (const handler of this.rejectHandlers) {
-            handler();
-          }
+          this.rollback();
         };
 
         request.onsuccess = () => {

--- a/packages/cojson-storage-indexeddb/src/IDBConnectionManager.ts
+++ b/packages/cojson-storage-indexeddb/src/IDBConnectionManager.ts
@@ -1,0 +1,93 @@
+import { DATABASE_VERSION, openDatabase } from "./idbSchema.js";
+
+function isDOMException(error: unknown, name: string) {
+  return (error as DOMException | null)?.name === name;
+}
+
+/**
+ * Owns the IDBDatabase connection and reopens it lazily after the browser
+ * closes it behind our back (tab suspension on iOS/Safari, storage pressure,
+ * IndexedDB backend restarts). The connection is a cache that can be
+ * invalidated, never a permanent handle.
+ */
+export class IDBConnectionManager {
+  private dbPromise: Promise<IDBDatabase> | undefined;
+  private currentDb: IDBDatabase | undefined;
+
+  constructor(private name: string) {}
+
+  getDb(): Promise<IDBDatabase> {
+    if (!this.dbPromise) {
+      this.dbPromise = this.open();
+    }
+    return this.dbPromise;
+  }
+
+  /**
+   * Runs an operation against the current connection, reopening the database
+   * and retrying the operation once when the browser closed the connection
+   * behind our back. A transaction on a closing connection never commits, so
+   * callers must only pass operations that are safe to run again after a
+   * failure that didn't commit.
+   */
+  async withConnection<T>(op: (db: IDBDatabase) => Promise<T>): Promise<T> {
+    // Fast path: skip the promise machinery while the connection is healthy
+    const db = this.currentDb ?? (await this.getDb());
+
+    try {
+      return await op(db);
+    } catch (error) {
+      if (!isDOMException(error, "InvalidStateError")) {
+        throw error;
+      }
+
+      this.invalidate(db);
+      return op(await this.getDb());
+    }
+  }
+
+  private async open(): Promise<IDBDatabase> {
+    try {
+      const db = await openDatabase(this.name, DATABASE_VERSION).catch(
+        (error) => {
+          if (!isDOMException(error, "VersionError")) {
+            throw error;
+          }
+          // A newer tab already upgraded the schema (migrations are
+          // additive), so open at whatever version currently exists.
+          return openDatabase(this.name);
+        },
+      );
+
+      // Fired when the browser force-closes the connection; not fired on
+      // an explicit db.close()
+      db.onclose = () => {
+        this.invalidate(db);
+      };
+      // Close so another tab can upgrade or delete the database instead of
+      // being blocked forever; the next operation reopens
+      db.onversionchange = () => {
+        db.close();
+        this.invalidate(db);
+      };
+
+      this.currentDb = db;
+      return db;
+    } catch (error) {
+      this.dbPromise = undefined;
+      throw error;
+    }
+  }
+
+  /**
+   * Drops the cached connection so the next operation reopens the database.
+   * No-op if a newer connection has already replaced `db`.
+   */
+  private invalidate(db: IDBDatabase) {
+    if (this.currentDb !== db) {
+      return;
+    }
+    this.currentDb = undefined;
+    this.dbPromise = undefined;
+  }
+}

--- a/packages/cojson-storage-indexeddb/src/idbClient.ts
+++ b/packages/cojson-storage-indexeddb/src/idbClient.ts
@@ -22,6 +22,7 @@ import {
   queryIndexedDbStore,
   StoreName,
 } from "./CoJsonIDBTransaction.js";
+import type { IDBConnectionManager } from "./IDBConnectionManager.js";
 
 type DeletedCoValueQueueEntry = {
   coValueID: RawCoID;
@@ -238,17 +239,19 @@ export class IDBTransaction implements DBTransactionInterfaceAsync {
 }
 
 export class IDBClient implements DBClientInterfaceAsync {
-  private db;
+  constructor(private dbManager: IDBConnectionManager) {}
 
-  activeTransaction: CoJsonIDBTransaction | undefined;
-  autoBatchingTransaction: CoJsonIDBTransaction | undefined;
-
-  constructor(db: IDBDatabase) {
-    this.db = db;
+  private query<T>(
+    storeName: StoreName,
+    callback: (store: IDBObjectStore) => IDBRequest<T>,
+  ): Promise<T> {
+    return this.dbManager.withConnection((db) =>
+      queryIndexedDbStore<T>(db, storeName, callback),
+    );
   }
 
   async getCoValue(coValueId: RawCoID): Promise<StoredCoValueRow | undefined> {
-    return queryIndexedDbStore(this.db, "coValues", (store) =>
+    return this.query("coValues", (store) =>
       store.index("coValuesById").get(coValueId),
     );
   }
@@ -258,7 +261,7 @@ export class IDBClient implements DBClientInterfaceAsync {
   }
 
   async getCoValueSessions(coValueRowId: number): Promise<StoredSessionRow[]> {
-    return queryIndexedDbStore(this.db, "sessions", (store) =>
+    return this.query("sessions", (store) =>
       store.index("sessionsByCoValue").getAll(coValueRowId),
     );
   }
@@ -268,7 +271,7 @@ export class IDBClient implements DBClientInterfaceAsync {
     fromIdx: number,
     toIdx: number,
   ): Promise<TransactionRow[]> {
-    return queryIndexedDbStore(this.db, "transactions", (store) =>
+    return this.query("transactions", (store) =>
       store.getAll(
         IDBKeyRange.bound([sessionRowId, fromIdx], [sessionRowId, toIdx]),
       ),
@@ -279,7 +282,7 @@ export class IDBClient implements DBClientInterfaceAsync {
     sessionRowId: number,
     firstNewTxIdx: number,
   ): Promise<SignatureAfterRow[]> {
-    return queryIndexedDbStore(this.db, "signatureAfter", (store) =>
+    return this.query("signatureAfter", (store) =>
       store.getAll(
         IDBKeyRange.bound(
           [sessionRowId, firstNewTxIdx],
@@ -297,15 +300,18 @@ export class IDBClient implements DBClientInterfaceAsync {
       return this.getCoValueRowID(id);
     }
 
-    return putIndexedDbStore<CoValueRow, number>(this.db, "coValues", {
-      id,
-      header,
-    }).catch(() => this.getCoValueRowID(id));
+    return this.dbManager
+      .withConnection((db) =>
+        putIndexedDbStore<CoValueRow, number>(db, "coValues", {
+          id,
+          header,
+        }),
+      )
+      .catch(() => this.getCoValueRowID(id));
   }
 
   async getAllCoValuesWaitingForDelete(): Promise<RawCoID[]> {
-    const entries = await queryIndexedDbStore<DeletedCoValueQueueEntry[]>(
-      this.db,
+    const entries = await this.query(
       "deletedCoValues",
       (store) =>
         store.index("deletedCoValuesByStatus").getAll("pending") as IDBRequest<
@@ -319,13 +325,27 @@ export class IDBClient implements DBClientInterfaceAsync {
     operationsCallback: (tx: IDBTransaction) => Promise<unknown>,
     storeNames?: StoreName[],
   ) {
-    const tx = new CoJsonIDBTransaction(this.db, storeNames);
-
     try {
-      await operationsCallback(new IDBTransaction(tx));
-      tx.commit(); // Tells the browser to not wait for another possible request and commit the transaction immediately
+      // A retry re-runs the whole callback: it may span multiple
+      // auto-committed IDB transactions (getObjectStore refreshes after an
+      // auto-commit), so callbacks must stay read-gated (re-read state
+      // before writing) to be safe to run again.
+      await this.dbManager.withConnection(async (db) => {
+        const tx = new CoJsonIDBTransaction(db, storeNames);
+
+        try {
+          await operationsCallback(new IDBTransaction(tx));
+        } catch (error) {
+          tx.rollback();
+          throw error;
+        }
+
+        tx.commit(); // Tells the browser to not wait for another possible request and commit the transaction immediately
+      });
     } catch (error) {
-      tx.rollback();
+      // Matches the previous rollback-and-continue behavior, but without
+      // leaking the rejection to callers that don't handle it
+      console.error("IndexedDB transaction failed", error);
     }
   }
 
@@ -386,24 +406,21 @@ export class IDBClient implements DBClientInterfaceAsync {
     limit: number,
     offset: number,
   ): Promise<{ id: RawCoID }[]> {
-    const rows = await queryIndexedDbStore<StoredCoValueRow[]>(
-      this.db,
-      "coValues",
-      (store) =>
-        // Include upper bound but not lower bound (offset starts at 0)
-        store.getAll(IDBKeyRange.bound(offset, offset + limit, true, false)),
+    const rows = await this.query<StoredCoValueRow[]>("coValues", (store) =>
+      // Include upper bound but not lower bound (offset starts at 0)
+      store.getAll(IDBKeyRange.bound(offset, offset + limit, true, false)),
     );
     return rows.map((row) => ({ id: row.id }));
   }
 
   async getCoValueCount(): Promise<number> {
-    return queryIndexedDbStore(this.db, "coValues", (store) => store.count());
+    return this.query("coValues", (store) => store.count());
   }
 
   async getUnsyncedCoValueIDs(): Promise<RawCoID[]> {
-    const records = await queryIndexedDbStore<
+    const records = await this.query<
       { rowID: number; coValueId: RawCoID; peerId: string }[]
-    >(this.db, "unsyncedCoValues", (store) => store.getAll());
+    >("unsyncedCoValues", (store) => store.getAll());
     const uniqueIds = new Set<RawCoID>();
     for (const record of records) {
       uniqueIds.add(record.coValueId);

--- a/packages/cojson-storage-indexeddb/src/idbNode.ts
+++ b/packages/cojson-storage-indexeddb/src/idbNode.ts
@@ -1,5 +1,6 @@
 import { StorageApiAsync } from "cojson";
 import { IDBClient } from "./idbClient.js";
+import { IDBConnectionManager } from "./IDBConnectionManager.js";
 
 let DATABASE_NAME = "jazz-storage";
 
@@ -8,76 +9,10 @@ export function internal_setDatabaseName(name: string) {
 }
 
 export async function getIndexedDBStorage(name = DATABASE_NAME) {
-  const dbPromise = new Promise<IDBDatabase>((resolve, reject) => {
-    const request = indexedDB.open(name, 7);
-    request.onerror = () => {
-      reject(request.error);
-    };
-    request.onsuccess = () => {
-      resolve(request.result);
-    };
-    request.onupgradeneeded = async (ev) => {
-      const db = request.result;
-      if (ev.oldVersion === 0) {
-        const coValues = db.createObjectStore("coValues", {
-          autoIncrement: true,
-          keyPath: "rowID",
-        });
+  const dbManager = new IDBConnectionManager(name);
 
-        coValues.createIndex("coValuesById", "id", {
-          unique: true,
-        });
+  // Open eagerly so migrations run and open errors surface at startup
+  await dbManager.getDb();
 
-        const sessions = db.createObjectStore("sessions", {
-          autoIncrement: true,
-          keyPath: "rowID",
-        });
-
-        sessions.createIndex("sessionsByCoValue", "coValue");
-        sessions.createIndex("uniqueSessions", ["coValue", "sessionID"], {
-          unique: true,
-        });
-
-        db.createObjectStore("transactions", {
-          keyPath: ["ses", "idx"],
-        });
-      }
-      if (ev.oldVersion <= 1) {
-        db.createObjectStore("signatureAfter", {
-          keyPath: ["ses", "idx"],
-        });
-      }
-      if (ev.oldVersion <= 4) {
-        const unsyncedCoValues = db.createObjectStore("unsyncedCoValues", {
-          autoIncrement: true,
-          keyPath: "rowID",
-        });
-        unsyncedCoValues.createIndex("byCoValueId", "coValueId");
-        unsyncedCoValues.createIndex(
-          "uniqueUnsyncedCoValues",
-          ["coValueId", "peerId"],
-          {
-            unique: true,
-          },
-        );
-      }
-      if (ev.oldVersion <= 5) {
-        const deletedCoValues = db.createObjectStore("deletedCoValues", {
-          keyPath: "coValueID",
-        });
-        deletedCoValues.createIndex("deletedCoValuesByStatus", "status", {
-          unique: false,
-        });
-      }
-      if (ev.oldVersion <= 6) {
-        db.createObjectStore("storageReconciliationLocks", {
-          keyPath: "key",
-        });
-      }
-    };
-  });
-
-  const db = await dbPromise;
-
-  return new StorageApiAsync(new IDBClient(db));
+  return new StorageApiAsync(new IDBClient(dbManager));
 }

--- a/packages/cojson-storage-indexeddb/src/idbSchema.ts
+++ b/packages/cojson-storage-indexeddb/src/idbSchema.ts
@@ -1,0 +1,72 @@
+export const DATABASE_VERSION = 7;
+
+export function openDatabase(name: string, version?: number) {
+  return new Promise<IDBDatabase>((resolve, reject) => {
+    const request = indexedDB.open(name, version);
+    request.onerror = () => {
+      reject(request.error);
+    };
+    request.onsuccess = () => {
+      resolve(request.result);
+    };
+    request.onupgradeneeded = (ev) => {
+      const db = request.result;
+      if (ev.oldVersion === 0) {
+        const coValues = db.createObjectStore("coValues", {
+          autoIncrement: true,
+          keyPath: "rowID",
+        });
+
+        coValues.createIndex("coValuesById", "id", {
+          unique: true,
+        });
+
+        const sessions = db.createObjectStore("sessions", {
+          autoIncrement: true,
+          keyPath: "rowID",
+        });
+
+        sessions.createIndex("sessionsByCoValue", "coValue");
+        sessions.createIndex("uniqueSessions", ["coValue", "sessionID"], {
+          unique: true,
+        });
+
+        db.createObjectStore("transactions", {
+          keyPath: ["ses", "idx"],
+        });
+      }
+      if (ev.oldVersion <= 1) {
+        db.createObjectStore("signatureAfter", {
+          keyPath: ["ses", "idx"],
+        });
+      }
+      if (ev.oldVersion <= 4) {
+        const unsyncedCoValues = db.createObjectStore("unsyncedCoValues", {
+          autoIncrement: true,
+          keyPath: "rowID",
+        });
+        unsyncedCoValues.createIndex("byCoValueId", "coValueId");
+        unsyncedCoValues.createIndex(
+          "uniqueUnsyncedCoValues",
+          ["coValueId", "peerId"],
+          {
+            unique: true,
+          },
+        );
+      }
+      if (ev.oldVersion <= 5) {
+        const deletedCoValues = db.createObjectStore("deletedCoValues", {
+          keyPath: "coValueID",
+        });
+        deletedCoValues.createIndex("deletedCoValuesByStatus", "status", {
+          unique: false,
+        });
+      }
+      if (ev.oldVersion <= 6) {
+        db.createObjectStore("storageReconciliationLocks", {
+          keyPath: "key",
+        });
+      }
+    };
+  });
+}

--- a/packages/cojson-storage-indexeddb/src/tests/connectionRecovery.test.ts
+++ b/packages/cojson-storage-indexeddb/src/tests/connectionRecovery.test.ts
@@ -1,0 +1,164 @@
+import { StorageApiAsync } from "cojson";
+import type { CojsonInternalTypes, RawCoID } from "cojson";
+import { afterEach, beforeEach, describe, expect, test } from "vitest";
+import { IDBClient } from "../idbClient.js";
+import { IDBConnectionManager } from "../IDBConnectionManager.js";
+import { getIndexedDBStorage, internal_setDatabaseName } from "../index.js";
+import { createTestNode } from "./testUtils.js";
+
+let dbName: string;
+
+beforeEach(() => {
+  dbName = `test-${crypto.randomUUID()}`;
+  internal_setDatabaseName(dbName);
+});
+
+afterEach(async () => {
+  indexedDB.deleteDatabase(dbName);
+});
+
+const TEST_HEADER = {
+  type: "comap",
+  ruleset: { type: "unsafeAllowAll" },
+  meta: null,
+} as unknown as CojsonInternalTypes.CoValueHeader;
+
+describe("IDBConnectionManager", () => {
+  let manager: IDBConnectionManager;
+
+  beforeEach(() => {
+    manager = new IDBConnectionManager(dbName);
+  });
+
+  afterEach(async () => {
+    (await manager.getDb()).close();
+  });
+
+  test("returns the same connection while it stays healthy", async () => {
+    const db1 = await manager.getDb();
+    const db2 = await manager.getDb();
+
+    expect(db2).toBe(db1);
+  });
+
+  test("reopens the connection after the browser fires close", async () => {
+    const db1 = await manager.getDb();
+
+    // The browser dispatches this event when it force-closes the connection
+    db1.dispatchEvent(new Event("close"));
+
+    const db2 = await manager.getDb();
+    expect(db2).not.toBe(db1);
+
+    db1.close();
+  });
+
+  test("closes and reopens the connection on versionchange", async () => {
+    const db1 = await manager.getDb();
+
+    db1.dispatchEvent(new Event("versionchange"));
+
+    const db2 = await manager.getDb();
+    expect(db2).not.toBe(db1);
+  });
+});
+
+describe("IDBClient connection recovery", () => {
+  let manager: IDBConnectionManager;
+  let client: IDBClient;
+
+  beforeEach(() => {
+    manager = new IDBConnectionManager(dbName);
+    client = new IDBClient(manager);
+  });
+
+  afterEach(async () => {
+    (await manager.getDb()).close();
+  });
+
+  test("reads succeed after the connection was closed", async () => {
+    const id = "co_ztest1" as RawCoID;
+    await client.upsertCoValue(id, TEST_HEADER);
+
+    const closedDb = await manager.getDb();
+    closedDb.close();
+
+    const row = await client.getCoValue(id);
+    expect(row?.id).toBe(id);
+
+    expect(await manager.getDb()).not.toBe(closedDb);
+  });
+
+  test("writes succeed after the connection was closed", async () => {
+    const closedDb = await manager.getDb();
+    closedDb.close();
+
+    const id = "co_ztest2" as RawCoID;
+    const rowID = await client.upsertCoValue(id, TEST_HEADER);
+    expect(rowID).toEqual(expect.any(Number));
+
+    const row = await client.getCoValue(id);
+    expect(row?.id).toBe(id);
+  });
+
+  test("readwrite transactions succeed after the connection was closed", async () => {
+    const closedDb = await manager.getDb();
+    closedDb.close();
+
+    const id = "co_ztest3" as RawCoID;
+    await client.trackCoValuesSyncState([
+      { id, peerId: "peer1", synced: false },
+    ]);
+
+    expect(await client.getUnsyncedCoValueIDs()).toEqual([id]);
+  });
+
+  test("does not reopen the connection on unrelated errors", async () => {
+    const id = "co_ztest4" as RawCoID;
+    await client.upsertCoValue(id, TEST_HEADER);
+
+    const dbBefore = await manager.getDb();
+
+    // Violates the unique coValuesById index (ConstraintError), which falls
+    // back to returning the existing row
+    const rowID = await client.upsertCoValue(id, TEST_HEADER);
+    expect(rowID).toEqual(expect.any(Number));
+
+    expect(await manager.getDb()).toBe(dbBefore);
+  });
+});
+
+test("storage keeps working after the browser closes the connection", async () => {
+  const node = createTestNode();
+  const manager = new IDBConnectionManager(dbName);
+  const storage = new StorageApiAsync(new IDBClient(manager));
+  node.setStorage(storage);
+
+  const group = node.createGroup();
+  const map = group.createMap();
+  map.set("hello", "world");
+  await map.core.waitForSync();
+
+  // Simulate the browser force-closing the connection (tab suspension,
+  // storage pressure, IndexedDB backend restart)
+  const db = await manager.getDb();
+  db.close();
+
+  const map2 = group.createMap();
+  map2.set("foo", "bar");
+  await map2.core.waitForSync();
+
+  node.gracefulShutdown();
+
+  // Load from a fresh node to prove the write actually persisted
+  const node2 = createTestNode({ secret: node.agentSecret });
+  node2.setStorage(await getIndexedDBStorage());
+
+  const loaded = await node2.load(map2.id);
+  if (loaded === "unavailable") {
+    throw new Error("Map is unavailable");
+  }
+  expect(loaded.get("foo")).toBe("bar");
+
+  node2.gracefulShutdown();
+});


### PR DESCRIPTION
Fixes the cascade of `InvalidStateError: Failed to execute 'transaction' on 'IDBDatabase': The database connection is closing` seen in production.

## Root cause

Browsers close IndexedDB connections outside the app's control — iOS/Safari tab suspension, storage pressure, IndexedDB backend restarts. `getIndexedDBStorage()` opened one `IDBDatabase` at startup and `IDBClient` held that handle forever, with no `onclose`/`onversionchange` handling and no reconnect path. After a single forced close, every subsequent `db.transaction()` call threw `InvalidStateError`. Since the sync layer hits storage for every message, that produced the endless error cascade — and, worse, persistence silently stopped for the rest of the session.

## Fix

- **`IDBConnectionManager`** (new) owns the connection lifecycle: it listens for `close` (browser force-closed the connection) and `versionchange` (closes so another tab can upgrade instead of being blocked forever), invalidates the cached connection, and lazily reopens on the next operation. If a newer tab already upgraded the schema, reopen falls back to a versionless open instead of failing with `VersionError` (migrations are additive).
- **`withConnection()`** wraps every storage operation and retries exactly once on `InvalidStateError` after reopening. Safe because a transaction on a closing connection never commits; batched `transaction()` callbacks are read-gated, so replaying them can't double-apply.
- **Failure-path hangs fixed in `CoJsonIDBTransaction`**: `rollback()` no longer throws on an already-aborted transaction (previously `abort()` threw inside `onerror`, skipping the `reject` and stalling the storage queue forever), and a request that fails synchronously now rejects all queued requests instead of leaving their promises pending.
- Schema/migrations split into `idbSchema.ts`; the migration handler is no longer `async` (upgrade transactions can't await — latent bug).
- `transaction()` failures are logged once (only if the retry also failed) instead of leaking as unhandled rejections.

## Tests

New `connectionRecovery.test.ts` (runs in real Chromium): reads, writes, and readwrite transactions succeed after the connection is closed mid-session; `close`/`versionchange` events invalidate and reopen; unrelated errors (`ConstraintError`) don't trigger a reopen; and an end-to-end test proving a node keeps syncing and persisting through a forced connection close. The end-to-end test reproduces the production failure exactly when run against the previous code.
