### PR TITLE
feat(cojson): node-level NodeCore registry for per-CoValue session state

### DIFF
--- a/.changeset/nodecore-registry.md
+++ b/.changeset/nodecore-registry.md
@@ -1,0 +1,9 @@
+---
+"cojson": patch
+"cojson-core-napi": patch
+---
+
+Introduce a node-level NodeCore registry owning all per-CoValue session state
+(native in napi; TS shim over per-CoValue session maps for wasm/RN). No
+behavior change; groundwork for moving permissions and group state into the
+Rust core.

--- a/crates/cojson-core-napi/index.d.ts
+++ b/crates/cojson-core-napi/index.d.ts
@@ -7,6 +7,64 @@ export declare class Blake3Hasher {
   clone(): Blake3Hasher
 }
 
+export declare class NodeCore {
+  /** Create a new empty NodeCore registry (one LocalNode owns one instance). */
+  constructor()
+  /**
+   * Creates or replaces; replacing drops the previous session state.
+   * Mirrors TS semantics where constructing a new VerifiedState for an
+   * already-known id creates a fresh SessionMap.
+   */
+  createCoValue(coId: string, headerJson: string, maxTxSize?: number | undefined | null, skipVerify?: boolean | undefined | null): void
+  hasCoValue(coId: string): boolean
+  removeCoValue(coId: string): boolean
+  coValueCount(): number
+  /** Get the header as JSON */
+  getHeader(coId: string): string
+  /** Add transactions to a session */
+  addTransactions(coId: string, sessionId: string, signerId: string | undefined | null, transactionsJson: string, signature: string, skipVerify: boolean): void
+  /**
+   * Create new private transaction (for local writes)
+   * Returns JSON: { signature: string, transaction: Transaction }
+   */
+  makeNewPrivateTransaction(coId: string, sessionId: string, signerSecret: string, changesJson: string, keyId: string, keySecret: string, metaJson: string | undefined | null, madeAt: number): string
+  /**
+   * Create new trusting transaction (for local writes)
+   * Returns JSON: { signature: string, transaction: Transaction }
+   */
+  makeNewTrustingTransaction(coId: string, sessionId: string, signerSecret: string, changesJson: string, metaJson: string | undefined | null, madeAt: number): string
+  /** Get all session IDs as native array */
+  getSessionIds(coId: string): Array<string>
+  /** Get transaction count for a session (returns -1 if session not found) */
+  getTransactionCount(coId: string, sessionId: string): number
+  /** Get single transaction by index as JSON string (returns undefined if not found) */
+  getTransaction(coId: string, sessionId: string, txIndex: number): string | null
+  /** Get transactions for a session from index as JSON strings (returns undefined if session not found) */
+  getSessionTransactions(coId: string, sessionId: string, fromIndex: number): Array<string> | null
+  /** Get last signature for a session (returns undefined if session not found) */
+  getLastSignature(coId: string, sessionId: string): string | null
+  /** Get signature after specific transaction index */
+  getSignatureAfter(coId: string, sessionId: string, txIndex: number): string | null
+  /** Get the last signature checkpoint index (-1 if no checkpoints, undefined if session not found) */
+  getLastSignatureCheckpoint(coId: string, sessionId: string): number | null
+  /** Get the known state as a native JavaScript object */
+  getKnownState(coId: string): KnownState
+  /** Get the known state with streaming as a native JavaScript object */
+  getKnownStateWithStreaming(coId: string): KnownState | null
+  /** Check whether the CoValue still has pending streaming content. */
+  isStreaming(coId: string): boolean
+  /** Set streaming known state */
+  setStreamingKnownState(coId: string, streamingJson: string): void
+  /** Mark this CoValue as deleted */
+  markAsDeleted(coId: string): void
+  /** Check if this CoValue is deleted */
+  isDeleted(coId: string): boolean
+  /** Decrypt transaction changes */
+  decryptTransaction(coId: string, sessionId: string, txIndex: number, keySecret: string): string | null
+  /** Decrypt transaction meta */
+  decryptTransactionMeta(coId: string, sessionId: string, txIndex: number, keySecret: string): string | null
+}
+
 export declare class SessionMap {
   /**
    * Create a new SessionMap for a CoValue.

--- a/crates/cojson-core-napi/src/lib.rs
+++ b/crates/cojson-core-napi/src/lib.rs
@@ -1,4 +1,6 @@
-use cojson_core::core::{CoJsonCoreError, KnownState as RustKnownState, SessionMapImpl};
+use cojson_core::core::{
+  CoJsonCoreError, KnownState as RustKnownState, NodeCore as RustNodeCore, SessionMapImpl,
+};
 use napi_derive::napi;
 use std::collections::HashMap;
 use thiserror::Error;
@@ -319,6 +321,356 @@ impl SessionMap {
       .internal
       .decrypt_transaction_meta(&session_id, tx_index, &key_secret)
       .map_err(|e| napi::Error::new(napi::Status::GenericFailure, e.to_string()))
+  }
+}
+
+// ============================================================================
+// NodeCore - NAPI wrapper for the node-level CoValue registry
+// ============================================================================
+
+/// Map any error implementing Display into a napi::Error (GenericFailure),
+/// preserving the message. SessionMapError implements Display, so the
+/// registry lookup errors map cleanly.
+fn to_napi_err<E: std::fmt::Display>(e: E) -> napi::Error {
+  napi::Error::new(napi::Status::GenericFailure, e.to_string())
+}
+
+#[napi]
+pub struct NodeCore {
+  internal: RustNodeCore,
+}
+
+#[napi]
+impl NodeCore {
+  /// Create a new empty NodeCore registry (one LocalNode owns one instance).
+  #[napi(constructor)]
+  #[allow(clippy::new_without_default)]
+  pub fn new() -> NodeCore {
+    NodeCore {
+      internal: RustNodeCore::new(),
+    }
+  }
+
+  // === Registry ===
+
+  /// Creates or replaces; replacing drops the previous session state.
+  /// Mirrors TS semantics where constructing a new VerifiedState for an
+  /// already-known id creates a fresh SessionMap.
+  #[napi]
+  pub fn create_co_value(
+    &mut self,
+    co_id: String,
+    header_json: String,
+    max_tx_size: Option<u32>,
+    skip_verify: Option<bool>,
+  ) -> napi::Result<()> {
+    self
+      .internal
+      .create_co_value(&co_id, &header_json, max_tx_size, skip_verify.unwrap_or(false))
+      .map_err(to_napi_err)
+  }
+
+  #[napi]
+  pub fn has_co_value(&self, co_id: String) -> bool {
+    self.internal.has_co_value(&co_id)
+  }
+
+  #[napi]
+  pub fn remove_co_value(&mut self, co_id: String) -> bool {
+    self.internal.remove_co_value(&co_id)
+  }
+
+  #[napi]
+  pub fn co_value_count(&self) -> u32 {
+    self.internal.co_value_count() as u32
+  }
+
+  // === Lifted SessionMap surface ===
+  // Each method prepends `co_id: String` and resolves the entry via
+  // get()/get_mut() before delegating, mapping UnknownCoValue through
+  // to_napi_err. Method bodies are lifted verbatim from impl SessionMap
+  // so every conversion (JSON strings, KnownState::from, -1 conventions,
+  // Option -> null) is preserved.
+
+  // --- Header ---
+
+  /// Get the header as JSON
+  #[napi]
+  pub fn get_header(&self, co_id: String) -> napi::Result<String> {
+    Ok(self.internal.get(&co_id).map_err(to_napi_err)?.get_header())
+  }
+
+  // --- Transaction Operations ---
+
+  /// Add transactions to a session
+  #[napi]
+  pub fn add_transactions(
+    &mut self,
+    co_id: String,
+    session_id: String,
+    signer_id: Option<String>,
+    transactions_json: String,
+    signature: String,
+    skip_verify: bool,
+  ) -> napi::Result<()> {
+    self
+      .internal
+      .get_mut(&co_id)
+      .map_err(to_napi_err)?
+      .add_transactions(
+        &session_id,
+        signer_id.as_deref(),
+        &transactions_json,
+        &signature,
+        skip_verify,
+      )
+      .map_err(to_napi_err)
+  }
+
+  /// Create new private transaction (for local writes)
+  /// Returns JSON: { signature: string, transaction: Transaction }
+  #[napi]
+  pub fn make_new_private_transaction(
+    &mut self,
+    co_id: String,
+    session_id: String,
+    signer_secret: String,
+    changes_json: String,
+    key_id: String,
+    key_secret: String,
+    meta_json: Option<String>,
+    made_at: f64,
+  ) -> napi::Result<String> {
+    let signed_tx = self
+      .internal
+      .get_mut(&co_id)
+      .map_err(to_napi_err)?
+      .make_new_private_transaction(
+        session_id,
+        signer_secret,
+        &changes_json,
+        key_id,
+        key_secret,
+        meta_json,
+        made_at as u64,
+      )
+      .map_err(to_napi_err)?;
+
+    let tx_json = serde_json::to_string(&signed_tx.transaction).map_err(to_napi_err)?;
+    Ok(format!(
+      r#"{{"signature":"{}","transaction":{}}}"#,
+      signed_tx.signature.0, tx_json
+    ))
+  }
+
+  /// Create new trusting transaction (for local writes)
+  /// Returns JSON: { signature: string, transaction: Transaction }
+  #[napi]
+  pub fn make_new_trusting_transaction(
+    &mut self,
+    co_id: String,
+    session_id: String,
+    signer_secret: String,
+    changes_json: String,
+    meta_json: Option<String>,
+    made_at: f64,
+  ) -> napi::Result<String> {
+    let signed_tx = self
+      .internal
+      .get_mut(&co_id)
+      .map_err(to_napi_err)?
+      .make_new_trusting_transaction(
+        session_id,
+        signer_secret,
+        &changes_json,
+        meta_json,
+        made_at as u64,
+      )
+      .map_err(to_napi_err)?;
+
+    let tx_json = serde_json::to_string(&signed_tx.transaction).map_err(to_napi_err)?;
+    Ok(format!(
+      r#"{{"signature":"{}","transaction":{}}}"#,
+      signed_tx.signature.0, tx_json
+    ))
+  }
+
+  // --- Session Queries ---
+
+  /// Get all session IDs as native array
+  #[napi]
+  pub fn get_session_ids(&self, co_id: String) -> napi::Result<Vec<String>> {
+    Ok(self.internal.get(&co_id).map_err(to_napi_err)?.get_session_ids())
+  }
+
+  /// Get transaction count for a session (returns -1 if session not found)
+  #[napi]
+  pub fn get_transaction_count(&self, co_id: String, session_id: String) -> napi::Result<i32> {
+    let sm = self.internal.get(&co_id).map_err(to_napi_err)?;
+    // Same -1-if-absent convention as the SessionMap wrapper
+    Ok(sm.get_transaction_count(&session_id).map(|c| c as i32).unwrap_or(-1))
+  }
+
+  /// Get single transaction by index as JSON string (returns undefined if not found)
+  #[napi]
+  pub fn get_transaction(
+    &self,
+    co_id: String,
+    session_id: String,
+    tx_index: u32,
+  ) -> napi::Result<Option<String>> {
+    Ok(self
+      .internal
+      .get(&co_id)
+      .map_err(to_napi_err)?
+      .get_transaction(&session_id, tx_index))
+  }
+
+  /// Get transactions for a session from index as JSON strings (returns undefined if session not found)
+  #[napi]
+  pub fn get_session_transactions(
+    &self,
+    co_id: String,
+    session_id: String,
+    from_index: u32,
+  ) -> napi::Result<Option<Vec<String>>> {
+    Ok(self
+      .internal
+      .get(&co_id)
+      .map_err(to_napi_err)?
+      .get_session_transactions(&session_id, from_index))
+  }
+
+  /// Get last signature for a session (returns undefined if session not found)
+  #[napi]
+  pub fn get_last_signature(&self, co_id: String, session_id: String) -> napi::Result<Option<String>> {
+    Ok(self
+      .internal
+      .get(&co_id)
+      .map_err(to_napi_err)?
+      .get_last_signature(&session_id))
+  }
+
+  /// Get signature after specific transaction index
+  #[napi]
+  pub fn get_signature_after(
+    &self,
+    co_id: String,
+    session_id: String,
+    tx_index: u32,
+  ) -> napi::Result<Option<String>> {
+    Ok(self
+      .internal
+      .get(&co_id)
+      .map_err(to_napi_err)?
+      .get_signature_after(&session_id, tx_index))
+  }
+
+  /// Get the last signature checkpoint index (-1 if no checkpoints, undefined if session not found)
+  #[napi]
+  pub fn get_last_signature_checkpoint(
+    &self,
+    co_id: String,
+    session_id: String,
+  ) -> napi::Result<Option<i32>> {
+    Ok(self
+      .internal
+      .get(&co_id)
+      .map_err(to_napi_err)?
+      .get_last_signature_checkpoint(&session_id))
+  }
+
+  // --- Known State ---
+
+  /// Get the known state as a native JavaScript object
+  #[napi]
+  pub fn get_known_state(&self, co_id: String) -> napi::Result<KnownState> {
+    Ok(self
+      .internal
+      .get(&co_id)
+      .map_err(to_napi_err)?
+      .get_known_state()
+      .clone()
+      .into())
+  }
+
+  /// Get the known state with streaming as a native JavaScript object
+  #[napi]
+  pub fn get_known_state_with_streaming(&self, co_id: String) -> napi::Result<Option<KnownState>> {
+    Ok(self
+      .internal
+      .get(&co_id)
+      .map_err(to_napi_err)?
+      .get_known_state_with_streaming()
+      .map(|ks| ks.clone().into()))
+  }
+
+  /// Check whether the CoValue still has pending streaming content.
+  #[napi]
+  pub fn is_streaming(&self, co_id: String) -> napi::Result<bool> {
+    Ok(self.internal.get(&co_id).map_err(to_napi_err)?.is_streaming())
+  }
+
+  /// Set streaming known state
+  #[napi]
+  pub fn set_streaming_known_state(&mut self, co_id: String, streaming_json: String) -> napi::Result<()> {
+    self
+      .internal
+      .get_mut(&co_id)
+      .map_err(to_napi_err)?
+      .set_streaming_known_state(&streaming_json)
+      .map_err(to_napi_err)
+  }
+
+  // --- Deletion ---
+
+  /// Mark this CoValue as deleted
+  #[napi]
+  pub fn mark_as_deleted(&mut self, co_id: String) -> napi::Result<()> {
+    self.internal.get_mut(&co_id).map_err(to_napi_err)?.mark_as_deleted();
+    Ok(())
+  }
+
+  /// Check if this CoValue is deleted
+  #[napi]
+  pub fn is_deleted(&self, co_id: String) -> napi::Result<bool> {
+    Ok(self.internal.get(&co_id).map_err(to_napi_err)?.is_deleted())
+  }
+
+  // --- Decryption ---
+
+  /// Decrypt transaction changes
+  #[napi]
+  pub fn decrypt_transaction(
+    &self,
+    co_id: String,
+    session_id: String,
+    tx_index: u32,
+    key_secret: String,
+  ) -> napi::Result<Option<String>> {
+    self
+      .internal
+      .get(&co_id)
+      .map_err(to_napi_err)?
+      .decrypt_transaction(&session_id, tx_index, &key_secret)
+      .map_err(to_napi_err)
+  }
+
+  /// Decrypt transaction meta
+  #[napi]
+  pub fn decrypt_transaction_meta(
+    &self,
+    co_id: String,
+    session_id: String,
+    tx_index: u32,
+    key_secret: String,
+  ) -> napi::Result<Option<String>> {
+    self
+      .internal
+      .get(&co_id)
+      .map_err(to_napi_err)?
+      .decrypt_transaction_meta(&session_id, tx_index, &key_secret)
+      .map_err(to_napi_err)
   }
 }
 

--- a/crates/cojson-core-napi/src/lib.rs
+++ b/crates/cojson-core-napi/src/lib.rs
@@ -369,7 +369,12 @@ impl NodeCore {
   ) -> napi::Result<()> {
     self
       .internal
-      .create_co_value(&co_id, &header_json, max_tx_size, skip_verify.unwrap_or(false))
+      .create_co_value(
+        &co_id,
+        &header_json,
+        max_tx_size,
+        skip_verify.unwrap_or(false),
+      )
       .map_err(to_napi_err)
   }
 
@@ -504,7 +509,13 @@ impl NodeCore {
   /// Get all session IDs as native array
   #[napi]
   pub fn get_session_ids(&self, co_id: String) -> napi::Result<Vec<String>> {
-    Ok(self.internal.get(&co_id).map_err(to_napi_err)?.get_session_ids())
+    Ok(
+      self
+        .internal
+        .get(&co_id)
+        .map_err(to_napi_err)?
+        .get_session_ids(),
+    )
   }
 
   /// Get transaction count for a session (returns -1 if session not found)
@@ -512,7 +523,11 @@ impl NodeCore {
   pub fn get_transaction_count(&self, co_id: String, session_id: String) -> napi::Result<i32> {
     let sm = self.internal.get(&co_id).map_err(to_napi_err)?;
     // Same -1-if-absent convention as the SessionMap wrapper
-    Ok(sm.get_transaction_count(&session_id).map(|c| c as i32).unwrap_or(-1))
+    Ok(
+      sm.get_transaction_count(&session_id)
+        .map(|c| c as i32)
+        .unwrap_or(-1),
+    )
   }
 
   /// Get single transaction by index as JSON string (returns undefined if not found)
@@ -523,11 +538,13 @@ impl NodeCore {
     session_id: String,
     tx_index: u32,
   ) -> napi::Result<Option<String>> {
-    Ok(self
-      .internal
-      .get(&co_id)
-      .map_err(to_napi_err)?
-      .get_transaction(&session_id, tx_index))
+    Ok(
+      self
+        .internal
+        .get(&co_id)
+        .map_err(to_napi_err)?
+        .get_transaction(&session_id, tx_index),
+    )
   }
 
   /// Get transactions for a session from index as JSON strings (returns undefined if session not found)
@@ -538,21 +555,29 @@ impl NodeCore {
     session_id: String,
     from_index: u32,
   ) -> napi::Result<Option<Vec<String>>> {
-    Ok(self
-      .internal
-      .get(&co_id)
-      .map_err(to_napi_err)?
-      .get_session_transactions(&session_id, from_index))
+    Ok(
+      self
+        .internal
+        .get(&co_id)
+        .map_err(to_napi_err)?
+        .get_session_transactions(&session_id, from_index),
+    )
   }
 
   /// Get last signature for a session (returns undefined if session not found)
   #[napi]
-  pub fn get_last_signature(&self, co_id: String, session_id: String) -> napi::Result<Option<String>> {
-    Ok(self
-      .internal
-      .get(&co_id)
-      .map_err(to_napi_err)?
-      .get_last_signature(&session_id))
+  pub fn get_last_signature(
+    &self,
+    co_id: String,
+    session_id: String,
+  ) -> napi::Result<Option<String>> {
+    Ok(
+      self
+        .internal
+        .get(&co_id)
+        .map_err(to_napi_err)?
+        .get_last_signature(&session_id),
+    )
   }
 
   /// Get signature after specific transaction index
@@ -563,11 +588,13 @@ impl NodeCore {
     session_id: String,
     tx_index: u32,
   ) -> napi::Result<Option<String>> {
-    Ok(self
-      .internal
-      .get(&co_id)
-      .map_err(to_napi_err)?
-      .get_signature_after(&session_id, tx_index))
+    Ok(
+      self
+        .internal
+        .get(&co_id)
+        .map_err(to_napi_err)?
+        .get_signature_after(&session_id, tx_index),
+    )
   }
 
   /// Get the last signature checkpoint index (-1 if no checkpoints, undefined if session not found)
@@ -577,11 +604,13 @@ impl NodeCore {
     co_id: String,
     session_id: String,
   ) -> napi::Result<Option<i32>> {
-    Ok(self
-      .internal
-      .get(&co_id)
-      .map_err(to_napi_err)?
-      .get_last_signature_checkpoint(&session_id))
+    Ok(
+      self
+        .internal
+        .get(&co_id)
+        .map_err(to_napi_err)?
+        .get_last_signature_checkpoint(&session_id),
+    )
   }
 
   // --- Known State ---
@@ -589,35 +618,49 @@ impl NodeCore {
   /// Get the known state as a native JavaScript object
   #[napi]
   pub fn get_known_state(&self, co_id: String) -> napi::Result<KnownState> {
-    Ok(self
-      .internal
-      .get(&co_id)
-      .map_err(to_napi_err)?
-      .get_known_state()
-      .clone()
-      .into())
+    Ok(
+      self
+        .internal
+        .get(&co_id)
+        .map_err(to_napi_err)?
+        .get_known_state()
+        .clone()
+        .into(),
+    )
   }
 
   /// Get the known state with streaming as a native JavaScript object
   #[napi]
   pub fn get_known_state_with_streaming(&self, co_id: String) -> napi::Result<Option<KnownState>> {
-    Ok(self
-      .internal
-      .get(&co_id)
-      .map_err(to_napi_err)?
-      .get_known_state_with_streaming()
-      .map(|ks| ks.clone().into()))
+    Ok(
+      self
+        .internal
+        .get(&co_id)
+        .map_err(to_napi_err)?
+        .get_known_state_with_streaming()
+        .map(|ks| ks.clone().into()),
+    )
   }
 
   /// Check whether the CoValue still has pending streaming content.
   #[napi]
   pub fn is_streaming(&self, co_id: String) -> napi::Result<bool> {
-    Ok(self.internal.get(&co_id).map_err(to_napi_err)?.is_streaming())
+    Ok(
+      self
+        .internal
+        .get(&co_id)
+        .map_err(to_napi_err)?
+        .is_streaming(),
+    )
   }
 
   /// Set streaming known state
   #[napi]
-  pub fn set_streaming_known_state(&mut self, co_id: String, streaming_json: String) -> napi::Result<()> {
+  pub fn set_streaming_known_state(
+    &mut self,
+    co_id: String,
+    streaming_json: String,
+  ) -> napi::Result<()> {
     self
       .internal
       .get_mut(&co_id)
@@ -631,7 +674,11 @@ impl NodeCore {
   /// Mark this CoValue as deleted
   #[napi]
   pub fn mark_as_deleted(&mut self, co_id: String) -> napi::Result<()> {
-    self.internal.get_mut(&co_id).map_err(to_napi_err)?.mark_as_deleted();
+    self
+      .internal
+      .get_mut(&co_id)
+      .map_err(to_napi_err)?
+      .mark_as_deleted();
     Ok(())
   }
 

--- a/crates/cojson-core-napi/src/lib.rs
+++ b/crates/cojson-core-napi/src/lib.rs
@@ -74,6 +74,8 @@ pub struct SessionMap {
   internal: SessionMapImpl,
 }
 
+// NOTE: a parallel copy of every method body below lives in `impl NodeCore`
+// (co_id-first). When editing a method here, update its NodeCore twin too.
 #[napi]
 impl SessionMap {
   /// Create a new SessionMap for a CoValue.
@@ -132,6 +134,7 @@ impl SessionMap {
   /// Create new private transaction (for local writes)
   /// Returns JSON: { signature: string, transaction: Transaction }
   #[napi]
+  #[allow(clippy::too_many_arguments)]
   pub fn make_new_private_transaction(
     &mut self,
     session_id: String,
@@ -430,6 +433,7 @@ impl NodeCore {
   /// Create new private transaction (for local writes)
   /// Returns JSON: { signature: string, transaction: Transaction }
   #[napi]
+  #[allow(clippy::too_many_arguments)]
   pub fn make_new_private_transaction(
     &mut self,
     co_id: String,

--- a/crates/cojson-core/src/core/node.rs
+++ b/crates/cojson-core/src/core/node.rs
@@ -1,0 +1,145 @@
+use std::collections::HashMap;
+
+use crate::core::session_map::{SessionMapError, SessionMapImpl};
+
+/// Node-level registry owning one SessionMapImpl per CoValue, keyed by CoID.
+/// One instance per LocalNode. Stage 2+ builds cross-CoValue features
+/// (group engine, permissions) on top of this registry.
+pub struct NodeCore {
+    covalues: HashMap<String, SessionMapImpl>,
+}
+
+impl NodeCore {
+    pub fn new() -> Self {
+        NodeCore {
+            covalues: HashMap::new(),
+        }
+    }
+
+    /// Create (or replace) the SessionMapImpl for a CoValue.
+    /// Replace-on-existing matches current TS semantics, where constructing a
+    /// new VerifiedState for an already-known id creates a fresh SessionMap.
+    pub fn create_co_value(
+        &mut self,
+        co_id: &str,
+        header_json: &str,
+        max_tx_size: Option<u32>,
+        skip_verify: bool,
+    ) -> Result<(), SessionMapError> {
+        let session_map =
+            SessionMapImpl::new_with_skip_verify(co_id, header_json, max_tx_size, skip_verify)?;
+        self.covalues.insert(co_id.to_string(), session_map);
+        Ok(())
+    }
+
+    pub fn has_co_value(&self, co_id: &str) -> bool {
+        self.covalues.contains_key(co_id)
+    }
+
+    /// Returns true if an entry was removed. Absent id is a no-op (false).
+    pub fn remove_co_value(&mut self, co_id: &str) -> bool {
+        self.covalues.remove(co_id).is_some()
+    }
+
+    pub fn co_value_count(&self) -> usize {
+        self.covalues.len()
+    }
+
+    pub fn get(&self, co_id: &str) -> Result<&SessionMapImpl, SessionMapError> {
+        self.covalues
+            .get(co_id)
+            .ok_or_else(|| SessionMapError::UnknownCoValue(co_id.to_string()))
+    }
+
+    pub fn get_mut(&mut self, co_id: &str) -> Result<&mut SessionMapImpl, SessionMapError> {
+        self.covalues
+            .get_mut(co_id)
+            .ok_or_else(|| SessionMapError::UnknownCoValue(co_id.to_string()))
+    }
+}
+
+impl Default for NodeCore {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::core::session_map::SessionMapError;
+
+    // Build a valid header + matching co_id, mirroring session_map.rs's
+    // `test_validation_with_matching_id`. NOTE: `compute_co_id_from_header` is
+    // private to session_map.rs, so we rebuild the same computation here via the
+    // public `short_hash_with_prefix` (see deviation note in report).
+    fn valid_header() -> (String, String) {
+        use crate::core::{CoValueHeader, NullableString, RulesetDef, Uniqueness};
+
+        let header = CoValueHeader {
+            created_at: NullableString::Missing,
+            meta: None,
+            ruleset: RulesetDef::unsafe_allow_all(),
+            co_type: "comap".to_string(),
+            uniqueness: Uniqueness::String("test".to_string()),
+        };
+        let header_json = serde_json::to_string(&header).unwrap();
+        let co_id = crate::hash::blake3::short_hash_with_prefix(header_json.as_bytes(), "co_z");
+        (co_id, header_json)
+    }
+
+    #[test]
+    fn create_has_remove_roundtrip() {
+        let (co_id, header_json) = valid_header();
+        let mut node = NodeCore::new();
+        assert!(!node.has_co_value(&co_id));
+        assert_eq!(node.co_value_count(), 0);
+
+        node.create_co_value(&co_id, &header_json, None, false).unwrap();
+        assert!(node.has_co_value(&co_id));
+        assert_eq!(node.co_value_count(), 1);
+        assert!(node.get(&co_id).is_ok());
+
+        assert!(node.remove_co_value(&co_id));
+        assert!(!node.has_co_value(&co_id));
+        assert_eq!(node.co_value_count(), 0);
+    }
+
+    #[test]
+    fn remove_absent_is_noop() {
+        let mut node = NodeCore::new();
+        assert!(!node.remove_co_value("co_zDoesNotExist"));
+        // double-remove after create
+        let (co_id, header_json) = valid_header();
+        node.create_co_value(&co_id, &header_json, None, false).unwrap();
+        assert!(node.remove_co_value(&co_id));
+        assert!(!node.remove_co_value(&co_id));
+    }
+
+    #[test]
+    fn get_unknown_covalue_errors() {
+        let node = NodeCore::new();
+        match node.get("co_zDoesNotExist") {
+            Err(SessionMapError::UnknownCoValue(id)) => assert_eq!(id, "co_zDoesNotExist"),
+            other => panic!("expected UnknownCoValue, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn create_replaces_existing_entry() {
+        // Matches TS semantics: `new VerifiedState(sameId)` today creates a fresh
+        // SessionMap; createCoValue must replace, not error.
+        let (co_id, header_json) = valid_header();
+        let mut node = NodeCore::new();
+        node.create_co_value(&co_id, &header_json, None, false).unwrap();
+        node.create_co_value(&co_id, &header_json, None, false).unwrap();
+        assert_eq!(node.co_value_count(), 1);
+    }
+
+    #[test]
+    fn invalid_header_does_not_insert() {
+        let mut node = NodeCore::new();
+        assert!(node.create_co_value("co_zBogus", "{not json", None, false).is_err());
+        assert!(!node.has_co_value("co_zBogus"));
+    }
+}

--- a/crates/cojson-core/src/core/node.rs
+++ b/crates/cojson-core/src/core/node.rs
@@ -95,7 +95,8 @@ mod tests {
         assert!(!node.has_co_value(&co_id));
         assert_eq!(node.co_value_count(), 0);
 
-        node.create_co_value(&co_id, &header_json, None, false).unwrap();
+        node.create_co_value(&co_id, &header_json, None, false)
+            .unwrap();
         assert!(node.has_co_value(&co_id));
         assert_eq!(node.co_value_count(), 1);
         assert!(node.get(&co_id).is_ok());
@@ -111,7 +112,8 @@ mod tests {
         assert!(!node.remove_co_value("co_zDoesNotExist"));
         // double-remove after create
         let (co_id, header_json) = valid_header();
-        node.create_co_value(&co_id, &header_json, None, false).unwrap();
+        node.create_co_value(&co_id, &header_json, None, false)
+            .unwrap();
         assert!(node.remove_co_value(&co_id));
         assert!(!node.remove_co_value(&co_id));
     }
@@ -131,15 +133,19 @@ mod tests {
         // SessionMap; createCoValue must replace, not error.
         let (co_id, header_json) = valid_header();
         let mut node = NodeCore::new();
-        node.create_co_value(&co_id, &header_json, None, false).unwrap();
-        node.create_co_value(&co_id, &header_json, None, false).unwrap();
+        node.create_co_value(&co_id, &header_json, None, false)
+            .unwrap();
+        node.create_co_value(&co_id, &header_json, None, false)
+            .unwrap();
         assert_eq!(node.co_value_count(), 1);
     }
 
     #[test]
     fn invalid_header_does_not_insert() {
         let mut node = NodeCore::new();
-        assert!(node.create_co_value("co_zBogus", "{not json", None, false).is_err());
+        assert!(node
+            .create_co_value("co_zBogus", "{not json", None, false)
+            .is_err());
         assert!(!node.has_co_value("co_zBogus"));
     }
 }

--- a/crates/cojson-core/src/core/session_map.rs
+++ b/crates/cojson-core/src/core/session_map.rs
@@ -263,6 +263,9 @@ pub enum SessionMapError {
     #[error("Cannot add to deleted CoValue: {0}")]
     DeletedCoValue(String),
 
+    #[error("Unknown CoValue: {0}")]
+    UnknownCoValue(String),
+
     #[error("Serialization error: {0}")]
     Serialization(#[from] serde_json::Error),
 

--- a/crates/cojson-core/src/crypto/seal.rs
+++ b/crates/cojson-core/src/crypto/seal.rs
@@ -264,7 +264,7 @@ mod tests {
 
         // Test sealing for group (no sender key needed)
         let sealed = seal_for_group(message, &recipient_id, nonce_material).unwrap();
-        
+
         // Sealed message should be at least 32 bytes (ephemeral public key) + ciphertext
         assert!(sealed.len() > 32);
 

--- a/crates/cojson-core/src/lib.rs
+++ b/crates/cojson-core/src/lib.rs
@@ -11,6 +11,8 @@ pub mod core {
     pub use nonce::*;
     pub use session_log::*;
     pub use session_map::*;
+    pub mod node;
+    pub use node::*;
     pub mod cache;
     pub use cache::*;
     pub mod error;

--- a/docs/superpowers/plans/2026-07-03-nodecore-registry-stage1.md
+++ b/docs/superpowers/plans/2026-07-03-nodecore-registry-stage1.md
@@ -24,26 +24,39 @@
 **Files:**
 - Create: `crates/cojson-core/src/core/node.rs`
 - Modify: `crates/cojson-core/src/lib.rs` (register module)
-- Modify: `crates/cojson-core/src/core/error.rs` (new error variant)
+- Modify: `crates/cojson-core/src/core/session_map.rs` (new error variant)
+
+Error-type note: `SessionMapImpl::new_with_skip_verify` returns
+`Result<Self, SessionMapError>` (session_map.rs:339-345), and `SessionMapError`
+has `#[from] CoJsonCoreError` (session_map.rs:270) — the reverse conversion
+does NOT exist. All `NodeCore` fallible methods therefore use
+`SessionMapError`, and the new variant goes on `SessionMapError`.
 
 - [ ] **Step 1: Add the `UnknownCoValue` error variant**
 
-In `crates/cojson-core/src/core/error.rs`, add to the `CoJsonCoreError` enum (alongside the existing variants):
+In `crates/cojson-core/src/core/session_map.rs`, add to the `SessionMapError` enum (declared at line 247, alongside the existing variants):
 
 ```rust
-  #[error("Unknown CoValue: {0}")]
-  UnknownCoValue(String),
+    #[error("Unknown CoValue: {0}")]
+    UnknownCoValue(String),
 ```
 
-- [ ] **Step 2: Write failing tests for the registry**
+- [ ] **Step 2: Write failing tests for the registry (and register the module)**
 
-Create `crates/cojson-core/src/core/node.rs` containing only the test module for now (the tests reference `NodeCore`, which doesn't exist yet). Reuse the header-construction helper style from `session_map.rs`'s tests — look at how existing tests in that file build a valid `(co_id, header_json)` pair (they use fixtures / `compute_co_id_from_header`); copy the same helper into this test module:
+Immediately register the module so the red step actually compiles the file: in `crates/cojson-core/src/lib.rs`, inside `pub mod core { ... }`, add after the `session_map` lines:
+
+```rust
+    pub mod node;
+    pub use node::*;
+```
+
+Then create `crates/cojson-core/src/core/node.rs` containing only the test module for now (the tests reference `NodeCore`, which doesn't exist yet). Reuse the header-construction helper style from `session_map.rs`'s tests — look at how existing tests in that file build a valid `(co_id, header_json)` pair (they use fixtures / `compute_co_id_from_header`); copy the same helper into this test module:
 
 ```rust
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::core::session_map::SessionMapImpl;
+    use crate::core::session_map::{SessionMapError, SessionMapImpl};
 
     // Build a valid header + matching co_id the same way session_map.rs tests do:
     // create a SessionMapImpl via an existing test fixture header, then reuse its
@@ -87,7 +100,7 @@ mod tests {
     fn get_unknown_covalue_errors() {
         let node = NodeCore::new();
         match node.get("co_zDoesNotExist") {
-            Err(CoJsonCoreError::UnknownCoValue(id)) => assert_eq!(id, "co_zDoesNotExist"),
+            Err(SessionMapError::UnknownCoValue(id)) => assert_eq!(id, "co_zDoesNotExist"),
             other => panic!("expected UnknownCoValue, got {other:?}"),
         }
     }
@@ -126,8 +139,7 @@ Add above the test module in `crates/cojson-core/src/core/node.rs`:
 ```rust
 use std::collections::HashMap;
 
-use crate::core::error::CoJsonCoreError;
-use crate::core::session_map::SessionMapImpl;
+use crate::core::session_map::{SessionMapError, SessionMapImpl};
 
 /// Node-level registry owning one SessionMapImpl per CoValue, keyed by CoID.
 /// One instance per LocalNode. Stage 2+ builds cross-CoValue features
@@ -152,7 +164,7 @@ impl NodeCore {
         header_json: &str,
         max_tx_size: Option<u32>,
         skip_verify: bool,
-    ) -> Result<(), CoJsonCoreError> {
+    ) -> Result<(), SessionMapError> {
         let session_map =
             SessionMapImpl::new_with_skip_verify(co_id, header_json, max_tx_size, skip_verify)?;
         self.covalues.insert(co_id.to_string(), session_map);
@@ -172,16 +184,16 @@ impl NodeCore {
         self.covalues.len()
     }
 
-    pub fn get(&self, co_id: &str) -> Result<&SessionMapImpl, CoJsonCoreError> {
+    pub fn get(&self, co_id: &str) -> Result<&SessionMapImpl, SessionMapError> {
         self.covalues
             .get(co_id)
-            .ok_or_else(|| CoJsonCoreError::UnknownCoValue(co_id.to_string()))
+            .ok_or_else(|| SessionMapError::UnknownCoValue(co_id.to_string()))
     }
 
-    pub fn get_mut(&mut self, co_id: &str) -> Result<&mut SessionMapImpl, CoJsonCoreError> {
+    pub fn get_mut(&mut self, co_id: &str) -> Result<&mut SessionMapImpl, SessionMapError> {
         self.covalues
             .get_mut(co_id)
-            .ok_or_else(|| CoJsonCoreError::UnknownCoValue(co_id.to_string()))
+            .ok_or_else(|| SessionMapError::UnknownCoValue(co_id.to_string()))
     }
 }
 
@@ -194,24 +206,15 @@ impl Default for NodeCore {
 
 Note: bindings resolve the entry via `get`/`get_mut` and call `SessionMapImpl` methods directly — `NodeCore` does not re-wrap the whole per-CoValue surface (that double delegation would be ~300 lines of noise; stage 2 adds cross-CoValue logic here instead).
 
-- [ ] **Step 5: Register the module**
-
-In `crates/cojson-core/src/lib.rs`, inside `pub mod core { ... }` add after the `session_map` lines:
-
-```rust
-    pub mod node;
-    pub use node::*;
-```
-
-- [ ] **Step 6: Run tests to verify they pass**
+- [ ] **Step 5: Run tests to verify they pass**
 
 Run: `cd crates && cargo test -p cojson-core`
 Expected: all tests pass, including the 5 new `node::tests`.
 
-- [ ] **Step 7: Commit**
+- [ ] **Step 6: Commit**
 
 ```bash
-git add crates/cojson-core/src/core/node.rs crates/cojson-core/src/core/error.rs crates/cojson-core/src/lib.rs
+git add crates/cojson-core/src/core/node.rs crates/cojson-core/src/core/session_map.rs crates/cojson-core/src/lib.rs
 git commit -m "feat(cojson-core): NodeCore registry owning SessionMapImpls by CoID"
 ```
 
@@ -367,7 +370,7 @@ git commit -m "feat(cojson-core-napi): NodeCore registry binding with lifted Ses
 
 - [ ] **Step 1: Define `NodeCoreImpl` in crypto.ts**
 
-Add after the `SessionMapImpl` interface (crypto.ts:390). It is the `SessionMapImpl` surface with `coId` as first parameter plus registry methods (`Transaction` is already imported in this file's module graph via the providers; import it here from `../coValueCore/verifiedState.js` the way NapiCrypto.ts does):
+Add after the `SessionMapImpl` interface (crypto.ts:390). It is the `SessionMapImpl` surface with `coId` as first parameter plus registry methods (`Transaction` is already imported in crypto.ts at line 13 — do NOT add a duplicate import):
 
 ```ts
 /**
@@ -1037,7 +1040,7 @@ becomes the same call with `this.node.nodeCore` inserted as the third argument (
 - [ ] **Step 4: Update direct constructions in tests**
 
 Run: `grep -rn "new VerifiedState" packages/cojson/src packages/jazz-tools/src 2>/dev/null`
-For every test hit, insert a registry as the third argument. Where the test has a `LocalNode`, use `node.nodeCore`; where it only has a crypto provider, use `crypto.createNodeCore()` (one per test is fine).
+Expected: exactly one hit — coValueCore.ts:591, already updated in Step 3. This step is a verification guard: if any other hits appear (e.g. tests added since this plan was written), insert a registry as the third argument (`node.nodeCore` where a LocalNode exists, else `crypto.createNodeCore()`).
 
 - [ ] **Step 5: Typecheck and run the full cojson suite**
 
@@ -1085,24 +1088,40 @@ describe("NodeCore eviction", () => {
     node.internalDeleteCoValue(map.id);
   });
 
-  test("internalUnmountCoValue removes the entry and reload re-registers it", async () => {
+  test("internalUnmountCoValue removes the registry entry", async () => {
+    // Unmount preconditions (no listeners, no in-memory dependants, synced):
+    // mirror the EXACT setup of the existing unmount test at
+    // src/tests/sync.concurrentLoad.test.ts:1074 (client/server pair, synced
+    // map, then client.node.internalUnmountCoValue(map.id)). Copy its helpers.
+    // ... setup copied from that test ...
+
+    const unmounted = client.node.internalUnmountCoValue(map.id);
+    expect(unmounted).toBe(true);
+    expect(client.node.nodeCore.hasCoValue(map.id)).toBe(false);
+    // The shell left in node.coValues must not resurrect a registry entry
+    client.node.getCoValue(map.id);
+    expect(client.node.nodeCore.hasCoValue(map.id)).toBe(false);
+  });
+
+  test("re-registration after unmount goes through VerifiedState creation", async () => {
+    // Same setup as above, then reload the CoValue's content from the peer
+    // the way the existing unmount test does (e.g. node.load(map.id) /
+    // loadCoValueCore — copy the reload mechanism from
+    // sync.concurrentLoad.test.ts's post-unmount assertions).
+    // After the reload completes, the header was re-provided, a new
+    // VerifiedState was constructed, and the registry entry must be back:
+    // expect(client.node.nodeCore.hasCoValue(map.id)).toBe(true);
+  });
+
+  test("gracefulShutdown evicts all registry entries", async () => {
     const { node } = setupTestNode();
     const group = node.createGroup();
-    const map = group.createMap();
-    map.set("k", "v");
-    const id = map.id;
+    group.createMap();
+    expect(node.nodeCore.coValueCount()).toBeGreaterThan(0);
 
-    // unmount preconditions: no listeners, no in-memory dependants, synced.
-    // If isSyncedToServerPeers blocks unmount in a storage-less test node,
-    // mirror how existing unmount tests satisfy it (grep tests for
-    // internalUnmountCoValue usage and copy their setup).
-    const unmounted = node.internalUnmountCoValue(id);
-    expect(unmounted).toBe(true);
-    expect(node.nodeCore.hasCoValue(id)).toBe(false);
+    await node.gracefulShutdown();
 
-    // Recreating state for the same id must work (createCoValue replaces/re-registers)
-    const reloaded = node.getCoValue(id);
-    expect(reloaded).toBeDefined();
+    expect(node.nodeCore.coValueCount()).toBe(0);
   });
 });
 ```
@@ -1133,7 +1152,18 @@ In `packages/cojson/src/localNode.ts`:
     this.nodeCore.removeCoValue(id);
 ```
 
-(No change to `gracefulShutdown`: dropping the node drops its single `nodeCore` binding object, whose native finalizer frees the whole registry at once.)
+`gracefulShutdown` (line 999) — the spec lists node shutdown as an eviction
+path; deterministic eviction also covers the wasm shim, whose per-entry
+`free()` otherwise waits for GC. Add at the start of the method:
+
+```ts
+  async gracefulShutdown(): Promise<unknown> {
+    for (const id of this.coValues.keys()) {
+      this.nodeCore.removeCoValue(id);
+    }
+    this.garbageCollector?.stop();
+    // ...existing body...
+```
 
 - [ ] **Step 4: Run the eviction test and the full suite**
 

--- a/docs/superpowers/plans/2026-07-03-nodecore-registry-stage1.md
+++ b/docs/superpowers/plans/2026-07-03-nodecore-registry-stage1.md
@@ -1,0 +1,1196 @@
+# NodeCore Registry (Stage 1) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace the per-CoValue Rust `SessionMap` binding objects with a single per-`LocalNode` `NodeCore` registry (coId-keyed), natively in napi and via a TS shim for wasm/RN — zero behavior change.
+
+**Architecture:** A `NodeCore` struct in `crates/cojson-core` owns all `SessionMapImpl`s keyed by CoID and exposes `create/has/remove/get/get_mut`. The napi binding lifts the existing `SessionMap` method surface onto a `#[napi] NodeCore` with `coId` as first parameter. On the TS side, a new `NodeCoreImpl` interface replaces `SessionMapImpl` as what `VerifiedState` talks to; `CryptoProvider.createNodeCore()` defaults to a TS shim over the existing per-CoValue `createSessionMap` (keeps wasm/RN working unchanged), and `NapiCrypto` overrides it with the native registry. `LocalNode` owns the instance and evicts CoValues explicitly.
+
+**Tech Stack:** Rust (cojson-core), napi-rs v3 (cojson-core-napi), TypeScript (packages/cojson), vitest, cargo test.
+
+**Spec:** `docs/superpowers/specs/2026-07-03-cojson-rust-permissions-migration-design.md` (Stage 1 section). Stages 2–3 get their own plans after this lands.
+
+**Working notes for the implementer:**
+
+- Build napi after Rust changes: `pnpm build:napi` (repo root; see CONTRIBUTING.md "cojson-core Setup"). Rust tests: `cargo test -p cojson-core` from `crates/`.
+- TS tests: `pnpm test` inside `packages/cojson` (runs `vitest --run --root ../../ --project cojson`). Run single files with `pnpm test <path substring>`.
+- Do NOT touch `crates/cojson-core-wasm` or `crates/cojson-core-rn` in this plan — the TS shim covers them; native ports are separate follow-up PRs per the spec's napi-first rollout.
+- No Claude/AI mentions in commits.
+
+---
+
+### Task 1: Rust `NodeCore` registry in cojson-core
+
+**Files:**
+- Create: `crates/cojson-core/src/core/node.rs`
+- Modify: `crates/cojson-core/src/lib.rs` (register module)
+- Modify: `crates/cojson-core/src/core/error.rs` (new error variant)
+
+- [ ] **Step 1: Add the `UnknownCoValue` error variant**
+
+In `crates/cojson-core/src/core/error.rs`, add to the `CoJsonCoreError` enum (alongside the existing variants):
+
+```rust
+  #[error("Unknown CoValue: {0}")]
+  UnknownCoValue(String),
+```
+
+- [ ] **Step 2: Write failing tests for the registry**
+
+Create `crates/cojson-core/src/core/node.rs` containing only the test module for now (the tests reference `NodeCore`, which doesn't exist yet). Reuse the header-construction helper style from `session_map.rs`'s tests — look at how existing tests in that file build a valid `(co_id, header_json)` pair (they use fixtures / `compute_co_id_from_header`); copy the same helper into this test module:
+
+```rust
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::core::session_map::SessionMapImpl;
+
+    // Build a valid header + matching co_id the same way session_map.rs tests do:
+    // create a SessionMapImpl via an existing test fixture header, then reuse its
+    // co_id/header. Simplest: copy the exact header JSON + co_id constants used by
+    // an existing passing test in session_map.rs.
+    fn valid_header() -> (String, String) {
+        // (co_id, header_json) — copy the constants from a session_map.rs test
+        // that constructs SessionMapImpl::new successfully.
+        unimplemented!("copy from session_map.rs test constants")
+    }
+
+    #[test]
+    fn create_has_remove_roundtrip() {
+        let (co_id, header_json) = valid_header();
+        let mut node = NodeCore::new();
+        assert!(!node.has_co_value(&co_id));
+        assert_eq!(node.co_value_count(), 0);
+
+        node.create_co_value(&co_id, &header_json, None, false).unwrap();
+        assert!(node.has_co_value(&co_id));
+        assert_eq!(node.co_value_count(), 1);
+        assert!(node.get(&co_id).is_ok());
+
+        assert!(node.remove_co_value(&co_id));
+        assert!(!node.has_co_value(&co_id));
+        assert_eq!(node.co_value_count(), 0);
+    }
+
+    #[test]
+    fn remove_absent_is_noop() {
+        let mut node = NodeCore::new();
+        assert!(!node.remove_co_value("co_zDoesNotExist"));
+        // double-remove after create
+        let (co_id, header_json) = valid_header();
+        node.create_co_value(&co_id, &header_json, None, false).unwrap();
+        assert!(node.remove_co_value(&co_id));
+        assert!(!node.remove_co_value(&co_id));
+    }
+
+    #[test]
+    fn get_unknown_covalue_errors() {
+        let node = NodeCore::new();
+        match node.get("co_zDoesNotExist") {
+            Err(CoJsonCoreError::UnknownCoValue(id)) => assert_eq!(id, "co_zDoesNotExist"),
+            other => panic!("expected UnknownCoValue, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn create_replaces_existing_entry() {
+        // Matches TS semantics: `new VerifiedState(sameId)` today creates a fresh
+        // SessionMap; createCoValue must replace, not error.
+        let (co_id, header_json) = valid_header();
+        let mut node = NodeCore::new();
+        node.create_co_value(&co_id, &header_json, None, false).unwrap();
+        node.create_co_value(&co_id, &header_json, None, false).unwrap();
+        assert_eq!(node.co_value_count(), 1);
+    }
+
+    #[test]
+    fn invalid_header_does_not_insert() {
+        let mut node = NodeCore::new();
+        assert!(node.create_co_value("co_zBogus", "{not json", None, false).is_err());
+        assert!(!node.has_co_value("co_zBogus"));
+    }
+}
+```
+
+Fill `valid_header()` with real constants copied from an existing green `session_map.rs` test before proceeding.
+
+- [ ] **Step 3: Run tests to verify they fail to compile**
+
+Run: `cd crates && cargo test -p cojson-core node::`
+Expected: compile error — `NodeCore` not found.
+
+- [ ] **Step 4: Implement `NodeCore`**
+
+Add above the test module in `crates/cojson-core/src/core/node.rs`:
+
+```rust
+use std::collections::HashMap;
+
+use crate::core::error::CoJsonCoreError;
+use crate::core::session_map::SessionMapImpl;
+
+/// Node-level registry owning one SessionMapImpl per CoValue, keyed by CoID.
+/// One instance per LocalNode. Stage 2+ builds cross-CoValue features
+/// (group engine, permissions) on top of this registry.
+pub struct NodeCore {
+    covalues: HashMap<String, SessionMapImpl>,
+}
+
+impl NodeCore {
+    pub fn new() -> Self {
+        NodeCore {
+            covalues: HashMap::new(),
+        }
+    }
+
+    /// Create (or replace) the SessionMapImpl for a CoValue.
+    /// Replace-on-existing matches current TS semantics, where constructing a
+    /// new VerifiedState for an already-known id creates a fresh SessionMap.
+    pub fn create_co_value(
+        &mut self,
+        co_id: &str,
+        header_json: &str,
+        max_tx_size: Option<u32>,
+        skip_verify: bool,
+    ) -> Result<(), CoJsonCoreError> {
+        let session_map =
+            SessionMapImpl::new_with_skip_verify(co_id, header_json, max_tx_size, skip_verify)?;
+        self.covalues.insert(co_id.to_string(), session_map);
+        Ok(())
+    }
+
+    pub fn has_co_value(&self, co_id: &str) -> bool {
+        self.covalues.contains_key(co_id)
+    }
+
+    /// Returns true if an entry was removed. Absent id is a no-op (false).
+    pub fn remove_co_value(&mut self, co_id: &str) -> bool {
+        self.covalues.remove(co_id).is_some()
+    }
+
+    pub fn co_value_count(&self) -> usize {
+        self.covalues.len()
+    }
+
+    pub fn get(&self, co_id: &str) -> Result<&SessionMapImpl, CoJsonCoreError> {
+        self.covalues
+            .get(co_id)
+            .ok_or_else(|| CoJsonCoreError::UnknownCoValue(co_id.to_string()))
+    }
+
+    pub fn get_mut(&mut self, co_id: &str) -> Result<&mut SessionMapImpl, CoJsonCoreError> {
+        self.covalues
+            .get_mut(co_id)
+            .ok_or_else(|| CoJsonCoreError::UnknownCoValue(co_id.to_string()))
+    }
+}
+
+impl Default for NodeCore {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+```
+
+Note: bindings resolve the entry via `get`/`get_mut` and call `SessionMapImpl` methods directly — `NodeCore` does not re-wrap the whole per-CoValue surface (that double delegation would be ~300 lines of noise; stage 2 adds cross-CoValue logic here instead).
+
+- [ ] **Step 5: Register the module**
+
+In `crates/cojson-core/src/lib.rs`, inside `pub mod core { ... }` add after the `session_map` lines:
+
+```rust
+    pub mod node;
+    pub use node::*;
+```
+
+- [ ] **Step 6: Run tests to verify they pass**
+
+Run: `cd crates && cargo test -p cojson-core`
+Expected: all tests pass, including the 5 new `node::tests`.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add crates/cojson-core/src/core/node.rs crates/cojson-core/src/core/error.rs crates/cojson-core/src/lib.rs
+git commit -m "feat(cojson-core): NodeCore registry owning SessionMapImpls by CoID"
+```
+
+---
+
+### Task 2: Napi `NodeCore` binding
+
+**Files:**
+- Modify: `crates/cojson-core-napi/src/lib.rs` (add `NodeCore` wrapper; keep the existing `SessionMap` wrapper untouched — wasm/RN parity and rollback both want it alive until the final cleanup PR)
+
+- [ ] **Step 1: Add the `NodeCore` napi wrapper**
+
+In `crates/cojson-core-napi/src/lib.rs`, add `NodeCore as RustNodeCore` to the existing `cojson_core::core::{...}` import, then append after the `SessionMap` impl block. The lifted methods are the existing `#[napi] impl SessionMap` bodies with (a) `co_id: String` prepended to the parameters, (b) `self.internal` replaced by the resolved entry. Error helper + registry methods + three fully worked examples:
+
+```rust
+fn to_napi_err<E: std::fmt::Display>(e: E) -> napi::Error {
+  napi::Error::new(napi::Status::GenericFailure, e.to_string())
+}
+
+#[napi]
+pub struct NodeCore {
+  internal: RustNodeCore,
+}
+
+#[napi]
+impl NodeCore {
+  #[napi(constructor)]
+  #[allow(clippy::new_without_default)]
+  pub fn new() -> NodeCore {
+    NodeCore {
+      internal: RustNodeCore::new(),
+    }
+  }
+
+  // === Registry ===
+
+  #[napi]
+  pub fn create_co_value(
+    &mut self,
+    co_id: String,
+    header_json: String,
+    max_tx_size: Option<u32>,
+    skip_verify: Option<bool>,
+  ) -> napi::Result<()> {
+    self
+      .internal
+      .create_co_value(&co_id, &header_json, max_tx_size, skip_verify.unwrap_or(false))
+      .map_err(to_napi_err)
+  }
+
+  #[napi]
+  pub fn has_co_value(&self, co_id: String) -> bool {
+    self.internal.has_co_value(&co_id)
+  }
+
+  #[napi]
+  pub fn remove_co_value(&mut self, co_id: String) -> bool {
+    self.internal.remove_co_value(&co_id)
+  }
+
+  #[napi]
+  pub fn co_value_count(&self) -> u32 {
+    self.internal.co_value_count() as u32
+  }
+
+  // === Lifted SessionMap surface (worked examples) ===
+
+  #[napi]
+  pub fn get_header(&self, co_id: String) -> napi::Result<String> {
+    Ok(self.internal.get(&co_id).map_err(to_napi_err)?.get_header())
+  }
+
+  #[napi]
+  pub fn add_transactions(
+    &mut self,
+    co_id: String,
+    session_id: String,
+    signer_id: Option<String>,
+    transactions_json: String,
+    signature: String,
+    skip_verify: bool,
+  ) -> napi::Result<()> {
+    self
+      .internal
+      .get_mut(&co_id)
+      .map_err(to_napi_err)?
+      .add_transactions(
+        &session_id,
+        signer_id.as_deref(),
+        &transactions_json,
+        &signature,
+        skip_verify,
+      )
+      .map_err(to_napi_err)
+  }
+
+  #[napi]
+  pub fn get_transaction_count(&self, co_id: String, session_id: String) -> napi::Result<i32> {
+    let sm = self.internal.get(&co_id).map_err(to_napi_err)?;
+    // Same -1-if-absent convention as the SessionMap wrapper
+    Ok(sm.get_transaction_count(&session_id).map(|c| c as i32).unwrap_or(-1))
+  }
+
+  // ... remaining methods
+}
+```
+
+Now lift the REMAINING methods by the same two-step transformation (prepend `co_id: String`; replace `self.internal` with `self.internal.get(&co_id).map_err(to_napi_err)?` for `&self` methods or `self.internal.get_mut(&co_id).map_err(to_napi_err)?` for `&mut self` methods), copying each body from the existing `#[napi] impl SessionMap` block in this same file so every conversion (JSON strings, `KnownState::from`, `-1` conventions, `Option` → `null`) is preserved exactly:
+
+`make_new_private_transaction`, `make_new_trusting_transaction`, `get_session_ids`, `get_transaction`, `get_session_transactions`, `get_last_signature`, `get_signature_after`, `get_last_signature_checkpoint`, `get_known_state`, `get_known_state_with_streaming`, `is_streaming`, `set_streaming_known_state`, `mark_as_deleted`, `is_deleted`, `decrypt_transaction`, `decrypt_transaction_meta`.
+
+Cross-check afterward: `grep -c "pub fn" ` on the `impl SessionMap` block vs the new `impl NodeCore` block — NodeCore must have every SessionMap method plus the constructor and 4 registry methods.
+
+- [ ] **Step 2: Build the napi package**
+
+Run: `pnpm build:napi` (repo root)
+Expected: build succeeds; `packages/cojson-core-napi` (the JS package wrapping the binary) regenerates its `.d.ts` including `export declare class NodeCore` with camelCased methods (`createCoValue`, `addTransactions`, …).
+
+- [ ] **Step 3: Smoke-test from Node**
+
+Run (repo root):
+
+```bash
+node -e "
+const { NodeCore } = require('cojson-core-napi');
+const n = new NodeCore();
+console.log('count', n.coValueCount());
+console.log('has', n.hasCoValue('co_zNope'));
+console.log('remove', n.removeCoValue('co_zNope'));
+try { n.getHeader('co_zNope'); } catch (e) { console.log('err ok:', /Unknown CoValue/.test(e.message)); }
+"
+```
+
+Expected output: `count 0`, `has false`, `remove false`, `err ok: true`.
+(If `require('cojson-core-napi')` fails from repo root, run inside `packages/cojson` where it is a dependency.)
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add crates/cojson-core-napi packages/cojson-core-napi
+git commit -m "feat(cojson-core-napi): NodeCore registry binding with lifted SessionMap surface"
+```
+
+---
+
+### Task 3: TS `NodeCoreImpl` interface + shim + provider default
+
+**Files:**
+- Modify: `packages/cojson/src/crypto/crypto.ts` (add `NodeCoreImpl`, `createNodeCore()`, `dispose?` on `SessionMapImpl`)
+- Create: `packages/cojson/src/crypto/ShimNodeCore.ts`
+- Modify: `packages/cojson/src/crypto/WasmCrypto.ts` (adapter `dispose()`)
+- Test: `packages/cojson/src/tests/shimNodeCore.test.ts`
+
+- [ ] **Step 1: Define `NodeCoreImpl` in crypto.ts**
+
+Add after the `SessionMapImpl` interface (crypto.ts:390). It is the `SessionMapImpl` surface with `coId` as first parameter plus registry methods (`Transaction` is already imported in this file's module graph via the providers; import it here from `../coValueCore/verifiedState.js` the way NapiCrypto.ts does):
+
+```ts
+/**
+ * NodeCoreImpl - node-level registry of per-CoValue session state.
+ * One instance per LocalNode; every method addresses a CoValue by its id.
+ */
+export interface NodeCoreImpl {
+  // === Registry ===
+  createCoValue(
+    coId: string,
+    headerJson: string,
+    maxTxSize?: number,
+    skipVerify?: boolean,
+  ): void;
+  hasCoValue(coId: string): boolean;
+  /** No-op if absent. Frees the CoValue's native memory. */
+  removeCoValue(coId: string): void;
+  coValueCount(): number;
+
+  // === Header ===
+  getHeader(coId: string): string;
+
+  // === Transaction Operations ===
+  addTransactions(
+    coId: string,
+    sessionId: string,
+    signerId: string | undefined,
+    transactionsJson: string,
+    signature: string,
+    skipVerify: boolean,
+  ): void;
+  makeNewPrivateTransaction(
+    coId: string,
+    sessionId: string,
+    signerSecret: string,
+    changesJson: string,
+    keyId: string,
+    keySecret: string,
+    metaJson: string | undefined,
+    madeAt: number,
+  ): string;
+  makeNewTrustingTransaction(
+    coId: string,
+    sessionId: string,
+    signerSecret: string,
+    changesJson: string,
+    metaJson: string | undefined,
+    madeAt: number,
+  ): string;
+
+  // === Session Queries ===
+  getSessionIds(coId: string): string[];
+  getTransactionCount(coId: string, sessionId: string): number;
+  getTransaction(
+    coId: string,
+    sessionId: string,
+    txIndex: number,
+  ): Transaction | undefined;
+  getSessionTransactions(
+    coId: string,
+    sessionId: string,
+    fromIndex: number,
+  ): Transaction[] | undefined;
+  getLastSignature(coId: string, sessionId: string): string | undefined;
+  getSignatureAfter(
+    coId: string,
+    sessionId: string,
+    txIndex: number,
+  ): string | undefined;
+  getLastSignatureCheckpoint(
+    coId: string,
+    sessionId: string,
+  ): number | undefined;
+
+  // === Known State ===
+  getKnownState(coId: string): {
+    id: string;
+    header: boolean;
+    sessions: Record<string, number>;
+  };
+  getKnownStateWithStreaming(
+    coId: string,
+  ):
+    | { id: string; header: boolean; sessions: Record<string, number> }
+    | undefined;
+  isStreaming(coId: string): boolean;
+  setStreamingKnownState(coId: string, streamingJson: string): void;
+
+  // === Deletion ===
+  markAsDeleted(coId: string): void;
+  isDeleted(coId: string): boolean;
+
+  // === Decryption ===
+  decryptTransaction(
+    coId: string,
+    sessionId: string,
+    txIndex: number,
+    keySecret: string,
+  ): string | undefined;
+  decryptTransactionMeta(
+    coId: string,
+    sessionId: string,
+    txIndex: number,
+    keySecret: string,
+  ): string | undefined;
+}
+```
+
+Also add to the existing `SessionMapImpl` interface (used by the shim to free wasm memory):
+
+```ts
+  /** Optional: free native resources eagerly (wasm). */
+  dispose?(): void;
+```
+
+And add to the `CryptoProvider` abstract class, next to `abstract createSessionMap`:
+
+```ts
+  /**
+   * Node-level registry. Default: TS shim over per-CoValue session maps
+   * (wasm/RN until their native NodeCore ports land). NapiCrypto overrides
+   * this with the native registry.
+   */
+  createNodeCore(): NodeCoreImpl {
+    return new ShimNodeCore((coId, headerJson, maxTxSize, skipVerify) =>
+      this.createSessionMap(coId, headerJson, maxTxSize, skipVerify),
+    );
+  }
+```
+
+with `import { ShimNodeCore } from "./ShimNodeCore.js";` at the top of crypto.ts. (ShimNodeCore imports only *types* from crypto.ts, so the cycle is type-only and safe.)
+
+- [ ] **Step 2: Write the failing shim test**
+
+Create `packages/cojson/src/tests/shimNodeCore.test.ts`. Use whatever crypto provider the existing tests in `src/tests` use to get a working `createSessionMap` (grep a neighboring test for its crypto setup helper and reuse it — most use a `WasmCrypto.create()` or `NapiCrypto.create()` awaited in `beforeAll`):
+
+```ts
+import { beforeAll, describe, expect, test } from "vitest";
+import { NapiCrypto } from "../crypto/NapiCrypto.js";
+import { ShimNodeCore } from "../crypto/ShimNodeCore.js";
+import type { CryptoProvider } from "../crypto/crypto.js";
+
+let crypto: CryptoProvider;
+
+beforeAll(async () => {
+  crypto = await NapiCrypto.create();
+});
+
+function makeShim() {
+  return new ShimNodeCore((coId, headerJson, maxTxSize, skipVerify) =>
+    crypto.createSessionMap(coId, headerJson, maxTxSize, skipVerify),
+  );
+}
+
+// Build a real header + coId the way VerifiedState does, so createCoValue
+// passes native header validation.
+function makeHeaderAndId() {
+  const header = {
+    type: "comap" as const,
+    ruleset: { type: "unsafeAllowAll" as const },
+    meta: null,
+    createdAt: null,
+    uniqueness: "test-uniqueness",
+  };
+  const coId = `co_z${crypto.shortHash(header).slice("shortHash_z".length)}`;
+  return { coId, headerJson: JSON.stringify(header) };
+}
+
+describe("ShimNodeCore", () => {
+  test("createCoValue / hasCoValue / removeCoValue roundtrip", () => {
+    const shim = makeShim();
+    const { coId, headerJson } = makeHeaderAndId();
+
+    expect(shim.hasCoValue(coId)).toBe(false);
+    expect(shim.coValueCount()).toBe(0);
+
+    shim.createCoValue(coId, headerJson);
+    expect(shim.hasCoValue(coId)).toBe(true);
+    expect(shim.coValueCount()).toBe(1);
+    expect(JSON.parse(shim.getHeader(coId))).toMatchObject({ type: "comap" });
+
+    shim.removeCoValue(coId);
+    expect(shim.hasCoValue(coId)).toBe(false);
+    expect(shim.coValueCount()).toBe(0);
+    // double remove is a no-op
+    shim.removeCoValue(coId);
+  });
+
+  test("unknown coId throws with Unknown CoValue message", () => {
+    const shim = makeShim();
+    expect(() => shim.getHeader("co_zNope")).toThrow(/Unknown CoValue: co_zNope/);
+    expect(() => shim.getSessionIds("co_zNope")).toThrow(/Unknown CoValue/);
+  });
+
+  test("delegates session queries to the underlying session map", () => {
+    const shim = makeShim();
+    const { coId, headerJson } = makeHeaderAndId();
+    shim.createCoValue(coId, headerJson);
+    expect(shim.getSessionIds(coId)).toEqual([]);
+    expect(shim.getTransactionCount(coId, "co_zAnybody_session_z123")).toBe(-1);
+    expect(shim.getKnownState(coId)).toMatchObject({ id: coId, header: true, sessions: {} });
+  });
+});
+```
+
+Adjust `makeHeaderAndId()` if native header validation rejects it: mirror exactly how `VerifiedState`/`CoValueCore` construct headers in existing tests (grep `createdAt: null` under `src/tests` for a working literal) — the assertion targets registry behavior, not header rules.
+
+- [ ] **Step 3: Run the test to verify it fails**
+
+Run: `cd packages/cojson && pnpm test shimNodeCore`
+Expected: FAIL — `ShimNodeCore` module not found.
+
+- [ ] **Step 4: Implement the shim**
+
+Create `packages/cojson/src/crypto/ShimNodeCore.ts`:
+
+```ts
+import type { Transaction } from "../coValueCore/verifiedState.js";
+import type { NodeCoreImpl, SessionMapImpl } from "./crypto.js";
+
+type SessionMapFactory = (
+  coId: string,
+  headerJson: string,
+  maxTxSize?: number,
+  skipVerify?: boolean,
+) => SessionMapImpl;
+
+/**
+ * NodeCoreImpl implemented over per-CoValue SessionMapImpl objects.
+ * Used by providers without a native NodeCore (wasm, RN) until their
+ * native ports land. Mirrors the native registry's semantics exactly:
+ * replace-on-create, no-op remove, "Unknown CoValue: <id>" on misses.
+ */
+export class ShimNodeCore implements NodeCoreImpl {
+  private readonly covalues = new Map<string, SessionMapImpl>();
+
+  constructor(private readonly createSessionMap: SessionMapFactory) {}
+
+  private get(coId: string): SessionMapImpl {
+    const entry = this.covalues.get(coId);
+    if (!entry) {
+      throw new Error(`Unknown CoValue: ${coId}`);
+    }
+    return entry;
+  }
+
+  createCoValue(
+    coId: string,
+    headerJson: string,
+    maxTxSize?: number,
+    skipVerify?: boolean,
+  ): void {
+    const replaced = this.covalues.get(coId);
+    this.covalues.set(
+      coId,
+      this.createSessionMap(coId, headerJson, maxTxSize, skipVerify),
+    );
+    replaced?.dispose?.();
+  }
+
+  hasCoValue(coId: string): boolean {
+    return this.covalues.has(coId);
+  }
+
+  removeCoValue(coId: string): void {
+    const entry = this.covalues.get(coId);
+    this.covalues.delete(coId);
+    entry?.dispose?.();
+  }
+
+  coValueCount(): number {
+    return this.covalues.size;
+  }
+
+  getHeader(coId: string): string {
+    return this.get(coId).getHeader();
+  }
+
+  addTransactions(
+    coId: string,
+    sessionId: string,
+    signerId: string | undefined,
+    transactionsJson: string,
+    signature: string,
+    skipVerify: boolean,
+  ): void {
+    this.get(coId).addTransactions(
+      sessionId,
+      signerId,
+      transactionsJson,
+      signature,
+      skipVerify,
+    );
+  }
+
+  makeNewPrivateTransaction(
+    coId: string,
+    sessionId: string,
+    signerSecret: string,
+    changesJson: string,
+    keyId: string,
+    keySecret: string,
+    metaJson: string | undefined,
+    madeAt: number,
+  ): string {
+    return this.get(coId).makeNewPrivateTransaction(
+      sessionId,
+      signerSecret,
+      changesJson,
+      keyId,
+      keySecret,
+      metaJson,
+      madeAt,
+    );
+  }
+
+  makeNewTrustingTransaction(
+    coId: string,
+    sessionId: string,
+    signerSecret: string,
+    changesJson: string,
+    metaJson: string | undefined,
+    madeAt: number,
+  ): string {
+    return this.get(coId).makeNewTrustingTransaction(
+      sessionId,
+      signerSecret,
+      changesJson,
+      metaJson,
+      madeAt,
+    );
+  }
+
+  getSessionIds(coId: string): string[] {
+    return this.get(coId).getSessionIds();
+  }
+
+  getTransactionCount(coId: string, sessionId: string): number {
+    return this.get(coId).getTransactionCount(sessionId);
+  }
+
+  getTransaction(
+    coId: string,
+    sessionId: string,
+    txIndex: number,
+  ): Transaction | undefined {
+    return this.get(coId).getTransaction(sessionId, txIndex);
+  }
+
+  getSessionTransactions(
+    coId: string,
+    sessionId: string,
+    fromIndex: number,
+  ): Transaction[] | undefined {
+    return this.get(coId).getSessionTransactions(sessionId, fromIndex);
+  }
+
+  getLastSignature(coId: string, sessionId: string): string | undefined {
+    return this.get(coId).getLastSignature(sessionId);
+  }
+
+  getSignatureAfter(
+    coId: string,
+    sessionId: string,
+    txIndex: number,
+  ): string | undefined {
+    return this.get(coId).getSignatureAfter(sessionId, txIndex);
+  }
+
+  getLastSignatureCheckpoint(
+    coId: string,
+    sessionId: string,
+  ): number | undefined {
+    return this.get(coId).getLastSignatureCheckpoint(sessionId);
+  }
+
+  getKnownState(coId: string): {
+    id: string;
+    header: boolean;
+    sessions: Record<string, number>;
+  } {
+    return this.get(coId).getKnownState();
+  }
+
+  getKnownStateWithStreaming(
+    coId: string,
+  ):
+    | { id: string; header: boolean; sessions: Record<string, number> }
+    | undefined {
+    return this.get(coId).getKnownStateWithStreaming();
+  }
+
+  isStreaming(coId: string): boolean {
+    return this.get(coId).isStreaming();
+  }
+
+  setStreamingKnownState(coId: string, streamingJson: string): void {
+    this.get(coId).setStreamingKnownState(streamingJson);
+  }
+
+  markAsDeleted(coId: string): void {
+    this.get(coId).markAsDeleted();
+  }
+
+  isDeleted(coId: string): boolean {
+    return this.get(coId).isDeleted();
+  }
+
+  decryptTransaction(
+    coId: string,
+    sessionId: string,
+    txIndex: number,
+    keySecret: string,
+  ): string | undefined {
+    return this.get(coId).decryptTransaction(sessionId, txIndex, keySecret);
+  }
+
+  decryptTransactionMeta(
+    coId: string,
+    sessionId: string,
+    txIndex: number,
+    keySecret: string,
+  ): string | undefined {
+    return this.get(coId).decryptTransactionMeta(sessionId, txIndex, keySecret);
+  }
+}
+```
+
+- [ ] **Step 5: Add `dispose()` to the wasm adapter**
+
+In `packages/cojson/src/crypto/WasmCrypto.ts`, the `SessionMapAdapter` class (around line 283) wraps the wasm-bindgen `SessionMap` object, which has a `free()` method. Add to the adapter:
+
+```ts
+  dispose(): void {
+    this.sessionMap.free();
+  }
+```
+
+(Leave `RNCrypto.ts` alone: uniffi objects are collected by JS GC as today; `dispose` is optional.)
+
+- [ ] **Step 6: Run tests to verify they pass**
+
+Run: `cd packages/cojson && pnpm test shimNodeCore`
+Expected: PASS (3 tests).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add packages/cojson/src/crypto/crypto.ts packages/cojson/src/crypto/ShimNodeCore.ts packages/cojson/src/crypto/WasmCrypto.ts packages/cojson/src/tests/shimNodeCore.test.ts
+git commit -m "feat(cojson): NodeCoreImpl interface with shim default over per-CoValue session maps"
+```
+
+---
+
+### Task 4: Native `NodeCoreImpl` in NapiCrypto
+
+**Files:**
+- Modify: `packages/cojson/src/crypto/NapiCrypto.ts`
+- Test: `packages/cojson/src/tests/shimNodeCore.test.ts` (extend to run the same suite against the native adapter)
+
+- [ ] **Step 1: Extend the test to cover the native adapter**
+
+In `packages/cojson/src/tests/shimNodeCore.test.ts`, refactor the `describe` block into a function parameterized by a `makeNodeCore(): NodeCoreImpl` factory and run it twice:
+
+```ts
+import type { NodeCoreImpl } from "../crypto/crypto.js";
+
+function nodeCoreSuite(name: string, makeNodeCore: () => NodeCoreImpl) {
+  describe(name, () => {
+    // ...the three existing tests, using makeNodeCore() instead of makeShim()...
+  });
+}
+
+nodeCoreSuite("ShimNodeCore", () =>
+  new ShimNodeCore((coId, headerJson, maxTxSize, skipVerify) =>
+    crypto.createSessionMap(coId, headerJson, maxTxSize, skipVerify),
+  ),
+);
+nodeCoreSuite("NapiNodeCore (native)", () => crypto.createNodeCore());
+```
+
+- [ ] **Step 2: Run to verify the native suite fails**
+
+Run: `cd packages/cojson && pnpm test shimNodeCore`
+Expected: Shim suite PASSES; native suite FAILS or falls back to the shim (because `NapiCrypto` doesn't override `createNodeCore` yet — the default returns the shim, so it may spuriously pass; to make the red step real, assert the adapter class name):
+
+```ts
+test("NapiCrypto.createNodeCore returns the native adapter", () => {
+  expect(crypto.createNodeCore().constructor.name).toBe("NapiNodeCoreAdapter");
+});
+```
+
+Expected: FAIL (`ShimNodeCore` !== `NapiNodeCoreAdapter`).
+
+- [ ] **Step 3: Implement the native adapter**
+
+In `packages/cojson/src/crypto/NapiCrypto.ts`:
+
+1. Add `NodeCore as NativeNodeCore` to the `cojson-core-napi` import list.
+2. Add `NodeCoreImpl` to the `./crypto.js` import list.
+3. Add to the `NapiCrypto` class:
+
+```ts
+  override createNodeCore(): NodeCoreImpl {
+    return new NapiNodeCoreAdapter(new NativeNodeCore());
+  }
+```
+
+4. Add the adapter class next to `SessionMapAdapter`. It is the same mechanical shape as `SessionMapAdapter` with `coId` threaded through — every method delegates to `this.nodeCore.<method>(coId, ...)` and applies the identical JSON-parse / `?? undefined` conversions. Worked examples plus the rule:
+
+```ts
+/**
+ * Adapter wrapping the native NodeCore registry to implement NodeCoreImpl.
+ */
+class NapiNodeCoreAdapter implements NodeCoreImpl {
+  constructor(private readonly nodeCore: NativeNodeCore) {}
+
+  createCoValue(
+    coId: string,
+    headerJson: string,
+    maxTxSize?: number,
+    skipVerify?: boolean,
+  ): void {
+    this.nodeCore.createCoValue(coId, headerJson, maxTxSize, skipVerify);
+  }
+
+  hasCoValue(coId: string): boolean {
+    return this.nodeCore.hasCoValue(coId);
+  }
+
+  removeCoValue(coId: string): void {
+    this.nodeCore.removeCoValue(coId);
+  }
+
+  coValueCount(): number {
+    return this.nodeCore.coValueCount();
+  }
+
+  getSessionTransactions(
+    coId: string,
+    sessionId: string,
+    fromIndex: number,
+  ): Transaction[] | undefined {
+    const result = this.nodeCore.getSessionTransactions(coId, sessionId, fromIndex);
+    if (!result) return undefined;
+    return result.map((tx) => JSON.parse(tx) as Transaction);
+  }
+
+  getLastSignature(coId: string, sessionId: string): string | undefined {
+    return this.nodeCore.getLastSignature(coId, sessionId) ?? undefined;
+  }
+
+  // ...remaining methods
+}
+```
+
+Implement the remaining `NodeCoreImpl` methods (`getHeader`, `addTransactions`, `makeNewPrivateTransaction`, `makeNewTrustingTransaction`, `getSessionIds`, `getTransactionCount`, `getTransaction`, `getSignatureAfter`, `getLastSignatureCheckpoint`, `getKnownState`, `getKnownStateWithStreaming`, `isStreaming`, `setStreamingKnownState`, `markAsDeleted`, `isDeleted`, `decryptTransaction`, `decryptTransactionMeta`) by copying the corresponding `SessionMapAdapter` method body in this same file and inserting `coId` as the first argument to the native call. Keep conversions identical (`JSON.parse` for `getTransaction`/`getSessionTransactions`, `?? undefined` for nullable returns, direct object return for known state).
+
+- [ ] **Step 4: Run tests to verify all pass**
+
+Run: `cd packages/cojson && pnpm test shimNodeCore`
+Expected: PASS — both suites plus the adapter-class assertion.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/cojson/src/crypto/NapiCrypto.ts packages/cojson/src/tests/shimNodeCore.test.ts
+git commit -m "feat(cojson): native NodeCore adapter in NapiCrypto"
+```
+
+---
+
+### Task 5: Rewire `VerifiedState` and `LocalNode` onto `NodeCoreImpl`
+
+**Files:**
+- Modify: `packages/cojson/src/localNode.ts` (own the NodeCore instance)
+- Modify: `packages/cojson/src/coValueCore/verifiedState.ts` (talk to NodeCoreImpl)
+- Modify: `packages/cojson/src/coValueCore/coValueCore.ts:591` (construction site)
+- Modify: test files constructing `VerifiedState` directly (found by grep)
+
+- [ ] **Step 1: LocalNode owns a NodeCore**
+
+In `packages/cojson/src/localNode.ts`, add a public readonly field and initialize it in the constructor (constructor is at line 85; add after `this.crypto = crypto;` at line 98):
+
+```ts
+  readonly nodeCore: NodeCoreImpl;
+```
+
+```ts
+    this.nodeCore = crypto.createNodeCore();
+```
+
+with `NodeCoreImpl` added to the existing `./crypto/crypto.js` type imports.
+
+- [ ] **Step 2: Rewire VerifiedState**
+
+In `packages/cojson/src/coValueCore/verifiedState.ts`:
+
+1. Replace the field (line 83) `private readonly impl: SessionMapImpl;` with:
+
+```ts
+  private readonly nodeCore: NodeCoreImpl;
+```
+
+2. Change the constructor (lines 97–121) to accept the registry and register the CoValue:
+
+```ts
+  constructor(
+    id: RawCoID,
+    crypto: CryptoProvider,
+    nodeCore: NodeCoreImpl,
+    header: CoValueHeader,
+    streamingKnownState?: KnownStateSessions,
+    skipVerify?: boolean,
+  ) {
+    this.id = id;
+    this.crypto = crypto;
+    this.header = header;
+    this.branchSourceId = header.meta?.source as RawCoID | undefined;
+    this.branchName = header.meta?.branch as string | undefined;
+
+    this.nodeCore = nodeCore;
+    this.nodeCore.createCoValue(
+      id,
+      JSON.stringify(header),
+      TRANSACTION_CONFIG.MAX_RECOMMENDED_TX_SIZE,
+      skipVerify,
+    );
+
+    if (streamingKnownState) {
+      this.nodeCore.setStreamingKnownState(
+        id,
+        JSON.stringify(streamingKnownState),
+      );
+    }
+  }
+```
+
+3. Mechanically rewrite every remaining `this.impl.<method>(<args>)` call in the file to `this.nodeCore.<method>(this.id, <args>)`. Find them all with `grep -n "this.impl" packages/cojson/src/coValueCore/verifiedState.ts` (they are concentrated in `updateSessionLogCache`, `getSessionLog`, `tryAddTransactions`, `makeNewPrivateTransaction`, `makeNewTrustingTransaction`, the signature/known-state/streaming getters, `markAsDeleted`, and the decrypt helpers). Example — line 145:
+
+```ts
+    const currentTxCount = this.impl.getTransactionCount(sessionID);
+```
+
+becomes
+
+```ts
+    const currentTxCount = this.nodeCore.getTransactionCount(this.id, sessionID);
+```
+
+After the rewrite, `grep -c "this.impl" verifiedState.ts` must be 0, and the `SessionMapImpl` import can be replaced with `NodeCoreImpl`.
+
+4. If `VerifiedState` has a `clone`/branch helper that constructs `new VerifiedState(...)` internally (check with `grep -n "new VerifiedState" verifiedState.ts`), thread `this.nodeCore` through it.
+
+- [ ] **Step 3: Update the construction site**
+
+At `packages/cojson/src/coValueCore/coValueCore.ts:591`, add the registry argument (the surrounding CoValueCore has `this.node`):
+
+```ts
+      this._verified = new VerifiedState(
+        // existing args...
+      );
+```
+
+becomes the same call with `this.node.nodeCore` inserted as the third argument (after `crypto`), matching the new signature `(id, crypto, nodeCore, header, streamingKnownState?, skipVerify?)`.
+
+- [ ] **Step 4: Update direct constructions in tests**
+
+Run: `grep -rn "new VerifiedState" packages/cojson/src packages/jazz-tools/src 2>/dev/null`
+For every test hit, insert a registry as the third argument. Where the test has a `LocalNode`, use `node.nodeCore`; where it only has a crypto provider, use `crypto.createNodeCore()` (one per test is fine).
+
+- [ ] **Step 5: Typecheck and run the full cojson suite**
+
+Run: `cd packages/cojson && pnpm exec tsc --noEmit && pnpm test`
+Expected: typecheck clean; full suite PASSES (this is the stage's behavior-preservation gate — any failure here is a real regression, fix before proceeding).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/cojson/src
+git commit -m "refactor(cojson): route VerifiedState through node-level NodeCore registry"
+```
+
+---
+
+### Task 6: Eviction wiring + eviction test
+
+**Files:**
+- Modify: `packages/cojson/src/localNode.ts:199-250` (`internalDeleteCoValue`, `internalUnmountCoValue`)
+- Test: `packages/cojson/src/tests/nodeCoreEviction.test.ts`
+
+- [ ] **Step 1: Write the failing eviction test**
+
+Create `packages/cojson/src/tests/nodeCoreEviction.test.ts`. Reuse the repo's standard test-node helper (grep `src/tests` for the helper used to create a connected `LocalNode` — e.g. `createTestNode`/`setupTestNode` in a `testUtils` module; use exactly that):
+
+```ts
+import { describe, expect, test } from "vitest";
+// import the same node-creation helper neighboring tests use, e.g.:
+// import { setupTestNode } from "./testUtils.js";
+
+describe("NodeCore eviction", () => {
+  test("internalDeleteCoValue removes the registry entry", () => {
+    const { node } = setupTestNode();
+    const group = node.createGroup();
+    const map = group.createMap();
+
+    expect(node.nodeCore.hasCoValue(map.id)).toBe(true);
+    const before = node.nodeCore.coValueCount();
+
+    node.internalDeleteCoValue(map.id);
+
+    expect(node.nodeCore.hasCoValue(map.id)).toBe(false);
+    expect(node.nodeCore.coValueCount()).toBe(before - 1);
+    // double delete is a no-op
+    node.internalDeleteCoValue(map.id);
+  });
+
+  test("internalUnmountCoValue removes the entry and reload re-registers it", async () => {
+    const { node } = setupTestNode();
+    const group = node.createGroup();
+    const map = group.createMap();
+    map.set("k", "v");
+    const id = map.id;
+
+    // unmount preconditions: no listeners, no in-memory dependants, synced.
+    // If isSyncedToServerPeers blocks unmount in a storage-less test node,
+    // mirror how existing unmount tests satisfy it (grep tests for
+    // internalUnmountCoValue usage and copy their setup).
+    const unmounted = node.internalUnmountCoValue(id);
+    expect(unmounted).toBe(true);
+    expect(node.nodeCore.hasCoValue(id)).toBe(false);
+
+    // Recreating state for the same id must work (createCoValue replaces/re-registers)
+    const reloaded = node.getCoValue(id);
+    expect(reloaded).toBeDefined();
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `cd packages/cojson && pnpm test nodeCoreEviction`
+Expected: FAIL — `hasCoValue` still true after delete/unmount (no eviction wired).
+
+- [ ] **Step 3: Wire eviction into LocalNode**
+
+In `packages/cojson/src/localNode.ts`:
+
+`internalDeleteCoValue` (line 199):
+
+```ts
+  internalDeleteCoValue(id: RawCoID) {
+    this.coValues.delete(id);
+    this.nodeCore.removeCoValue(id);
+    this.storage?.onCoValueUnmounted(id);
+  }
+```
+
+`internalUnmountCoValue` (line 210) — add the removal right after the shell replacement (after `this.coValues.set(id, shell);` at line 244):
+
+```ts
+    this.coValues.set(id, shell);
+    this.nodeCore.removeCoValue(id);
+```
+
+(No change to `gracefulShutdown`: dropping the node drops its single `nodeCore` binding object, whose native finalizer frees the whole registry at once.)
+
+- [ ] **Step 4: Run the eviction test and the full suite**
+
+Run: `cd packages/cojson && pnpm test nodeCoreEviction && pnpm test`
+Expected: eviction tests PASS; full suite still green (the GC path in `GarbageCollector.collect()` calls `internalUnmountCoValue`, so it is covered by this wiring).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/cojson/src/localNode.ts packages/cojson/src/tests/nodeCoreEviction.test.ts
+git commit -m "feat(cojson): evict CoValues from NodeCore registry on delete/unmount"
+```
+
+---
+
+### Task 7: Cross-package verification + changeset
+
+**Files:**
+- Create: `.changeset/<generated-name>.md`
+
+- [ ] **Step 1: Run the dependent-package suites**
+
+Run from repo root: `pnpm build:all-packages && pnpm exec turbo run test --filter=cojson --filter=jazz-tools`
+Expected: builds and tests green. jazz-tools exercises wasm (`WasmCrypto` + shim path) in its browser-targeted tests — this validates the shim under a real consumer.
+
+- [ ] **Step 2: Rust + napi final check**
+
+Run: `cd crates && cargo test -p cojson-core && cargo clippy -p cojson-core -p cojson-core-napi -- -D warnings`
+Expected: green, no clippy warnings.
+
+- [ ] **Step 3: Add a changeset**
+
+Create a changeset covering `cojson`, `cojson-core-napi` (patch bumps, consistent with the repo's fixed-version group — check `.changeset/config.json` `fixed` entry to confirm package names):
+
+```markdown
+---
+"cojson": patch
+"cojson-core-napi": patch
+---
+
+Introduce a node-level NodeCore registry owning all per-CoValue session state
+(native in napi; TS shim over per-CoValue session maps for wasm/RN). No
+behavior change; groundwork for moving permissions and group state into the
+Rust core.
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add .changeset
+git commit -m "chore: changeset for NodeCore registry"
+```
+
+---
+
+## Explicitly out of scope (follow-up plans)
+
+- Native `NodeCore` in `cojson-core-wasm` and `cojson-core-rn` (napi-first rollout; the shim keeps those platforms shippable).
+- Stage 2 (group engine: `validateGroup`, `roleOf`) and Stage 3 (`validateTransactions`, `resetValidation`) — separate plans, per the spec.
+- Removing the per-CoValue `SessionMap` binding surface — happens in the final cleanup PR after wasm/RN native ports land.

--- a/docs/superpowers/plans/2026-07-04-group-engine-stage2.md
+++ b/docs/superpowers/plans/2026-07-04-group-engine-stage2.md
@@ -1,0 +1,822 @@
+# Group Engine (Stage 2) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Port group/account permission validation (`determineValidTransactionsForGroup` + `MemberRoleResolver`) and read-side role resolution (`roleOfInternal` and its indices) into a Rust `GroupEngine` inside the stage-1 `NodeCore` registry, exposed as `validateGroup` and `roleOf`, with TypeScript delegating behind capability detection and the TS implementation kept as fallback + differential-test oracle.
+
+**Architecture:** One `GroupEngine` per group/account CoValue, cached in the `NodeCore` entry, rebuilt from scratch whenever that CoValue gains transactions (full recompute — never incremental). Two distinct role structures per the spec: validation-order plain maps (time-ignoring direct-role lookups) and time-indexed `TimeBasedEntry` histories for read queries. Parent-group resolution goes through the registry with on-demand recursive engine builds and a cycle guard. Fixtures generated from the TS implementation are the executable spec; a randomized differential harness guards equivalence until the TS path is deleted (after wasm/RN native ports, out of scope here).
+
+**Tech Stack:** Rust (cojson-core), napi-rs (cojson-core-napi), TypeScript (packages/cojson), vitest, cargo test.
+
+**Spec:** `docs/superpowers/specs/2026-07-03-cojson-rust-permissions-migration-design.md` — the "Stage 2" section and ALL of "Fidelity constraints (normative)". Read both before starting any task.
+
+**Prerequisite:** The stage-1 plan (`2026-07-03-nodecore-registry-stage1.md`) fully landed, including the generation-aware eviction fix and the stage-1 changeset. `NodeCore` (Rust: `crates/cojson-core/src/core/node.rs`), the napi `NodeCore` binding, and TS `NodeCoreImpl`/`ShimNodeCore`/`NapiNodeCoreAdapter` all exist.
+
+**Working notes for the implementer:**
+
+- Build napi after Rust changes: `pnpm build:napi` (repo root). Rust tests: `cargo test -p cojson-core` from `crates/`. TS tests: `pnpm test` inside `packages/cojson`.
+- Rust fixtures live at `crates/cojson-core/data/` and are loaded in tests with `fs::read_to_string("data/<name>.json")` (cwd = crate root; see `session_log.rs:809` for the pattern). Stage-2 fixtures go under `crates/cojson-core/data/group_engine/`.
+- Do NOT touch `crates/cojson-core-wasm` or `crates/cojson-core-rn` — napi-first; the TS fallback keeps wasm/RN working.
+- No Claude/AI mentions in commits.
+
+## Porting oracles (exact sources of truth)
+
+| What | Where |
+| --- | --- |
+| Group validation algorithm | `packages/cojson/src/permissions.ts:229-571` (`determineValidTransactionsForGroup`) |
+| Validation-side role state | `permissions.ts:183-227` (`MemberRoleResolver`; NOTE `getRoleAtTime` ignores `time` for direct roles — `permissions.ts:207-212`) |
+| Validation-side comparator | `permissions.ts:171-181` (`isHigherRole`; `revoked` is never higher) |
+| Read-side role resolution | `packages/cojson/src/coValues/group.ts:451-488` (`roleOfInternal`) |
+| Read-side comparator | `group.ts:1693-1727` (`isMorePermissiveAndShouldInherit`; NOTE `revoked` in parent returns `true` — an inherited `revoked` OVERRIDES the child role, unlike validation-side) |
+| Inheritable-role filter | `group.ts:1681-1691` (`isInheritableRole` — includes `revoked`) |
+| Time-indexed entries | `group.ts:254-286` (`TimeBasedEntry`: chronological insert scanning backwards over `> madeAt` — equal-`madeAt` inserts AFTER existing equals; `getAtTime(undefined)` = latest; else `findLast(madeAt <= t)`) |
+| Account overrides | `packages/cojson/src/coValues/account.ts:44-62` (`currentAgentID` = header `initialAdmin`, static) and `account.ts:68-75` (self → `"admin"`) |
+| Author from session id | `packages/cojson/src/typeUtils/accountOrAgentIDfromSessionID.ts` (substring before `"_session"`) |
+| Transaction ordering | `packages/cojson/src/coValueCore/coValueCore.ts:1842-1855` (`compareTransactions`: effective `madeAt` asc; `txIndex` tiebreak only within same session; cross-session ties equal → stable sort) |
+| Key-shape classifiers | `permissions.ts:583-642` (`isWriteKeyForMember`, `isKeyForKeyField`, `isKeyForAccountField`, `isKeySealedForGroupField`, `isParentExtension`, `isChildExtension`, `isOwnWriteKeyRevelation`) |
+| TS behavior test suites (fixture sources) | `packages/cojson/src/tests/permissions.test.ts`, `group.roleOf.test.ts`, `group.inheritance.test.ts`, `group.addMember.test.ts`, `group.removeMember.test.ts`, `group.invite.test.ts` |
+
+## Verbatim invalid-reason strings (normative — tests assert on these)
+
+`Can't make private transactions in groups` · `Only admins can make private transactions in groups` · `Group transaction must have exactly one change` · `Group transaction must set a role or readKey` · `Only admins can set readKeys` · `Only admins can set groupSealer` · `Only admins can set profile` · `Only admins can set root` · `Only admins and managers can reveal keys` · `Only admins and managers can set parent extensions` · `Parent group is not a group` · `Parent group is a circular dependency` · `Child extensions are not allowed anymore` · `Only admins and managers can set writeKeys` · `Write key already exists and can't be overridden by invite` · `Group transaction must set a valid role` · `Everyone can only be set to reader, writer, writeOnly or revoked` · `Admins can't demote admins.` · `Managers can't demote admins.` · `Managers can't promote to admin.` · `Managers can't invite admins.` · `Managers can't invite managers.` · `AdminInvites can only create admins.` · `managerInvite can only create managers.` · `WriterInvites can only create writers.` · `ReaderInvites can only create reader.` · `WriteOnlyInvites can only create writeOnly.` · `Group transaction must be made by current admin, manager, or invite`
+
+(Cross-check this list against `permissions.ts` at implementation time — the file is the source of truth if it has drifted.)
+
+---
+
+### Task 1: Fixture exporter (TS) + corpus
+
+**Files:**
+- Create: `packages/cojson/src/tests/groupEngineFixtures.export.test.ts` (a vitest file that WRITES fixtures when `EXPORT_GROUP_ENGINE_FIXTURES=1`)
+- Create: `crates/cojson-core/data/group_engine/*.json` (generated, committed)
+
+The fixtures are the executable spec for every Rust task below. Format (one JSON file per scenario):
+
+```json
+{
+  "description": "all invite kinds accept exactly their role",
+  "covalues": [
+    {
+      "coId": "co_z...",
+      "headerJson": "{...stableStringify'd header...}",
+      "sessions": [
+        {
+          "sessionId": "co_zAcc_session_z...",
+          "signerId": "signer_z...",
+          "transactions": ["{...tx json...}", "..."],
+          "lastSignature": "signature_z..."
+        }
+      ]
+    }
+  ],
+  "verdicts": {
+    "co_z<groupId>": [
+      { "sessionId": "...", "txIndex": 0, "valid": true, "reason": null },
+      { "sessionId": "...", "txIndex": 1, "valid": false, "reason": "Managers can't promote to admin." }
+    ]
+  },
+  "roleQueries": [
+    { "groupId": "co_z...", "member": "co_zAcc | sealer_.../signer_... agent id | everyone", "atTime": 1234567 , "expectedRole": "writer" },
+    { "groupId": "co_z...", "member": "co_zAcc", "atTime": null, "expectedRole": null }
+  ]
+}
+```
+
+- [ ] **Step 1: Write the exporter harness**
+
+The file is a normal vitest suite so it can reuse the repo's test helpers. Each scenario is one `test(...)`. Skeleton:
+
+```ts
+import { mkdirSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, test } from "vitest";
+// reuse the exact node-creation helper permissions.test.ts uses (read its imports and copy)
+
+const EXPORT = process.env.EXPORT_GROUP_ENGINE_FIXTURES === "1";
+const OUT_DIR = join(__dirname, "../../../../crates/cojson-core/data/group_engine");
+
+function exportScenario(name: string, node: LocalNode, opts: {
+  covalueIds: RawCoID[];          // groups/accounts the scenario touches (incl. accounts of all members)
+  verdictIds: RawCoID[];          // covalues whose verdicts to record
+  roleQueries: { groupId: RawCoID; member: string; atTime: number | null }[];
+}) {
+  // 1. covalues: for each id, read from node.nodeCore:
+  //    headerJson = nodeCore.getHeader(id)
+  //    for each sessionId of nodeCore.getSessionIds(id):
+  //      transactions = raw JSON strings — re-stringify the parsed Transaction objects
+  //        with the same stableStringify used by VerifiedState, or better: add a tiny
+  //        test-only helper that reads the raw strings (nodeCore.getSessionTransactions
+  //        returns parsed; JSON.stringify(tx) of the parsed object is acceptable because
+  //        Rust re-parses it — key order does not matter for parsing)
+  //      signerId: from the session's signer — reuse VerifiedState.getSessionLog(sessionId).signerID
+  //      lastSignature: nodeCore.getLastSignature(id, sessionId)
+  // 2. verdicts: for each verdictId: get the CoValueCore, call core.getValidTransactions({} /* forces parseNewTransactions */),
+  //    then read core.verifiedTransactions: { sessionId: t.currentTxID.sessionID, txIndex: t.currentTxID.txIndex,
+  //    valid: t.isValid, reason: t.validationErrorMessage ?? null }
+  // 3. roleQueries: for each query: const g = expectGroup(node.expectCoValueLoaded(q.groupId).getCurrentContent());
+  //    const view = q.atTime === null ? g : g.atTime(q.atTime);
+  //    expectedRole = view.roleOfInternal(q.member) ?? null
+  // 4. if (EXPORT) { mkdirSync(OUT_DIR, {recursive:true}); writeFileSync(join(OUT_DIR, `${name}.json`), JSON.stringify(fixture, null, 2)); }
+  // 5. ALWAYS assert the fixture is internally consistent (verdicts non-empty, every roleQuery group present)
+  //    so the suite has value even when not exporting.
+}
+```
+
+- [ ] **Step 2: Write the scenario generators (one test each)**
+
+Each scenario builds real state through public APIs (`node.createGroup()`, `group.addMember`, `group.removeMember`, `createInvite`, `group.extend`/parent-extension APIs — copy the idioms from the oracle test suites listed above). Required scenarios (file names = scenario names):
+
+1. `basic_roles` — admin adds reader/writer/writeOnly/manager; role changes over time; roleQueries at timestamps between changes (use `map.core.verifiedTransactions` timestamps or record `Date.now()` snapshots between operations).
+2. `initial_admin_self_promotion` — fresh group; first tx is the self-promotion; also a non-initialAdmin trying the same (invalid).
+3. `self_revoke` — member revokes themselves (valid even without admin role).
+4. `all_invites` — adminInvite/managerInvite/writerInvite/readerInvite/writeOnlyInvite each: correct acceptance (valid) + wrong-role acceptance (invalid, exact reason).
+5. `admin_demotion_rules` — admin demotes admin (invalid), admin demotes self (valid), admin demotes writer (valid).
+6. `manager_rules` — manager demotes admin / promotes to admin / invites admin / invites manager (all invalid) + manager adds writer (valid).
+7. `write_only_keys` — writeOnly member's own writeKey set (valid), invite overriding an existing writeKey (invalid), admin overriding (valid), own write-key revelation by writeOnly member (valid).
+8. `key_revelations` — readKey/groupSealer/profile/root set by admin (valid) and by writer (invalid); key_for fields revealed by admin and by each invite kind (valid).
+9. `everyone_roles` — everyone set to reader/writer/writeOnly/revoked (valid) and to admin (invalid); roleQueries exercising the everyone fallback (member with no direct role) and the no-fallback-when-querying-everyone case.
+10. `parent_extend` — parent group `extend` mapping; member gets role via parent; roleQueries at times before/after the parent membership change.
+11. `parent_capped` — parent extension with a capping role mapping (e.g. parent admin capped to writer in child).
+12. `parent_revoked_inheritance` — member has reader in child, `revoked` in parent with `extend` mapping — read-side role must come out per `isMorePermissiveAndShouldInherit("revoked", ...)` semantics (export whatever TS produces; this pins the override behavior).
+13. `deep_parent_chain` — 3-level chain (grandparent → parent → child), including a revocation mid-chain and time-based queries.
+14. `self_extension_cycle` — attempt to extend a group with itself / a cycle (invalid: `Parent group is a circular dependency`).
+15. `account_agent_resolution` — an account-owned scenario where the transactor is the account id itself (exercises `agentInAccountOrMemberInGroup` in validation on the ACCOUNT covalue) + account self roleQuery (expects `"admin"`).
+16. `malformed_changes` — a transaction with two changes; an op that isn't `set`; an invalid role value; everyone with invalid role. (Craft via `core.makeTransaction` with raw changes if the public API blocks these — copy how permissions.test.ts crafts hostile transactions.)
+17. `cross_session_ties` — two sessions of different accounts with equal `madeAt` transactions (freeze `Date.now` via `vi.setSystemTime` to force ties); verdicts + role queries pin the stable-order outcome.
+18. `private_tx_in_group` — a private transaction on a group (invalid: `Can't make private transactions in groups`) and on an account (export whatever TS produces — accounts take the other branch of the `isGroup` check; this pins the account/private semantics).
+
+- [ ] **Step 3: Run without export, then with export**
+
+Run: `cd packages/cojson && pnpm test groupEngineFixtures` → all scenarios pass their internal-consistency assertions.
+Run: `EXPORT_GROUP_ENGINE_FIXTURES=1 pnpm test groupEngineFixtures` → files appear under `crates/cojson-core/data/group_engine/`.
+Spot-check one file by eye: verdicts include both valid and invalid entries with exact reason strings.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add packages/cojson/src/tests/groupEngineFixtures.export.test.ts crates/cojson-core/data/group_engine
+git commit -m "test(cojson): group-engine fixture corpus exported from TS permissions oracle"
+```
+
+---
+
+### Task 2: Rust foundation types — roles, TimeBasedEntry, key classifiers
+
+**Files:**
+- Create: `crates/cojson-core/src/core/group_engine/mod.rs` (module root: `pub mod types; pub mod classify; pub mod engine;` — engine.rs added in Task 4)
+- Create: `crates/cojson-core/src/core/group_engine/types.rs`
+- Create: `crates/cojson-core/src/core/group_engine/classify.rs`
+- Modify: `crates/cojson-core/src/lib.rs` (add `pub mod group_engine;` + re-export inside `pub mod core`)
+
+- [ ] **Step 1: Write failing tests for types.rs**
+
+Tests for `Role` parsing/serialization (every variant round-trips its exact TS string: `admin`, `manager`, `writer`, `reader`, `writeOnly`, `revoked`, `adminInvite`, `managerInvite`, `writerInvite`, `readerInvite`, `writeOnlyInvite`), `is_account_role`, `can_admin` (admin|manager), `is_inheritable_role` (revoked|admin|manager|writer|reader), `is_higher_role` (validation-side, table from `permissions.ts:171-181`), `is_more_permissive_and_should_inherit` (read-side, table from `group.ts:1693-1727` — include the `revoked → true` case), and `TimeBasedEntry`:
+
+```rust
+#[test]
+fn time_based_entry_matches_ts_semantics() {
+    let mut e = TimeBasedEntry::new();
+    e.add_change(10, "a");
+    e.add_change(30, "c");
+    e.add_change(20, "b");            // out-of-order insert lands in the middle
+    assert_eq!(e.get_at_time(Some(15)), Some(&"a"));
+    assert_eq!(e.get_at_time(Some(20)), Some(&"b"));
+    assert_eq!(e.get_at_time(None), Some(&"c"));   // None = latest
+    assert_eq!(e.get_at_time(Some(5)), None);
+    // equal madeAt inserts AFTER existing equals (TS scans `> madeAt`)
+    e.add_change(20, "b2");
+    assert_eq!(e.get_at_time(Some(20)), Some(&"b2"));
+}
+```
+
+- [ ] **Step 2: Implement types.rs**
+
+```rust
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum Role {
+    #[serde(rename = "admin")] Admin,
+    #[serde(rename = "manager")] Manager,
+    #[serde(rename = "writer")] Writer,
+    #[serde(rename = "reader")] Reader,
+    #[serde(rename = "writeOnly")] WriteOnly,
+    #[serde(rename = "revoked")] Revoked,
+    #[serde(rename = "adminInvite")] AdminInvite,
+    #[serde(rename = "managerInvite")] ManagerInvite,
+    #[serde(rename = "writerInvite")] WriterInvite,
+    #[serde(rename = "readerInvite")] ReaderInvite,
+    #[serde(rename = "writeOnlyInvite")] WriteOnlyInvite,
+}
+
+impl Role {
+    pub fn parse(s: &str) -> Option<Role> { /* match on the 11 strings */ }
+    pub fn as_str(&self) -> &'static str { /* inverse */ }
+    pub fn can_admin(role: Option<Role>) -> bool { matches!(role, Some(Role::Admin) | Some(Role::Manager)) }
+    pub fn is_inheritable(role: Option<Role>) -> bool { /* revoked|admin|manager|writer|reader */ }
+}
+
+/// Validation-side comparator — permissions.ts:171-181. `a` higher than `b`?
+pub fn is_higher_role(a: Role, b: Option<Role>) -> bool { /* port exactly: revoked never higher; admin > manager > writer-over-reader */ }
+
+/// Read-side comparator — group.ts:1693-1727. NOTE: revoked parent role returns true.
+pub fn is_more_permissive_and_should_inherit(role_in_parent: Role, role_in_child: Option<Role>) -> bool { /* port the 6-branch table exactly */ }
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum ParentRoleMapping { Extend, Capped(Role), Revoked }
+// parsed from the parent_<id> change value: "extend" | a role string | "revoked"
+
+pub struct TimeBasedEntry<T> { changes: Vec<(u64, T)> }
+impl<T> TimeBasedEntry<T> {
+    pub fn new() -> Self { TimeBasedEntry { changes: Vec::new() } }
+    pub fn add_change(&mut self, made_at: u64, value: T) {
+        let mut idx = self.changes.len();
+        while idx > 0 && self.changes[idx - 1].0 > made_at { idx -= 1; }
+        self.changes.insert(idx, (made_at, value));
+    }
+    pub fn get_latest(&self) -> Option<&T> { self.changes.last().map(|(_, v)| v) }
+    pub fn get_at_time(&self, at_time: Option<u64>) -> Option<&T> {
+        match at_time {
+            None => self.get_latest(),
+            Some(t) => self.changes.iter().rev().find(|(m, _)| *m <= t).map(|(_, v)| v),
+        }
+    }
+}
+```
+
+- [ ] **Step 3: Write failing tests + implement classify.rs**
+
+Port the seven key classifiers with the EXACT TS string logic (`permissions.ts:583-642` — note `isKeyForAccountField`'s odd `||` grouping: `(starts key_ && (contains _for_sealer || _for_co)) || contains _for_everyone`), plus:
+
+```rust
+pub fn author_from_session_id(session_id: &str) -> &str {
+    // substring before "_session" — accountOrAgentIDfromSessionID.ts
+    match session_id.find("_session") { Some(i) => &session_id[..i], None => session_id }
+}
+pub fn parent_group_id_from_key(key: &str) -> &str { &key["parent_".len()..] }
+```
+
+Tests: one case per classifier true/false branch, mirroring the TS shapes (`writeKeyFor_co_z1`, `key_z1_for_key_z2`, `key_z1_for_sealer_z...`, `key_z1_for_everyone`, `key_z1_sealedFor_sealer_z...`, `parent_co_z1`, `child_co_z1`), plus `author_from_session_id("co_zA_session_z123") == "co_zA"`.
+
+- [ ] **Step 4: Run and commit**
+
+Run: `cd crates && cargo test -p cojson-core group_engine::` → green.
+
+```bash
+git add crates/cojson-core/src/core/group_engine crates/cojson-core/src/lib.rs
+git commit -m "feat(cojson-core): group-engine foundation types and key classifiers"
+```
+
+---
+
+### Task 3: Rust transaction view + validation ordering
+
+**Files:**
+- Create: `crates/cojson-core/src/core/group_engine/tx_view.rs` (add `pub mod tx_view;` to mod.rs)
+
+- [ ] **Step 1: Write failing tests**
+
+Load `data/group_engine/cross_session_ties.json` and `basic_roles.json` (serde structs for the fixture format defined here too — they'll be reused by later tasks; put them in `tx_view.rs` under `#[cfg(test)] pub(crate) mod fixtures`). Tests assert: transactions extracted per session in insertion order; ordering by the comparator below reproduces a hand-verified order for the ties fixture (derive the expected order once from the fixture's verdict list order semantics — validation state evolution depends on it, so if the order were wrong Task 4's fixtures would fail; here just pin: equal-madeAt cross-session preserves session-insertion order, same-session orders by txIndex, different madeAt orders ascending).
+
+- [ ] **Step 2: Implement**
+
+```rust
+/// Extra per-tx info TS supplies (merge-meta-derived source times). Keyed lookup.
+#[derive(Debug, Clone, serde::Deserialize)]
+pub struct PendingTxIn {
+    pub session_id: String,
+    pub tx_index: u32,
+    pub source_made_at: Option<u64>,
+}
+
+#[derive(Debug, Clone)]
+pub struct GroupTxView {
+    pub session_id: String,
+    pub tx_index: u32,
+    pub author: String,            // author_from_session_id(session_id)
+    pub current_made_at: u64,      // tx.madeAt — used for permission checks
+    pub effective_made_at: u64,    // source_made_at.unwrap_or(current_made_at) — used for ORDERING
+    pub privacy: Privacy,          // Private | Trusting
+    pub changes: Option<Vec<serde_json::Value>>,  // parsed for trusting; None for private
+}
+
+/// Build views from a SessionMapImpl: iterate sessions in insertion order (the sessions
+/// field is an IndexMap), within each session by tx index; parse each transaction JSON once.
+pub fn collect_group_txs(sm: &SessionMapImpl, pending_info: &[PendingTxIn]) -> Vec<GroupTxView> { ... }
+
+/// compareTransactions port (coValueCore.ts:1842-1855) + STABLE sort:
+/// effective_made_at asc; equal → same session ? tx_index : keep relative order.
+pub fn sort_for_validation(txs: &mut Vec<GroupTxView>) {
+    txs.sort_by(|a, b| {
+        match a.effective_made_at.cmp(&b.effective_made_at) {
+            core::cmp::Ordering::Equal if a.session_id == b.session_id => a.tx_index.cmp(&b.tx_index),
+            core::cmp::Ordering::Equal => core::cmp::Ordering::Equal,  // stable sort preserves insertion order
+            other => other,
+        }
+    });
+}
+```
+
+Use whatever accessor `SessionMapImpl` exposes for raw transactions (`get_session_transactions`/internal session iteration — read `session_map.rs` and use the least-copying path; adding a `pub(crate)` iterator to `SessionMapImpl` is allowed if none fits).
+
+- [ ] **Step 3: Run and commit**
+
+Run: `cd crates && cargo test -p cojson-core group_engine::` → green.
+
+```bash
+git add crates/cojson-core/src/core/group_engine
+git commit -m "feat(cojson-core): group transaction views with validation ordering"
+```
+
+---
+
+### Task 4: Rust GroupEngine — validation + read-side roles
+
+This is the core port. It is one task because validation and role state are one algorithm (spec), but implement in the three internal phases below, running fixture subsets as you go.
+
+**Files:**
+- Create: `crates/cojson-core/src/core/group_engine/engine.rs` (add to mod.rs)
+- Modify: `crates/cojson-core/src/core/node.rs` (engine storage + registry access)
+- Modify: `crates/cojson-core/src/core/session_map.rs` (error variant)
+
+- [ ] **Step 1: Add error variants**
+
+On `SessionMapError` (session_map.rs), add:
+
+```rust
+    #[error("CoValue not loaded: {0}")]
+    CoValueNotLoaded(String),
+```
+
+(`UnknownCoValue` stays for API misuse on the CoValue itself; `CoValueNotLoaded` is for a missing DEPENDENCY — parent group / owning account — and is what TS translates to its `expectCoValueLoaded` throw.)
+
+- [ ] **Step 2: Define the engine structures**
+
+```rust
+pub struct Verdict {
+    pub session_id: String,
+    pub tx_index: u32,
+    pub valid: bool,
+    pub reason: Option<String>,      // verbatim TS reason string when invalid
+}
+
+/// Built by one full validation pass; cached per CoValue keyed by session tx-counts.
+pub struct GroupEngineState {
+    /// snapshot for cache validity: (session_id, tx_count) at build time
+    pub session_counts: Vec<(String, u32)>,
+    pub verdicts: Vec<Verdict>,
+    /// READ state (time-indexed), built from VALIDATED set-role ops only:
+    pub role_history: HashMap<String, TimeBasedEntry<Role>>,          // member -> role over time (madeAt = effective_made_at of the op, matching CoMap op indexing)
+    pub parent_history: HashMap<String, TimeBasedEntry<ParentRoleMapping>>, // parent coId -> mapping over time
+    /// header facts:
+    pub initial_admin: Option<String>,
+    pub is_account: bool,            // header meta type == "account" — mirror how TS distinguishes (check RawAccount creation: accountHeaderForInitialAgentSecret; verify against fixtures)
+}
+```
+
+Validation state (function-local, NOT stored — mirrors `MemberRoleResolver` being rebuilt per call):
+
+```rust
+struct ResolverState {
+    member_roles: HashMap<String, Role>,                 // plain, time-ignoring (permissions.ts:184-185)
+    parent_groups: HashMap<String, ParentRoleMapping>,   // current mappings in validation order
+    write_only_keys: HashMap<String, String>,            // member -> KeyID
+    write_keys: HashSet<String>,                         // seen writeKeyFor_ change keys
+}
+```
+
+- [ ] **Step 3: Port the validation loop (`validate_group_covalue`)**
+
+Signature and flow:
+
+```rust
+/// Full recompute. `node` gives registry access for parents/accounts.
+/// Returns the freshly built state. NEVER incremental (spec: recompute-don't-increment).
+pub fn build_group_engine(
+    node: &NodeCore,
+    co_id: &str,
+    pending_info: &[PendingTxIn],
+    visited: &mut HashSet<String>,        // cycle guard across recursive builds
+) -> Result<GroupEngineState, SessionMapError>
+```
+
+Port `determineValidTransactionsForGroup` (`permissions.ts:229-571`) branch by branch, in source order, preserving every reason string verbatim (see the normative list above). Structural mappings:
+
+- `coValue.verifiedTransactions.sort(compareTransactions)` → `sort_for_validation` from Task 3.
+- `transaction.author` → `GroupTxView.author`; the `getRoleAtTime(transactor, currentMadeAt)` call → `resolver_role_at(state, node, transactor, current_made_at, visited)?` which reads the PLAIN map for the direct role (time ignored) and does the time-based parent walk: for each `(parent_id, mapping)` in `parent_groups` (skip `Revoked`), `role = role_of_internal(node, parent_id, member, Some(time), visited)?`; if inheritable: resolved = mapping==Extend ? parent_role : capped; if `is_higher_role(resolved, current)` upgrade. (This is `MemberRoleResolver.getRoleAtTime`, `permissions.ts:207-226`.)
+- `tx.privacy === "private"` branch: `is_group` = NOT `is_account` (verify against the `private_tx_in_group` fixture — TS `coValue.isGroup()` semantics; the fixture is authoritative).
+- Parent-extension branch: `node.get(parent_id)` failing → return `Err(CoValueNotLoaded(parent_id))` (mirrors `expectCoValueLoaded` throwing). "Parent group is not a group" ← parent's header ruleset != group. Self-extension/cycle ← `visited` guard + direct self-reference (mirror `isSelfExtension` — read its TS impl in group.ts when porting).
+- On every `markValid` of a set-role change: update BOTH the resolver's plain map AND `role_history.add_change(effective_made_at, role)`; parent set/revoke updates `parent_groups` AND `parent_history`.
+- Verdicts pushed for EVERY transaction in validation order.
+
+- [ ] **Step 4: Port read-side `role_of_internal`**
+
+```rust
+/// group.ts:451-488 + account.ts:68-75 overrides. at_time None = latest.
+pub fn role_of_internal(
+    node: &NodeCore,
+    group_id: &str,
+    member: &str,
+    at_time: Option<u64>,
+    visited: &mut HashSet<String>,
+) -> Result<Option<Role>, SessionMapError>
+```
+
+- Ensures the group's engine is fresh (see Step 5) — building it recursively if needed.
+- Account override first: if the engine `is_account` and `member == group_id` → `Some(Admin)`.
+- Direct role: `role_history[member].get_at_time(at_time)`; `Revoked` → treated as none for `role_here` (but keep the raw value: the parent-walk result may still produce Revoked per `is_more_permissive_and_should_inherit`).
+- Parent walk: for each parent in `parent_history`, mapping at `at_time`; skip none/Revoked mapping; recurse `role_of_internal(node, parent_id, member, at_time, visited)` (cycle guard: if parent already in `visited`, skip that edge); filter by `Role::is_inheritable`; `Extend` inherits parent role else capped; upgrade via `is_more_permissive_and_should_inherit`.
+- Everyone fallback: only if no role resolved and `member != "everyone"`: `role_history["everyone"].get_at_time(at_time)` unless Revoked.
+- Transactor-is-account resolution for validation (`agentInAccountOrMemberInGroup`, `permissions.ts:573-581`) — implemented where the VALIDATOR needs it: if transactor == the covalue's id and the covalue is an account → resolve to the account's static header agent (`initial_admin` from the header, which for accounts IS the agent id — `account.ts:44-62`).
+
+- [ ] **Step 5: NodeCore integration + freshness**
+
+In `node.rs`:
+
+```rust
+pub struct CoValueEntry {                 // refactor: HashMap<String, SessionMapImpl> becomes HashMap<String, CoValueEntry>
+    pub session_map: SessionMapImpl,
+    pub group_engine: Option<GroupEngineState>,
+}
+```
+
+(Adjust `get`/`get_mut` to return `&CoValueEntry`/`&mut CoValueEntry` OR keep signatures returning the session map and add `entry`/`entry_mut` — pick whichever keeps the napi/binding diff smallest; the stage-1 binding calls `get(...)?.method(...)` on the session map.)
+
+```rust
+impl NodeCore {
+    /// Rebuild engine iff session tx-counts changed since last build (full recompute).
+    fn ensure_engine(&mut self, co_id: &str, pending: &[PendingTxIn], visited: &mut HashSet<String>) -> Result<(), SessionMapError> { ... }
+
+    pub fn validate_group(&mut self, co_id: &str, pending: &[PendingTxIn]) -> Result<Vec<Verdict>, SessionMapError> {
+        let mut visited = HashSet::new();
+        self.ensure_engine(co_id, pending, &mut visited)?;
+        Ok(self.entry(co_id)?.group_engine.as_ref().unwrap().verdicts.clone())
+    }
+
+    pub fn role_of(&mut self, group_id: &str, member: &str, at_time: Option<u64>) -> Result<Option<Role>, SessionMapError> {
+        let mut visited = HashSet::new();
+        role_of_internal(self, group_id, member, at_time, &mut visited).map(...)
+    }
+}
+```
+
+NOTE on borrows: recursive engine builds over `&mut self` won't borrow-check naively. Acceptable approaches (pick one, document it): (a) two-phase — collect the dependency closure first (walk parent ids from raw transactions), build engines bottom-up iteratively; (b) take the engine out of the entry during build (`Option::take`), put it back after. Do NOT clone entire session maps. Cycle guard applies in both.
+
+- [ ] **Step 6: Fixture tests — the main gate**
+
+One test per fixture file (all 18): load JSON, `NodeCore::new()`, `create_co_value(skip_verify=true)` + `add_transactions(skip_verify=true)` for every covalue/session, then:
+- `validate_group(coId, pending=[])` for each verdict-bearing covalue → verdict list must equal the fixture's (order, valid flags, and reason strings EXACTLY).
+- every `roleQuery` → `role_of` result string (or None) equals `expectedRole`.
+
+Run: `cd crates && cargo test -p cojson-core group_engine::` → all 18 fixture tests green. Debug divergences by comparing against the TS oracle files — fixtures are authoritative; the TS source tells you WHY.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add crates/cojson-core/src/core
+git commit -m "feat(cojson-core): GroupEngine — group validation and role resolution over NodeCore"
+```
+
+---
+
+### Task 5: Napi binding for validateGroup / roleOf
+
+**Files:**
+- Modify: `crates/cojson-core-napi/src/lib.rs`
+
+- [ ] **Step 1: Add napi types + methods**
+
+```rust
+#[napi(object)]
+pub struct PendingTx {
+  pub session_id: String,
+  pub tx_index: u32,
+  pub source_made_at: Option<f64>,
+}
+
+#[napi(object)]
+pub struct GroupVerdict {
+  pub session_id: String,
+  pub tx_index: u32,
+  pub valid: bool,
+  pub reason: Option<String>,
+}
+
+#[napi]
+impl NodeCore {
+  /// Validate a group/account CoValue; verdicts for ALL its transactions in validation order.
+  #[napi]
+  pub fn validate_group(&mut self, co_id: String, pending: Vec<PendingTx>) -> napi::Result<Vec<GroupVerdict>> { /* convert, delegate, map_err(to_napi_err) */ }
+
+  /// Role of member in group at time (ms). Returns the role string or null.
+  #[napi]
+  pub fn role_of(&mut self, group_id: String, member: String, at_time: Option<f64>) -> napi::Result<Option<String>> { ... }
+}
+```
+
+Error mapping note: `CoValueNotLoaded` must stay distinguishable in JS — it flows through `to_napi_err` as message `"CoValue not loaded: co_z..."`; TS matches on that prefix (Task 7). Keep the message format stable.
+
+- [ ] **Step 2: Build + smoke test**
+
+Run: `pnpm build:napi`. Then from `packages/cojson`:
+
+```bash
+node -e "
+const { NodeCore } = require('cojson-core-napi');
+const n = new NodeCore();
+try { n.validateGroup('co_zNope', []); } catch (e) { console.log('unknown ok:', /Unknown CoValue/.test(e.message)); }
+try { n.roleOf('co_zNope', 'co_zX'); } catch (e) { console.log('unknown ok2:', /Unknown CoValue/.test(e.message)); }
+"
+```
+
+Expected: both `ok: true` lines. Confirm `index.d.ts` gained `validateGroup`, `roleOf`, `PendingTx`, `GroupVerdict`.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add crates/cojson-core-napi
+git commit -m "feat(cojson-core-napi): expose validateGroup and roleOf on NodeCore"
+```
+
+---
+
+### Task 6: TS capability surface
+
+**Files:**
+- Modify: `packages/cojson/src/crypto/crypto.ts` (optional methods on `NodeCoreImpl`)
+- Modify: `packages/cojson/src/crypto/NapiCrypto.ts` (adapter implements them)
+- Test: `packages/cojson/src/tests/shimNodeCore.test.ts` (extend)
+
+- [ ] **Step 1: Extend NodeCoreImpl (optional = capability detection)**
+
+```ts
+export type NodeCorePendingTx = {
+  sessionId: string;
+  txIndex: number;
+  sourceMadeAt?: number;
+};
+export type NodeCoreGroupVerdict = {
+  sessionId: string;
+  txIndex: number;
+  valid: boolean;
+  reason?: string;
+};
+
+export interface NodeCoreImpl {
+  // ...existing...
+  /** Native group validation (stage 2). Absent on providers without a native NodeCore. */
+  validateGroup?(coId: string, pending: NodeCorePendingTx[]): NodeCoreGroupVerdict[];
+  /** Native role resolution (stage 2). Absent on providers without a native NodeCore. */
+  roleOf?(groupId: string, member: string, atTime?: number): string | undefined;
+}
+```
+
+`ShimNodeCore` intentionally does NOT implement them (TS fallback runs).
+
+- [ ] **Step 2: Implement on NapiNodeCoreAdapter**
+
+```ts
+  validateGroup(coId: string, pending: NodeCorePendingTx[]): NodeCoreGroupVerdict[] {
+    return this.nodeCore.validateGroup(coId, pending).map((v) => ({
+      sessionId: v.sessionId,
+      txIndex: v.txIndex,
+      valid: v.valid,
+      reason: v.reason ?? undefined,
+    }));
+  }
+
+  roleOf(groupId: string, member: string, atTime?: number): string | undefined {
+    return this.nodeCore.roleOf(groupId, member, atTime) ?? undefined;
+  }
+```
+
+- [ ] **Step 3: Extend the registry tests**
+
+In shimNodeCore.test.ts add to the parameterized suite: shim → `expect(nodeCore.validateGroup).toBeUndefined()`; native → `expect(typeof nodeCore.validateGroup).toBe("function")` and an unknown-coId throw assertion for both methods. Run: `pnpm test shimNodeCore` → green. `pnpm exec tsc --noEmit` → clean.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add packages/cojson/src/crypto packages/cojson/src/tests/shimNodeCore.test.ts
+git commit -m "feat(cojson): optional native validateGroup/roleOf on NodeCoreImpl"
+```
+
+---
+
+### Task 7: TS delegation — permissions.ts group branch
+
+**Files:**
+- Modify: `packages/cojson/src/permissions.ts`
+
+- [ ] **Step 1: Write the delegation**
+
+In `determineValidTransactions` (`permissions.ts:73`), the `ruleset.type === "group"` branch becomes:
+
+```ts
+  if (coValue.verified.header.ruleset.type === "group") {
+    const initialAdmin = coValue.verified.header.ruleset.initialAdmin;
+    if (!initialAdmin) {
+      throw new Error("Group must have initialAdmin");
+    }
+
+    const nodeCore = coValue.node.nodeCore;
+    if (nodeCore.validateGroup && !nativeValidationDisabled()) {
+      determineValidTransactionsForGroupNative(coValue, nodeCore);
+    } else {
+      determineValidTransactionsForGroup(coValue, initialAdmin);
+    }
+    return;
+  }
+```
+
+Also add the kill switch helper (exported so group.ts and the differential
+harness reuse it) — browser-safe (`process` may not exist in wasm/browser
+environments):
+
+```ts
+/** Operational kill switch + differential-test escape hatch. */
+export function nativeValidationDisabled(): boolean {
+  return (
+    (globalThis as { process?: { env?: Record<string, string> } }).process
+      ?.env?.COJSON_DISABLE_NATIVE_VALIDATION === "1"
+  );
+}
+```
+
+```ts
+function determineValidTransactionsForGroupNative(
+  coValue: CoValueCore,
+  nodeCore: NodeCoreImpl,
+): void {
+  const pending: NodeCorePendingTx[] = [];
+  for (const tx of coValue.verifiedTransactions) {
+    if (tx.sourceTxMadeAt !== undefined) {
+      pending.push({
+        sessionId: tx.currentTxID.sessionID,
+        txIndex: tx.currentTxID.txIndex,
+        sourceMadeAt: tx.sourceTxMadeAt,
+      });
+    }
+  }
+  const verdicts = nodeCore.validateGroup!(coValue.id, pending);
+
+  const byKey = new Map<string, VerifiedTransaction>();
+  for (const tx of coValue.verifiedTransactions) {
+    byKey.set(`${tx.currentTxID.sessionID}/${tx.currentTxID.txIndex}`, tx);
+  }
+  // Apply IN THE ORDER RUST RETURNS (spec: dispatch order feeds downstream stable sorts)
+  for (const v of verdicts) {
+    const tx = byKey.get(`${v.sessionId}/${v.txIndex}`);
+    if (!tx) continue; // verdict for a tx TS hasn't wrapped yet — next parseNewTransactions pass picks it up
+    if (v.valid) {
+      tx.markValid();
+    } else {
+      tx.markInvalid(v.reason ?? "Invalid group transaction", {
+        transactor: tx.author,
+      });
+    }
+  }
+}
+```
+
+Error translation: wrap the `nodeCore.validateGroup` call in try/catch; if `e.message` starts with `"CoValue not loaded: "`, re-throw via the same path TS uses today — call `coValue.node.expectCoValueLoaded(extractedId, "Expected parent group to be loaded")` (which throws the canonical error). Otherwise rethrow.
+
+- [ ] **Step 2: Run the oracle suites against the native path**
+
+Run: `cd packages/cojson && pnpm test permissions && pnpm test group` (NapiCrypto default makes these exercise the Rust path).
+Expected: green. Any failure is a Rust-port divergence — fix in Rust (fixtures should have caught it; add the failing case as a new fixture scenario first, then fix).
+
+- [ ] **Step 3: Full suite + commit**
+
+Run: `pnpm test` (full cojson) + `pnpm exec tsc --noEmit`.
+
+```bash
+git add packages/cojson/src/permissions.ts
+git commit -m "feat(cojson): delegate group permission validation to native NodeCore"
+```
+
+---
+
+### Task 8: TS delegation — group.ts roleOfInternal
+
+**Files:**
+- Modify: `packages/cojson/src/coValues/group.ts`
+
+- [ ] **Step 1: Write the gated delegation**
+
+In `RawGroup.roleOfInternal` (`group.ts:451`), add at the top:
+
+```ts
+    const nodeCore = this.core.node.nodeCore;
+    if (
+      nodeCore.roleOf &&
+      !nativeValidationDisabled() &&                       // shared kill switch from permissions.ts (Task 7)
+      this.core.verified.branchSourceId === undefined &&  // branch views keep TS semantics in stage 2
+      !this.hasFrontierFilter()                            // any frontier/time-travel machinery beyond atTimeFilter — check what exists on RawCoMap; if only atTimeFilter exists, drop this condition
+    ) {
+      const role = nodeCore.roleOf(this.core.id, accountID, this.atTimeFilter);
+      return role as Role | undefined;
+    }
+    // ...existing TS implementation unchanged (fallback)...
+```
+
+IMPORTANT gating caveats to resolve while implementing (read the actual RawCoMap/RawGroup view machinery):
+- `atTime` views are prototype clones — `this.core` is shared, so `this.core.id` is correct on views.
+- If `RawCoMap` has additional read filters beyond `atTimeFilter` (frontier/branch filters — grep for other filter fields on the class), the delegation must be skipped when they're active; enumerate them and gate on each.
+- `RawAccount.roleOfInternal` override (self → admin) stays in TS and short-circuits BEFORE calling super — Rust implements it too, so either path is consistent.
+
+- [ ] **Step 2: Verify against the read-side oracle suites**
+
+Run: `cd packages/cojson && pnpm test group.roleOf && pnpm test group.inheritance && pnpm test group` → green.
+Then FULL cojson suite + `tsc --noEmit` → green.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add packages/cojson/src/coValues/group.ts
+git commit -m "feat(cojson): delegate group role resolution to native NodeCore"
+```
+
+---
+
+### Task 9: Randomized differential harness
+
+**Files:**
+- Create: `packages/cojson/src/tests/groupEngineDifferential.test.ts`
+
+- [ ] **Step 1: Write the harness**
+
+A seeded PRNG (e.g. mulberry32, seed logged on failure and overridable via `DIFF_SEED` env) drives N=50 random group scenarios: random member count (2-5 accounts), random operation sequences (addMember with random roles, removeMember, invites + acceptances, parent extensions incl. extend/capped, revocations, everyone roles), interleaved across members. For each scenario:
+
+1. Build the scenario on a test node (native crypto).
+2. Compute verdicts + a grid of role queries (every member × 3 random timestamps + latest) via the **TS path**: set `COJSON_DISABLE_NATIVE_VALIDATION=1` through the `nativeValidationDisabled()` kill switch already wired into both gates in Tasks 7-8 (in vitest, stub it via `vi.stubEnv` or set/unset `globalThis.process.env` around the TS-path run), forcing `determineValidTransactionsForGroup` and TS `roleOfInternal`.
+3. Compute the same via the **native path** (gate enabled).
+4. Assert deep equality of: every transaction's `(isValid, validationErrorMessage)` and every role query result.
+
+- [ ] **Step 2: Run it**
+
+Run: `cd packages/cojson && pnpm test groupEngineDifferential` → green, reasonable runtime (<60s; reduce N if slower).
+Also run once with a different seed (`DIFF_SEED=1234`) to shake out seed-dependence.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add packages/cojson/src/tests/groupEngineDifferential.test.ts packages/cojson/src/permissions.ts packages/cojson/src/coValues/group.ts
+git commit -m "test(cojson): randomized differential harness for native group engine"
+```
+
+---
+
+### Task 10: Cross-package verification + changeset + spec status
+
+- [ ] **Step 1: Full verification**
+
+- `pnpm build:packages` (repo root) → green (skip the RN NDK step if the environment lacks an Android NDK — known limitation).
+- `pnpm exec turbo run test --filter=cojson --filter=jazz-tools` → green. jazz-tools runs the wasm/shim (fallback) path — proving the capability gate keeps non-native providers working.
+- `cd crates && cargo test -p cojson-core` → green; `cargo clippy -p cojson-core -p cojson_core_napi` → no NEW warnings vs the branch base (pre-existing set documented in the stage-1 plan run: doc_lazy_continuation in docs, blake3.rs:55, session_map.rs make_new_private_transaction).
+
+- [ ] **Step 2: Benchmarks (spec testing layer 4)**
+
+Add `bench/cojson/groupEngine.bench.ts` (mirror the structure of existing files under `bench/`): (a) `roleOf` on a 3-level parent chain with 20 members, queried 1000×; (b) full validation of a 200-transaction group (invalidate + re-validate via `COJSON_DISABLE_NATIVE_VALIDATION` toggling for the TS baseline vs native). Run `pnpm bench:cojson` (or the repo's actual bench script — check bench/package.json) and record both numbers in the PR description. The kill switch makes the TS baseline measurable at any time, so no pre-landing baseline capture is needed.
+
+- [ ] **Step 3: Changeset**
+
+`.changeset/group-engine-native.md`:
+
+```markdown
+---
+"cojson": patch
+"cojson-core-napi": patch
+---
+
+Move group/account permission validation and role resolution into the native
+NodeCore (napi), behind capability detection — wasm/RN keep the TypeScript
+path until their native ports land. Adds a fixture corpus generated from the
+TypeScript implementation and a randomized differential test harness.
+```
+
+- [ ] **Step 4: Update the spec status line**
+
+In `docs/superpowers/specs/2026-07-03-cojson-rust-permissions-migration-design.md`, note under Stage 2 that it is implemented napi-first with the `COJSON_DISABLE_NATIVE_VALIDATION` kill switch and branch-view role queries still on the TS path.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add .changeset docs/superpowers/specs bench
+git commit -m "chore: changeset and spec status for native group engine"
+```
+
+---
+
+## Explicitly out of scope (later plans)
+
+- Stage 3 (`validateTransactions` for ownedByGroup/unsafeAllowAll, `resetValidation`, PendingTx meta plumbing) — next plan.
+- Wasm/RN native `NodeCore` + group engine ports; deletion of the TS permissions logic and the differential harness — final cleanup after all bindings reach parity.
+- Branch-view (`branchSourceId`) role-query delegation — kept on the TS path in stage 2; revisit in stage 3 with branch fixtures.
+
+## Known risks to watch during execution
+
+- **Account vs group semantics** (`isGroup()` in the private-tx branch, account header detection): resolved empirically by fixtures 15 and 18 — the fixture output is authoritative, don't guess.
+- **Rust borrow structure for recursive engine builds** (Task 4 Step 5): decide the two-phase vs take-and-put-back approach early; it shapes the whole engine module.
+- **`madeAt` used for role_history indexing** must be the same time base the TS CoMap op index uses (`madeAt` getter = effective time) — fixtures 10-13 with time-based queries pin this; if they fail, check effective vs current time first.
+- **Verdict application order** feeds TS dispatch order (spec fidelity constraint 2) — the Task 7 code applies in Rust-returned order; don't "optimize" into map iteration.

--- a/docs/superpowers/specs/2026-07-03-cojson-rust-permissions-migration-design.md
+++ b/docs/superpowers/specs/2026-07-03-cojson-rust-permissions-migration-design.md
@@ -1,7 +1,7 @@
 # Migrating cojson permissions & group state to Rust
 
 **Date:** 2026-07-03
-**Status:** Draft (sections 1 approved in discussion; sections 2–3 pending user review)
+**Status:** Draft, revised after external review (GLM-5.2 findings verified against code and incorporated)
 
 ## Goal
 
@@ -85,15 +85,21 @@ New `core/node.rs` in `cojson-core`:
   `NodeCoreImpl` over a `Map<coId, SessionMap>` of the existing per-CoValue
   native objects, until their native `NodeCore` ports land.
 - Garbage collection: freeing a CoValue's Rust memory no longer rides on
-  dropping a per-CoValue binding object. `LocalNode` (and the existing
-  `GarbageCollector` unload path) must call `nodeCore.removeCoValue(coId)`
-  when a `CoValueCore` is evicted. The wasm shim's `Map` entry `free()`s the
-  wrapped object.
+  dropping a per-CoValue binding object (JS GC finalizers stop working as
+  the cleanup mechanism). Every eviction path must call
+  `nodeCore.removeCoValue(coId)` explicitly: the `GarbageCollector` unload
+  path, `LocalNode` CoValue unmount/teardown, and node shutdown. The wasm
+  shim's `Map` entry `free()`s the wrapped object on eviction.
+  `removeCoValue` on an absent coId is a no-op (double-eviction safe).
 
 ### Acceptance
 
 Zero behavior change; the entire existing cojson + jazz-tools test suite
 passing on all three providers (napi native, wasm/RN shimmed) is the gate.
+Because the suite cannot detect native-memory leaks, stage 1 additionally
+ships an explicit eviction test: create/unload CoValues through every
+eviction path and assert `hasCoValue` is false and (napi) registry size
+returns to baseline.
 
 ## Stage 2 — Group engine: validation + role resolution for groups/accounts
 
@@ -102,17 +108,41 @@ passing on all three providers (napi native, wasm/RN shimmed) is the gate.
 New `core/group_engine.rs`; one `GroupEngine` per group/account CoValue,
 stored in the `NodeCore` entry, built incrementally in validation order.
 
-Internal state (mirrors TS `MemberRoleResolver` + `RawGroup` indices):
+The engine keeps **two distinct role structures** — validation state and
+read state are *not* the same thing in TS and must not be merged (a single
+time-indexed map would diverge from TS semantics for merged transactions
+where `currentMadeAt != sourceTxMadeAt`):
 
-- `member_roles: HashMap<MemberId, TimeBasedEntry<Role>>` — validated role
-  assignments; `TimeBasedEntry` = chronologically sorted `(made_at, value)`
-  pairs, query = last entry with `made_at <= t` (semantics of
-  `group.ts:254` `TimeBasedEntry` and the CoMap `atTime`/`getRaw` read).
-- `parent_groups: HashMap<CoId, TimeBasedEntry<ParentRoleMapping>>` —
-  parent extensions (`extend` | capped role | revoked).
-- `write_only_keys: HashMap<MemberId, KeyId>` and `write_keys: HashSet<String>`
-  (the writeOnly invite/override rules, `permissions.ts:385-418`).
-- Per-session validation watermarks + ordered verdict log.
+- **Validation state (order-sensitive, deliberately not time-indexed):**
+  `current_roles: HashMap<MemberId, Role>` — mirrors TS
+  `MemberRoleResolver.memberRoles` (`permissions.ts:184-185`), a plain map
+  mutated in validation order. During validation, a transactor's *direct*
+  role is "resolver state after the previous transaction in effective-madeAt
+  order" — `getRoleAtTime` ignores its time argument for direct roles
+  (`permissions.ts:207-212`); the time argument only drives the
+  parent-group walk. Plus `parent_groups_current: HashMap<CoId,
+  ParentRoleMapping>`, `write_only_keys: HashMap<MemberId, KeyId>`, and
+  `write_keys: HashSet<String>` (the writeOnly invite/override rules,
+  `permissions.ts:385-418`), all evolving in validation order.
+- **Read state (time-indexed):** `role_history: HashMap<MemberId,
+  TimeBasedEntry<Role>>` and `parent_groups_history: HashMap<CoId,
+  TimeBasedEntry<ParentRoleMapping>>` — built from the *validated* set-role
+  ops; `TimeBasedEntry` = chronologically sorted `(made_at, value)` pairs,
+  query = last entry with `made_at <= t` (semantics of `group.ts:254`
+  `TimeBasedEntry` and the CoMap `atTime`/`getRaw` read). These serve
+  `roleOf(_, _, atTime)`.
+
+**Recompute, don't increment.** TS group validation constructs a fresh
+`MemberRoleResolver` and re-derives every verdict from the full
+`verifiedTransactions` set on every call (`permissions.ts:229-240`) —
+necessarily so, because a newly arrived transaction can sort into the
+*middle* of the effective-madeAt order (clock skew, merge source times) and
+flip verdicts of transactions after it. The Rust engine replicates this:
+when a group has new transactions since the last run, its engine and
+verdicts are rebuilt from scratch over all transactions; the only caching is
+"no new transactions since the last run → reuse the previous verdicts"
+(keyed by per-session transaction counts). Append-only/watermark
+incremental validation is explicitly ruled out for groups.
 
 Algorithm: a direct port of `determineValidTransactionsForGroup`
 (`permissions.ts:229-571`) — every rule branch preserved: initial-admin
@@ -133,10 +163,29 @@ Read-side role resolution, a port of `RawGroup.roleOfInternal`
   only when no role resolved and the query isn't `everyone` itself.
 - Account→agent resolution (`agentInAccountOrMemberInGroup`,
   `permissions.ts:573`): when the transactor equals the owning account's id,
-  resolve to the account's current agent id at that time, read from the
-  account's engine via the registry.
+  resolve to the account's agent id — which is **static**: TS
+  `currentAgentID()` returns the header's `initialAdmin`, cached, with no
+  time component (`account.ts:44-62`). Rust must read it from the header,
+  not time-resolve it from engine state.
+- Account self-role override: `RawAccount.roleOfInternal(accountOwnId)`
+  returns `"admin"` unconditionally (`account.ts:68-75`). The engine
+  replicates this for account CoValues before falling through to group
+  resolution.
 - A visited-set cycle guard on the parent walk (defense in depth; validation
   already rejects self-extensions).
+
+**Freshness and re-entrancy contract for `roleOf`.** Unlike TS — which
+reads already-materialized CoMap content — `roleOf` answers from engine
+state, so it must never answer from a stale or unbuilt engine. Contract:
+`roleOf(groupId, …)` first ensures the group's engine is current (rebuild if
+new transactions arrived since the last validation run), transitively doing
+the same for parent groups and owning accounts encountered during the walk,
+with the visited-set guarding re-entrancy. Engine build for group G may
+itself query parents' engines; builds are therefore reentrant-by-recursion
+with cycle detection, never concurrent (NodeCore is single-threaded per
+node). Cross-CoValue *verdict* revalidation ordering (a group change
+invalidating owned CoValues) remains TS-driven via `invalidateDependants` →
+`resetValidation`, unchanged.
 
 ### Exposed API (napi first)
 
@@ -182,12 +231,22 @@ Dispatch on the CoValue's ruleset:
   `invalid` with reason.
 - `unsafeAllowAll` → all valid.
 
-Verdicts and engine state are cached per CoValue with per-session watermarks
-(mirroring `verifiedTransactionsKnownSessions`). A group receiving new
-transactions invalidates its own engine internally; cross-CoValue
-revalidation stays TS-triggered: `resetParsedTransactions`
-(`coValueCore.ts:1317`) calls `resetValidation(coId)` before re-running
-validation.
+Caching follows the stage-2 rule: reuse verdicts only when a CoValue has no
+new transactions since the last run (keyed by per-session transaction
+counts); otherwise recompute in full. Because a recompute can *flip*
+previously returned verdicts (mid-sequence insertion), `validateTransactions`
+returns verdicts for the `pending` set **plus any previously reported
+transaction whose verdict changed**; TS applies flips through the existing
+`markValid`/`markInvalid`, whose processed-stage re-dispatch already handles
+validity changes (`coValueCore.ts:182-218`). `pending` therefore means "the
+transactions TS currently wants verdicts for", not "the only inputs" — for
+groups, Rust always evaluates the full history internally, exactly like TS.
+TS must apply returned verdicts in the order Rust returns them
+(effective-madeAt sorted, stable), since dispatch order feeds
+`toProcessTransactions` and downstream stable re-sorts
+(`coValueCore.ts:1826-1840`). Cross-CoValue revalidation stays TS-triggered:
+`resetParsedTransactions` (`coValueCore.ts:1317`) calls
+`resetValidation(coId)` before re-running validation.
 
 ### Wire types
 
@@ -208,7 +267,13 @@ type Verdict = {
 
 Contract points:
 
-- TS passes decrypted private-transaction meta in; key management and meta
+- TS passes decrypted private-transaction meta in **when it has it at the
+  validation call point** — which, matching today's pipeline, is only for
+  locally created transactions (via the parsing cache) or on revalidation
+  passes: validation runs *before* the decrypt phase in
+  `parseNewTransactions` (`coValueCore.ts:1581-1602`), so freshly received
+  private transactions validate with `metaJson` absent, exactly as TS
+  validates them with `meta === undefined` today. Key management and meta
   parsing (`parseMetaInformation`, source-time derivation and its tamper
   check) stay in TS. Rust reads trusting changes/meta directly from its own
   transaction store; nothing else crosses the boundary.
@@ -243,8 +308,16 @@ stage-1 wasm/RN shims, and the `hasNativeValidation` gate.
    cross-session equal-timestamp cases.
 3. **Validation-order state.** `writeOnlyKeys`/`writeKeys` and role state
    evolve in validation order; verdicts for a transaction depend only on
-   state from transactions ordered before it.
-4. **Error-for-error parity.** Every `markInvalid` reason string in
+   state from transactions ordered before it. During validation, *direct*
+   role lookups ignore the query time entirely — `MemberRoleResolver.
+   getRoleAtTime` uses its time argument only for the parent-group walk
+   (`permissions.ts:207-226`); replicating this asymmetry exactly is
+   mandatory (do not "fix" it into a time-indexed lookup).
+4. **Full recompute on change.** Group verdicts are a function of the whole
+   sorted history; new transactions can insert mid-sequence and flip later
+   verdicts. Verdict caches are only valid while per-session transaction
+   counts are unchanged.
+5. **Error-for-error parity.** Every `markInvalid` reason string in
    `permissions.ts` is preserved verbatim in Rust verdict reasons (tests
    assert on them).
 
@@ -253,6 +326,12 @@ stage-1 wasm/RN shims, and the `hasNativeValidation` gate.
 - `coValueNotLoaded { coId }`: `validateTransactions`/`roleOf` needs a
   group/parent/account not in the registry. TS translates to the existing
   `expectCoValueLoaded` throw; load ordering remains a TS responsibility.
+  Note: verdicts already applied before the error are not rolled back —
+  this matches TS, where `markValid`/`markInvalid` dispatch has the same
+  partial-application behavior when the throw interrupts the loop
+  (`permissions.ts:355-358`). Rust should surface the error *before*
+  returning any verdicts for the batch where practical (validate-then-
+  return), narrowing but not eliminating this window.
 - `unknownCoValue`: any coId-first call for an unregistered CoValue —
   programming error, throws.
 - Malformed change payloads never throw: they classify the transaction
@@ -269,9 +348,13 @@ stage-1 wasm/RN shims, and the `hasNativeValidation` gate.
    Required coverage: all invite flows; admin/manager demotion and
    promotion rules; writeOnly key revelation and override rules; parent
    extensions (`extend` and capped, revocation, deep chains); everyone
-   fallback; account-agent resolution; merged/branched transactions
-   (source-time ordering, reader branch pointers); cross-session
-   equal-timestamp ordering ties.
+   fallback; account-agent resolution (static header agent, account
+   self→admin); merged/branched transactions (source-time ordering, reader
+   branch pointers, and merged group transactions where `currentMadeAt !=
+   sourceTxMadeAt` exercises the validation-order vs time-indexed
+   asymmetry); late-arriving transactions with earlier `madeAt` that flip
+   previously computed verdicts; cross-session equal-timestamp ordering
+   ties.
 2. **Existing TS suite as acceptance.** CI already runs `packages/cojson`
    against napi; the unchanged suite passing after each stage's delegation
    is the regression gate.

--- a/docs/superpowers/specs/2026-07-03-cojson-rust-permissions-migration-design.md
+++ b/docs/superpowers/specs/2026-07-03-cojson-rust-permissions-migration-design.md
@@ -91,6 +91,14 @@ New `core/node.rs` in `cojson-core`:
   path, `LocalNode` CoValue unmount/teardown, and node shutdown. The wasm
   shim's `Map` entry `free()`s the wrapped object on eviction.
   `removeCoValue` on an absent coId is a no-op (double-eviction safe).
+  As implemented, delete/unmount eviction is **deferred one microtask**
+  (with a skip-if-reloaded guard): `LocalTransactionsSyncQueue` flushes
+  pending local transactions on a `queueMicrotask` that reads the registry,
+  so synchronous eviction would break the final flush of a
+  deleted-with-pending-tx CoValue; microtask FIFO guarantees the flush runs
+  first. Shutdown evicts synchronously after the sync-manager drain, for
+  the same reason. `nodeCore.hasCoValue(id)` therefore reads true until the
+  next microtask turn after eviction.
 
 ### Acceptance
 

--- a/docs/superpowers/specs/2026-07-03-cojson-rust-permissions-migration-design.md
+++ b/docs/superpowers/specs/2026-07-03-cojson-rust-permissions-migration-design.md
@@ -96,9 +96,14 @@ New `core/node.rs` in `cojson-core`:
   pending local transactions on a `queueMicrotask` that reads the registry,
   so synchronous eviction would break the final flush of a
   deleted-with-pending-tx CoValue; microtask FIFO guarantees the flush runs
-  first. Shutdown evicts synchronously after the sync-manager drain, for
-  the same reason. `nodeCore.hasCoValue(id)` therefore reads true until the
-  next microtask turn after eviction.
+  first. `nodeCore.hasCoValue(id)` therefore reads true until the next
+  microtask turn after eviction. **Node shutdown does NOT evict**: a closing
+  node must stay readable for in-flight handoff work (peer LOADs, final
+  sync) after `gracefulShutdown` resolves — eagerly emptying the registry
+  made those reads throw (found via a jazz-tools auth-flow regression). The
+  registry, and every native session map it owns, is released when the
+  `LocalNode` itself is dropped, so shutdown eviction is unnecessary for
+  memory reclamation.
 
 ### Acceptance
 

--- a/docs/superpowers/specs/2026-07-03-cojson-rust-permissions-migration-design.md
+++ b/docs/superpowers/specs/2026-07-03-cojson-rust-permissions-migration-design.md
@@ -1,0 +1,310 @@
+# Migrating cojson permissions & group state to Rust
+
+**Date:** 2026-07-03
+**Status:** Draft (sections 1 approved in discussion; sections 2–3 pending user review)
+
+## Goal
+
+Move the next layer of cojson logic into `crates/cojson-core`: permission
+checking (`determineValidTransactions`) and group role resolution
+(`roleOfInternal` and friends). Today Rust owns crypto primitives and the
+per-CoValue verified session log (`SessionMapImpl`); every transaction is
+verified in Rust, then serialized out as JSON so TypeScript can re-parse it to
+decide validity and resolve roles. This migration removes that boundary tax on
+the security-critical path and leaves a single cross-platform implementation
+of role semantics.
+
+Out of scope: general CRDT materialization (coMap/coList views), sync
+protocol, storage, key management (read-key unsealing stays in TS).
+
+## Decisions made
+
+| Decision | Choice |
+| --- | --- |
+| Rollout | Direct replacement per stage; safety via fixture-based differential tests (no production shadow mode) |
+| Registry shape | Full node-level API: one Rust `NodeCore` per `LocalNode`; `verifiedState.ts` rewritten against it (no per-CoValue facades) |
+| Stage-3 surface | Verdicts **and** role queries: Rust exposes `roleOf` so `group.ts` role resolution delegates too |
+| Binding order | Napi-first per stage; wasm and RN ports follow; TS fallback stays capability-gated until all bindings port |
+| Execution model | Lazy, TS-orchestrated (approach A): Rust computes verdicts and maintains incremental group role indices; TS keeps validation timing, queues, and dependant revalidation |
+
+## Architecture overview
+
+```
+TypeScript (packages/cojson)                 Rust (crates/cojson-core)
+─────────────────────────────                ─────────────────────────
+LocalNode ──────────────────── owns ───────► NodeCore (registry: CoID → CoValueEntry)
+CoValueCore                                    ├─ SessionMapImpl   (existing: verified log)
+  ├─ VerifiedState ─── calls (coId, …) ───►    ├─ GroupEngine      (stage 2: roles + group validation)
+  ├─ tx state machine (unchanged)              └─ verdict cache    (stage 3, per-session watermarks)
+  └─ parseNewTransactions ─ validateTransactions(coId, pending) ─► Verdict[]
+RawGroup.roleOfInternal ─── roleOf(groupId, member, atTime) ────► Role
+```
+
+TS remains the orchestrator: it decides *when* to validate (lazy, on read,
+via `parseNewTransactions`), owns the `to-validate`/`validated`/`processed`
+state machine, decrypt queues, content rebuilds, and the
+`invalidateDependants` walk. Rust owns *what is valid* and *who has which
+role*.
+
+A key structural fact discovered during design: group state materialization
+and group self-validation are one algorithm. In TS,
+`determineValidTransactionsForGroup` (`permissions.ts:229`) builds the
+`MemberRoleResolver` *while* validating, transaction by transaction — role
+state does not exist independently of verdicts. They therefore migrate
+together (stage 2), and the registry they need migrates first (stage 1) as a
+pure behavior-preserving refactor.
+
+## Stage 1 — `NodeCore` registry (plumbing, no behavior change)
+
+### Rust
+
+New `core/node.rs` in `cojson-core`:
+
+- `NodeCore { covalues: HashMap<CoId, SessionMapImpl> }` (plus, later,
+  per-CoValue engine/verdict state).
+- Methods: the existing `SessionMapImpl` surface lifted to take `co_id` as
+  first parameter, plus `create_co_value(co_id, header_json, skip_verify)`,
+  `has_co_value(co_id)`, `remove_co_value(co_id)`.
+
+`cojson-core-napi` exposes `#[napi] NodeCore` with the same lifted surface
+(camelCased). Wasm and RN ports mirror it in their follow-up PRs.
+
+### TypeScript
+
+- `crypto/crypto.ts`: the `SessionMapImpl` interface (currently
+  `crypto.ts:320`) is replaced by `NodeCoreImpl` — same methods, coId-first —
+  and `CryptoProvider` gains `createNodeCore(): NodeCoreImpl`.
+- `coValueCore/verifiedState.ts`: keeps its class shape and its `SessionLog`
+  / known-state caches; `this.impl.X(...)` becomes
+  `this.nodeCore.X(this.id, ...)`. The `NodeCore` instance is created by
+  `LocalNode` and passed to every `VerifiedState`.
+- `NapiCrypto.ts`: implements `NodeCoreImpl` natively (the per-provider
+  `SessionMapAdapter` becomes a `NodeCoreAdapter`; JSON parse/stringify at
+  the boundary is unchanged).
+- `WasmCrypto.ts` / `RNCrypto.ts`: a shared ~50-line TS shim class implements
+  `NodeCoreImpl` over a `Map<coId, SessionMap>` of the existing per-CoValue
+  native objects, until their native `NodeCore` ports land.
+- Garbage collection: freeing a CoValue's Rust memory no longer rides on
+  dropping a per-CoValue binding object. `LocalNode` (and the existing
+  `GarbageCollector` unload path) must call `nodeCore.removeCoValue(coId)`
+  when a `CoValueCore` is evicted. The wasm shim's `Map` entry `free()`s the
+  wrapped object.
+
+### Acceptance
+
+Zero behavior change; the entire existing cojson + jazz-tools test suite
+passing on all three providers (napi native, wasm/RN shimmed) is the gate.
+
+## Stage 2 — Group engine: validation + role resolution for groups/accounts
+
+### Rust
+
+New `core/group_engine.rs`; one `GroupEngine` per group/account CoValue,
+stored in the `NodeCore` entry, built incrementally in validation order.
+
+Internal state (mirrors TS `MemberRoleResolver` + `RawGroup` indices):
+
+- `member_roles: HashMap<MemberId, TimeBasedEntry<Role>>` — validated role
+  assignments; `TimeBasedEntry` = chronologically sorted `(made_at, value)`
+  pairs, query = last entry with `made_at <= t` (semantics of
+  `group.ts:254` `TimeBasedEntry` and the CoMap `atTime`/`getRaw` read).
+- `parent_groups: HashMap<CoId, TimeBasedEntry<ParentRoleMapping>>` —
+  parent extensions (`extend` | capped role | revoked).
+- `write_only_keys: HashMap<MemberId, KeyId>` and `write_keys: HashSet<String>`
+  (the writeOnly invite/override rules, `permissions.ts:385-418`).
+- Per-session validation watermarks + ordered verdict log.
+
+Algorithm: a direct port of `determineValidTransactionsForGroup`
+(`permissions.ts:229-571`) — every rule branch preserved: initial-admin
+self-promotion, self-revoke, admin/manager demotion and invite restrictions,
+all invite kinds, `readKey`/`groupSealer`/`profile`/`root` admin-only sets,
+key-revelation fields, parent-extension set/revoke with self-extension
+(cycle) rejection, child-extension rejection, everyone-role restrictions,
+"exactly one set change" shape rule, and privacy rules (private transactions
+invalid in groups).
+
+Read-side role resolution, a port of `RawGroup.roleOfInternal`
+(`group.ts:451-488`) over the engine's validated state:
+
+- direct role (revoked → none), recursive parent walk via the registry
+  (mapping `extend` inherits parent role; otherwise the mapping caps it;
+  only `isInheritableRole` parent roles count;
+  `isMorePermissiveAndShouldInherit` decides upgrades), `everyone` fallback
+  only when no role resolved and the query isn't `everyone` itself.
+- Account→agent resolution (`agentInAccountOrMemberInGroup`,
+  `permissions.ts:573`): when the transactor equals the owning account's id,
+  resolve to the account's current agent id at that time, read from the
+  account's engine via the registry.
+- A visited-set cycle guard on the parent walk (defense in depth; validation
+  already rejects self-extensions).
+
+### Exposed API (napi first)
+
+```
+validateGroup(coId, pending: PendingTx[]) → Verdict[]   // groups & accounts
+roleOf(groupId, member, atTimeMs?) → Role | undefined
+```
+
+`validateGroup` is the stage-2 interim entry point; stage 3's
+`validateTransactions` subsumes it (group ruleset dispatches to the same
+engine) and `validateGroup` is removed from the public surface then.
+
+### TypeScript
+
+- `permissions.ts`: the `ruleset.type === "group"` branch calls
+  `nodeCore.validateGroup(...)` and maps verdicts onto the
+  `toValidateTransactions` queue via the existing `markValid`/`markInvalid`,
+  when `nodeCore.hasNativeValidation` is true; otherwise the current TS code
+  runs (shim providers).
+- `group.ts` `roleOfInternal`: delegates to `nodeCore.roleOf(this.id,
+  member, this.atTimeFilter)` under the same capability flag. The TS
+  implementation remains as fallback and as the differential-test oracle.
+
+## Stage 3 — Unified `validateTransactions`
+
+### Rust
+
+```
+validateTransactions(coId, pending: PendingTx[]) → Verdict[]
+resetValidation(coId) → void
+```
+
+Dispatch on the CoValue's ruleset:
+
+- `group` → stage-2 engine.
+- `ownedByGroup` → for each pending transaction, resolve the effective
+  transactor (account→agent resolution against the owning group when it is
+  an account) and its role via the owning group's engine **at
+  `currentMadeAt`** (the transaction's physical time — never the
+  meta-derived source time; see `permissions.ts:104-107`). Writer-tier roles
+  (admin/manager/writer/writeOnly) → `valid`; a `reader` whose decrypted
+  meta carries `branch` + `ownerId` → `validBranchPointerOnly`; otherwise
+  `invalid` with reason.
+- `unsafeAllowAll` → all valid.
+
+Verdicts and engine state are cached per CoValue with per-session watermarks
+(mirroring `verifiedTransactionsKnownSessions`). A group receiving new
+transactions invalidates its own engine internally; cross-CoValue
+revalidation stays TS-triggered: `resetParsedTransactions`
+(`coValueCore.ts:1317`) calls `resetValidation(coId)` before re-running
+validation.
+
+### Wire types
+
+```ts
+type PendingTx = {
+  sessionId: SessionID;
+  txIndex: number;
+  metaJson?: string;      // decrypted meta, when TS has it (private txs)
+  sourceMadeAt?: number;  // merge-meta-derived time, when TS has parsed it
+};
+type Verdict = {
+  sessionId: SessionID;
+  txIndex: number;
+  outcome: "valid" | "invalid" | "validBranchPointerOnly";
+  reason?: string;        // feeds markInvalid's log message
+};
+```
+
+Contract points:
+
+- TS passes decrypted private-transaction meta in; key management and meta
+  parsing (`parseMetaInformation`, source-time derivation and its tamper
+  check) stay in TS. Rust reads trusting changes/meta directly from its own
+  transaction store; nothing else crosses the boundary.
+- `validBranchPointerOnly`: Rust only classifies; TS performs today's
+  forced trimming of `tx.changes = []` / `tx.meta = {branch, ownerId}`
+  (`permissions.ts:129-137`).
+- TS calls `validateTransactions` from `parseNewTransactions` at exactly the
+  point `determineValidTransactions` is called today; re-validation after
+  meta decryption/parsing flows through the same existing re-dispatch
+  mechanics, unchanged.
+
+### TypeScript deletion (end state)
+
+Once wasm and RN native ports pass the full suite: delete the rule logic in
+`permissions.ts` (keep the thin dispatch + types), `MemberRoleResolver`, the
+internals of `roleOfInternal` and its supporting indices in `group.ts`
+(`parentGroupsChanges`, `TimeBasedEntry` where unused elsewhere), the
+stage-1 wasm/RN shims, and the `hasNativeValidation` gate.
+
+## Fidelity constraints (normative)
+
+1. **Two time axes.** Permission checks use `currentMadeAt` (physical time in
+   the session log). Group-transaction *ordering* for validation uses
+   effective `madeAt` = `sourceTxMadeAt ?? currentMadeAt`
+   (`coValueCore.ts:163`), where `sourceTxMadeAt` comes from merge meta and
+   is supplied by TS via `PendingTx.sourceMadeAt`.
+2. **Ordering quirk preserved.** `compareTransactions`
+   (`coValueCore.ts:1842`): `madeAt` ascending; ties broken by `txIndex`
+   only within the same session; cross-session ties compare equal and rely
+   on stable sort. The Rust sort must be stable over the same input order TS
+   produces (session-entry iteration order), and fixtures must include
+   cross-session equal-timestamp cases.
+3. **Validation-order state.** `writeOnlyKeys`/`writeKeys` and role state
+   evolve in validation order; verdicts for a transaction depend only on
+   state from transactions ordered before it.
+4. **Error-for-error parity.** Every `markInvalid` reason string in
+   `permissions.ts` is preserved verbatim in Rust verdict reasons (tests
+   assert on them).
+
+## Error handling
+
+- `coValueNotLoaded { coId }`: `validateTransactions`/`roleOf` needs a
+  group/parent/account not in the registry. TS translates to the existing
+  `expectCoValueLoaded` throw; load ordering remains a TS responsibility.
+- `unknownCoValue`: any coId-first call for an unregistered CoValue —
+  programming error, throws.
+- Malformed change payloads never throw: they classify the transaction
+  `invalid` with a reason, as TS does today.
+- Wasm panics already surface as JS errors via the existing panic hook.
+
+## Testing
+
+1. **Fixture differential corpus (safety backbone).** A TS export script
+   replays the `permissions`/`group` test scenarios through the *current TS
+   implementation* and writes transaction histories + expected
+   verdicts/roles to `crates/cojson-core/src/core/data/` (extending the
+   existing `singleTxSession*.json` pattern). Rust unit tests replay them.
+   Required coverage: all invite flows; admin/manager demotion and
+   promotion rules; writeOnly key revelation and override rules; parent
+   extensions (`extend` and capped, revocation, deep chains); everyone
+   fallback; account-agent resolution; merged/branched transactions
+   (source-time ordering, reader branch pointers); cross-session
+   equal-timestamp ordering ties.
+2. **Existing TS suite as acceptance.** CI already runs `packages/cojson`
+   against napi; the unchanged suite passing after each stage's delegation
+   is the regression gate.
+3. **Test-only differential harness.** A vitest helper runs native and TS
+   fallback implementations over randomized group histories and asserts
+   identical verdicts and roles. Runs in CI until the TS path is deleted,
+   then retires with it.
+4. **Benchmarks.** Add `bench/` cases for `roleOf` on deep parent chains and
+   bulk validation of owned CoValues; record baselines before stage 2 and
+   compare after stage 3.
+
+## Rollout
+
+Per stage: (a) `cojson-core` + napi + TS wiring behind the capability gate,
+(b) wasm port, (c) RN/uniffi port. Stage N+1 may start once stage N's napi
+PR lands — the gate keeps wasm/RN on the TS path meanwhile. Final PR (after
+all bindings pass): TS logic deletion. Changesets stay within the existing
+fixed-version group; CI's `napi.yml`/`unit-test.yml` already build the
+native core on `crates/` changes.
+
+## Risks
+
+- **Semantic drift in a security-critical port.** Mitigated by the fixture
+  corpus, verbatim reason strings, the randomized differential harness, and
+  keeping orchestration in TS (approach A) so only verdict computation
+  changes per stage.
+- **Registry lifetime bugs (stage 1).** CoValues freed on GC/unload must be
+  evicted explicitly; missing eviction leaks Rust memory, double eviction
+  must be a no-op. Covered by GC tests on all providers.
+- **Napi-first window.** Wasm/RN run the TS shim + TS validation until
+  ported; the capability gate must be exercised in CI for both code paths
+  the whole window.
+- **`atTime` view semantics.** TS role queries happen on prototype-cloned
+  time-travel views; Rust replaces this with explicit `atTimeMs` parameters.
+  Any TS call site that reads other keys off the time-view (not just roles)
+  keeps using the TS CoMap view — only role resolution delegates.

--- a/packages/cojson/src/coValueCore/coValueCore.ts
+++ b/packages/cojson/src/coValueCore/coValueCore.ts
@@ -591,6 +591,7 @@ export class CoValueCore {
       this._verified = new VerifiedState(
         this.id,
         this.node.crypto,
+        this.node.nodeCore,
         header,
         streamingKnownState,
         skipVerify,

--- a/packages/cojson/src/coValueCore/verifiedState.ts
+++ b/packages/cojson/src/coValueCore/verifiedState.ts
@@ -12,7 +12,7 @@ import {
   KeySecret,
   Signature,
   SignerID,
-  SessionMapImpl,
+  NodeCoreImpl,
 } from "../crypto/crypto.js";
 import {
   isDeleteSessionID,
@@ -80,7 +80,7 @@ export class VerifiedState {
   readonly id: RawCoID;
   readonly crypto: CryptoProvider;
   readonly header: CoValueHeader;
-  private readonly impl: SessionMapImpl;
+  private readonly nodeCore: NodeCoreImpl;
   public lastAccessed: number | undefined;
   public branchSourceId?: RawCoID;
   public branchName?: string;
@@ -97,6 +97,7 @@ export class VerifiedState {
   constructor(
     id: RawCoID,
     crypto: CryptoProvider,
+    nodeCore: NodeCoreImpl,
     header: CoValueHeader,
     streamingKnownState?: KnownStateSessions,
     skipVerify?: boolean,
@@ -107,7 +108,8 @@ export class VerifiedState {
     this.branchSourceId = header.meta?.source as RawCoID | undefined;
     this.branchName = header.meta?.branch as string | undefined;
 
-    this.impl = crypto.createSessionMap(
+    this.nodeCore = nodeCore;
+    this.nodeCore.createCoValue(
       id,
       JSON.stringify(header),
       TRANSACTION_CONFIG.MAX_RECOMMENDED_TX_SIZE,
@@ -116,7 +118,10 @@ export class VerifiedState {
 
     // Set streaming known state if provided
     if (streamingKnownState) {
-      this.impl.setStreamingKnownState(JSON.stringify(streamingKnownState));
+      this.nodeCore.setStreamingKnownState(
+        id,
+        JSON.stringify(streamingKnownState),
+      );
     }
   }
 
@@ -142,7 +147,10 @@ export class VerifiedState {
     newSignature: Signature,
   ) {
     const cached = this.sessionLogCache.get(sessionID);
-    const currentTxCount = this.impl.getTransactionCount(sessionID);
+    const currentTxCount = this.nodeCore.getTransactionCount(
+      this.id,
+      sessionID,
+    );
 
     if (cached) {
       // Append to existing cache
@@ -180,13 +188,20 @@ export class VerifiedState {
     sessionID: SessionID,
     signatureAfter: { [txIdx: number]: Signature | undefined },
   ): void {
-    const lastCheckpoint = this.impl.getLastSignatureCheckpoint(sessionID);
+    const lastCheckpoint = this.nodeCore.getLastSignatureCheckpoint(
+      this.id,
+      sessionID,
+    );
     if (
       lastCheckpoint !== undefined &&
       lastCheckpoint !== null &&
       lastCheckpoint >= 0
     ) {
-      const sig = this.impl.getSignatureAfter(sessionID, lastCheckpoint);
+      const sig = this.nodeCore.getSignatureAfter(
+        this.id,
+        sessionID,
+        lastCheckpoint,
+      );
       if (sig) {
         signatureAfter[lastCheckpoint] = sig as Signature;
       }
@@ -201,14 +216,17 @@ export class VerifiedState {
     [txIdx: number]: Signature | undefined;
   } {
     const signatureAfter: { [txIdx: number]: Signature | undefined } = {};
-    const lastCheckpoint = this.impl.getLastSignatureCheckpoint(sessionID);
+    const lastCheckpoint = this.nodeCore.getLastSignatureCheckpoint(
+      this.id,
+      sessionID,
+    );
     if (
       lastCheckpoint !== undefined &&
       lastCheckpoint !== null &&
       lastCheckpoint >= 0
     ) {
       for (let i = 0; i <= lastCheckpoint; i++) {
-        const sig = this.impl.getSignatureAfter(sessionID, i);
+        const sig = this.nodeCore.getSignatureAfter(this.id, sessionID, i);
         if (sig) {
           signatureAfter[i] = sig as Signature;
         }
@@ -218,7 +236,10 @@ export class VerifiedState {
   }
 
   private getSessionLog(sessionID: SessionID): SessionLog {
-    const currentTxCount = this.impl.getTransactionCount(sessionID);
+    const currentTxCount = this.nodeCore.getTransactionCount(
+      this.id,
+      sessionID,
+    );
     const cachedTxCount = this.sessionLogCacheValid.get(sessionID);
 
     // Check if cache is valid
@@ -230,13 +251,13 @@ export class VerifiedState {
     // Fetch all transactions from Rust
     const transactions: Transaction[] =
       currentTxCount > 0
-        ? (this.impl.getSessionTransactions(sessionID, 0) ?? [])
+        ? (this.nodeCore.getSessionTransactions(this.id, sessionID, 0) ?? [])
         : [];
 
     // Build signatureAfter map
     const signatureAfter = this.buildSignatureAfterMap(sessionID);
 
-    const lastSignature = this.impl.getLastSignature(sessionID) as
+    const lastSignature = this.nodeCore.getLastSignature(this.id, sessionID) as
       | Signature
       | undefined;
 
@@ -257,7 +278,7 @@ export class VerifiedState {
 
   markAsDeleted() {
     this.isDeleted = true;
-    this.impl.markAsDeleted();
+    this.nodeCore.markAsDeleted(this.id);
     this.invalidateCache();
   }
 
@@ -275,7 +296,8 @@ export class VerifiedState {
     // Convert transactions to JSON array
     const txJson = JSON.stringify(newTransactions);
 
-    this.impl.addTransactions(
+    this.nodeCore.addTransactions(
+      this.id,
       sessionID,
       signerID,
       txJson,
@@ -310,7 +332,8 @@ export class VerifiedState {
     const metaJson = meta ? JSON.stringify(meta) : undefined;
     const signerSecret = signerAgent.currentSignerSecret();
 
-    const resultJson = this.impl.makeNewTrustingTransaction(
+    const resultJson = this.nodeCore.makeNewTrustingTransaction(
+      this.id,
       sessionID,
       signerSecret,
       changesJson,
@@ -359,7 +382,8 @@ export class VerifiedState {
     const metaJson = meta ? JSON.stringify(meta) : undefined;
     const signerSecret = signerAgent.currentSignerSecret();
 
-    const resultJson = this.impl.makeNewPrivateTransaction(
+    const resultJson = this.nodeCore.makeNewPrivateTransaction(
+      this.id,
       sessionID,
       signerSecret,
       changesJson,
@@ -395,12 +419,15 @@ export class VerifiedState {
     if (this.isDeleted) {
       return;
     }
-    this.impl.setStreamingKnownState(JSON.stringify(streamingKnownState));
+    this.nodeCore.setStreamingKnownState(
+      this.id,
+      JSON.stringify(streamingKnownState),
+    );
     this.cachedKnownStateWithStreaming = undefined;
   }
 
   getSession(sessionID: SessionID): SessionLog | undefined {
-    const txCount = this.impl.getTransactionCount(sessionID);
+    const txCount = this.nodeCore.getTransactionCount(this.id, sessionID);
     if (txCount === -1) {
       return undefined;
     }
@@ -408,7 +435,7 @@ export class VerifiedState {
   }
 
   getTransactionsCount(sessionID: SessionID): number | undefined {
-    const txCount = this.impl.getTransactionCount(sessionID);
+    const txCount = this.nodeCore.getTransactionCount(this.id, sessionID);
     if (txCount === -1) {
       return undefined;
     }
@@ -416,13 +443,13 @@ export class VerifiedState {
   }
 
   get sessionCount(): number {
-    return this.impl.getSessionIds().length;
+    return this.nodeCore.getSessionIds(this.id).length;
   }
 
   getSessions(): Map<SessionID, SessionLog> {
     // Build a Map from all sessions
     const map = new Map<SessionID, SessionLog>();
-    const sessionIds = this.impl.getSessionIds() as SessionID[];
+    const sessionIds = this.nodeCore.getSessionIds(this.id) as SessionID[];
     for (const sessionID of sessionIds) {
       map.set(sessionID, this.getSessionLog(sessionID));
     }
@@ -430,7 +457,7 @@ export class VerifiedState {
   }
 
   *sessionEntries(): IterableIterator<[SessionID, SessionLog]> {
-    const sessionIds = this.impl.getSessionIds() as SessionID[];
+    const sessionIds = this.nodeCore.getSessionIds(this.id) as SessionID[];
     for (const sessionID of sessionIds) {
       yield [sessionID, this.getSessionLog(sessionID)];
     }
@@ -590,14 +617,16 @@ export class VerifiedState {
 
   knownState(): CoValueKnownState {
     if (!this.cachedKnownState) {
-      this.cachedKnownState = this.impl.getKnownState() as CoValueKnownState;
+      this.cachedKnownState = this.nodeCore.getKnownState(
+        this.id,
+      ) as CoValueKnownState;
     }
     return this.cachedKnownState;
   }
 
   knownStateWithStreaming(): CoValueKnownState {
     if (!this.cachedKnownStateWithStreaming) {
-      const result = this.impl.getKnownStateWithStreaming();
+      const result = this.nodeCore.getKnownStateWithStreaming(this.id);
       if (!result || result === undefined) {
         this.cachedKnownStateWithStreaming = this.knownState();
       } else {
@@ -608,7 +637,7 @@ export class VerifiedState {
   }
 
   isStreaming(): boolean {
-    return this.impl.isStreaming();
+    return this.nodeCore.isStreaming(this.id);
   }
 
   decryptTransaction(
@@ -616,7 +645,8 @@ export class VerifiedState {
     txIndex: number,
     keySecret: KeySecret,
   ): JsonValue[] | undefined {
-    const decrypted = this.impl.decryptTransaction(
+    const decrypted = this.nodeCore.decryptTransaction(
+      this.id,
       sessionID,
       txIndex,
       keySecret,
@@ -636,7 +666,8 @@ export class VerifiedState {
     if (!sessionLog?.transactions[txIndex]?.meta) {
       return undefined;
     }
-    const decrypted = this.impl.decryptTransactionMeta(
+    const decrypted = this.nodeCore.decryptTransactionMeta(
+      this.id,
       sessionID,
       txIndex,
       keySecret,

--- a/packages/cojson/src/crypto/NapiCrypto.ts
+++ b/packages/cojson/src/crypto/NapiCrypto.ts
@@ -1,5 +1,6 @@
 import {
   SessionMap as NativeSessionMap,
+  NodeCore as NativeNodeCore,
   Blake3Hasher,
   blake3HashOnce,
   blake3HashOnceWithContext,
@@ -26,6 +27,7 @@ import {
   CryptoProvider,
   Encrypted,
   KeySecret,
+  NodeCoreImpl,
   Sealed,
   SealedForGroup,
   SealerID,
@@ -230,6 +232,10 @@ export class NapiCrypto extends CryptoProvider<Blake3State> {
       new NativeSessionMap(coID, headerJson, maxTxSize, skipVerify),
     );
   }
+
+  override createNodeCore(): NodeCoreImpl {
+    return new NapiNodeCoreAdapter(new NativeNodeCore());
+  }
 }
 
 /**
@@ -396,6 +402,230 @@ class SessionMapAdapter implements SessionMapImpl {
     return (
       this.sessionMap.decryptTransactionMeta(sessionId, txIndex, keySecret) ??
       undefined
+    );
+  }
+}
+
+/**
+ * Adapter wrapping the native NodeCore registry to implement NodeCoreImpl.
+ */
+class NapiNodeCoreAdapter implements NodeCoreImpl {
+  constructor(private readonly nodeCore: NativeNodeCore) {}
+
+  // === Registry ===
+  createCoValue(
+    coId: string,
+    headerJson: string,
+    maxTxSize?: number,
+    skipVerify?: boolean,
+  ): void {
+    this.nodeCore.createCoValue(coId, headerJson, maxTxSize, skipVerify);
+  }
+
+  hasCoValue(coId: string): boolean {
+    return this.nodeCore.hasCoValue(coId);
+  }
+
+  removeCoValue(coId: string): void {
+    this.nodeCore.removeCoValue(coId);
+  }
+
+  coValueCount(): number {
+    return this.nodeCore.coValueCount();
+  }
+
+  // === Header ===
+  getHeader(coId: string): string {
+    return this.nodeCore.getHeader(coId);
+  }
+
+  // === Transaction Operations ===
+  addTransactions(
+    coId: string,
+    sessionId: string,
+    signerId: string | undefined,
+    transactionsJson: string,
+    signature: string,
+    skipVerify: boolean,
+  ): void {
+    this.nodeCore.addTransactions(
+      coId,
+      sessionId,
+      signerId,
+      transactionsJson,
+      signature,
+      skipVerify,
+    );
+  }
+
+  makeNewPrivateTransaction(
+    coId: string,
+    sessionId: string,
+    signerSecret: string,
+    changesJson: string,
+    keyId: string,
+    keySecret: string,
+    metaJson: string | undefined,
+    madeAt: number,
+  ): string {
+    return this.nodeCore.makeNewPrivateTransaction(
+      coId,
+      sessionId,
+      signerSecret,
+      changesJson,
+      keyId,
+      keySecret,
+      metaJson,
+      madeAt,
+    );
+  }
+
+  makeNewTrustingTransaction(
+    coId: string,
+    sessionId: string,
+    signerSecret: string,
+    changesJson: string,
+    metaJson: string | undefined,
+    madeAt: number,
+  ): string {
+    return this.nodeCore.makeNewTrustingTransaction(
+      coId,
+      sessionId,
+      signerSecret,
+      changesJson,
+      metaJson,
+      madeAt,
+    );
+  }
+
+  // === Session Queries ===
+  getSessionIds(coId: string): string[] {
+    return this.nodeCore.getSessionIds(coId);
+  }
+
+  getTransactionCount(coId: string, sessionId: string): number {
+    return this.nodeCore.getTransactionCount(coId, sessionId);
+  }
+
+  getTransaction(
+    coId: string,
+    sessionId: string,
+    txIndex: number,
+  ): Transaction | undefined {
+    const result = this.nodeCore.getTransaction(coId, sessionId, txIndex);
+    if (!result) return undefined;
+    return JSON.parse(result) as Transaction;
+  }
+
+  getSessionTransactions(
+    coId: string,
+    sessionId: string,
+    fromIndex: number,
+  ): Transaction[] | undefined {
+    const result = this.nodeCore.getSessionTransactions(
+      coId,
+      sessionId,
+      fromIndex,
+    );
+    if (!result) return undefined;
+    return result.map((tx) => JSON.parse(tx) as Transaction);
+  }
+
+  getLastSignature(coId: string, sessionId: string): string | undefined {
+    return this.nodeCore.getLastSignature(coId, sessionId) ?? undefined;
+  }
+
+  getSignatureAfter(
+    coId: string,
+    sessionId: string,
+    txIndex: number,
+  ): string | undefined {
+    return (
+      this.nodeCore.getSignatureAfter(coId, sessionId, txIndex) ?? undefined
+    );
+  }
+
+  getLastSignatureCheckpoint(
+    coId: string,
+    sessionId: string,
+  ): number | undefined {
+    return (
+      this.nodeCore.getLastSignatureCheckpoint(coId, sessionId) ?? undefined
+    );
+  }
+
+  // === Known State ===
+  getKnownState(coId: string): {
+    id: string;
+    header: boolean;
+    sessions: Record<string, number>;
+  } {
+    // NAPI returns a native JS object via #[napi(object)]
+    return this.nodeCore.getKnownState(coId) as {
+      id: string;
+      header: boolean;
+      sessions: Record<string, number>;
+    };
+  }
+
+  getKnownStateWithStreaming(
+    coId: string,
+  ):
+    | { id: string; header: boolean; sessions: Record<string, number> }
+    | undefined {
+    // NAPI returns a native JS object via #[napi(object)], or undefined
+    const result = this.nodeCore.getKnownStateWithStreaming(coId);
+    if (!result || result === undefined) return undefined;
+    return result as {
+      id: string;
+      header: boolean;
+      sessions: Record<string, number>;
+    };
+  }
+
+  isStreaming(coId: string): boolean {
+    return this.nodeCore.isStreaming(coId);
+  }
+
+  setStreamingKnownState(coId: string, streamingJson: string): void {
+    this.nodeCore.setStreamingKnownState(coId, streamingJson);
+  }
+
+  // === Deletion ===
+  markAsDeleted(coId: string): void {
+    this.nodeCore.markAsDeleted(coId);
+  }
+
+  isDeleted(coId: string): boolean {
+    return this.nodeCore.isDeleted(coId);
+  }
+
+  // === Decryption ===
+  decryptTransaction(
+    coId: string,
+    sessionId: string,
+    txIndex: number,
+    keySecret: string,
+  ): string | undefined {
+    return (
+      this.nodeCore.decryptTransaction(coId, sessionId, txIndex, keySecret) ??
+      undefined
+    );
+  }
+
+  decryptTransactionMeta(
+    coId: string,
+    sessionId: string,
+    txIndex: number,
+    keySecret: string,
+  ): string | undefined {
+    return (
+      this.nodeCore.decryptTransactionMeta(
+        coId,
+        sessionId,
+        txIndex,
+        keySecret,
+      ) ?? undefined
     );
   }
 }

--- a/packages/cojson/src/crypto/ShimNodeCore.ts
+++ b/packages/cojson/src/crypto/ShimNodeCore.ts
@@ -1,0 +1,209 @@
+import type { Transaction } from "../coValueCore/verifiedState.js";
+import type { NodeCoreImpl, SessionMapImpl } from "./crypto.js";
+
+type SessionMapFactory = (
+  coId: string,
+  headerJson: string,
+  maxTxSize?: number,
+  skipVerify?: boolean,
+) => SessionMapImpl;
+
+/**
+ * NodeCoreImpl implemented over per-CoValue SessionMapImpl objects.
+ * Used by providers without a native NodeCore (wasm, RN) until their
+ * native ports land. Mirrors the native registry's semantics exactly:
+ * replace-on-create, no-op remove, "Unknown CoValue: <id>" on misses.
+ */
+export class ShimNodeCore implements NodeCoreImpl {
+  private readonly covalues = new Map<string, SessionMapImpl>();
+
+  constructor(private readonly createSessionMap: SessionMapFactory) {}
+
+  private get(coId: string): SessionMapImpl {
+    const entry = this.covalues.get(coId);
+    if (!entry) {
+      throw new Error(`Unknown CoValue: ${coId}`);
+    }
+    return entry;
+  }
+
+  createCoValue(
+    coId: string,
+    headerJson: string,
+    maxTxSize?: number,
+    skipVerify?: boolean,
+  ): void {
+    const replaced = this.covalues.get(coId);
+    this.covalues.set(
+      coId,
+      this.createSessionMap(coId, headerJson, maxTxSize, skipVerify),
+    );
+    replaced?.dispose?.();
+  }
+
+  hasCoValue(coId: string): boolean {
+    return this.covalues.has(coId);
+  }
+
+  removeCoValue(coId: string): void {
+    const entry = this.covalues.get(coId);
+    this.covalues.delete(coId);
+    entry?.dispose?.();
+  }
+
+  coValueCount(): number {
+    return this.covalues.size;
+  }
+
+  getHeader(coId: string): string {
+    return this.get(coId).getHeader();
+  }
+
+  addTransactions(
+    coId: string,
+    sessionId: string,
+    signerId: string | undefined,
+    transactionsJson: string,
+    signature: string,
+    skipVerify: boolean,
+  ): void {
+    this.get(coId).addTransactions(
+      sessionId,
+      signerId,
+      transactionsJson,
+      signature,
+      skipVerify,
+    );
+  }
+
+  makeNewPrivateTransaction(
+    coId: string,
+    sessionId: string,
+    signerSecret: string,
+    changesJson: string,
+    keyId: string,
+    keySecret: string,
+    metaJson: string | undefined,
+    madeAt: number,
+  ): string {
+    return this.get(coId).makeNewPrivateTransaction(
+      sessionId,
+      signerSecret,
+      changesJson,
+      keyId,
+      keySecret,
+      metaJson,
+      madeAt,
+    );
+  }
+
+  makeNewTrustingTransaction(
+    coId: string,
+    sessionId: string,
+    signerSecret: string,
+    changesJson: string,
+    metaJson: string | undefined,
+    madeAt: number,
+  ): string {
+    return this.get(coId).makeNewTrustingTransaction(
+      sessionId,
+      signerSecret,
+      changesJson,
+      metaJson,
+      madeAt,
+    );
+  }
+
+  getSessionIds(coId: string): string[] {
+    return this.get(coId).getSessionIds();
+  }
+
+  getTransactionCount(coId: string, sessionId: string): number {
+    return this.get(coId).getTransactionCount(sessionId);
+  }
+
+  getTransaction(
+    coId: string,
+    sessionId: string,
+    txIndex: number,
+  ): Transaction | undefined {
+    return this.get(coId).getTransaction(sessionId, txIndex);
+  }
+
+  getSessionTransactions(
+    coId: string,
+    sessionId: string,
+    fromIndex: number,
+  ): Transaction[] | undefined {
+    return this.get(coId).getSessionTransactions(sessionId, fromIndex);
+  }
+
+  getLastSignature(coId: string, sessionId: string): string | undefined {
+    return this.get(coId).getLastSignature(sessionId);
+  }
+
+  getSignatureAfter(
+    coId: string,
+    sessionId: string,
+    txIndex: number,
+  ): string | undefined {
+    return this.get(coId).getSignatureAfter(sessionId, txIndex);
+  }
+
+  getLastSignatureCheckpoint(
+    coId: string,
+    sessionId: string,
+  ): number | undefined {
+    return this.get(coId).getLastSignatureCheckpoint(sessionId);
+  }
+
+  getKnownState(coId: string): {
+    id: string;
+    header: boolean;
+    sessions: Record<string, number>;
+  } {
+    return this.get(coId).getKnownState();
+  }
+
+  getKnownStateWithStreaming(
+    coId: string,
+  ):
+    | { id: string; header: boolean; sessions: Record<string, number> }
+    | undefined {
+    return this.get(coId).getKnownStateWithStreaming();
+  }
+
+  isStreaming(coId: string): boolean {
+    return this.get(coId).isStreaming();
+  }
+
+  setStreamingKnownState(coId: string, streamingJson: string): void {
+    this.get(coId).setStreamingKnownState(streamingJson);
+  }
+
+  markAsDeleted(coId: string): void {
+    this.get(coId).markAsDeleted();
+  }
+
+  isDeleted(coId: string): boolean {
+    return this.get(coId).isDeleted();
+  }
+
+  decryptTransaction(
+    coId: string,
+    sessionId: string,
+    txIndex: number,
+    keySecret: string,
+  ): string | undefined {
+    return this.get(coId).decryptTransaction(sessionId, txIndex, keySecret);
+  }
+
+  decryptTransactionMeta(
+    coId: string,
+    sessionId: string,
+    txIndex: number,
+    keySecret: string,
+  ): string | undefined {
+    return this.get(coId).decryptTransactionMeta(sessionId, txIndex, keySecret);
+  }
+}

--- a/packages/cojson/src/crypto/WasmCrypto.ts
+++ b/packages/cojson/src/crypto/WasmCrypto.ts
@@ -283,6 +283,10 @@ export class WasmCrypto extends CryptoProvider<Blake3State> {
 class SessionMapAdapter implements SessionMapImpl {
   constructor(private readonly sessionMap: WasmSessionMap) {}
 
+  dispose(): void {
+    this.sessionMap.free();
+  }
+
   // === Header ===
   getHeader(): string {
     return this.sessionMap.getHeader();

--- a/packages/cojson/src/crypto/crypto.ts
+++ b/packages/cojson/src/crypto/crypto.ts
@@ -11,6 +11,7 @@ import { Stringified, parseJSON, stableStringify } from "../jsonStringify.js";
 import { JsonValue } from "../jsonValue.js";
 import { logger } from "../logger.js";
 import { Transaction } from "../coValueCore/verifiedState.js";
+import { ShimNodeCore } from "./ShimNodeCore.js";
 
 function randomBytes(bytesLength = 32): Uint8Array {
   return crypto.getRandomValues(new Uint8Array(bytesLength));
@@ -297,6 +298,17 @@ export abstract class CryptoProvider<Blake3State = any> {
     maxTxSize?: number,
     skipVerify?: boolean,
   ): SessionMapImpl;
+
+  /**
+   * Node-level registry. Default: TS shim over per-CoValue session maps
+   * (wasm/RN until their native NodeCore ports land). NapiCrypto overrides
+   * this with the native registry.
+   */
+  createNodeCore(): NodeCoreImpl {
+    return new ShimNodeCore((coId, headerJson, maxTxSize, skipVerify) =>
+      this.createSessionMap(coId as RawCoID, headerJson, maxTxSize, skipVerify),
+    );
+  }
 }
 
 export type Hash = `hash_z${string}`;
@@ -383,6 +395,114 @@ export interface SessionMapImpl {
     keySecret: string,
   ): string | undefined;
   decryptTransactionMeta(
+    sessionId: string,
+    txIndex: number,
+    keySecret: string,
+  ): string | undefined;
+
+  /** Optional: free native resources eagerly (wasm). */
+  dispose?(): void;
+}
+
+/**
+ * NodeCoreImpl - node-level registry of per-CoValue session state.
+ * One instance per LocalNode; every method addresses a CoValue by its id.
+ */
+export interface NodeCoreImpl {
+  // === Registry ===
+  createCoValue(
+    coId: string,
+    headerJson: string,
+    maxTxSize?: number,
+    skipVerify?: boolean,
+  ): void;
+  hasCoValue(coId: string): boolean;
+  /** No-op if absent. Frees the CoValue's native memory. */
+  removeCoValue(coId: string): void;
+  coValueCount(): number;
+
+  // === Header ===
+  getHeader(coId: string): string;
+
+  // === Transaction Operations ===
+  addTransactions(
+    coId: string,
+    sessionId: string,
+    signerId: string | undefined,
+    transactionsJson: string,
+    signature: string,
+    skipVerify: boolean,
+  ): void;
+  makeNewPrivateTransaction(
+    coId: string,
+    sessionId: string,
+    signerSecret: string,
+    changesJson: string,
+    keyId: string,
+    keySecret: string,
+    metaJson: string | undefined,
+    madeAt: number,
+  ): string;
+  makeNewTrustingTransaction(
+    coId: string,
+    sessionId: string,
+    signerSecret: string,
+    changesJson: string,
+    metaJson: string | undefined,
+    madeAt: number,
+  ): string;
+
+  // === Session Queries ===
+  getSessionIds(coId: string): string[];
+  getTransactionCount(coId: string, sessionId: string): number;
+  getTransaction(
+    coId: string,
+    sessionId: string,
+    txIndex: number,
+  ): Transaction | undefined;
+  getSessionTransactions(
+    coId: string,
+    sessionId: string,
+    fromIndex: number,
+  ): Transaction[] | undefined;
+  getLastSignature(coId: string, sessionId: string): string | undefined;
+  getSignatureAfter(
+    coId: string,
+    sessionId: string,
+    txIndex: number,
+  ): string | undefined;
+  getLastSignatureCheckpoint(
+    coId: string,
+    sessionId: string,
+  ): number | undefined;
+
+  // === Known State ===
+  getKnownState(coId: string): {
+    id: string;
+    header: boolean;
+    sessions: Record<string, number>;
+  };
+  getKnownStateWithStreaming(
+    coId: string,
+  ):
+    | { id: string; header: boolean; sessions: Record<string, number> }
+    | undefined;
+  isStreaming(coId: string): boolean;
+  setStreamingKnownState(coId: string, streamingJson: string): void;
+
+  // === Deletion ===
+  markAsDeleted(coId: string): void;
+  isDeleted(coId: string): boolean;
+
+  // === Decryption ===
+  decryptTransaction(
+    coId: string,
+    sessionId: string,
+    txIndex: number,
+    keySecret: string,
+  ): string | undefined;
+  decryptTransactionMeta(
+    coId: string,
     sessionId: string,
     txIndex: number,
     keySecret: string,

--- a/packages/cojson/src/localNode.ts
+++ b/packages/cojson/src/localNode.ts
@@ -267,8 +267,10 @@ export class LocalNode {
    * the CoValue has been (re)loaded in the meantime, so a freshly registered
    * entry is never dropped.
    *
-   * {@link gracefulShutdown} evicts synchronously instead, because it drains
-   * in-flight work via `await` before evicting.
+   * {@link gracefulShutdown} does NOT evict: a shutting-down node's registry is
+   * released wholesale when the node is dropped, and eagerly emptying it while
+   * sync messages are still in flight would make in-flight reads throw
+   * "Unknown CoValue".
    *
    * @internal
    */
@@ -1031,12 +1033,13 @@ export class LocalNode {
   async gracefulShutdown(): Promise<unknown> {
     this.garbageCollector?.stop();
     await this.syncManager.gracefulShutdown();
-    // Drain in-flight work (e.g. the LocalTransactionsSyncQueue microtask)
-    // before dropping the NodeCore registry entries: those reads target the
-    // registry and would throw once it is empty.
-    for (const id of this.coValues.keys()) {
-      this.nodeCore.removeCoValue(id);
-    }
+    // NOTE: NodeCore registry entries are intentionally NOT dropped here.
+    // Emptying the shared registry while sync messages are still in flight
+    // (e.g. a LOAD queued before shutdown, or one that arrives before the peer
+    // is fully torn down) makes a still-available CoValueCore's session reads
+    // throw "Unknown CoValue". The whole registry — and every SessionMap it
+    // owns (native included) — is released when this node is dropped, so
+    // eager removal is unnecessary for reclamation.
     return this.storage?.close();
   }
 }

--- a/packages/cojson/src/localNode.ts
+++ b/packages/cojson/src/localNode.ts
@@ -32,7 +32,7 @@ import {
   secretSeedFromInviteSecret,
 } from "./coValues/group.js";
 import { CO_VALUE_LOADING_CONFIG } from "./config.js";
-import { AgentSecret, CryptoProvider } from "./crypto/crypto.js";
+import { AgentSecret, CryptoProvider, NodeCoreImpl } from "./crypto/crypto.js";
 import { AgentID, RawCoID, SessionID, isAgentID, isRawCoID } from "./ids.js";
 import { logger } from "./logger.js";
 import { StorageAPI } from "./storage/index.js";
@@ -63,6 +63,8 @@ const { localNode } = useJazz();
 export class LocalNode {
   /** @internal */
   crypto: CryptoProvider;
+  /** @internal */
+  readonly nodeCore: NodeCoreImpl;
   /** @internal */
   private readonly coValues = new Map<RawCoID, CoValueCore>();
 
@@ -96,6 +98,7 @@ export class LocalNode {
     this.agentSecret = agentSecret;
     this.currentSessionID = currentSessionID;
     this.crypto = crypto;
+    this.nodeCore = crypto.createNodeCore();
     if (enableFullStorageReconciliation) {
       this.syncManager.fullStorageReconciliationEnabled = true;
     }

--- a/packages/cojson/src/localNode.ts
+++ b/packages/cojson/src/localNode.ts
@@ -201,6 +201,7 @@ export class LocalNode {
    */
   internalDeleteCoValue(id: RawCoID) {
     this.coValues.delete(id);
+    this.scheduleNodeCoreEviction(id);
     this.storage?.onCoValueUnmounted(id);
   }
 
@@ -245,11 +246,39 @@ export class LocalNode {
 
     // Single map update (replacing old with shell)
     this.coValues.set(id, shell);
+    this.scheduleNodeCoreEviction(id);
 
     // Notify storage
     this.storage?.onCoValueUnmounted(id);
 
     return true;
+  }
+
+  /**
+   * Drop the NodeCore registry entry for a CoValue that has just been deleted
+   * or unmounted.
+   *
+   * The removal is deferred to the next microtask so that any already-queued
+   * {@link LocalTransactionsSyncQueue} batch — which reads the registry to
+   * persist and sync local transactions — flushes first (microtasks run in
+   * FIFO order). This matters when a CoValue is garbage-collected (or
+   * force-deleted) before its last local transaction has been synced: the
+   * batch must still be able to read the entry. The guard skips removal when
+   * the CoValue has been (re)loaded in the meantime, so a freshly registered
+   * entry is never dropped.
+   *
+   * {@link gracefulShutdown} evicts synchronously instead, because it drains
+   * in-flight work via `await` before evicting.
+   *
+   * @internal
+   */
+  private scheduleNodeCoreEviction(id: RawCoID) {
+    queueMicrotask(() => {
+      const current = this.coValues.get(id);
+      if (!current || !current.isAvailable()) {
+        this.nodeCore.removeCoValue(id);
+      }
+    });
   }
 
   getCurrentAccountOrAgentID(): RawAccountID | AgentID {
@@ -1002,6 +1031,12 @@ export class LocalNode {
   async gracefulShutdown(): Promise<unknown> {
     this.garbageCollector?.stop();
     await this.syncManager.gracefulShutdown();
+    // Drain in-flight work (e.g. the LocalTransactionsSyncQueue microtask)
+    // before dropping the NodeCore registry entries: those reads target the
+    // registry and would throw once it is empty.
+    for (const id of this.coValues.keys()) {
+      this.nodeCore.removeCoValue(id);
+    }
     return this.storage?.close();
   }
 }

--- a/packages/cojson/src/tests/coValueCore.isStreaming.test.ts
+++ b/packages/cojson/src/tests/coValueCore.isStreaming.test.ts
@@ -140,7 +140,7 @@ describe("isStreaming", () => {
     }
 
     const mapInNewSession = await loadCoValueOrFail(newSession.node, map.id);
-    const impl = (mapInNewSession.core.verified as any).impl;
+    const impl = (mapInNewSession.core.verified as any).nodeCore;
     const isStreamingSpy = vi.spyOn(impl, "isStreaming");
     const getKnownStateWithStreamingSpy = vi.spyOn(
       impl,
@@ -171,7 +171,7 @@ describe("isStreaming", () => {
 
     map.core.verified.setStreamingKnownState({ [sessionId]: 2 });
 
-    const impl = (map.core.verified as any).impl;
+    const impl = (map.core.verified as any).nodeCore;
     const isStreamingSpy = vi.spyOn(impl, "isStreaming");
     const getKnownStateWithStreamingSpy = vi.spyOn(
       impl,

--- a/packages/cojson/src/tests/nodeCoreEviction.test.ts
+++ b/packages/cojson/src/tests/nodeCoreEviction.test.ts
@@ -79,14 +79,32 @@ describe("NodeCore eviction", () => {
     expect(client.node.nodeCore.hasCoValue(map.id)).toBe(true);
   });
 
-  test("gracefulShutdown evicts all registry entries", async () => {
+  test("gracefulShutdown keeps registry entries readable for in-flight work", async () => {
+    // Regression: gracefulShutdown must NOT empty the NodeCore registry. Sync
+    // messages can still be processed after shutdown begins (a LOAD queued
+    // before shutdown, or one arriving before a peer is fully torn down). The
+    // handler path LOAD -> sendNewContent -> CoValueCore.newContentSince ->
+    // VerifiedState.getSessions -> getSessionIds reads session state out of the
+    // registry; if the entry had been dropped, an otherwise-available
+    // CoValueCore would throw "Unknown CoValue". The per-node registry (and its
+    // native SessionMaps) is released wholesale when the node is dropped, so
+    // eager eviction here is both unnecessary and unsafe.
     const { node } = setupTestNode();
     const group = node.createGroup();
-    group.createMap();
-    expect(node.nodeCore.coValueCount()).toBeGreaterThan(0);
+    const map = group.createMap();
+
+    expect(node.nodeCore.hasCoValue(map.id)).toBe(true);
 
     await node.gracefulShutdown();
 
-    expect(node.nodeCore.coValueCount()).toBe(0);
+    // Entry survives shutdown and session reads still work.
+    expect(node.nodeCore.hasCoValue(map.id)).toBe(true);
+    expect(() => node.nodeCore.getSessionIds(map.id)).not.toThrow();
+
+    // The exact path that regressed: an available CoValueCore serving a LOAD
+    // after shutdown computes newContentSince, which reads its sessions.
+    const core = node.getCoValue(map.id);
+    expect(core.isAvailable()).toBe(true);
+    expect(() => core.newContentSince(undefined)).not.toThrow();
   });
 });

--- a/packages/cojson/src/tests/nodeCoreEviction.test.ts
+++ b/packages/cojson/src/tests/nodeCoreEviction.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, test } from "vitest";
+import { loadCoValueOrFail, setupTestNode } from "./testUtils.js";
+
+// Eviction of the NodeCore registry entry is deferred to the next microtask
+// (past any pending LocalTransactionsSyncQueue batch, which must still be able
+// to read the entry to persist local transactions). Flush before asserting.
+const flushMicrotasks = () => new Promise((resolve) => setTimeout(resolve, 0));
+
+describe("NodeCore eviction", () => {
+  test("internalDeleteCoValue removes the registry entry", async () => {
+    const { node } = setupTestNode();
+    const group = node.createGroup();
+    const map = group.createMap();
+
+    expect(node.nodeCore.hasCoValue(map.id)).toBe(true);
+    const before = node.nodeCore.coValueCount();
+
+    node.internalDeleteCoValue(map.id);
+    await flushMicrotasks();
+
+    expect(node.nodeCore.hasCoValue(map.id)).toBe(false);
+    expect(node.nodeCore.coValueCount()).toBe(before - 1);
+    // double delete is a no-op (removeCoValue is a no-op when absent)
+    node.internalDeleteCoValue(map.id);
+    await flushMicrotasks();
+  });
+
+  test("internalUnmountCoValue removes the registry entry", async () => {
+    // Unmount preconditions (no listeners, no in-memory dependants, synced to
+    // server peers) are met by the same client/server setup as
+    // sync.concurrentLoad.test.ts:1048 — content created on the sync server,
+    // primed on the client via loadCoValueOrFail, then unmounted there.
+    const jazzCloud = setupTestNode({ isSyncServer: true });
+    const client = setupTestNode({ connected: false });
+    client.connectToSyncServer();
+
+    const group = jazzCloud.node.createGroup();
+    const map = group.createMap();
+    map.set("key", "value", "trusting");
+
+    await loadCoValueOrFail(client.node, map.id);
+
+    expect(client.node.nodeCore.hasCoValue(map.id)).toBe(true);
+
+    const unmounted = client.node.internalUnmountCoValue(map.id);
+    expect(unmounted).toBe(true);
+    await flushMicrotasks();
+    expect(client.node.nodeCore.hasCoValue(map.id)).toBe(false);
+
+    // The shell left in node.coValues must not resurrect a registry entry:
+    // getCoValue only returns the existing shell, it does not build a
+    // VerifiedState, so nodeCore must stay empty for this id.
+    client.node.getCoValue(map.id);
+    expect(client.node.nodeCore.hasCoValue(map.id)).toBe(false);
+  });
+
+  test("re-registration after unmount goes through VerifiedState creation", async () => {
+    const jazzCloud = setupTestNode({ isSyncServer: true });
+    const client = setupTestNode({ connected: false });
+    client.connectToSyncServer();
+
+    const group = jazzCloud.node.createGroup();
+    const map = group.createMap();
+    map.set("key", "value", "trusting");
+
+    await loadCoValueOrFail(client.node, map.id);
+
+    const unmounted = client.node.internalUnmountCoValue(map.id);
+    expect(unmounted).toBe(true);
+    await flushMicrotasks();
+    expect(client.node.nodeCore.hasCoValue(map.id)).toBe(false);
+
+    // Reload the CoValue's contents from the peer — same mechanism the
+    // concurrent-load test uses post-unmount (loadCoValueCore). Re-providing
+    // the header constructs a fresh VerifiedState, whose constructor calls
+    // nodeCore.createCoValue (replace semantics), so the registry entry must
+    // be back.
+    await client.node.loadCoValueCore(map.id);
+    expect(client.node.nodeCore.hasCoValue(map.id)).toBe(true);
+  });
+
+  test("gracefulShutdown evicts all registry entries", async () => {
+    const { node } = setupTestNode();
+    const group = node.createGroup();
+    group.createMap();
+    expect(node.nodeCore.coValueCount()).toBeGreaterThan(0);
+
+    await node.gracefulShutdown();
+
+    expect(node.nodeCore.coValueCount()).toBe(0);
+  });
+});

--- a/packages/cojson/src/tests/shimNodeCore.test.ts
+++ b/packages/cojson/src/tests/shimNodeCore.test.ts
@@ -1,0 +1,73 @@
+import { beforeAll, describe, expect, test } from "vitest";
+import { NapiCrypto } from "../crypto/NapiCrypto.js";
+import { ShimNodeCore } from "../crypto/ShimNodeCore.js";
+import type { CryptoProvider } from "../crypto/crypto.js";
+import type { RawCoID } from "../ids.js";
+
+let crypto: CryptoProvider;
+
+beforeAll(async () => {
+  crypto = await NapiCrypto.create();
+});
+
+function makeShim() {
+  return new ShimNodeCore((coId, headerJson, maxTxSize, skipVerify) =>
+    crypto.createSessionMap(coId as RawCoID, headerJson, maxTxSize, skipVerify),
+  );
+}
+
+// Build a real header + coId the way VerifiedState does, so createCoValue
+// passes native header validation.
+function makeHeaderAndId() {
+  const header = {
+    type: "comap" as const,
+    ruleset: { type: "unsafeAllowAll" as const },
+    meta: null,
+    createdAt: null,
+    uniqueness: "test-uniqueness",
+  };
+  const coId = `co_z${crypto.shortHash(header).slice("shortHash_z".length)}`;
+  return { coId, headerJson: JSON.stringify(header) };
+}
+
+describe("ShimNodeCore", () => {
+  test("createCoValue / hasCoValue / removeCoValue roundtrip", () => {
+    const shim = makeShim();
+    const { coId, headerJson } = makeHeaderAndId();
+
+    expect(shim.hasCoValue(coId)).toBe(false);
+    expect(shim.coValueCount()).toBe(0);
+
+    shim.createCoValue(coId, headerJson);
+    expect(shim.hasCoValue(coId)).toBe(true);
+    expect(shim.coValueCount()).toBe(1);
+    expect(JSON.parse(shim.getHeader(coId))).toMatchObject({ type: "comap" });
+
+    shim.removeCoValue(coId);
+    expect(shim.hasCoValue(coId)).toBe(false);
+    expect(shim.coValueCount()).toBe(0);
+    // double remove is a no-op
+    shim.removeCoValue(coId);
+  });
+
+  test("unknown coId throws with Unknown CoValue message", () => {
+    const shim = makeShim();
+    expect(() => shim.getHeader("co_zNope")).toThrow(
+      /Unknown CoValue: co_zNope/,
+    );
+    expect(() => shim.getSessionIds("co_zNope")).toThrow(/Unknown CoValue/);
+  });
+
+  test("delegates session queries to the underlying session map", () => {
+    const shim = makeShim();
+    const { coId, headerJson } = makeHeaderAndId();
+    shim.createCoValue(coId, headerJson);
+    expect(shim.getSessionIds(coId)).toEqual([]);
+    expect(shim.getTransactionCount(coId, "co_zAnybody_session_z123")).toBe(-1);
+    expect(shim.getKnownState(coId)).toMatchObject({
+      id: coId,
+      header: true,
+      sessions: {},
+    });
+  });
+});

--- a/packages/cojson/src/tests/shimNodeCore.test.ts
+++ b/packages/cojson/src/tests/shimNodeCore.test.ts
@@ -1,7 +1,7 @@
 import { beforeAll, describe, expect, test } from "vitest";
 import { NapiCrypto } from "../crypto/NapiCrypto.js";
 import { ShimNodeCore } from "../crypto/ShimNodeCore.js";
-import type { CryptoProvider } from "../crypto/crypto.js";
+import type { CryptoProvider, SessionMapImpl } from "../crypto/crypto.js";
 import type { RawCoID } from "../ids.js";
 
 let crypto: CryptoProvider;
@@ -68,6 +68,73 @@ describe("ShimNodeCore", () => {
       id: coId,
       header: true,
       sessions: {},
+    });
+  });
+
+  describe("dispose semantics", () => {
+    function makeFakeShim() {
+      let disposed = 0;
+      let shouldThrow = false;
+      const shim = new ShimNodeCore(() => {
+        if (shouldThrow) {
+          throw new Error("factory failed");
+        }
+        return {
+          dispose: () => {
+            disposed++;
+          },
+        } as unknown as SessionMapImpl;
+      });
+      return {
+        shim,
+        getDisposedCount: () => disposed,
+        setShouldThrow: (value: boolean) => {
+          shouldThrow = value;
+        },
+      };
+    }
+
+    test("dispose-once-on-remove: removeCoValue disposes exactly once, double-remove is a no-op", () => {
+      const { shim, getDisposedCount } = makeFakeShim();
+      const { coId, headerJson } = makeHeaderAndId();
+
+      shim.createCoValue(coId, headerJson);
+      expect(getDisposedCount()).toBe(0);
+
+      shim.removeCoValue(coId);
+      expect(getDisposedCount()).toBe(1);
+
+      // Second remove must not double-dispose.
+      shim.removeCoValue(coId);
+      expect(getDisposedCount()).toBe(1);
+    });
+
+    test("dispose-of-replaced-on-recreate: recreating the same coId disposes only the replaced entry", () => {
+      const { shim, getDisposedCount } = makeFakeShim();
+      const { coId, headerJson } = makeHeaderAndId();
+
+      shim.createCoValue(coId, headerJson);
+      expect(getDisposedCount()).toBe(0);
+
+      shim.createCoValue(coId, headerJson);
+      expect(getDisposedCount()).toBe(1);
+      expect(shim.hasCoValue(coId)).toBe(true);
+    });
+
+    test("no-dispose-when-factory-throws: throwing factory leaves the existing entry undisposed", () => {
+      const { shim, getDisposedCount, setShouldThrow } = makeFakeShim();
+      const { coId, headerJson } = makeHeaderAndId();
+
+      shim.createCoValue(coId, headerJson);
+      expect(getDisposedCount()).toBe(0);
+
+      setShouldThrow(true);
+      expect(() => shim.createCoValue(coId, headerJson)).toThrow(
+        "factory failed",
+      );
+
+      expect(getDisposedCount()).toBe(0);
+      expect(shim.hasCoValue(coId)).toBe(true);
     });
   });
 });

--- a/packages/cojson/src/tests/shimNodeCore.test.ts
+++ b/packages/cojson/src/tests/shimNodeCore.test.ts
@@ -1,7 +1,11 @@
 import { beforeAll, describe, expect, test } from "vitest";
 import { NapiCrypto } from "../crypto/NapiCrypto.js";
 import { ShimNodeCore } from "../crypto/ShimNodeCore.js";
-import type { CryptoProvider, SessionMapImpl } from "../crypto/crypto.js";
+import type {
+  CryptoProvider,
+  NodeCoreImpl,
+  SessionMapImpl,
+} from "../crypto/crypto.js";
 import type { RawCoID } from "../ids.js";
 
 let crypto: CryptoProvider;
@@ -30,47 +34,62 @@ function makeHeaderAndId() {
   return { coId, headerJson: JSON.stringify(header) };
 }
 
-describe("ShimNodeCore", () => {
-  test("createCoValue / hasCoValue / removeCoValue roundtrip", () => {
-    const shim = makeShim();
-    const { coId, headerJson } = makeHeaderAndId();
+function nodeCoreSuite(name: string, makeNodeCore: () => NodeCoreImpl) {
+  describe(name, () => {
+    test("createCoValue / hasCoValue / removeCoValue roundtrip", () => {
+      const shim = makeNodeCore();
+      const { coId, headerJson } = makeHeaderAndId();
 
-    expect(shim.hasCoValue(coId)).toBe(false);
-    expect(shim.coValueCount()).toBe(0);
+      expect(shim.hasCoValue(coId)).toBe(false);
+      expect(shim.coValueCount()).toBe(0);
 
-    shim.createCoValue(coId, headerJson);
-    expect(shim.hasCoValue(coId)).toBe(true);
-    expect(shim.coValueCount()).toBe(1);
-    expect(JSON.parse(shim.getHeader(coId))).toMatchObject({ type: "comap" });
+      shim.createCoValue(coId, headerJson);
+      expect(shim.hasCoValue(coId)).toBe(true);
+      expect(shim.coValueCount()).toBe(1);
+      expect(JSON.parse(shim.getHeader(coId))).toMatchObject({
+        type: "comap",
+      });
 
-    shim.removeCoValue(coId);
-    expect(shim.hasCoValue(coId)).toBe(false);
-    expect(shim.coValueCount()).toBe(0);
-    // double remove is a no-op
-    shim.removeCoValue(coId);
-  });
+      shim.removeCoValue(coId);
+      expect(shim.hasCoValue(coId)).toBe(false);
+      expect(shim.coValueCount()).toBe(0);
+      // double remove is a no-op
+      shim.removeCoValue(coId);
+    });
 
-  test("unknown coId throws with Unknown CoValue message", () => {
-    const shim = makeShim();
-    expect(() => shim.getHeader("co_zNope")).toThrow(
-      /Unknown CoValue: co_zNope/,
-    );
-    expect(() => shim.getSessionIds("co_zNope")).toThrow(/Unknown CoValue/);
-  });
+    test("unknown coId throws with Unknown CoValue message", () => {
+      const shim = makeNodeCore();
+      expect(() => shim.getHeader("co_zNope")).toThrow(
+        /Unknown CoValue: co_zNope/,
+      );
+      expect(() => shim.getSessionIds("co_zNope")).toThrow(/Unknown CoValue/);
+    });
 
-  test("delegates session queries to the underlying session map", () => {
-    const shim = makeShim();
-    const { coId, headerJson } = makeHeaderAndId();
-    shim.createCoValue(coId, headerJson);
-    expect(shim.getSessionIds(coId)).toEqual([]);
-    expect(shim.getTransactionCount(coId, "co_zAnybody_session_z123")).toBe(-1);
-    expect(shim.getKnownState(coId)).toMatchObject({
-      id: coId,
-      header: true,
-      sessions: {},
+    test("delegates session queries to the underlying session map", () => {
+      const shim = makeNodeCore();
+      const { coId, headerJson } = makeHeaderAndId();
+      shim.createCoValue(coId, headerJson);
+      expect(shim.getSessionIds(coId)).toEqual([]);
+      expect(shim.getTransactionCount(coId, "co_zAnybody_session_z123")).toBe(
+        -1,
+      );
+      expect(shim.getKnownState(coId)).toMatchObject({
+        id: coId,
+        header: true,
+        sessions: {},
+      });
     });
   });
+}
 
+nodeCoreSuite("ShimNodeCore", () => makeShim());
+nodeCoreSuite("NapiNodeCore (native)", () => crypto.createNodeCore());
+
+test("NapiCrypto.createNodeCore returns the native adapter", () => {
+  expect(crypto.createNodeCore().constructor.name).toBe("NapiNodeCoreAdapter");
+});
+
+describe("ShimNodeCore", () => {
   describe("dispose semantics", () => {
     function makeFakeShim() {
       let disposed = 0;

--- a/packages/cojson/src/tests/sync.concurrentLoad.test.ts
+++ b/packages/cojson/src/tests/sync.concurrentLoad.test.ts
@@ -9,7 +9,6 @@ import {
   blockMessageTypeOnOutgoingPeer,
   fillCoMapWithLargeData,
   loadCoValueOrFail,
-  importContentIntoNode,
   setupTestNode,
   SyncMessagesLog,
   TEST_NODE_CONFIG,
@@ -437,6 +436,14 @@ describe("concurrent load", () => {
     // Delete the Group from server so it won't be pushed with the Map content
     // skipVerify prevents the server from checking dependencies before sending
     server.node.syncManager.disableTransactionVerification();
+    // Capture the Group content before deleting it: internalDeleteCoValue now
+    // evicts the NodeCore registry entry, so group.core can no longer be read
+    // back afterwards. Re-inject this captured content below (step 6) to
+    // simulate the Group becoming available again.
+    const groupContent = group.core.newContentSince(undefined);
+    if (!groupContent) {
+      throw new Error("Expected group content before delete");
+    }
     server.node.internalDeleteCoValue(group.id);
 
     // Load the map from the client
@@ -455,7 +462,12 @@ describe("concurrent load", () => {
     // Wait for the Map content to be sent
     await waitFor(() => SyncMessagesLog.messages.length >= 2);
 
-    importContentIntoNode(group.core, server.node, 1);
+    // 6. Group content is moved back to server (simulating it becoming available)
+    const groupChunk = groupContent[0];
+    if (!groupChunk) {
+      throw new Error("Expected at least one group content chunk");
+    }
+    server.node.syncManager.handleNewContent(groupChunk, "import");
 
     const result = await promise;
     expect(result.get("key")).toBe("value");


### PR DESCRIPTION
## Summary

- Introduces a `NodeCore` registry in `cojson-core` (Rust) owning all per-CoValue `SessionMapImpl`s keyed by CoID — one registry per `LocalNode` instead of one native binding object per CoValue. Groundwork for moving permissions and group-state resolution into the Rust core (cross-CoValue lookups need a shared registry).
- Exposes it natively through `cojson-core-napi` (`NodeCore` class, full lifted `SessionMap` surface with `coId`-first methods); wasm/RN keep working unchanged via a TS shim (`ShimNodeCore`) behind the new `NodeCoreImpl` interface, with `NapiCrypto` overriding `createNodeCore()` with the native adapter.
- Rewires `VerifiedState`/`LocalNode` through the registry (zero behavior change) and adds explicit eviction: delete/unmount evict deferred by one microtask (so pending local-transaction flushes can still read the registry), with a skip-if-reloaded guard; node shutdown intentionally does not evict — a closing node must stay readable for in-flight handoff, and the registry is freed with the node.
- Design spec and per-stage implementation plans are included under `docs/superpowers/`.

## Test Plan

- [x] `packages/cojson` full suite: 1397 passed / 13 skipped (76 files)
- [x] `jazz-tools` full suite: 2120 passed / 8 skipped (133 files), including the better-auth sign-out/sign-in flow that caught the shutdown-eviction regression during development (verified 3× stable)
- [x] `cargo test -p cojson-core`: 97 passed (5 new registry tests)
- [x] `tsc --noEmit` clean; no new clippy warnings vs merge-base
- [x] New test suites: NodeCore registry round-trips (shim + native parameterized), `ShimNodeCore` dispose semantics via fake session maps, eviction lifecycle (delete / unmount / re-registration / shutdown-keeps-readable)