### PR TITLE
feat(cojson): native group permission validation and role resolution

### DIFF
--- a/.changeset/group-engine-native.md
+++ b/.changeset/group-engine-native.md
@@ -1,0 +1,9 @@
+---
+"cojson": patch
+"cojson-core-napi": patch
+---
+
+Move group/account permission validation and role resolution into the native
+NodeCore (napi), behind capability detection — wasm/RN keep the TypeScript
+path until their native ports land. Adds a fixture corpus generated from the
+TypeScript implementation and a randomized differential test harness.

--- a/bench/cojson/groupEngine.bench.ts
+++ b/bench/cojson/groupEngine.bench.ts
@@ -125,11 +125,15 @@ function buildValidationScenario(): ValidationScenario {
 
 function revalidateFully(scenario: ValidationScenario) {
   // resetParsedTransactions() marks every verified transaction as
-  // to-validate again and re-runs parseNewTransactions, which forces a full
-  // recompute of the whole (200-transaction) history - both the native
-  // GroupEngine and the TS MemberRoleResolver rebuild from scratch on every
-  // validation call by design (see the migration spec's "recompute, don't
-  // increment" rule), so this exercises the real per-call cost either way.
+  // to-validate again and re-runs parseNewTransactions over the whole
+  // (200-transaction) history. NOTE what each variant then measures:
+  // - TS fallback: a genuine full recompute (fresh MemberRoleResolver) per call.
+  // - Native: the Rust engine's (session_id, tx_count) cache SHORT-CIRCUITS
+  //   (no new transactions), so the native number is the end-to-end
+  //   DELEGATION-PATH cost — pending[] build, napi crossing, marshaling ~200
+  //   verdicts back, byKey map + verdict application — NOT Rust compute time.
+  // Both numbers are real user-visible costs of their paths; they are not a
+  // compute-vs-compute comparison.
   scenario.group.core.resetParsedTransactions();
 }
 

--- a/bench/cojson/groupEngine.bench.ts
+++ b/bench/cojson/groupEngine.bench.ts
@@ -1,0 +1,206 @@
+import cronometro from "cronometro";
+import { ControlledAccount, EVERYONE, LocalNode, RawGroup } from "cojson";
+import { NapiCrypto } from "cojson/crypto/NapiCrypto";
+
+/**
+ * Benchmarks for the native (napi) group engine vs. the TypeScript fallback
+ * path, toggled via the COJSON_DISABLE_NATIVE_VALIDATION kill switch. Both
+ * variants run against the same NapiCrypto-backed node/group structures —
+ * the kill switch is what routes validation/role-resolution through the
+ * pure-TS algorithm instead of the native NodeCore, so this is an
+ * apples-to-apples comparison of the two code paths, not two crypto
+ * backends. (WasmCrypto/RNCrypto have no native validateGroup/roleOf at all,
+ * so they always run the TS path regardless of the kill switch — see
+ * permissions.ts/group.ts capability gates.)
+ */
+
+const Crypto = await NapiCrypto.create();
+
+function freshAccountInNode(node: LocalNode): ControlledAccount {
+  const accountOnTempNode = LocalNode.internalCreateAccount({
+    crypto: node.crypto,
+  });
+  const accountCoreEntry = node.getCoValue(accountOnTempNode.id);
+  const content = accountOnTempNode.core.newContentSince(undefined)?.[0]!;
+  node.syncManager.handleNewContent(content, "import");
+  return new ControlledAccount(
+    accountCoreEntry.getCurrentContent() as any,
+    accountOnTempNode.core.node.agentSecret,
+  );
+}
+
+function newNode(): LocalNode {
+  const agentSecret = Crypto.newRandomAgentSecret();
+  const sessionID = Crypto.newRandomSessionID(Crypto.getAgentID(agentSecret));
+  return new LocalNode(agentSecret, sessionID, Crypto);
+}
+
+// ---------------------------------------------------------------------------
+// (a) roleOf on a 3-level parent chain with 20 members, queried 1000x
+// ---------------------------------------------------------------------------
+
+const ROLE_CHAIN_MEMBER_COUNT = 20;
+const ROLE_QUERY_COUNT = 1000;
+const ACCOUNT_ROLES = [
+  "reader",
+  "writer",
+  "manager",
+  "admin",
+  "writeOnly",
+] as const;
+
+interface RoleChainScenario {
+  leaf: RawGroup;
+  memberIds: string[];
+}
+
+function buildRoleChainScenario(): RoleChainScenario {
+  const node = newNode();
+  const leaf = node.createGroup();
+  const mid = node.createGroup();
+  const root = node.createGroup();
+
+  leaf.extend(mid);
+  mid.extend(root);
+
+  const memberIds: string[] = [];
+  for (let i = 0; i < ROLE_CHAIN_MEMBER_COUNT; i++) {
+    const member = freshAccountInNode(node);
+    memberIds.push(member.id);
+    const role = ACCOUNT_ROLES[i % ACCOUNT_ROLES.length]!;
+
+    if (i < 10) {
+      // Direct role on the leaf group - no parent walk required.
+      (leaf.set as any)(member.id, role, "trusting");
+    } else if (i < 15) {
+      // Role only on the mid group - one parent hop.
+      (mid.set as any)(member.id, role, "trusting");
+    } else {
+      // Role only on the root group - two parent hops.
+      (root.set as any)(member.id, role, "trusting");
+    }
+  }
+  // A couple of everyone-role lookups too, exercised via the roleOf grid below.
+  (leaf.set as any)(EVERYONE, "reader", "trusting");
+
+  return { leaf, memberIds };
+}
+
+function queryRolesRepeatedly(scenario: RoleChainScenario) {
+  for (let i = 0; i < ROLE_QUERY_COUNT; i++) {
+    const memberId = scenario.memberIds[i % scenario.memberIds.length]!;
+    scenario.leaf.roleOfInternal(memberId as any);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// (b) full validation of a 200-transaction group (native vs TS, via kill
+// switch), forcing a full invalidate + re-validate pass each iteration.
+// ---------------------------------------------------------------------------
+
+const VALIDATION_TX_COUNT = 200;
+const VALIDATION_MEMBER_COUNT = 5;
+
+interface ValidationScenario {
+  group: RawGroup;
+}
+
+function buildValidationScenario(): ValidationScenario {
+  const node = newNode();
+  const group = node.createGroup();
+
+  const memberIds: string[] = [];
+  for (let i = 0; i < VALIDATION_MEMBER_COUNT; i++) {
+    memberIds.push(freshAccountInNode(node).id);
+  }
+
+  for (let i = 0; i < VALIDATION_TX_COUNT; i++) {
+    const memberId = memberIds[i % memberIds.length]!;
+    const role = ACCOUNT_ROLES[i % ACCOUNT_ROLES.length]!;
+    (group.set as any)(memberId, role, "trusting");
+  }
+
+  return { group };
+}
+
+function revalidateFully(scenario: ValidationScenario) {
+  // resetParsedTransactions() marks every verified transaction as
+  // to-validate again and re-runs parseNewTransactions, which forces a full
+  // recompute of the whole (200-transaction) history - both the native
+  // GroupEngine and the TS MemberRoleResolver rebuild from scratch on every
+  // validation call by design (see the migration spec's "recompute, don't
+  // increment" rule), so this exercises the real per-call cost either way.
+  scenario.group.core.resetParsedTransactions();
+}
+
+// ---------------------------------------------------------------------------
+// Runner
+// ---------------------------------------------------------------------------
+
+let roleChainScenario: RoleChainScenario;
+let validationScenario: ValidationScenario;
+
+const benchOptions = {
+  iterations: 50,
+  warmup: true,
+  print: {
+    colors: true,
+    compare: true,
+  },
+  onTestError: (testName: string, error: unknown) => {
+    console.error(`\nError in test "${testName}":`);
+    console.error(error);
+  },
+};
+
+await cronometro(
+  {
+    "roleOf - 3-level parent chain, 20 members x1000 (native)": {
+      async before() {
+        delete (process.env as Record<string, string | undefined>)
+          .COJSON_DISABLE_NATIVE_VALIDATION;
+        roleChainScenario = buildRoleChainScenario();
+      },
+      test() {
+        queryRolesRepeatedly(roleChainScenario);
+      },
+    },
+    "roleOf - 3-level parent chain, 20 members x1000 (TS fallback)": {
+      async before() {
+        process.env.COJSON_DISABLE_NATIVE_VALIDATION = "1";
+        roleChainScenario = buildRoleChainScenario();
+      },
+      test() {
+        queryRolesRepeatedly(roleChainScenario);
+      },
+      async after() {
+        delete (process.env as Record<string, string | undefined>)
+          .COJSON_DISABLE_NATIVE_VALIDATION;
+      },
+    },
+    "validateGroup - 200-tx group, full revalidate (native)": {
+      async before() {
+        delete (process.env as Record<string, string | undefined>)
+          .COJSON_DISABLE_NATIVE_VALIDATION;
+        validationScenario = buildValidationScenario();
+      },
+      test() {
+        revalidateFully(validationScenario);
+      },
+    },
+    "validateGroup - 200-tx group, full revalidate (TS fallback)": {
+      async before() {
+        process.env.COJSON_DISABLE_NATIVE_VALIDATION = "1";
+        validationScenario = buildValidationScenario();
+      },
+      test() {
+        revalidateFully(validationScenario);
+      },
+      async after() {
+        delete (process.env as Record<string, string | undefined>)
+          .COJSON_DISABLE_NATIVE_VALIDATION;
+      },
+    },
+  },
+  benchOptions,
+);

--- a/crates/cojson-core-napi/index.d.ts
+++ b/crates/cojson-core-napi/index.d.ts
@@ -63,6 +63,10 @@ export declare class NodeCore {
   decryptTransaction(coId: string, sessionId: string, txIndex: number, keySecret: string): string | null
   /** Decrypt transaction meta */
   decryptTransactionMeta(coId: string, sessionId: string, txIndex: number, keySecret: string): string | null
+  /** Validate a group/account CoValue; verdicts for ALL its transactions in validation order. */
+  validateGroup(coId: string, pending: Array<PendingTx>): Array<GroupVerdict>
+  /** Role of member in group at time (ms). Returns the role string or null. */
+  roleOf(groupId: string, member: string, atTime?: number | undefined | null): string | null
 }
 
 export declare class SessionMap {
@@ -256,6 +260,17 @@ export declare function getSealerId(secret: Uint8Array): string
  */
 export declare function getSignerId(secret: Uint8Array): string
 
+/**
+ * Validation verdict for a single transaction, mirroring `Verdict` on the
+ * Rust side.
+ */
+export interface GroupVerdict {
+  sessionId: string
+  txIndex: number
+  valid: boolean
+  reason?: string
+}
+
 /** KnownState as a native JavaScript object (no JSON serialization needed) */
 export interface KnownState {
   id: string
@@ -275,6 +290,16 @@ export declare function newEd25519SigningKey(): Uint8Array
  * This key can be reused for multiple Diffie-Hellman exchanges.
  */
 export declare function newX25519PrivateKey(): Uint8Array
+
+/**
+ * A pending (not-yet-persisted) transaction handed to `validate_group`,
+ * mirroring `PendingTxIn` on the Rust side.
+ */
+export interface PendingTx {
+  sessionId: string
+  txIndex: number
+  sourceMadeAt?: number
+}
 
 /**
  * NAPI-exposed function for sealing a message using X25519 + XSalsa20-Poly1305.

--- a/crates/cojson-core-napi/index.d.ts
+++ b/crates/cojson-core-napi/index.d.ts
@@ -63,9 +63,17 @@ export declare class NodeCore {
   decryptTransaction(coId: string, sessionId: string, txIndex: number, keySecret: string): string | null
   /** Decrypt transaction meta */
   decryptTransactionMeta(coId: string, sessionId: string, txIndex: number, keySecret: string): string | null
-  /** Validate a group/account CoValue; verdicts for ALL its transactions in validation order. */
+  /**
+   * Validate a group/account CoValue; verdicts for ALL its transactions in validation order.
+   * Throws "Unknown CoValue: <id>" if `co_id` itself is not registered, and
+   * "CoValue not loaded: <id>" if a dependency (parent group / owning account) is missing.
+   */
   validateGroup(coId: string, pending: Array<PendingTx>): Array<GroupVerdict>
-  /** Role of member in group at time (ms). Returns the role string or null. */
+  /**
+   * Role of member in group at time (ms). Returns the role string or null.
+   * Throws "Unknown CoValue: <id>" if `group_id` itself is not registered, and
+   * "CoValue not loaded: <id>" if a parent group / owning account is missing.
+   */
   roleOf(groupId: string, member: string, atTime?: number | undefined | null): string | null
 }
 

--- a/crates/cojson-core-napi/src/lib.rs
+++ b/crates/cojson-core-napi/src/lib.rs
@@ -704,6 +704,8 @@ impl NodeCore {
   // above; the "lifted verbatim" breadcrumb on that section doesn't apply here.
 
   /// Validate a group/account CoValue; verdicts for ALL its transactions in validation order.
+  /// Throws "Unknown CoValue: <id>" if `co_id` itself is not registered, and
+  /// "CoValue not loaded: <id>" if a dependency (parent group / owning account) is missing.
   #[napi]
   pub fn validate_group(
     &mut self,
@@ -736,6 +738,8 @@ impl NodeCore {
   }
 
   /// Role of member in group at time (ms). Returns the role string or null.
+  /// Throws "Unknown CoValue: <id>" if `group_id` itself is not registered, and
+  /// "CoValue not loaded: <id>" if a parent group / owning account is missing.
   #[napi]
   pub fn role_of(
     &mut self,

--- a/crates/cojson-core-napi/src/lib.rs
+++ b/crates/cojson-core-napi/src/lib.rs
@@ -1,5 +1,6 @@
 use cojson_core::core::{
-  CoJsonCoreError, KnownState as RustKnownState, NodeCore as RustNodeCore, SessionMapImpl,
+  CoJsonCoreError, KnownState as RustKnownState, NodeCore as RustNodeCore,
+  PendingTxIn as RustPendingTxIn, SessionMapImpl, Verdict as RustVerdict,
 };
 use napi_derive::napi;
 use std::collections::HashMap;
@@ -336,6 +337,25 @@ impl SessionMap {
 /// registry lookup errors map cleanly.
 fn to_napi_err<E: std::fmt::Display>(e: E) -> napi::Error {
   napi::Error::new(napi::Status::GenericFailure, e.to_string())
+}
+
+/// A pending (not-yet-persisted) transaction handed to `validate_group`,
+/// mirroring `PendingTxIn` on the Rust side.
+#[napi(object)]
+pub struct PendingTx {
+  pub session_id: String,
+  pub tx_index: u32,
+  pub source_made_at: Option<f64>,
+}
+
+/// Validation verdict for a single transaction, mirroring `Verdict` on the
+/// Rust side.
+#[napi(object)]
+pub struct GroupVerdict {
+  pub session_id: String,
+  pub tx_index: u32,
+  pub valid: bool,
+  pub reason: Option<String>,
 }
 
 #[napi]
@@ -675,6 +695,59 @@ impl NodeCore {
       .map_err(to_napi_err)?
       .decrypt_transaction_meta(&session_id, tx_index, &key_secret)
       .map_err(to_napi_err)
+  }
+
+  // === Stage 2: Group engine surface ===
+  // These two methods are NodeCore-ONLY — there is no SessionMap twin (the
+  // group engine is inherently cross-CoValue, so it can't live on a single
+  // SessionMap). Do not go looking for a `parallel copy` in `impl SessionMap`
+  // above; the "lifted verbatim" breadcrumb on that section doesn't apply here.
+
+  /// Validate a group/account CoValue; verdicts for ALL its transactions in validation order.
+  #[napi]
+  pub fn validate_group(
+    &mut self,
+    co_id: String,
+    pending: Vec<PendingTx>,
+  ) -> napi::Result<Vec<GroupVerdict>> {
+    let pending: Vec<RustPendingTxIn> = pending
+      .into_iter()
+      .map(|p| RustPendingTxIn {
+        session_id: p.session_id,
+        tx_index: p.tx_index,
+        source_made_at: p.source_made_at.map(|v| v as u64),
+      })
+      .collect();
+    let verdicts = self
+      .internal
+      .validate_group(&co_id, &pending)
+      .map_err(to_napi_err)?;
+    Ok(
+      verdicts
+        .into_iter()
+        .map(|v: RustVerdict| GroupVerdict {
+          session_id: v.session_id,
+          tx_index: v.tx_index,
+          valid: v.valid,
+          reason: v.reason,
+        })
+        .collect(),
+    )
+  }
+
+  /// Role of member in group at time (ms). Returns the role string or null.
+  #[napi]
+  pub fn role_of(
+    &mut self,
+    group_id: String,
+    member: String,
+    at_time: Option<f64>,
+  ) -> napi::Result<Option<String>> {
+    let role = self
+      .internal
+      .role_of(&group_id, &member, at_time.map(|v| v as u64))
+      .map_err(to_napi_err)?;
+    Ok(role.map(|r| r.as_str().to_string()))
   }
 }
 

--- a/crates/cojson-core-napi/src/lib.rs
+++ b/crates/cojson-core-napi/src/lib.rs
@@ -389,7 +389,12 @@ impl NodeCore {
   ) -> napi::Result<()> {
     self
       .internal
-      .create_co_value(&co_id, &header_json, max_tx_size, skip_verify.unwrap_or(false))
+      .create_co_value(
+        &co_id,
+        &header_json,
+        max_tx_size,
+        skip_verify.unwrap_or(false),
+      )
       .map_err(to_napi_err)
   }
 
@@ -524,7 +529,13 @@ impl NodeCore {
   /// Get all session IDs as native array
   #[napi]
   pub fn get_session_ids(&self, co_id: String) -> napi::Result<Vec<String>> {
-    Ok(self.internal.get(&co_id).map_err(to_napi_err)?.get_session_ids())
+    Ok(
+      self
+        .internal
+        .get(&co_id)
+        .map_err(to_napi_err)?
+        .get_session_ids(),
+    )
   }
 
   /// Get transaction count for a session (returns -1 if session not found)
@@ -532,7 +543,11 @@ impl NodeCore {
   pub fn get_transaction_count(&self, co_id: String, session_id: String) -> napi::Result<i32> {
     let sm = self.internal.get(&co_id).map_err(to_napi_err)?;
     // Same -1-if-absent convention as the SessionMap wrapper
-    Ok(sm.get_transaction_count(&session_id).map(|c| c as i32).unwrap_or(-1))
+    Ok(
+      sm.get_transaction_count(&session_id)
+        .map(|c| c as i32)
+        .unwrap_or(-1),
+    )
   }
 
   /// Get single transaction by index as JSON string (returns undefined if not found)
@@ -543,11 +558,13 @@ impl NodeCore {
     session_id: String,
     tx_index: u32,
   ) -> napi::Result<Option<String>> {
-    Ok(self
-      .internal
-      .get(&co_id)
-      .map_err(to_napi_err)?
-      .get_transaction(&session_id, tx_index))
+    Ok(
+      self
+        .internal
+        .get(&co_id)
+        .map_err(to_napi_err)?
+        .get_transaction(&session_id, tx_index),
+    )
   }
 
   /// Get transactions for a session from index as JSON strings (returns undefined if session not found)
@@ -558,21 +575,29 @@ impl NodeCore {
     session_id: String,
     from_index: u32,
   ) -> napi::Result<Option<Vec<String>>> {
-    Ok(self
-      .internal
-      .get(&co_id)
-      .map_err(to_napi_err)?
-      .get_session_transactions(&session_id, from_index))
+    Ok(
+      self
+        .internal
+        .get(&co_id)
+        .map_err(to_napi_err)?
+        .get_session_transactions(&session_id, from_index),
+    )
   }
 
   /// Get last signature for a session (returns undefined if session not found)
   #[napi]
-  pub fn get_last_signature(&self, co_id: String, session_id: String) -> napi::Result<Option<String>> {
-    Ok(self
-      .internal
-      .get(&co_id)
-      .map_err(to_napi_err)?
-      .get_last_signature(&session_id))
+  pub fn get_last_signature(
+    &self,
+    co_id: String,
+    session_id: String,
+  ) -> napi::Result<Option<String>> {
+    Ok(
+      self
+        .internal
+        .get(&co_id)
+        .map_err(to_napi_err)?
+        .get_last_signature(&session_id),
+    )
   }
 
   /// Get signature after specific transaction index
@@ -583,11 +608,13 @@ impl NodeCore {
     session_id: String,
     tx_index: u32,
   ) -> napi::Result<Option<String>> {
-    Ok(self
-      .internal
-      .get(&co_id)
-      .map_err(to_napi_err)?
-      .get_signature_after(&session_id, tx_index))
+    Ok(
+      self
+        .internal
+        .get(&co_id)
+        .map_err(to_napi_err)?
+        .get_signature_after(&session_id, tx_index),
+    )
   }
 
   /// Get the last signature checkpoint index (-1 if no checkpoints, undefined if session not found)
@@ -597,11 +624,13 @@ impl NodeCore {
     co_id: String,
     session_id: String,
   ) -> napi::Result<Option<i32>> {
-    Ok(self
-      .internal
-      .get(&co_id)
-      .map_err(to_napi_err)?
-      .get_last_signature_checkpoint(&session_id))
+    Ok(
+      self
+        .internal
+        .get(&co_id)
+        .map_err(to_napi_err)?
+        .get_last_signature_checkpoint(&session_id),
+    )
   }
 
   // --- Known State ---
@@ -609,35 +638,49 @@ impl NodeCore {
   /// Get the known state as a native JavaScript object
   #[napi]
   pub fn get_known_state(&self, co_id: String) -> napi::Result<KnownState> {
-    Ok(self
-      .internal
-      .get(&co_id)
-      .map_err(to_napi_err)?
-      .get_known_state()
-      .clone()
-      .into())
+    Ok(
+      self
+        .internal
+        .get(&co_id)
+        .map_err(to_napi_err)?
+        .get_known_state()
+        .clone()
+        .into(),
+    )
   }
 
   /// Get the known state with streaming as a native JavaScript object
   #[napi]
   pub fn get_known_state_with_streaming(&self, co_id: String) -> napi::Result<Option<KnownState>> {
-    Ok(self
-      .internal
-      .get(&co_id)
-      .map_err(to_napi_err)?
-      .get_known_state_with_streaming()
-      .map(|ks| ks.clone().into()))
+    Ok(
+      self
+        .internal
+        .get(&co_id)
+        .map_err(to_napi_err)?
+        .get_known_state_with_streaming()
+        .map(|ks| ks.clone().into()),
+    )
   }
 
   /// Check whether the CoValue still has pending streaming content.
   #[napi]
   pub fn is_streaming(&self, co_id: String) -> napi::Result<bool> {
-    Ok(self.internal.get(&co_id).map_err(to_napi_err)?.is_streaming())
+    Ok(
+      self
+        .internal
+        .get(&co_id)
+        .map_err(to_napi_err)?
+        .is_streaming(),
+    )
   }
 
   /// Set streaming known state
   #[napi]
-  pub fn set_streaming_known_state(&mut self, co_id: String, streaming_json: String) -> napi::Result<()> {
+  pub fn set_streaming_known_state(
+    &mut self,
+    co_id: String,
+    streaming_json: String,
+  ) -> napi::Result<()> {
     self
       .internal
       .get_mut(&co_id)
@@ -651,7 +694,11 @@ impl NodeCore {
   /// Mark this CoValue as deleted
   #[napi]
   pub fn mark_as_deleted(&mut self, co_id: String) -> napi::Result<()> {
-    self.internal.get_mut(&co_id).map_err(to_napi_err)?.mark_as_deleted();
+    self
+      .internal
+      .get_mut(&co_id)
+      .map_err(to_napi_err)?
+      .mark_as_deleted();
     Ok(())
   }
 

--- a/crates/cojson-core/data/group_engine/account_agent_resolution.json
+++ b/crates/cojson-core/data/group_engine/account_agent_resolution.json
@@ -1,0 +1,80 @@
+{
+  "description": "a CoValue owned by an account: the account-id transactor is resolved to its agent; account self-role is admin",
+  "covalues": [
+    {
+      "coId": "co_z17w9mDSdEpcHTDbjv2h59zkHxZ",
+      "headerJson": "{\"createdAt\":\"2026-07-03T23:11:07.016Z\",\"meta\":null,\"ruleset\":{\"group\":\"co_zd1rPKRSAYHvb8WdzJG1dY5qDoY\",\"type\":\"ownedByGroup\"},\"type\":\"comap\",\"uniqueness\":\"z5P9u6ZxK8B8gEHJUA\"}",
+      "sessions": [
+        {
+          "sessionId": "co_zd1rPKRSAYHvb8WdzJG1dY5qDoY_session_zhW6KSNaNhf6",
+          "signerId": "co_zd1rPKRSAYHvb8WdzJG1dY5qDoY",
+          "transactions": [
+            "{\"changes\":\"[{\\\"op\\\":\\\"set\\\",\\\"key\\\":\\\"foo\\\",\\\"value\\\":\\\"bar\\\"}]\",\"madeAt\":1783120267016,\"privacy\":\"trusting\"}"
+          ],
+          "lastSignature": "signature_z5grQs86JmsLqHeFz4FCNtGHxS4f8q9ephNiBrAttPkn3HY5wEEDE8Dzb3i2D6aZ9AbrbfVCv3C9vFDyiosD6Xrcs"
+        }
+      ]
+    },
+    {
+      "coId": "co_zd1rPKRSAYHvb8WdzJG1dY5qDoY",
+      "headerJson": "{\"createdAt\":null,\"meta\":{\"type\":\"account\"},\"ruleset\":{\"initialAdmin\":\"sealer_z9SeR8nz6m7jPpNqZNkB4YTPy28eF4chja6Kaog7QSknn/signer_zD3H2oXhNuiMRqgmqe9JoCYy6afw2n6bDfnxDFMYo2LsH\",\"type\":\"group\"},\"type\":\"comap\",\"uniqueness\":null}",
+      "sessions": [
+        {
+          "sessionId": "sealer_z9SeR8nz6m7jPpNqZNkB4YTPy28eF4chja6Kaog7QSknn/signer_zD3H2oXhNuiMRqgmqe9JoCYy6afw2n6bDfnxDFMYo2LsH_session_zhW6KSNaNhf6",
+          "signerId": "co_zd1rPKRSAYHvb8WdzJG1dY5qDoY",
+          "transactions": [
+            "{\"changes\":\"[{\\\"op\\\":\\\"set\\\",\\\"key\\\":\\\"sealer_z9SeR8nz6m7jPpNqZNkB4YTPy28eF4chja6Kaog7QSknn/signer_zD3H2oXhNuiMRqgmqe9JoCYy6afw2n6bDfnxDFMYo2LsH\\\",\\\"value\\\":\\\"admin\\\"}]\",\"madeAt\":1783120267014,\"privacy\":\"trusting\"}",
+            "{\"changes\":\"[{\\\"op\\\":\\\"set\\\",\\\"key\\\":\\\"key_z3dRSvW2NPqqKzUtZj_for_sealer_z9SeR8nz6m7jPpNqZNkB4YTPy28eF4chja6Kaog7QSknn/signer_zD3H2oXhNuiMRqgmqe9JoCYy6afw2n6bDfnxDFMYo2LsH\\\",\\\"value\\\":\\\"sealed_U7Fcy079pPEvesLX_99O6moWgxI-GajTSfNoNBmaycKzcMOhmBUunv9N7ooLyLFQFYy1G4u42DHgM25dzlIyhlEYPazLqnax22Q==\\\"}]\",\"madeAt\":1783120267014,\"privacy\":\"trusting\"}",
+            "{\"changes\":\"[{\\\"op\\\":\\\"set\\\",\\\"key\\\":\\\"readKey\\\",\\\"value\\\":\\\"key_z3dRSvW2NPqqKzUtZj\\\"}]\",\"madeAt\":1783120267014,\"privacy\":\"trusting\"}",
+            "{\"changes\":\"[{\\\"op\\\":\\\"set\\\",\\\"key\\\":\\\"profile\\\",\\\"value\\\":\\\"co_zhJe6FZ9hrYEJeVLZLUJ1u3yCxF\\\"}]\",\"madeAt\":1783120267016,\"privacy\":\"trusting\"}"
+          ],
+          "lastSignature": "signature_zs1CEAZJaAYjCnWbj2axXwge5JWeKR6PrZwneE8row4tkn7wGrT9xnUouJVBn3G1oc5pMbHDAoLFhM9JGcpChhHx"
+        }
+      ]
+    }
+  ],
+  "verdicts": {
+    "co_z17w9mDSdEpcHTDbjv2h59zkHxZ": [
+      {
+        "sessionId": "co_zd1rPKRSAYHvb8WdzJG1dY5qDoY_session_zhW6KSNaNhf6",
+        "txIndex": 0,
+        "valid": true,
+        "reason": null
+      }
+    ],
+    "co_zd1rPKRSAYHvb8WdzJG1dY5qDoY": [
+      {
+        "sessionId": "sealer_z9SeR8nz6m7jPpNqZNkB4YTPy28eF4chja6Kaog7QSknn/signer_zD3H2oXhNuiMRqgmqe9JoCYy6afw2n6bDfnxDFMYo2LsH_session_zhW6KSNaNhf6",
+        "txIndex": 0,
+        "valid": true,
+        "reason": null
+      },
+      {
+        "sessionId": "sealer_z9SeR8nz6m7jPpNqZNkB4YTPy28eF4chja6Kaog7QSknn/signer_zD3H2oXhNuiMRqgmqe9JoCYy6afw2n6bDfnxDFMYo2LsH_session_zhW6KSNaNhf6",
+        "txIndex": 1,
+        "valid": true,
+        "reason": null
+      },
+      {
+        "sessionId": "sealer_z9SeR8nz6m7jPpNqZNkB4YTPy28eF4chja6Kaog7QSknn/signer_zD3H2oXhNuiMRqgmqe9JoCYy6afw2n6bDfnxDFMYo2LsH_session_zhW6KSNaNhf6",
+        "txIndex": 2,
+        "valid": true,
+        "reason": null
+      },
+      {
+        "sessionId": "sealer_z9SeR8nz6m7jPpNqZNkB4YTPy28eF4chja6Kaog7QSknn/signer_zD3H2oXhNuiMRqgmqe9JoCYy6afw2n6bDfnxDFMYo2LsH_session_zhW6KSNaNhf6",
+        "txIndex": 3,
+        "valid": true,
+        "reason": null
+      }
+    ]
+  },
+  "roleQueries": [
+    {
+      "groupId": "co_zd1rPKRSAYHvb8WdzJG1dY5qDoY",
+      "member": "co_zd1rPKRSAYHvb8WdzJG1dY5qDoY",
+      "atTime": null,
+      "expectedRole": "admin"
+    }
+  ]
+}

--- a/crates/cojson-core/data/group_engine/admin_demotion_rules.json
+++ b/crates/cojson-core/data/group_engine/admin_demotion_rules.json
@@ -1,0 +1,145 @@
+{
+  "description": "admin cannot demote another admin, but can demote a writer and demote self",
+  "covalues": [
+    {
+      "coId": "co_zj5EHgyXoFMm87aUfXkHi42wqRu",
+      "headerJson": "{\"createdAt\":\"2026-07-03T23:11:06.982Z\",\"meta\":null,\"ruleset\":{\"initialAdmin\":\"sealer_z4hpJ6CBYrXnwAD4Ko9HZfkRcQ7uaiCQ2ovmXpc8GzahZ/signer_zBmCaGqiqz8vSL9hTNnBoac4wSrcNjAxJrE3NMhPhQ5j3\",\"type\":\"group\"},\"type\":\"comap\",\"uniqueness\":\"z3QU3wZpCoreC8PtGz\"}",
+      "sessions": [
+        {
+          "sessionId": "sealer_z4hpJ6CBYrXnwAD4Ko9HZfkRcQ7uaiCQ2ovmXpc8GzahZ/signer_zBmCaGqiqz8vSL9hTNnBoac4wSrcNjAxJrE3NMhPhQ5j3_session_zGDLS9bjUxua",
+          "signerId": "sealer_z4hpJ6CBYrXnwAD4Ko9HZfkRcQ7uaiCQ2ovmXpc8GzahZ/signer_zBmCaGqiqz8vSL9hTNnBoac4wSrcNjAxJrE3NMhPhQ5j3",
+          "transactions": [
+            "{\"changes\":\"[{\\\"op\\\":\\\"set\\\",\\\"key\\\":\\\"sealer_z4hpJ6CBYrXnwAD4Ko9HZfkRcQ7uaiCQ2ovmXpc8GzahZ/signer_zBmCaGqiqz8vSL9hTNnBoac4wSrcNjAxJrE3NMhPhQ5j3\\\",\\\"value\\\":\\\"admin\\\"}]\",\"madeAt\":1783120266982,\"privacy\":\"trusting\"}",
+            "{\"changes\":\"[{\\\"op\\\":\\\"set\\\",\\\"key\\\":\\\"key_zYd73SXd9G4gTpNgC_for_sealer_z4hpJ6CBYrXnwAD4Ko9HZfkRcQ7uaiCQ2ovmXpc8GzahZ/signer_zBmCaGqiqz8vSL9hTNnBoac4wSrcNjAxJrE3NMhPhQ5j3\\\",\\\"value\\\":\\\"sealed_UZdZbro08TThRRc_CyCjKNe4VmK296tibmR8Ll7wnlZCsWAdlbvSHdViwYyHj0Py2kGwpQ6XvBI66dj-aKc5MTRPNmL75YT7hbQ==\\\"}]\",\"madeAt\":1783120266982,\"privacy\":\"trusting\"}",
+            "{\"changes\":\"[{\\\"op\\\":\\\"set\\\",\\\"key\\\":\\\"readKey\\\",\\\"value\\\":\\\"key_zYd73SXd9G4gTpNgC\\\"}]\",\"madeAt\":1783120266982,\"privacy\":\"trusting\"}",
+            "{\"changes\":\"[{\\\"op\\\":\\\"set\\\",\\\"key\\\":\\\"groupSealer\\\",\\\"value\\\":\\\"key_zYd73SXd9G4gTpNgC@sealer_zHHb68bh86GGy6DuM49cAKDrv5jt3SCngUzMeJqoReEP6\\\"}]\",\"madeAt\":1783120266982,\"privacy\":\"trusting\"}",
+            "{\"changes\":\"[{\\\"op\\\":\\\"set\\\",\\\"key\\\":\\\"co_zFT5aNyS1sVG548NShLE3M1zZx8\\\",\\\"value\\\":\\\"admin\\\"}]\",\"madeAt\":1783120266983,\"privacy\":\"trusting\"}",
+            "{\"changes\":\"[{\\\"op\\\":\\\"set\\\",\\\"key\\\":\\\"key_zYd73SXd9G4gTpNgC_for_co_zFT5aNyS1sVG548NShLE3M1zZx8\\\",\\\"value\\\":\\\"sealed_UsmiIBCjnkfRh1F9shwjksqOFnwiRdrtMD6NFgIuLHvDnXi6hppDQQG6h1hq8CrkySdh7YNWxWJJ7QNnF8m5guMSWUH0XQmo2Tw==\\\"}]\",\"madeAt\":1783120266983,\"privacy\":\"trusting\"}",
+            "{\"changes\":\"[{\\\"op\\\":\\\"set\\\",\\\"key\\\":\\\"co_zdKXDNQ74fA1UEVNTcCSGJTakhr\\\",\\\"value\\\":\\\"writer\\\"}]\",\"madeAt\":1783120266983,\"privacy\":\"trusting\"}",
+            "{\"changes\":\"[{\\\"op\\\":\\\"set\\\",\\\"key\\\":\\\"key_zYd73SXd9G4gTpNgC_for_co_zdKXDNQ74fA1UEVNTcCSGJTakhr\\\",\\\"value\\\":\\\"sealed_UD6x72q0a_QdHORJt3ev3RuHZHW_H9kbAn4FsVZxCrXARXADc0tqZMTKTIlc6ychqYhI3C6aLdk51qruZ-wysHMQP52YpHBaUPA==\\\"}]\",\"madeAt\":1783120266984,\"privacy\":\"trusting\"}",
+            "{\"changes\":\"[{\\\"op\\\":\\\"set\\\",\\\"key\\\":\\\"co_zFT5aNyS1sVG548NShLE3M1zZx8\\\",\\\"value\\\":\\\"writer\\\"}]\",\"madeAt\":1783120266984,\"privacy\":\"trusting\"}",
+            "{\"changes\":\"[{\\\"op\\\":\\\"set\\\",\\\"key\\\":\\\"co_zdKXDNQ74fA1UEVNTcCSGJTakhr\\\",\\\"value\\\":\\\"reader\\\"}]\",\"madeAt\":1783120266984,\"privacy\":\"trusting\"}",
+            "{\"changes\":\"[{\\\"op\\\":\\\"set\\\",\\\"key\\\":\\\"sealer_z4hpJ6CBYrXnwAD4Ko9HZfkRcQ7uaiCQ2ovmXpc8GzahZ/signer_zBmCaGqiqz8vSL9hTNnBoac4wSrcNjAxJrE3NMhPhQ5j3\\\",\\\"value\\\":\\\"writer\\\"}]\",\"madeAt\":1783120266984,\"privacy\":\"trusting\"}"
+          ],
+          "lastSignature": "signature_z4At3SFatrCBRoKvUWhCBM9tVYV2sRgU6nTRDeKj3zLYF8YdbB7bGLcsdVzfEvbd7jgLiz3wPD4SjxppkJatVmt3c"
+        }
+      ]
+    },
+    {
+      "coId": "co_zFT5aNyS1sVG548NShLE3M1zZx8",
+      "headerJson": "{\"createdAt\":null,\"meta\":{\"type\":\"account\"},\"ruleset\":{\"initialAdmin\":\"sealer_zCScRryq84kR5tiszeRKqo2dXa9uYRBJ6BbcJrKp8YDgX/signer_z4pGAZD73hgzgMEm6H9a7otMX1wS2V4jueg4XkMqnHt9y\",\"type\":\"group\"},\"type\":\"comap\",\"uniqueness\":null}",
+      "sessions": [
+        {
+          "sessionId": "sealer_zCScRryq84kR5tiszeRKqo2dXa9uYRBJ6BbcJrKp8YDgX/signer_z4pGAZD73hgzgMEm6H9a7otMX1wS2V4jueg4XkMqnHt9y_session_zEzV8L4wuZSY",
+          "signerId": "signer_z4pGAZD73hgzgMEm6H9a7otMX1wS2V4jueg4XkMqnHt9y",
+          "transactions": [
+            "{\"changes\":\"[{\\\"op\\\":\\\"set\\\",\\\"key\\\":\\\"sealer_zCScRryq84kR5tiszeRKqo2dXa9uYRBJ6BbcJrKp8YDgX/signer_z4pGAZD73hgzgMEm6H9a7otMX1wS2V4jueg4XkMqnHt9y\\\",\\\"value\\\":\\\"admin\\\"}]\",\"madeAt\":1783120266983,\"privacy\":\"trusting\"}",
+            "{\"changes\":\"[{\\\"op\\\":\\\"set\\\",\\\"key\\\":\\\"key_z4xbrHe6jcwZ37eZbc_for_sealer_zCScRryq84kR5tiszeRKqo2dXa9uYRBJ6BbcJrKp8YDgX/signer_z4pGAZD73hgzgMEm6H9a7otMX1wS2V4jueg4XkMqnHt9y\\\",\\\"value\\\":\\\"sealed_UeIMf6VY-ZNseAPG_L5AU-JdKHa4Mkcf3C4WePxYi9PiMuTACN6RLk15_7iMqMIXrKeV_JsBMnvrGBXbrii_z1PZZLRn8gWTK8g==\\\"}]\",\"madeAt\":1783120266983,\"privacy\":\"trusting\"}",
+            "{\"changes\":\"[{\\\"op\\\":\\\"set\\\",\\\"key\\\":\\\"readKey\\\",\\\"value\\\":\\\"key_z4xbrHe6jcwZ37eZbc\\\"}]\",\"madeAt\":1783120266983,\"privacy\":\"trusting\"}"
+          ],
+          "lastSignature": "signature_z4VfeUppbnXJqN6n6uRBvGxBhpfkLumbHdqZjC17ESmS4ekWwTMhceCmJKd5o4GUnM3A5VbqdS7pLM1CjFT3paFdC"
+        }
+      ]
+    },
+    {
+      "coId": "co_zdKXDNQ74fA1UEVNTcCSGJTakhr",
+      "headerJson": "{\"createdAt\":null,\"meta\":{\"type\":\"account\"},\"ruleset\":{\"initialAdmin\":\"sealer_zDVtSFq6rDPepC38kGUjTX5HypTcs9DfkiycN6kWp4Gsk/signer_z49ai2pMhyvPap3ncRBYcb4jszr1fTxiUzQfWWANcaEaG\",\"type\":\"group\"},\"type\":\"comap\",\"uniqueness\":null}",
+      "sessions": [
+        {
+          "sessionId": "sealer_zDVtSFq6rDPepC38kGUjTX5HypTcs9DfkiycN6kWp4Gsk/signer_z49ai2pMhyvPap3ncRBYcb4jszr1fTxiUzQfWWANcaEaG_session_zawG5mwycavH",
+          "signerId": "signer_z49ai2pMhyvPap3ncRBYcb4jszr1fTxiUzQfWWANcaEaG",
+          "transactions": [
+            "{\"changes\":\"[{\\\"op\\\":\\\"set\\\",\\\"key\\\":\\\"sealer_zDVtSFq6rDPepC38kGUjTX5HypTcs9DfkiycN6kWp4Gsk/signer_z49ai2pMhyvPap3ncRBYcb4jszr1fTxiUzQfWWANcaEaG\\\",\\\"value\\\":\\\"admin\\\"}]\",\"madeAt\":1783120266983,\"privacy\":\"trusting\"}",
+            "{\"changes\":\"[{\\\"op\\\":\\\"set\\\",\\\"key\\\":\\\"key_z3ftG4xK7MeY4vWK9g_for_sealer_zDVtSFq6rDPepC38kGUjTX5HypTcs9DfkiycN6kWp4Gsk/signer_z49ai2pMhyvPap3ncRBYcb4jszr1fTxiUzQfWWANcaEaG\\\",\\\"value\\\":\\\"sealed_UCl-gCywda8SewBUVdK_ZjNz_dOq-7SWX2hpz_w8Ji7RKWdxlkQ9PrjCmhOUmx-VFtmngYYxRPBrwIPy6WUxKLE9oQqgMBn7_MA==\\\"}]\",\"madeAt\":1783120266983,\"privacy\":\"trusting\"}",
+            "{\"changes\":\"[{\\\"op\\\":\\\"set\\\",\\\"key\\\":\\\"readKey\\\",\\\"value\\\":\\\"key_z3ftG4xK7MeY4vWK9g\\\"}]\",\"madeAt\":1783120266983,\"privacy\":\"trusting\"}"
+          ],
+          "lastSignature": "signature_z5nMzGEnYGkUshyS7QDqbHcuGrb2hgg3RgQ2svoRpH4eC46WBBy7KeauqNMyUnAdT2h5ZTiuZaVXKQbejiGQNiTP7"
+        }
+      ]
+    }
+  ],
+  "verdicts": {
+    "co_zj5EHgyXoFMm87aUfXkHi42wqRu": [
+      {
+        "sessionId": "sealer_z4hpJ6CBYrXnwAD4Ko9HZfkRcQ7uaiCQ2ovmXpc8GzahZ/signer_zBmCaGqiqz8vSL9hTNnBoac4wSrcNjAxJrE3NMhPhQ5j3_session_zGDLS9bjUxua",
+        "txIndex": 0,
+        "valid": true,
+        "reason": null
+      },
+      {
+        "sessionId": "sealer_z4hpJ6CBYrXnwAD4Ko9HZfkRcQ7uaiCQ2ovmXpc8GzahZ/signer_zBmCaGqiqz8vSL9hTNnBoac4wSrcNjAxJrE3NMhPhQ5j3_session_zGDLS9bjUxua",
+        "txIndex": 1,
+        "valid": true,
+        "reason": null
+      },
+      {
+        "sessionId": "sealer_z4hpJ6CBYrXnwAD4Ko9HZfkRcQ7uaiCQ2ovmXpc8GzahZ/signer_zBmCaGqiqz8vSL9hTNnBoac4wSrcNjAxJrE3NMhPhQ5j3_session_zGDLS9bjUxua",
+        "txIndex": 2,
+        "valid": true,
+        "reason": null
+      },
+      {
+        "sessionId": "sealer_z4hpJ6CBYrXnwAD4Ko9HZfkRcQ7uaiCQ2ovmXpc8GzahZ/signer_zBmCaGqiqz8vSL9hTNnBoac4wSrcNjAxJrE3NMhPhQ5j3_session_zGDLS9bjUxua",
+        "txIndex": 3,
+        "valid": true,
+        "reason": null
+      },
+      {
+        "sessionId": "sealer_z4hpJ6CBYrXnwAD4Ko9HZfkRcQ7uaiCQ2ovmXpc8GzahZ/signer_zBmCaGqiqz8vSL9hTNnBoac4wSrcNjAxJrE3NMhPhQ5j3_session_zGDLS9bjUxua",
+        "txIndex": 4,
+        "valid": true,
+        "reason": null
+      },
+      {
+        "sessionId": "sealer_z4hpJ6CBYrXnwAD4Ko9HZfkRcQ7uaiCQ2ovmXpc8GzahZ/signer_zBmCaGqiqz8vSL9hTNnBoac4wSrcNjAxJrE3NMhPhQ5j3_session_zGDLS9bjUxua",
+        "txIndex": 5,
+        "valid": true,
+        "reason": null
+      },
+      {
+        "sessionId": "sealer_z4hpJ6CBYrXnwAD4Ko9HZfkRcQ7uaiCQ2ovmXpc8GzahZ/signer_zBmCaGqiqz8vSL9hTNnBoac4wSrcNjAxJrE3NMhPhQ5j3_session_zGDLS9bjUxua",
+        "txIndex": 6,
+        "valid": true,
+        "reason": null
+      },
+      {
+        "sessionId": "sealer_z4hpJ6CBYrXnwAD4Ko9HZfkRcQ7uaiCQ2ovmXpc8GzahZ/signer_zBmCaGqiqz8vSL9hTNnBoac4wSrcNjAxJrE3NMhPhQ5j3_session_zGDLS9bjUxua",
+        "txIndex": 7,
+        "valid": true,
+        "reason": null
+      },
+      {
+        "sessionId": "sealer_z4hpJ6CBYrXnwAD4Ko9HZfkRcQ7uaiCQ2ovmXpc8GzahZ/signer_zBmCaGqiqz8vSL9hTNnBoac4wSrcNjAxJrE3NMhPhQ5j3_session_zGDLS9bjUxua",
+        "txIndex": 8,
+        "valid": false,
+        "reason": "Admins can't demote admins."
+      },
+      {
+        "sessionId": "sealer_z4hpJ6CBYrXnwAD4Ko9HZfkRcQ7uaiCQ2ovmXpc8GzahZ/signer_zBmCaGqiqz8vSL9hTNnBoac4wSrcNjAxJrE3NMhPhQ5j3_session_zGDLS9bjUxua",
+        "txIndex": 9,
+        "valid": true,
+        "reason": null
+      },
+      {
+        "sessionId": "sealer_z4hpJ6CBYrXnwAD4Ko9HZfkRcQ7uaiCQ2ovmXpc8GzahZ/signer_zBmCaGqiqz8vSL9hTNnBoac4wSrcNjAxJrE3NMhPhQ5j3_session_zGDLS9bjUxua",
+        "txIndex": 10,
+        "valid": true,
+        "reason": null
+      }
+    ]
+  },
+  "roleQueries": [
+    {
+      "groupId": "co_zj5EHgyXoFMm87aUfXkHi42wqRu",
+      "member": "co_zFT5aNyS1sVG548NShLE3M1zZx8",
+      "atTime": null,
+      "expectedRole": "admin"
+    },
+    {
+      "groupId": "co_zj5EHgyXoFMm87aUfXkHi42wqRu",
+      "member": "co_zdKXDNQ74fA1UEVNTcCSGJTakhr",
+      "atTime": null,
+      "expectedRole": "reader"
+    }
+  ]
+}

--- a/crates/cojson-core/data/group_engine/all_invites.json
+++ b/crates/cojson-core/data/group_engine/all_invites.json
@@ -1,0 +1,191 @@
+{
+  "description": "each invite kind accepts exactly its role (valid) and rejects any other role (invalid, with exact reason)",
+  "covalues": [
+    {
+      "coId": "co_zRFB3XSDFxZ6kHe1Cq2YoxBoCta",
+      "headerJson": "{\"createdAt\":\"2026-07-03T23:11:06.973Z\",\"meta\":null,\"ruleset\":{\"initialAdmin\":\"sealer_zvRTTandYL6MYrtMdyrJ4J2F9HrngdT7NhnGZHtraC7A/signer_z2fnibX5T7ywWpDjW1ct6gvJYiX3745SK5N5CXbRxFeEv\",\"type\":\"group\"},\"type\":\"comap\",\"uniqueness\":\"z3x8PthkaHiLujdij1\"}",
+      "sessions": [
+        {
+          "sessionId": "sealer_zvRTTandYL6MYrtMdyrJ4J2F9HrngdT7NhnGZHtraC7A/signer_z2fnibX5T7ywWpDjW1ct6gvJYiX3745SK5N5CXbRxFeEv_session_zcPPMyNiu1VB",
+          "signerId": "sealer_zvRTTandYL6MYrtMdyrJ4J2F9HrngdT7NhnGZHtraC7A/signer_z2fnibX5T7ywWpDjW1ct6gvJYiX3745SK5N5CXbRxFeEv",
+          "transactions": [
+            "{\"changes\":\"[{\\\"op\\\":\\\"set\\\",\\\"key\\\":\\\"sealer_zvRTTandYL6MYrtMdyrJ4J2F9HrngdT7NhnGZHtraC7A/signer_z2fnibX5T7ywWpDjW1ct6gvJYiX3745SK5N5CXbRxFeEv\\\",\\\"value\\\":\\\"admin\\\"}]\",\"madeAt\":1783120266973,\"privacy\":\"trusting\"}",
+            "{\"changes\":\"[{\\\"op\\\":\\\"set\\\",\\\"key\\\":\\\"key_z53rjkAiPrKm9eNxzw_for_sealer_zvRTTandYL6MYrtMdyrJ4J2F9HrngdT7NhnGZHtraC7A/signer_z2fnibX5T7ywWpDjW1ct6gvJYiX3745SK5N5CXbRxFeEv\\\",\\\"value\\\":\\\"sealed_Ux3loS2XSQEq-O27rOTwmyWmCgpmXBjGoBE5bdS0fGTo0zoyEUgePk3ZZx2O2_Jc-9GuPl_3wxIh40nQp13ETJSF5mVU0SK72eQ==\\\"}]\",\"madeAt\":1783120266973,\"privacy\":\"trusting\"}",
+            "{\"changes\":\"[{\\\"op\\\":\\\"set\\\",\\\"key\\\":\\\"readKey\\\",\\\"value\\\":\\\"key_z53rjkAiPrKm9eNxzw\\\"}]\",\"madeAt\":1783120266973,\"privacy\":\"trusting\"}",
+            "{\"changes\":\"[{\\\"op\\\":\\\"set\\\",\\\"key\\\":\\\"groupSealer\\\",\\\"value\\\":\\\"key_z53rjkAiPrKm9eNxzw@sealer_z8wjGkTbvcQdTroLkrCFqJk9FA6wTveZtKjauBVx58wm6\\\"}]\",\"madeAt\":1783120266973,\"privacy\":\"trusting\"}",
+            "{\"changes\":\"[{\\\"op\\\":\\\"set\\\",\\\"key\\\":\\\"sealer_z8Fd7npfWs85hVRVkLnKAdGYznKDqBQwbuxw3PY6q6wc7/signer_z9EEty8EucHrpHexFeqLeTCbUP7e18LQN3ep1KM6sFBSz\\\",\\\"value\\\":\\\"adminInvite\\\"}]\",\"madeAt\":1783120266973,\"privacy\":\"trusting\"}",
+            "{\"changes\":\"[{\\\"op\\\":\\\"set\\\",\\\"key\\\":\\\"sealer_z6JUQvF1vMvM5LMgbrJ6FjeychJQnvraUotjaWgNjGqh1/signer_zJAUySEe2FGhs6fnHME16gBmAkWeFnpvqCRnxMnmasMbH\\\",\\\"value\\\":\\\"managerInvite\\\"}]\",\"madeAt\":1783120266975,\"privacy\":\"trusting\"}",
+            "{\"changes\":\"[{\\\"op\\\":\\\"set\\\",\\\"key\\\":\\\"sealer_z3ZeQo3XGnr5prqoowmZqzQhgj7528vNpqVjBtXoAnr58/signer_z3UMCatLQbAggZmQG5VDnhHJCCX8DyvAFhSE289YXC5zv\\\",\\\"value\\\":\\\"writerInvite\\\"}]\",\"madeAt\":1783120266976,\"privacy\":\"trusting\"}",
+            "{\"changes\":\"[{\\\"op\\\":\\\"set\\\",\\\"key\\\":\\\"sealer_z6Ck8TXpu4X4XG7cjYRG9kH9B93Z1AGLzAmfzEgaNHMpy/signer_zHH7qQTCRybSxKn22EPaivWBLWQmkh7q6iv8QTLqGWRVq\\\",\\\"value\\\":\\\"readerInvite\\\"}]\",\"madeAt\":1783120266977,\"privacy\":\"trusting\"}",
+            "{\"changes\":\"[{\\\"op\\\":\\\"set\\\",\\\"key\\\":\\\"sealer_zAiTsfenEG8zRaG26aeognEhuDAWwyK45s1fp9jtB2ZVJ/signer_z6JFzGQkxapok8eX9z381Vpu1BapG7FeWWRoz6928biaD\\\",\\\"value\\\":\\\"writeOnlyInvite\\\"}]\",\"madeAt\":1783120266978,\"privacy\":\"trusting\"}"
+          ],
+          "lastSignature": "signature_z3f2HRv49UnG3sp1bKCaht5jL2W4p2ENCyvH4mMFAjYQJHtjXJ3dMUSRT2BUh47CzFvHH9kFDibiJrJJfKBiphamX"
+        },
+        {
+          "sessionId": "sealer_z8Fd7npfWs85hVRVkLnKAdGYznKDqBQwbuxw3PY6q6wc7/signer_z9EEty8EucHrpHexFeqLeTCbUP7e18LQN3ep1KM6sFBSz_session_zBJ2FwbqHVvQ",
+          "signerId": "signer_z9EEty8EucHrpHexFeqLeTCbUP7e18LQN3ep1KM6sFBSz",
+          "transactions": [
+            "{\"changes\":\"[{\\\"op\\\":\\\"set\\\",\\\"key\\\":\\\"sealer_zCrChyEPjkWNrY3p2N55PUqGd25P2TEqrk83VFogeaXxR/signer_zDdXQA2HwN2XCrbTzqLWQ1H1xb1gBRNsCvPyMAr1dXrCe\\\",\\\"value\\\":\\\"admin\\\"}]\",\"madeAt\":1783120266974,\"privacy\":\"trusting\"}",
+            "{\"changes\":\"[{\\\"op\\\":\\\"set\\\",\\\"key\\\":\\\"sealer_z9vRDesck4PKZoNbb7zwjrrNC5pgBHMFmeV6pcupm4sv9/signer_zFtGKvXRa69kfaVYVCEWuUPe1kbzYbGnHe1R6ossDnvvE\\\",\\\"value\\\":\\\"manager\\\"}]\",\"madeAt\":1783120266974,\"privacy\":\"trusting\"}"
+          ],
+          "lastSignature": "signature_z4X3t9nBCFfTfwCwMn6hqUvatoEHPnNKHyhXDgA8Q7b2uDCtymDrw5GkFQmGMrnQnpVarkgCZ7vDTDV8e5qZRoExC"
+        },
+        {
+          "sessionId": "sealer_z6JUQvF1vMvM5LMgbrJ6FjeychJQnvraUotjaWgNjGqh1/signer_zJAUySEe2FGhs6fnHME16gBmAkWeFnpvqCRnxMnmasMbH_session_zXcACHe1RTnW",
+          "signerId": "signer_zJAUySEe2FGhs6fnHME16gBmAkWeFnpvqCRnxMnmasMbH",
+          "transactions": [
+            "{\"changes\":\"[{\\\"op\\\":\\\"set\\\",\\\"key\\\":\\\"sealer_z9tdembjB7TUrC6v7roce9tABWjAKbS93JH8SJEgW29Kc/signer_zwCGC4cRtENuPM4YJnSLLNnn9rWd8qBFyF53hXH8yUez\\\",\\\"value\\\":\\\"manager\\\"}]\",\"madeAt\":1783120266975,\"privacy\":\"trusting\"}",
+            "{\"changes\":\"[{\\\"op\\\":\\\"set\\\",\\\"key\\\":\\\"sealer_zD3zWa8kci6WzvLsR6qGCcFoZWPPapkVwcuCK7FhwqoC2/signer_zBRv4umU6ney5bSZ6BwRcLFnnwcdscVYi8SybwhMkqNMC\\\",\\\"value\\\":\\\"writer\\\"}]\",\"madeAt\":1783120266976,\"privacy\":\"trusting\"}"
+          ],
+          "lastSignature": "signature_z3p5cxbtjJsoTUnDZTS7pshCcyqvZXys4vkJnX8mPqGqAVQ7tK6rDcnei2ezuS7qGbavJqV7XYzMfvmFsTVkjXqqr"
+        },
+        {
+          "sessionId": "sealer_z3ZeQo3XGnr5prqoowmZqzQhgj7528vNpqVjBtXoAnr58/signer_z3UMCatLQbAggZmQG5VDnhHJCCX8DyvAFhSE289YXC5zv_session_z3M16Gy7HopG",
+          "signerId": "signer_z3UMCatLQbAggZmQG5VDnhHJCCX8DyvAFhSE289YXC5zv",
+          "transactions": [
+            "{\"changes\":\"[{\\\"op\\\":\\\"set\\\",\\\"key\\\":\\\"sealer_zEib69CdXTUPseiq5CpQXYbMBqr6BdgbFDEcCqxrX3ZYM/signer_z294up9k3iMGgW7TxAnpqGowfVjoX97Zfir84SuLVVsyr\\\",\\\"value\\\":\\\"writer\\\"}]\",\"madeAt\":1783120266977,\"privacy\":\"trusting\"}",
+            "{\"changes\":\"[{\\\"op\\\":\\\"set\\\",\\\"key\\\":\\\"sealer_z3jr5yBFtBqyXtrtsVwWtuqHEHrQ15H7U3eLceQ1boizV/signer_zFn94bz7ERRzRf8gPiSg6AxnVKjLArjR8fYr7CHiF5f85\\\",\\\"value\\\":\\\"reader\\\"}]\",\"madeAt\":1783120266977,\"privacy\":\"trusting\"}"
+          ],
+          "lastSignature": "signature_z4dQ2UHEvVeJJpzUHdSopF29EWW67Qh11DgG5R2si7qwEjFwX4tW7uH963E6rfetHJE9DBXanw9j7MucSFXsiGQrJ"
+        },
+        {
+          "sessionId": "sealer_z6Ck8TXpu4X4XG7cjYRG9kH9B93Z1AGLzAmfzEgaNHMpy/signer_zHH7qQTCRybSxKn22EPaivWBLWQmkh7q6iv8QTLqGWRVq_session_zbkoTnKNd3qU",
+          "signerId": "signer_zHH7qQTCRybSxKn22EPaivWBLWQmkh7q6iv8QTLqGWRVq",
+          "transactions": [
+            "{\"changes\":\"[{\\\"op\\\":\\\"set\\\",\\\"key\\\":\\\"sealer_z6tyWvJuQqPdw3YUDiypFXdmiZbz5puZsUfbsHP3sWAxj/signer_zJAjv5vqUg2DwvRX9jDBqZmD9h6FAvLnd2G55jMYPLMJ2\\\",\\\"value\\\":\\\"reader\\\"}]\",\"madeAt\":1783120266978,\"privacy\":\"trusting\"}",
+            "{\"changes\":\"[{\\\"op\\\":\\\"set\\\",\\\"key\\\":\\\"sealer_z5DsPL9KsfAZ5zfba7ppLKM9ZHC9qSvhJuzAZtQVmJJ3F/signer_z8eggQSZLYG7tU6EzW3rJTbANkd4o5hYej9aTTsHmc1ga\\\",\\\"value\\\":\\\"writer\\\"}]\",\"madeAt\":1783120266978,\"privacy\":\"trusting\"}"
+          ],
+          "lastSignature": "signature_zBFcvMLSo3zYYtmYTzvS4jNtgfuVe5uBkNV5cPzuatDTH18q9gTxFtZirXmMa3TnB9q9Canoh2hGuY56hWqMC5hm"
+        },
+        {
+          "sessionId": "sealer_zAiTsfenEG8zRaG26aeognEhuDAWwyK45s1fp9jtB2ZVJ/signer_z6JFzGQkxapok8eX9z381Vpu1BapG7FeWWRoz6928biaD_session_zCUdDkfG7c4d",
+          "signerId": "signer_z6JFzGQkxapok8eX9z381Vpu1BapG7FeWWRoz6928biaD",
+          "transactions": [
+            "{\"changes\":\"[{\\\"op\\\":\\\"set\\\",\\\"key\\\":\\\"sealer_z22ockY5JFJZJbgbNzVSuiB2pYcDEiPocB3hWY55rgnWP/signer_zHCDkyRGG4EBEN8KDpEUC264cwDW8ys83cWCSMLjjXWBi\\\",\\\"value\\\":\\\"writeOnly\\\"}]\",\"madeAt\":1783120266980,\"privacy\":\"trusting\"}",
+            "{\"changes\":\"[{\\\"op\\\":\\\"set\\\",\\\"key\\\":\\\"sealer_zYJtT9zAzVEonHGhhXNptMELi8X5xAXwpaWpx4yLMih2/signer_z5naUcwaAGBpBes9KxXJPhp7AVwRoMV4QgCYkoaFEMqAX\\\",\\\"value\\\":\\\"reader\\\"}]\",\"madeAt\":1783120266981,\"privacy\":\"trusting\"}"
+          ],
+          "lastSignature": "signature_z4JDv2osQ8Kw4JmkV6MwquJPmkcGgcJ2y5TwHqwz912M8J2Y1SnEM58L4RG8XnoJBx7MscULWwc4pkcmoth7Rj7JB"
+        }
+      ]
+    }
+  ],
+  "verdicts": {
+    "co_zRFB3XSDFxZ6kHe1Cq2YoxBoCta": [
+      {
+        "sessionId": "sealer_zvRTTandYL6MYrtMdyrJ4J2F9HrngdT7NhnGZHtraC7A/signer_z2fnibX5T7ywWpDjW1ct6gvJYiX3745SK5N5CXbRxFeEv_session_zcPPMyNiu1VB",
+        "txIndex": 0,
+        "valid": true,
+        "reason": null
+      },
+      {
+        "sessionId": "sealer_zvRTTandYL6MYrtMdyrJ4J2F9HrngdT7NhnGZHtraC7A/signer_z2fnibX5T7ywWpDjW1ct6gvJYiX3745SK5N5CXbRxFeEv_session_zcPPMyNiu1VB",
+        "txIndex": 1,
+        "valid": true,
+        "reason": null
+      },
+      {
+        "sessionId": "sealer_zvRTTandYL6MYrtMdyrJ4J2F9HrngdT7NhnGZHtraC7A/signer_z2fnibX5T7ywWpDjW1ct6gvJYiX3745SK5N5CXbRxFeEv_session_zcPPMyNiu1VB",
+        "txIndex": 2,
+        "valid": true,
+        "reason": null
+      },
+      {
+        "sessionId": "sealer_zvRTTandYL6MYrtMdyrJ4J2F9HrngdT7NhnGZHtraC7A/signer_z2fnibX5T7ywWpDjW1ct6gvJYiX3745SK5N5CXbRxFeEv_session_zcPPMyNiu1VB",
+        "txIndex": 3,
+        "valid": true,
+        "reason": null
+      },
+      {
+        "sessionId": "sealer_zvRTTandYL6MYrtMdyrJ4J2F9HrngdT7NhnGZHtraC7A/signer_z2fnibX5T7ywWpDjW1ct6gvJYiX3745SK5N5CXbRxFeEv_session_zcPPMyNiu1VB",
+        "txIndex": 4,
+        "valid": true,
+        "reason": null
+      },
+      {
+        "sessionId": "sealer_z8Fd7npfWs85hVRVkLnKAdGYznKDqBQwbuxw3PY6q6wc7/signer_z9EEty8EucHrpHexFeqLeTCbUP7e18LQN3ep1KM6sFBSz_session_zBJ2FwbqHVvQ",
+        "txIndex": 0,
+        "valid": true,
+        "reason": null
+      },
+      {
+        "sessionId": "sealer_z8Fd7npfWs85hVRVkLnKAdGYznKDqBQwbuxw3PY6q6wc7/signer_z9EEty8EucHrpHexFeqLeTCbUP7e18LQN3ep1KM6sFBSz_session_zBJ2FwbqHVvQ",
+        "txIndex": 1,
+        "valid": false,
+        "reason": "AdminInvites can only create admins."
+      },
+      {
+        "sessionId": "sealer_zvRTTandYL6MYrtMdyrJ4J2F9HrngdT7NhnGZHtraC7A/signer_z2fnibX5T7ywWpDjW1ct6gvJYiX3745SK5N5CXbRxFeEv_session_zcPPMyNiu1VB",
+        "txIndex": 5,
+        "valid": true,
+        "reason": null
+      },
+      {
+        "sessionId": "sealer_z6JUQvF1vMvM5LMgbrJ6FjeychJQnvraUotjaWgNjGqh1/signer_zJAUySEe2FGhs6fnHME16gBmAkWeFnpvqCRnxMnmasMbH_session_zXcACHe1RTnW",
+        "txIndex": 0,
+        "valid": true,
+        "reason": null
+      },
+      {
+        "sessionId": "sealer_z6JUQvF1vMvM5LMgbrJ6FjeychJQnvraUotjaWgNjGqh1/signer_zJAUySEe2FGhs6fnHME16gBmAkWeFnpvqCRnxMnmasMbH_session_zXcACHe1RTnW",
+        "txIndex": 1,
+        "valid": false,
+        "reason": "managerInvite can only create managers."
+      },
+      {
+        "sessionId": "sealer_zvRTTandYL6MYrtMdyrJ4J2F9HrngdT7NhnGZHtraC7A/signer_z2fnibX5T7ywWpDjW1ct6gvJYiX3745SK5N5CXbRxFeEv_session_zcPPMyNiu1VB",
+        "txIndex": 6,
+        "valid": true,
+        "reason": null
+      },
+      {
+        "sessionId": "sealer_z3ZeQo3XGnr5prqoowmZqzQhgj7528vNpqVjBtXoAnr58/signer_z3UMCatLQbAggZmQG5VDnhHJCCX8DyvAFhSE289YXC5zv_session_z3M16Gy7HopG",
+        "txIndex": 0,
+        "valid": true,
+        "reason": null
+      },
+      {
+        "sessionId": "sealer_z3ZeQo3XGnr5prqoowmZqzQhgj7528vNpqVjBtXoAnr58/signer_z3UMCatLQbAggZmQG5VDnhHJCCX8DyvAFhSE289YXC5zv_session_z3M16Gy7HopG",
+        "txIndex": 1,
+        "valid": false,
+        "reason": "WriterInvites can only create writers."
+      },
+      {
+        "sessionId": "sealer_zvRTTandYL6MYrtMdyrJ4J2F9HrngdT7NhnGZHtraC7A/signer_z2fnibX5T7ywWpDjW1ct6gvJYiX3745SK5N5CXbRxFeEv_session_zcPPMyNiu1VB",
+        "txIndex": 7,
+        "valid": true,
+        "reason": null
+      },
+      {
+        "sessionId": "sealer_z6Ck8TXpu4X4XG7cjYRG9kH9B93Z1AGLzAmfzEgaNHMpy/signer_zHH7qQTCRybSxKn22EPaivWBLWQmkh7q6iv8QTLqGWRVq_session_zbkoTnKNd3qU",
+        "txIndex": 0,
+        "valid": true,
+        "reason": null
+      },
+      {
+        "sessionId": "sealer_z6Ck8TXpu4X4XG7cjYRG9kH9B93Z1AGLzAmfzEgaNHMpy/signer_zHH7qQTCRybSxKn22EPaivWBLWQmkh7q6iv8QTLqGWRVq_session_zbkoTnKNd3qU",
+        "txIndex": 1,
+        "valid": false,
+        "reason": "ReaderInvites can only create reader."
+      },
+      {
+        "sessionId": "sealer_zvRTTandYL6MYrtMdyrJ4J2F9HrngdT7NhnGZHtraC7A/signer_z2fnibX5T7ywWpDjW1ct6gvJYiX3745SK5N5CXbRxFeEv_session_zcPPMyNiu1VB",
+        "txIndex": 8,
+        "valid": true,
+        "reason": null
+      },
+      {
+        "sessionId": "sealer_zAiTsfenEG8zRaG26aeognEhuDAWwyK45s1fp9jtB2ZVJ/signer_z6JFzGQkxapok8eX9z381Vpu1BapG7FeWWRoz6928biaD_session_zCUdDkfG7c4d",
+        "txIndex": 0,
+        "valid": true,
+        "reason": null
+      },
+      {
+        "sessionId": "sealer_zAiTsfenEG8zRaG26aeognEhuDAWwyK45s1fp9jtB2ZVJ/signer_z6JFzGQkxapok8eX9z381Vpu1BapG7FeWWRoz6928biaD_session_zCUdDkfG7c4d",
+        "txIndex": 1,
+        "valid": false,
+        "reason": "WriteOnlyInvites can only create writeOnly."
+      }
+    ]
+  },
+  "roleQueries": []
+}

--- a/crates/cojson-core/data/group_engine/basic_roles.json
+++ b/crates/cojson-core/data/group_engine/basic_roles.json
@@ -1,0 +1,270 @@
+{
+  "description": "admin adds reader/writer/writeOnly/manager; a role changes over time",
+  "covalues": [
+    {
+      "coId": "co_zSwsoHJ9ytViWJyoLeMwG8GLJ3T",
+      "headerJson": "{\"createdAt\":\"2023-11-14T22:13:20.000Z\",\"meta\":null,\"ruleset\":{\"initialAdmin\":\"sealer_zBgQ1oWguc6zAniUstuNEwgpHH84je1gr7aiYk9nSxs7N/signer_zEpuxR4QxL14seEt67bdxBgb8oXXPGptcHPMu2ZqCZs5B\",\"type\":\"group\"},\"type\":\"comap\",\"uniqueness\":\"zHVkrbznHGECWrSXe\"}",
+      "sessions": [
+        {
+          "sessionId": "sealer_zBgQ1oWguc6zAniUstuNEwgpHH84je1gr7aiYk9nSxs7N/signer_zEpuxR4QxL14seEt67bdxBgb8oXXPGptcHPMu2ZqCZs5B_session_zc6kYsKaxrYV",
+          "signerId": "sealer_zBgQ1oWguc6zAniUstuNEwgpHH84je1gr7aiYk9nSxs7N/signer_zEpuxR4QxL14seEt67bdxBgb8oXXPGptcHPMu2ZqCZs5B",
+          "transactions": [
+            "{\"changes\":\"[{\\\"op\\\":\\\"set\\\",\\\"key\\\":\\\"sealer_zBgQ1oWguc6zAniUstuNEwgpHH84je1gr7aiYk9nSxs7N/signer_zEpuxR4QxL14seEt67bdxBgb8oXXPGptcHPMu2ZqCZs5B\\\",\\\"value\\\":\\\"admin\\\"}]\",\"madeAt\":1700000000000,\"privacy\":\"trusting\"}",
+            "{\"changes\":\"[{\\\"op\\\":\\\"set\\\",\\\"key\\\":\\\"key_z2VDaoVPSYV5Q6zoD1_for_sealer_zBgQ1oWguc6zAniUstuNEwgpHH84je1gr7aiYk9nSxs7N/signer_zEpuxR4QxL14seEt67bdxBgb8oXXPGptcHPMu2ZqCZs5B\\\",\\\"value\\\":\\\"sealed_UvhJV8LRE0fvQbrFN1Vq01nP4U_DU-WUXoLavM3u4PUEbX8RtOe19bXXylvmfTGCAHyM4LbSv45GZHzmmrjpzhsxEzhFRrhNJbw==\\\"}]\",\"madeAt\":1700000000000,\"privacy\":\"trusting\"}",
+            "{\"changes\":\"[{\\\"op\\\":\\\"set\\\",\\\"key\\\":\\\"readKey\\\",\\\"value\\\":\\\"key_z2VDaoVPSYV5Q6zoD1\\\"}]\",\"madeAt\":1700000000000,\"privacy\":\"trusting\"}",
+            "{\"changes\":\"[{\\\"op\\\":\\\"set\\\",\\\"key\\\":\\\"groupSealer\\\",\\\"value\\\":\\\"key_z2VDaoVPSYV5Q6zoD1@sealer_zCor3e6NpUSzSAUHJ65ieQ1aNjTUMmWgia4sqJ7Yx42tC\\\"}]\",\"madeAt\":1700000000000,\"privacy\":\"trusting\"}",
+            "{\"changes\":\"[{\\\"op\\\":\\\"set\\\",\\\"key\\\":\\\"co_z3d2FuXsQZRLPc5gc6H1GReDK5w\\\",\\\"value\\\":\\\"reader\\\"}]\",\"madeAt\":1700000010000,\"privacy\":\"trusting\"}",
+            "{\"changes\":\"[{\\\"op\\\":\\\"set\\\",\\\"key\\\":\\\"key_z2VDaoVPSYV5Q6zoD1_for_co_z3d2FuXsQZRLPc5gc6H1GReDK5w\\\",\\\"value\\\":\\\"sealed_UiRuyROFyg-jbJlNuCnWVLGGH3DthMBEPbnJCmym2cQbtg-NxlCkctjfpPnC-NKXHtE73MuOFqIxQKQidiPCeXozV2KDLmDisXQ==\\\"}]\",\"madeAt\":1700000010000,\"privacy\":\"trusting\"}",
+            "{\"changes\":\"[{\\\"op\\\":\\\"set\\\",\\\"key\\\":\\\"co_zdCt9XjscNwZTkfiFDcTE5YeoTp\\\",\\\"value\\\":\\\"writer\\\"}]\",\"madeAt\":1700000020000,\"privacy\":\"trusting\"}",
+            "{\"changes\":\"[{\\\"op\\\":\\\"set\\\",\\\"key\\\":\\\"key_z2VDaoVPSYV5Q6zoD1_for_co_zdCt9XjscNwZTkfiFDcTE5YeoTp\\\",\\\"value\\\":\\\"sealed_UMBdN8ykQ1XDpbx-4kTl2mOMvRnWLi6u1PNI623CyrjRRxS-u7mCo33iqegpD1I2yjNlUYSDmD5PSjLA_MK-uDLqOm7gzpA1shA==\\\"}]\",\"madeAt\":1700000020000,\"privacy\":\"trusting\"}",
+            "{\"changes\":\"[{\\\"op\\\":\\\"set\\\",\\\"key\\\":\\\"co_zEuQbALQ2Fk6iVjWtcrEfAgwBiX\\\",\\\"value\\\":\\\"writeOnly\\\"}]\",\"madeAt\":1700000030000,\"privacy\":\"trusting\"}",
+            "{\"changes\":\"[{\\\"op\\\":\\\"set\\\",\\\"key\\\":\\\"writeKeyFor_co_zEuQbALQ2Fk6iVjWtcrEfAgwBiX\\\",\\\"value\\\":\\\"key_zhZP8Tse4UEu9uAqo\\\"}]\",\"madeAt\":1700000030000,\"privacy\":\"trusting\"}",
+            "{\"changes\":\"[{\\\"op\\\":\\\"set\\\",\\\"key\\\":\\\"key_zhZP8Tse4UEu9uAqo_for_co_zEuQbALQ2Fk6iVjWtcrEfAgwBiX\\\",\\\"value\\\":\\\"sealed_U1V6NzfOGfQk36tKOhNfe5VpfKOjiriSKR7_AeeIRrr-aI_VfWyEUQDS7WP9y64lXg1VN5HvlVsyRp2J5A1OcbylpshSM8isg4A==\\\"}]\",\"madeAt\":1700000030000,\"privacy\":\"trusting\"}",
+            "{\"changes\":\"[{\\\"op\\\":\\\"set\\\",\\\"key\\\":\\\"key_zhZP8Tse4UEu9uAqo_for_sealer_zBgQ1oWguc6zAniUstuNEwgpHH84je1gr7aiYk9nSxs7N/signer_zEpuxR4QxL14seEt67bdxBgb8oXXPGptcHPMu2ZqCZs5B\\\",\\\"value\\\":\\\"sealed_UrIr3s3j46RoCSxhpx7MDgWrk2ihzwglKJrzL8ST9zK72eT6NCG2BTrHA43ONBlfF2kumI4K5Bv48uZZm7eXciXykDAiAby5hag==\\\"}]\",\"madeAt\":1700000030000,\"privacy\":\"trusting\"}",
+            "{\"changes\":\"[{\\\"op\\\":\\\"set\\\",\\\"key\\\":\\\"key_zhZP8Tse4UEu9uAqo_for_co_z3d2FuXsQZRLPc5gc6H1GReDK5w\\\",\\\"value\\\":\\\"sealed_UYIDcbRuncHZWIpNmpys7PYnNGtwfq8hbkLLI4HhIjqAjjhqehnthBCO49rcv_IK9k_ycoS0gEtSgDqSOsR8M46Scw-1O9yTjoA==\\\"}]\",\"madeAt\":1700000030000,\"privacy\":\"trusting\"}",
+            "{\"changes\":\"[{\\\"op\\\":\\\"set\\\",\\\"key\\\":\\\"key_zhZP8Tse4UEu9uAqo_for_co_zdCt9XjscNwZTkfiFDcTE5YeoTp\\\",\\\"value\\\":\\\"sealed_UmEG7nEKGLHFy6mXcnxW50TbYlnjSVopv29S42GNXKgHwLvnLudsMlT0-wnCk-B30wMtIAVwu36RGQ7jY25zaR5u4NoxU8hyQMw==\\\"}]\",\"madeAt\":1700000030000,\"privacy\":\"trusting\"}",
+            "{\"changes\":\"[{\\\"op\\\":\\\"set\\\",\\\"key\\\":\\\"co_zJwRUj1McRjUo5MsqpdTFTmhYEQ\\\",\\\"value\\\":\\\"manager\\\"}]\",\"madeAt\":1700000040000,\"privacy\":\"trusting\"}",
+            "{\"changes\":\"[{\\\"op\\\":\\\"set\\\",\\\"key\\\":\\\"key_z2VDaoVPSYV5Q6zoD1_for_co_zJwRUj1McRjUo5MsqpdTFTmhYEQ\\\",\\\"value\\\":\\\"sealed_UnkRxgnR4N6evFQB8NwTRVvpAo2o6_5R3q4c5eEBA7xavGBqCJXTCsnbHUJnayIbMnp-kibivRRBafcfs4wf8SLZBTGXN32ynDw==\\\"}]\",\"madeAt\":1700000040000,\"privacy\":\"trusting\"}",
+            "{\"changes\":\"[{\\\"op\\\":\\\"set\\\",\\\"key\\\":\\\"key_zhZP8Tse4UEu9uAqo_for_co_zJwRUj1McRjUo5MsqpdTFTmhYEQ\\\",\\\"value\\\":\\\"sealed_U2xC9lWpZscyUmFJl2MiSqixkoulZdN4RyYQtABOvE9Aj_yUnlCvFkxh-ieiHVRlxKFbu2YsYSvDSjpldE2lFrGdeNTlMC2WmZg==\\\"}]\",\"madeAt\":1700000040000,\"privacy\":\"trusting\"}",
+            "{\"changes\":\"[{\\\"op\\\":\\\"set\\\",\\\"key\\\":\\\"co_z3d2FuXsQZRLPc5gc6H1GReDK5w\\\",\\\"value\\\":\\\"writer\\\"}]\",\"madeAt\":1700000050000,\"privacy\":\"trusting\"}",
+            "{\"changes\":\"[{\\\"op\\\":\\\"set\\\",\\\"key\\\":\\\"key_z2VDaoVPSYV5Q6zoD1_for_co_z3d2FuXsQZRLPc5gc6H1GReDK5w\\\",\\\"value\\\":\\\"sealed_U_a0rUQDwXV4Op3VcOjZpfbhnrZHPjj-Ryc7qTf8bAgh7fd_iY6ebpGE4-3DTTFpwNGGOolfZ48SvoQKMHzzWK5xt4kHNj48qyw==\\\"}]\",\"madeAt\":1700000050000,\"privacy\":\"trusting\"}",
+            "{\"changes\":\"[{\\\"op\\\":\\\"set\\\",\\\"key\\\":\\\"key_zhZP8Tse4UEu9uAqo_for_co_z3d2FuXsQZRLPc5gc6H1GReDK5w\\\",\\\"value\\\":\\\"sealed_U9fUJGOprb5yGg-r9JH9tgg5-EAcrpBJrvLf4eCSnigUs9BwDIOnPxg1XtSchKcV2wekCNdQ9NMcY0SzrDWv5XFsp3GHQYYKOfg==\\\"}]\",\"madeAt\":1700000050000,\"privacy\":\"trusting\"}"
+          ],
+          "lastSignature": "signature_z2jxX9cknBaarG1AT4zVod3sMxzDgDQFc3xk4nvjb1BMsjZe7omaKZEKRGMowZGSsgzfifPoTaNjga5NCdat6NUCD"
+        }
+      ]
+    },
+    {
+      "coId": "co_z3d2FuXsQZRLPc5gc6H1GReDK5w",
+      "headerJson": "{\"createdAt\":null,\"meta\":{\"type\":\"account\"},\"ruleset\":{\"initialAdmin\":\"sealer_z6VSjdLE4v8CUbZneBdGXT359o2mqxNqYMkV4Wf8tm9Mb/signer_z4hL6fZCxTXn5SBLLZDGizJYDTVWS2xWZ2B2S17FeXXXf\",\"type\":\"group\"},\"type\":\"comap\",\"uniqueness\":null}",
+      "sessions": [
+        {
+          "sessionId": "sealer_z6VSjdLE4v8CUbZneBdGXT359o2mqxNqYMkV4Wf8tm9Mb/signer_z4hL6fZCxTXn5SBLLZDGizJYDTVWS2xWZ2B2S17FeXXXf_session_zTWGRPRybdCf",
+          "signerId": "signer_z4hL6fZCxTXn5SBLLZDGizJYDTVWS2xWZ2B2S17FeXXXf",
+          "transactions": [
+            "{\"changes\":\"[{\\\"op\\\":\\\"set\\\",\\\"key\\\":\\\"sealer_z6VSjdLE4v8CUbZneBdGXT359o2mqxNqYMkV4Wf8tm9Mb/signer_z4hL6fZCxTXn5SBLLZDGizJYDTVWS2xWZ2B2S17FeXXXf\\\",\\\"value\\\":\\\"admin\\\"}]\",\"madeAt\":1700000000000,\"privacy\":\"trusting\"}",
+            "{\"changes\":\"[{\\\"op\\\":\\\"set\\\",\\\"key\\\":\\\"key_zF8v28EPbCLdBN8Hd_for_sealer_z6VSjdLE4v8CUbZneBdGXT359o2mqxNqYMkV4Wf8tm9Mb/signer_z4hL6fZCxTXn5SBLLZDGizJYDTVWS2xWZ2B2S17FeXXXf\\\",\\\"value\\\":\\\"sealed_UuJA4u7yJIGnTSZh85qDXv2Xk995kjWmnBKjCtDypItAKwMwA1F6uB84iMw0cZUHYWrZGMjpR2bM234RZXxmqTf1jfVM_3z0e8Q==\\\"}]\",\"madeAt\":1700000000000,\"privacy\":\"trusting\"}",
+            "{\"changes\":\"[{\\\"op\\\":\\\"set\\\",\\\"key\\\":\\\"readKey\\\",\\\"value\\\":\\\"key_zF8v28EPbCLdBN8Hd\\\"}]\",\"madeAt\":1700000000000,\"privacy\":\"trusting\"}"
+          ],
+          "lastSignature": "signature_z2VxuLXCNQdMZEhumy6rbxjUUbyk2xGkh75vr1z2d8baq4mQ6bWyyJa1bZ85mRYZ8TWhUFD8ST3H1twob2Pw1aotZ"
+        }
+      ]
+    },
+    {
+      "coId": "co_zdCt9XjscNwZTkfiFDcTE5YeoTp",
+      "headerJson": "{\"createdAt\":null,\"meta\":{\"type\":\"account\"},\"ruleset\":{\"initialAdmin\":\"sealer_zAadjSeWgZxCnEpV83YhpGon5kMCybNtnYbBndsBsDv9v/signer_z6QMUg1qGSvi9KvknSTehEMkbQcHsD3HWmySDA3SPbwkN\",\"type\":\"group\"},\"type\":\"comap\",\"uniqueness\":null}",
+      "sessions": [
+        {
+          "sessionId": "sealer_zAadjSeWgZxCnEpV83YhpGon5kMCybNtnYbBndsBsDv9v/signer_z6QMUg1qGSvi9KvknSTehEMkbQcHsD3HWmySDA3SPbwkN_session_zFdhkwkaPCt9",
+          "signerId": "signer_z6QMUg1qGSvi9KvknSTehEMkbQcHsD3HWmySDA3SPbwkN",
+          "transactions": [
+            "{\"changes\":\"[{\\\"op\\\":\\\"set\\\",\\\"key\\\":\\\"sealer_zAadjSeWgZxCnEpV83YhpGon5kMCybNtnYbBndsBsDv9v/signer_z6QMUg1qGSvi9KvknSTehEMkbQcHsD3HWmySDA3SPbwkN\\\",\\\"value\\\":\\\"admin\\\"}]\",\"madeAt\":1700000000000,\"privacy\":\"trusting\"}",
+            "{\"changes\":\"[{\\\"op\\\":\\\"set\\\",\\\"key\\\":\\\"key_z5fBY5YYfkN3y8oUzJ_for_sealer_zAadjSeWgZxCnEpV83YhpGon5kMCybNtnYbBndsBsDv9v/signer_z6QMUg1qGSvi9KvknSTehEMkbQcHsD3HWmySDA3SPbwkN\\\",\\\"value\\\":\\\"sealed_U40RMfgDBqmzoV7NjAfTfWCNHptRPgrV_xLUpY7iMggGhyS97hHTDIQFoCK_HcqyISgEmBYKineGRRJKCos27ppdPz2CdqQ-Gyg==\\\"}]\",\"madeAt\":1700000000000,\"privacy\":\"trusting\"}",
+            "{\"changes\":\"[{\\\"op\\\":\\\"set\\\",\\\"key\\\":\\\"readKey\\\",\\\"value\\\":\\\"key_z5fBY5YYfkN3y8oUzJ\\\"}]\",\"madeAt\":1700000000000,\"privacy\":\"trusting\"}"
+          ],
+          "lastSignature": "signature_zcYfyY4ua3vnqtatUsKYD1G7kCD8VoLetVmLxGLw7Cd4FruKdxjr3wiGTy4MXJNSid9BDRKB4dh4kvVgf9wC62Rz"
+        }
+      ]
+    },
+    {
+      "coId": "co_zEuQbALQ2Fk6iVjWtcrEfAgwBiX",
+      "headerJson": "{\"createdAt\":null,\"meta\":{\"type\":\"account\"},\"ruleset\":{\"initialAdmin\":\"sealer_z7dH9RbdW2ckHirem8ZFWqx3sBDr7mTaHg2fjrRQicyW3/signer_zE7iVmqGW7P26ZDhzk9j98c3hQjwnrP6S1SZA14RmHgYD\",\"type\":\"group\"},\"type\":\"comap\",\"uniqueness\":null}",
+      "sessions": [
+        {
+          "sessionId": "sealer_z7dH9RbdW2ckHirem8ZFWqx3sBDr7mTaHg2fjrRQicyW3/signer_zE7iVmqGW7P26ZDhzk9j98c3hQjwnrP6S1SZA14RmHgYD_session_z8YgZsn61FAk",
+          "signerId": "signer_zE7iVmqGW7P26ZDhzk9j98c3hQjwnrP6S1SZA14RmHgYD",
+          "transactions": [
+            "{\"changes\":\"[{\\\"op\\\":\\\"set\\\",\\\"key\\\":\\\"sealer_z7dH9RbdW2ckHirem8ZFWqx3sBDr7mTaHg2fjrRQicyW3/signer_zE7iVmqGW7P26ZDhzk9j98c3hQjwnrP6S1SZA14RmHgYD\\\",\\\"value\\\":\\\"admin\\\"}]\",\"madeAt\":1700000000000,\"privacy\":\"trusting\"}",
+            "{\"changes\":\"[{\\\"op\\\":\\\"set\\\",\\\"key\\\":\\\"key_z5DuF52sKR6GGUjNgA_for_sealer_z7dH9RbdW2ckHirem8ZFWqx3sBDr7mTaHg2fjrRQicyW3/signer_zE7iVmqGW7P26ZDhzk9j98c3hQjwnrP6S1SZA14RmHgYD\\\",\\\"value\\\":\\\"sealed_UE-FlC4g1-elzgbG0z0lN3qTDGPTJgp21fbAJPHDoFykctsQnVvmUA6NNJ3VoVqjHsxcC3_b9yarDJDt1J9biNmVgfZu08yfVTQ==\\\"}]\",\"madeAt\":1700000000000,\"privacy\":\"trusting\"}",
+            "{\"changes\":\"[{\\\"op\\\":\\\"set\\\",\\\"key\\\":\\\"readKey\\\",\\\"value\\\":\\\"key_z5DuF52sKR6GGUjNgA\\\"}]\",\"madeAt\":1700000000000,\"privacy\":\"trusting\"}"
+          ],
+          "lastSignature": "signature_zHrrSfyCjZ46MskhRdhZLefXCrsk6dEaCgi21vQRnxo1DcPXroZSvWfaPBox6WDuV5iNYNEQjsRCbQSpsuL8tbJP"
+        }
+      ]
+    },
+    {
+      "coId": "co_zJwRUj1McRjUo5MsqpdTFTmhYEQ",
+      "headerJson": "{\"createdAt\":null,\"meta\":{\"type\":\"account\"},\"ruleset\":{\"initialAdmin\":\"sealer_zGm9p1ZStwE1rqeDgLNE28Sxfc1syzW9nMYF8dkANuy2X/signer_zkpUmKmLe2MqPgsLEWrrrhxj5MLydiPirCJyRcsceJnj\",\"type\":\"group\"},\"type\":\"comap\",\"uniqueness\":null}",
+      "sessions": [
+        {
+          "sessionId": "sealer_zGm9p1ZStwE1rqeDgLNE28Sxfc1syzW9nMYF8dkANuy2X/signer_zkpUmKmLe2MqPgsLEWrrrhxj5MLydiPirCJyRcsceJnj_session_zinSUTTMtXMF",
+          "signerId": "signer_zkpUmKmLe2MqPgsLEWrrrhxj5MLydiPirCJyRcsceJnj",
+          "transactions": [
+            "{\"changes\":\"[{\\\"op\\\":\\\"set\\\",\\\"key\\\":\\\"sealer_zGm9p1ZStwE1rqeDgLNE28Sxfc1syzW9nMYF8dkANuy2X/signer_zkpUmKmLe2MqPgsLEWrrrhxj5MLydiPirCJyRcsceJnj\\\",\\\"value\\\":\\\"admin\\\"}]\",\"madeAt\":1700000000000,\"privacy\":\"trusting\"}",
+            "{\"changes\":\"[{\\\"op\\\":\\\"set\\\",\\\"key\\\":\\\"key_z5Cb1gvAgh8KbGcy35_for_sealer_zGm9p1ZStwE1rqeDgLNE28Sxfc1syzW9nMYF8dkANuy2X/signer_zkpUmKmLe2MqPgsLEWrrrhxj5MLydiPirCJyRcsceJnj\\\",\\\"value\\\":\\\"sealed_UNEeryBPdSAUcV2FPD3zGDxoO4dWAFIsL22aRczLXjbthsNfBPDY47tJ7YzwbMUklgB2__U0kNVVkzKG-hMn0wxRdN5xxLzffWg==\\\"}]\",\"madeAt\":1700000000000,\"privacy\":\"trusting\"}",
+            "{\"changes\":\"[{\\\"op\\\":\\\"set\\\",\\\"key\\\":\\\"readKey\\\",\\\"value\\\":\\\"key_z5Cb1gvAgh8KbGcy35\\\"}]\",\"madeAt\":1700000000000,\"privacy\":\"trusting\"}"
+          ],
+          "lastSignature": "signature_z2DBQ19JixFHZtW67rfd4BKFXxppvwUU9yViMQ2U5hJwFJ9mSFRk42ogCfNLwTqAouqt6dq7AZWtQ3xt5zK5xvU9z"
+        }
+      ]
+    }
+  ],
+  "verdicts": {
+    "co_zSwsoHJ9ytViWJyoLeMwG8GLJ3T": [
+      {
+        "sessionId": "sealer_zBgQ1oWguc6zAniUstuNEwgpHH84je1gr7aiYk9nSxs7N/signer_zEpuxR4QxL14seEt67bdxBgb8oXXPGptcHPMu2ZqCZs5B_session_zc6kYsKaxrYV",
+        "txIndex": 0,
+        "valid": true,
+        "reason": null
+      },
+      {
+        "sessionId": "sealer_zBgQ1oWguc6zAniUstuNEwgpHH84je1gr7aiYk9nSxs7N/signer_zEpuxR4QxL14seEt67bdxBgb8oXXPGptcHPMu2ZqCZs5B_session_zc6kYsKaxrYV",
+        "txIndex": 1,
+        "valid": true,
+        "reason": null
+      },
+      {
+        "sessionId": "sealer_zBgQ1oWguc6zAniUstuNEwgpHH84je1gr7aiYk9nSxs7N/signer_zEpuxR4QxL14seEt67bdxBgb8oXXPGptcHPMu2ZqCZs5B_session_zc6kYsKaxrYV",
+        "txIndex": 2,
+        "valid": true,
+        "reason": null
+      },
+      {
+        "sessionId": "sealer_zBgQ1oWguc6zAniUstuNEwgpHH84je1gr7aiYk9nSxs7N/signer_zEpuxR4QxL14seEt67bdxBgb8oXXPGptcHPMu2ZqCZs5B_session_zc6kYsKaxrYV",
+        "txIndex": 3,
+        "valid": true,
+        "reason": null
+      },
+      {
+        "sessionId": "sealer_zBgQ1oWguc6zAniUstuNEwgpHH84je1gr7aiYk9nSxs7N/signer_zEpuxR4QxL14seEt67bdxBgb8oXXPGptcHPMu2ZqCZs5B_session_zc6kYsKaxrYV",
+        "txIndex": 4,
+        "valid": true,
+        "reason": null
+      },
+      {
+        "sessionId": "sealer_zBgQ1oWguc6zAniUstuNEwgpHH84je1gr7aiYk9nSxs7N/signer_zEpuxR4QxL14seEt67bdxBgb8oXXPGptcHPMu2ZqCZs5B_session_zc6kYsKaxrYV",
+        "txIndex": 5,
+        "valid": true,
+        "reason": null
+      },
+      {
+        "sessionId": "sealer_zBgQ1oWguc6zAniUstuNEwgpHH84je1gr7aiYk9nSxs7N/signer_zEpuxR4QxL14seEt67bdxBgb8oXXPGptcHPMu2ZqCZs5B_session_zc6kYsKaxrYV",
+        "txIndex": 6,
+        "valid": true,
+        "reason": null
+      },
+      {
+        "sessionId": "sealer_zBgQ1oWguc6zAniUstuNEwgpHH84je1gr7aiYk9nSxs7N/signer_zEpuxR4QxL14seEt67bdxBgb8oXXPGptcHPMu2ZqCZs5B_session_zc6kYsKaxrYV",
+        "txIndex": 7,
+        "valid": true,
+        "reason": null
+      },
+      {
+        "sessionId": "sealer_zBgQ1oWguc6zAniUstuNEwgpHH84je1gr7aiYk9nSxs7N/signer_zEpuxR4QxL14seEt67bdxBgb8oXXPGptcHPMu2ZqCZs5B_session_zc6kYsKaxrYV",
+        "txIndex": 8,
+        "valid": true,
+        "reason": null
+      },
+      {
+        "sessionId": "sealer_zBgQ1oWguc6zAniUstuNEwgpHH84je1gr7aiYk9nSxs7N/signer_zEpuxR4QxL14seEt67bdxBgb8oXXPGptcHPMu2ZqCZs5B_session_zc6kYsKaxrYV",
+        "txIndex": 9,
+        "valid": true,
+        "reason": null
+      },
+      {
+        "sessionId": "sealer_zBgQ1oWguc6zAniUstuNEwgpHH84je1gr7aiYk9nSxs7N/signer_zEpuxR4QxL14seEt67bdxBgb8oXXPGptcHPMu2ZqCZs5B_session_zc6kYsKaxrYV",
+        "txIndex": 10,
+        "valid": true,
+        "reason": null
+      },
+      {
+        "sessionId": "sealer_zBgQ1oWguc6zAniUstuNEwgpHH84je1gr7aiYk9nSxs7N/signer_zEpuxR4QxL14seEt67bdxBgb8oXXPGptcHPMu2ZqCZs5B_session_zc6kYsKaxrYV",
+        "txIndex": 11,
+        "valid": true,
+        "reason": null
+      },
+      {
+        "sessionId": "sealer_zBgQ1oWguc6zAniUstuNEwgpHH84je1gr7aiYk9nSxs7N/signer_zEpuxR4QxL14seEt67bdxBgb8oXXPGptcHPMu2ZqCZs5B_session_zc6kYsKaxrYV",
+        "txIndex": 12,
+        "valid": true,
+        "reason": null
+      },
+      {
+        "sessionId": "sealer_zBgQ1oWguc6zAniUstuNEwgpHH84je1gr7aiYk9nSxs7N/signer_zEpuxR4QxL14seEt67bdxBgb8oXXPGptcHPMu2ZqCZs5B_session_zc6kYsKaxrYV",
+        "txIndex": 13,
+        "valid": true,
+        "reason": null
+      },
+      {
+        "sessionId": "sealer_zBgQ1oWguc6zAniUstuNEwgpHH84je1gr7aiYk9nSxs7N/signer_zEpuxR4QxL14seEt67bdxBgb8oXXPGptcHPMu2ZqCZs5B_session_zc6kYsKaxrYV",
+        "txIndex": 14,
+        "valid": true,
+        "reason": null
+      },
+      {
+        "sessionId": "sealer_zBgQ1oWguc6zAniUstuNEwgpHH84je1gr7aiYk9nSxs7N/signer_zEpuxR4QxL14seEt67bdxBgb8oXXPGptcHPMu2ZqCZs5B_session_zc6kYsKaxrYV",
+        "txIndex": 15,
+        "valid": true,
+        "reason": null
+      },
+      {
+        "sessionId": "sealer_zBgQ1oWguc6zAniUstuNEwgpHH84je1gr7aiYk9nSxs7N/signer_zEpuxR4QxL14seEt67bdxBgb8oXXPGptcHPMu2ZqCZs5B_session_zc6kYsKaxrYV",
+        "txIndex": 16,
+        "valid": true,
+        "reason": null
+      },
+      {
+        "sessionId": "sealer_zBgQ1oWguc6zAniUstuNEwgpHH84je1gr7aiYk9nSxs7N/signer_zEpuxR4QxL14seEt67bdxBgb8oXXPGptcHPMu2ZqCZs5B_session_zc6kYsKaxrYV",
+        "txIndex": 17,
+        "valid": true,
+        "reason": null
+      },
+      {
+        "sessionId": "sealer_zBgQ1oWguc6zAniUstuNEwgpHH84je1gr7aiYk9nSxs7N/signer_zEpuxR4QxL14seEt67bdxBgb8oXXPGptcHPMu2ZqCZs5B_session_zc6kYsKaxrYV",
+        "txIndex": 18,
+        "valid": true,
+        "reason": null
+      },
+      {
+        "sessionId": "sealer_zBgQ1oWguc6zAniUstuNEwgpHH84je1gr7aiYk9nSxs7N/signer_zEpuxR4QxL14seEt67bdxBgb8oXXPGptcHPMu2ZqCZs5B_session_zc6kYsKaxrYV",
+        "txIndex": 19,
+        "valid": true,
+        "reason": null
+      }
+    ]
+  },
+  "roleQueries": [
+    {
+      "groupId": "co_zSwsoHJ9ytViWJyoLeMwG8GLJ3T",
+      "member": "co_z3d2FuXsQZRLPc5gc6H1GReDK5w",
+      "atTime": 1700000020000,
+      "expectedRole": "reader"
+    },
+    {
+      "groupId": "co_zSwsoHJ9ytViWJyoLeMwG8GLJ3T",
+      "member": "co_z3d2FuXsQZRLPc5gc6H1GReDK5w",
+      "atTime": 1700000050000,
+      "expectedRole": "writer"
+    },
+    {
+      "groupId": "co_zSwsoHJ9ytViWJyoLeMwG8GLJ3T",
+      "member": "co_z3d2FuXsQZRLPc5gc6H1GReDK5w",
+      "atTime": null,
+      "expectedRole": "writer"
+    },
+    {
+      "groupId": "co_zSwsoHJ9ytViWJyoLeMwG8GLJ3T",
+      "member": "co_zdCt9XjscNwZTkfiFDcTE5YeoTp",
+      "atTime": 1700000020000,
+      "expectedRole": "writer"
+    },
+    {
+      "groupId": "co_zSwsoHJ9ytViWJyoLeMwG8GLJ3T",
+      "member": "co_zEuQbALQ2Fk6iVjWtcrEfAgwBiX",
+      "atTime": 1700000030000,
+      "expectedRole": "writeOnly"
+    },
+    {
+      "groupId": "co_zSwsoHJ9ytViWJyoLeMwG8GLJ3T",
+      "member": "co_zJwRUj1McRjUo5MsqpdTFTmhYEQ",
+      "atTime": 1700000040000,
+      "expectedRole": "manager"
+    },
+    {
+      "groupId": "co_zSwsoHJ9ytViWJyoLeMwG8GLJ3T",
+      "member": "co_zdCt9XjscNwZTkfiFDcTE5YeoTp",
+      "atTime": 1700000010000,
+      "expectedRole": null
+    }
+  ]
+}

--- a/crates/cojson-core/data/group_engine/cross_session_ties.json
+++ b/crates/cojson-core/data/group_engine/cross_session_ties.json
@@ -1,0 +1,146 @@
+{
+  "description": "two sessions of different admins assign conflicting roles with equal madeAt; pins the stable-order outcome",
+  "covalues": [
+    {
+      "coId": "co_zfF4FnTK4hX5gj2Lzss8Zxp2HTh",
+      "headerJson": "{\"createdAt\":\"2023-11-14T22:13:20.000Z\",\"meta\":null,\"ruleset\":{\"initialAdmin\":\"sealer_z2LpqCDsxqjirjfpv5gr1szi2Jr7GXexhhrnLZMQnVJKE/signer_z9MvDTsziXXoNhw4DCB26f6UYJ9EtSGbDy9LM7HmxDfjE\",\"type\":\"group\"},\"type\":\"comap\",\"uniqueness\":\"z5p32dC9ESHELXsT5z\"}",
+      "sessions": [
+        {
+          "sessionId": "sealer_z2LpqCDsxqjirjfpv5gr1szi2Jr7GXexhhrnLZMQnVJKE/signer_z9MvDTsziXXoNhw4DCB26f6UYJ9EtSGbDy9LM7HmxDfjE_session_zF8hAYBAgfGu",
+          "signerId": "sealer_z2LpqCDsxqjirjfpv5gr1szi2Jr7GXexhhrnLZMQnVJKE/signer_z9MvDTsziXXoNhw4DCB26f6UYJ9EtSGbDy9LM7HmxDfjE",
+          "transactions": [
+            "{\"changes\":\"[{\\\"op\\\":\\\"set\\\",\\\"key\\\":\\\"sealer_z2LpqCDsxqjirjfpv5gr1szi2Jr7GXexhhrnLZMQnVJKE/signer_z9MvDTsziXXoNhw4DCB26f6UYJ9EtSGbDy9LM7HmxDfjE\\\",\\\"value\\\":\\\"admin\\\"}]\",\"madeAt\":1700000000000,\"privacy\":\"trusting\"}",
+            "{\"changes\":\"[{\\\"op\\\":\\\"set\\\",\\\"key\\\":\\\"key_z3G1sH68mugDPWtmmY_for_sealer_z2LpqCDsxqjirjfpv5gr1szi2Jr7GXexhhrnLZMQnVJKE/signer_z9MvDTsziXXoNhw4DCB26f6UYJ9EtSGbDy9LM7HmxDfjE\\\",\\\"value\\\":\\\"sealed_UvK-g79GAyhgBQSUuicvLjH2AfZO7cbUS_kgPLX0vX4HCJk7ZtU4Fij0iCv88_nh1D8q5HwokT3IG76MZLzS8lrK1m8YspoXvbA==\\\"}]\",\"madeAt\":1700000000000,\"privacy\":\"trusting\"}",
+            "{\"changes\":\"[{\\\"op\\\":\\\"set\\\",\\\"key\\\":\\\"readKey\\\",\\\"value\\\":\\\"key_z3G1sH68mugDPWtmmY\\\"}]\",\"madeAt\":1700000000000,\"privacy\":\"trusting\"}",
+            "{\"changes\":\"[{\\\"op\\\":\\\"set\\\",\\\"key\\\":\\\"groupSealer\\\",\\\"value\\\":\\\"key_z3G1sH68mugDPWtmmY@sealer_zD9fptQFCmZ66jiDoT2wcJtCoWQ2rh2r7QVoU4KzxoTW3\\\"}]\",\"madeAt\":1700000000000,\"privacy\":\"trusting\"}",
+            "{\"changes\":\"[{\\\"op\\\":\\\"set\\\",\\\"key\\\":\\\"co_zUGQrkaYiZrjKaNgqQgARcDd54d\\\",\\\"value\\\":\\\"admin\\\"}]\",\"madeAt\":1700000000000,\"privacy\":\"trusting\"}",
+            "{\"changes\":\"[{\\\"op\\\":\\\"set\\\",\\\"key\\\":\\\"key_z3G1sH68mugDPWtmmY_for_co_zUGQrkaYiZrjKaNgqQgARcDd54d\\\",\\\"value\\\":\\\"sealed_U3zF_hj96jhhpgi-lcVwNx3Y1gpPbmeV0AsHYdQhgZvaGdHy3DCzuC1RQJkm2V9_5euRJRFMnhioZPmbdN0mfB7MoPh2xU_Q8Fw==\\\"}]\",\"madeAt\":1700000000000,\"privacy\":\"trusting\"}",
+            "{\"changes\":\"[{\\\"op\\\":\\\"set\\\",\\\"key\\\":\\\"co_zLCKesN77eKw7wmv4qFTvNko3AK\\\",\\\"value\\\":\\\"admin\\\"}]\",\"madeAt\":1700000000000,\"privacy\":\"trusting\"}",
+            "{\"changes\":\"[{\\\"op\\\":\\\"set\\\",\\\"key\\\":\\\"key_z3G1sH68mugDPWtmmY_for_co_zLCKesN77eKw7wmv4qFTvNko3AK\\\",\\\"value\\\":\\\"sealed_UPVsX-xJbYpCMndNSJvtmp0g-9U-7Ke8HRx2jNsYvn6zbbc5hjeJnrxqXM8fr2t6ekE3Yboyi4DJp3wFbTeuyqioqSwIisbEqQg==\\\"}]\",\"madeAt\":1700000000000,\"privacy\":\"trusting\"}"
+          ],
+          "lastSignature": "signature_zN7ANViK3NNw56cckHMjiLtVBZCUwW6AVZQQxt5QfTGEYdLSyLYXWo9t8w7FrNejB5AhicBAMy9AkwpFfWZatdHD"
+        },
+        {
+          "sessionId": "co_zUGQrkaYiZrjKaNgqQgARcDd54d_session_zG8MqseX8L3A",
+          "signerId": "signer_zDruMRDEak534vwq2jLXRLzpX5pLcmVwKNvL3t7Aga2Fu",
+          "transactions": [
+            "{\"changes\":\"[{\\\"op\\\":\\\"set\\\",\\\"key\\\":\\\"sealer_zGrkQ8Tp2PDA2jbpdeLW4fGCag48uoKkYAEyuspPrLuBr/signer_zF522K9jkQMKQ5vLVRpgiHH4R65Z8f6E9wJcuh2D4XL4Y\\\",\\\"value\\\":\\\"writer\\\"}]\",\"madeAt\":1700000000000,\"privacy\":\"trusting\"}"
+          ],
+          "lastSignature": "signature_ztRy5o1ASnNSaTdx7rG8cii61tScpR7oybrGJgdeqDDUBzCEcHAXCcazGvDRx9vCS3Pde2d6hMBPbNWnVuprJCZe"
+        },
+        {
+          "sessionId": "co_zLCKesN77eKw7wmv4qFTvNko3AK_session_zKueyxTmgVCU",
+          "signerId": "signer_z4wTCgS3PBV2naiSxExwxXsXJ3pXsFVn1ZVUB4dRdXUX5",
+          "transactions": [
+            "{\"changes\":\"[{\\\"op\\\":\\\"set\\\",\\\"key\\\":\\\"sealer_zGrkQ8Tp2PDA2jbpdeLW4fGCag48uoKkYAEyuspPrLuBr/signer_zF522K9jkQMKQ5vLVRpgiHH4R65Z8f6E9wJcuh2D4XL4Y\\\",\\\"value\\\":\\\"reader\\\"}]\",\"madeAt\":1700000000000,\"privacy\":\"trusting\"}"
+          ],
+          "lastSignature": "signature_z5tpQxAdkfEbHyaY6pBGXHuY4s3DYCNGryDw3FMtsnjCbHbXuuxdmSZ9c4GNiGTGJ6PCbx65bvWtrb8sngqN7jbax"
+        }
+      ]
+    },
+    {
+      "coId": "co_zUGQrkaYiZrjKaNgqQgARcDd54d",
+      "headerJson": "{\"createdAt\":null,\"meta\":{\"type\":\"account\"},\"ruleset\":{\"initialAdmin\":\"sealer_z3UGZzHmcH4ZcCSDJWNbz64yR61aQnNiyCotGX3jHYWSe/signer_zDruMRDEak534vwq2jLXRLzpX5pLcmVwKNvL3t7Aga2Fu\",\"type\":\"group\"},\"type\":\"comap\",\"uniqueness\":null}",
+      "sessions": [
+        {
+          "sessionId": "sealer_z3UGZzHmcH4ZcCSDJWNbz64yR61aQnNiyCotGX3jHYWSe/signer_zDruMRDEak534vwq2jLXRLzpX5pLcmVwKNvL3t7Aga2Fu_session_zEVKr3GHzYsK",
+          "signerId": "signer_zDruMRDEak534vwq2jLXRLzpX5pLcmVwKNvL3t7Aga2Fu",
+          "transactions": [
+            "{\"changes\":\"[{\\\"op\\\":\\\"set\\\",\\\"key\\\":\\\"sealer_z3UGZzHmcH4ZcCSDJWNbz64yR61aQnNiyCotGX3jHYWSe/signer_zDruMRDEak534vwq2jLXRLzpX5pLcmVwKNvL3t7Aga2Fu\\\",\\\"value\\\":\\\"admin\\\"}]\",\"madeAt\":1700000000000,\"privacy\":\"trusting\"}",
+            "{\"changes\":\"[{\\\"op\\\":\\\"set\\\",\\\"key\\\":\\\"key_zhERs1SiZond2SwAf_for_sealer_z3UGZzHmcH4ZcCSDJWNbz64yR61aQnNiyCotGX3jHYWSe/signer_zDruMRDEak534vwq2jLXRLzpX5pLcmVwKNvL3t7Aga2Fu\\\",\\\"value\\\":\\\"sealed_U7ZqDBCtvKhI-LifoTEMou0bueD_DDoHsGWqyQHkq8Ez085iIsu9pHF-ETVuzLJBHhNpzzEpx2Domt6dOYicYMqw4YEnrpKjWVA==\\\"}]\",\"madeAt\":1700000000000,\"privacy\":\"trusting\"}",
+            "{\"changes\":\"[{\\\"op\\\":\\\"set\\\",\\\"key\\\":\\\"readKey\\\",\\\"value\\\":\\\"key_zhERs1SiZond2SwAf\\\"}]\",\"madeAt\":1700000000000,\"privacy\":\"trusting\"}"
+          ],
+          "lastSignature": "signature_z2JU4Y8P7wJ5AN7Ztvi2s6SJeQdz6XaZyrw9PyQbpneeDrAHniHfMJgd5tjLdkqviwM6qnNRHQCZjyZpCaheP2jgf"
+        }
+      ]
+    },
+    {
+      "coId": "co_zLCKesN77eKw7wmv4qFTvNko3AK",
+      "headerJson": "{\"createdAt\":null,\"meta\":{\"type\":\"account\"},\"ruleset\":{\"initialAdmin\":\"sealer_zB2xngFnT5bTqi2qCb1vuhQdgyinRbn3waYbLV23rG6X1/signer_z4wTCgS3PBV2naiSxExwxXsXJ3pXsFVn1ZVUB4dRdXUX5\",\"type\":\"group\"},\"type\":\"comap\",\"uniqueness\":null}",
+      "sessions": [
+        {
+          "sessionId": "sealer_zB2xngFnT5bTqi2qCb1vuhQdgyinRbn3waYbLV23rG6X1/signer_z4wTCgS3PBV2naiSxExwxXsXJ3pXsFVn1ZVUB4dRdXUX5_session_zh5pzQtXC5xg",
+          "signerId": "signer_z4wTCgS3PBV2naiSxExwxXsXJ3pXsFVn1ZVUB4dRdXUX5",
+          "transactions": [
+            "{\"changes\":\"[{\\\"op\\\":\\\"set\\\",\\\"key\\\":\\\"sealer_zB2xngFnT5bTqi2qCb1vuhQdgyinRbn3waYbLV23rG6X1/signer_z4wTCgS3PBV2naiSxExwxXsXJ3pXsFVn1ZVUB4dRdXUX5\\\",\\\"value\\\":\\\"admin\\\"}]\",\"madeAt\":1700000000000,\"privacy\":\"trusting\"}",
+            "{\"changes\":\"[{\\\"op\\\":\\\"set\\\",\\\"key\\\":\\\"key_z2dt3CuscmzfkHewJh_for_sealer_zB2xngFnT5bTqi2qCb1vuhQdgyinRbn3waYbLV23rG6X1/signer_z4wTCgS3PBV2naiSxExwxXsXJ3pXsFVn1ZVUB4dRdXUX5\\\",\\\"value\\\":\\\"sealed_UeMGZC_WblBIwWRkMKOg6WfOIGGqPa8vE9yCMNDUsJx-6nzKTQ-mVVCO1IHzHYVCFQraroZ0_taZMUEMSKXQ5zQWeVwanLUXMqg==\\\"}]\",\"madeAt\":1700000000000,\"privacy\":\"trusting\"}",
+            "{\"changes\":\"[{\\\"op\\\":\\\"set\\\",\\\"key\\\":\\\"readKey\\\",\\\"value\\\":\\\"key_z2dt3CuscmzfkHewJh\\\"}]\",\"madeAt\":1700000000000,\"privacy\":\"trusting\"}"
+          ],
+          "lastSignature": "signature_z2yWKDMquLBgEGR96X1nCucLp7aVJumj1FCMvmjqbURJE1PxJTtv9fgsBiq3192grvPwpeMWTnqBXKZJzFhajdNF1"
+        }
+      ]
+    }
+  ],
+  "verdicts": {
+    "co_zfF4FnTK4hX5gj2Lzss8Zxp2HTh": [
+      {
+        "sessionId": "sealer_z2LpqCDsxqjirjfpv5gr1szi2Jr7GXexhhrnLZMQnVJKE/signer_z9MvDTsziXXoNhw4DCB26f6UYJ9EtSGbDy9LM7HmxDfjE_session_zF8hAYBAgfGu",
+        "txIndex": 0,
+        "valid": true,
+        "reason": null
+      },
+      {
+        "sessionId": "sealer_z2LpqCDsxqjirjfpv5gr1szi2Jr7GXexhhrnLZMQnVJKE/signer_z9MvDTsziXXoNhw4DCB26f6UYJ9EtSGbDy9LM7HmxDfjE_session_zF8hAYBAgfGu",
+        "txIndex": 1,
+        "valid": true,
+        "reason": null
+      },
+      {
+        "sessionId": "sealer_z2LpqCDsxqjirjfpv5gr1szi2Jr7GXexhhrnLZMQnVJKE/signer_z9MvDTsziXXoNhw4DCB26f6UYJ9EtSGbDy9LM7HmxDfjE_session_zF8hAYBAgfGu",
+        "txIndex": 2,
+        "valid": true,
+        "reason": null
+      },
+      {
+        "sessionId": "sealer_z2LpqCDsxqjirjfpv5gr1szi2Jr7GXexhhrnLZMQnVJKE/signer_z9MvDTsziXXoNhw4DCB26f6UYJ9EtSGbDy9LM7HmxDfjE_session_zF8hAYBAgfGu",
+        "txIndex": 3,
+        "valid": true,
+        "reason": null
+      },
+      {
+        "sessionId": "sealer_z2LpqCDsxqjirjfpv5gr1szi2Jr7GXexhhrnLZMQnVJKE/signer_z9MvDTsziXXoNhw4DCB26f6UYJ9EtSGbDy9LM7HmxDfjE_session_zF8hAYBAgfGu",
+        "txIndex": 4,
+        "valid": true,
+        "reason": null
+      },
+      {
+        "sessionId": "sealer_z2LpqCDsxqjirjfpv5gr1szi2Jr7GXexhhrnLZMQnVJKE/signer_z9MvDTsziXXoNhw4DCB26f6UYJ9EtSGbDy9LM7HmxDfjE_session_zF8hAYBAgfGu",
+        "txIndex": 5,
+        "valid": true,
+        "reason": null
+      },
+      {
+        "sessionId": "sealer_z2LpqCDsxqjirjfpv5gr1szi2Jr7GXexhhrnLZMQnVJKE/signer_z9MvDTsziXXoNhw4DCB26f6UYJ9EtSGbDy9LM7HmxDfjE_session_zF8hAYBAgfGu",
+        "txIndex": 6,
+        "valid": true,
+        "reason": null
+      },
+      {
+        "sessionId": "sealer_z2LpqCDsxqjirjfpv5gr1szi2Jr7GXexhhrnLZMQnVJKE/signer_z9MvDTsziXXoNhw4DCB26f6UYJ9EtSGbDy9LM7HmxDfjE_session_zF8hAYBAgfGu",
+        "txIndex": 7,
+        "valid": true,
+        "reason": null
+      },
+      {
+        "sessionId": "co_zUGQrkaYiZrjKaNgqQgARcDd54d_session_zG8MqseX8L3A",
+        "txIndex": 0,
+        "valid": true,
+        "reason": null
+      },
+      {
+        "sessionId": "co_zLCKesN77eKw7wmv4qFTvNko3AK_session_zKueyxTmgVCU",
+        "txIndex": 0,
+        "valid": true,
+        "reason": null
+      }
+    ]
+  },
+  "roleQueries": [
+    {
+      "groupId": "co_zfF4FnTK4hX5gj2Lzss8Zxp2HTh",
+      "member": "sealer_zGrkQ8Tp2PDA2jbpdeLW4fGCag48uoKkYAEyuspPrLuBr/signer_zF522K9jkQMKQ5vLVRpgiHH4R65Z8f6E9wJcuh2D4XL4Y",
+      "atTime": null,
+      "expectedRole": "reader"
+    }
+  ]
+}

--- a/crates/cojson-core/data/group_engine/deep_parent_chain.json
+++ b/crates/cojson-core/data/group_engine/deep_parent_chain.json
@@ -1,0 +1,311 @@
+{
+  "description": "3-level chain (grandparent -> parent -> child) with a mid-chain revocation and time-based queries",
+  "covalues": [
+    {
+      "coId": "co_z76qaFotJb3Nbnar8k3Hk3CXCTg",
+      "headerJson": "{\"createdAt\":\"2023-11-14T22:13:20.000Z\",\"meta\":null,\"ruleset\":{\"initialAdmin\":\"sealer_z86wRtf3PXp3GNtEJezxAxPyCb9L7iZxqGBJTPs6wxSdX/signer_zAsTRxudTbx2kxjukDb6ndC5NBZqmfFULMthLdScVdr3e\",\"type\":\"group\"},\"type\":\"comap\",\"uniqueness\":\"z3Per1dGwwdjbFxztQ\"}",
+      "sessions": [
+        {
+          "sessionId": "sealer_z86wRtf3PXp3GNtEJezxAxPyCb9L7iZxqGBJTPs6wxSdX/signer_zAsTRxudTbx2kxjukDb6ndC5NBZqmfFULMthLdScVdr3e_session_zD4h7Mxmjetx",
+          "signerId": "sealer_z86wRtf3PXp3GNtEJezxAxPyCb9L7iZxqGBJTPs6wxSdX/signer_zAsTRxudTbx2kxjukDb6ndC5NBZqmfFULMthLdScVdr3e",
+          "transactions": [
+            "{\"changes\":\"[{\\\"op\\\":\\\"set\\\",\\\"key\\\":\\\"sealer_z86wRtf3PXp3GNtEJezxAxPyCb9L7iZxqGBJTPs6wxSdX/signer_zAsTRxudTbx2kxjukDb6ndC5NBZqmfFULMthLdScVdr3e\\\",\\\"value\\\":\\\"admin\\\"}]\",\"madeAt\":1700000000000,\"privacy\":\"trusting\"}",
+            "{\"changes\":\"[{\\\"op\\\":\\\"set\\\",\\\"key\\\":\\\"key_z3kr8bxzaRhgHhAziM_for_sealer_z86wRtf3PXp3GNtEJezxAxPyCb9L7iZxqGBJTPs6wxSdX/signer_zAsTRxudTbx2kxjukDb6ndC5NBZqmfFULMthLdScVdr3e\\\",\\\"value\\\":\\\"sealed_UD6IK_iI16RniBeiWzXiVttkcYy0Pgx6NiuvmmvVOuEePo9YQeohohe3Em2hjOfXynTUR7ayOAa47FQr4uBZkwgWEJgbFlUUP5Q==\\\"}]\",\"madeAt\":1700000000000,\"privacy\":\"trusting\"}",
+            "{\"changes\":\"[{\\\"op\\\":\\\"set\\\",\\\"key\\\":\\\"readKey\\\",\\\"value\\\":\\\"key_z3kr8bxzaRhgHhAziM\\\"}]\",\"madeAt\":1700000000000,\"privacy\":\"trusting\"}",
+            "{\"changes\":\"[{\\\"op\\\":\\\"set\\\",\\\"key\\\":\\\"groupSealer\\\",\\\"value\\\":\\\"key_z3kr8bxzaRhgHhAziM@sealer_zDkXje9kPnrSCkv2pGEj8Fm23DxuM9ekY4m1jG1PjUaim\\\"}]\",\"madeAt\":1700000000000,\"privacy\":\"trusting\"}",
+            "{\"changes\":\"[{\\\"op\\\":\\\"set\\\",\\\"key\\\":\\\"parent_co_zKreXms5Qn24Fnv9cuSk24jeybm\\\",\\\"value\\\":\\\"extend\\\"}]\",\"madeAt\":1700000001000,\"privacy\":\"trusting\"}",
+            "{\"changes\":\"[{\\\"op\\\":\\\"set\\\",\\\"key\\\":\\\"key_z3kr8bxzaRhgHhAziM_for_key_z2Uj9c7gitYysPp1PD\\\",\\\"value\\\":\\\"encrypted_ULbmA24LxWmGpJ_cbLoHvdMR1BLKbKacx4wzXJsFnk35OdZMLJdcrecgK87w24ti3ecYSeIPfU8hK\\\"}]\",\"madeAt\":1700000001000,\"privacy\":\"trusting\"}",
+            "{\"changes\":\"[{\\\"op\\\":\\\"set\\\",\\\"key\\\":\\\"key_z527SmygB4k9HAZTaJ_for_sealer_z86wRtf3PXp3GNtEJezxAxPyCb9L7iZxqGBJTPs6wxSdX/signer_zAsTRxudTbx2kxjukDb6ndC5NBZqmfFULMthLdScVdr3e\\\",\\\"value\\\":\\\"sealed_UnWkT7Olf-iCh0k90lRWWOmyKZE86cGKATuZ_Aex12RKnllvGJJDBRDqkivfZr652CRM7qjYGzdaV9BJtQQqpNXTSt7qNScuJWw==\\\"}]\",\"madeAt\":1700000004000,\"privacy\":\"trusting\"}",
+            "{\"changes\":\"[{\\\"op\\\":\\\"set\\\",\\\"key\\\":\\\"key_z3kr8bxzaRhgHhAziM_for_key_z527SmygB4k9HAZTaJ\\\",\\\"value\\\":\\\"encrypted_Ui8-gaPBbf0sVlJFIpnmjtPOwP1qBlMqDbzlMeuctt9j1UYLniTFpMxeyjdAusM2909M6Jd9QW9th\\\"}]\",\"madeAt\":1700000004000,\"privacy\":\"trusting\"}",
+            "{\"changes\":\"[{\\\"op\\\":\\\"set\\\",\\\"key\\\":\\\"readKey\\\",\\\"value\\\":\\\"key_z527SmygB4k9HAZTaJ\\\"}]\",\"madeAt\":1700000004000,\"privacy\":\"trusting\"}",
+            "{\"changes\":\"[{\\\"op\\\":\\\"set\\\",\\\"key\\\":\\\"groupSealer\\\",\\\"value\\\":\\\"key_z527SmygB4k9HAZTaJ@sealer_zGk3iNb3nwUrQ4wkSqU43qwP6cYsSD567zAeoRWqHbLcd\\\"}]\",\"madeAt\":1700000004000,\"privacy\":\"trusting\"}",
+            "{\"changes\":\"[{\\\"op\\\":\\\"set\\\",\\\"key\\\":\\\"key_z527SmygB4k9HAZTaJ_for_key_zFTXRM388DMmUs5A2\\\",\\\"value\\\":\\\"encrypted_UB_mr0EJ74AwLFaeTmE2DZ-lK7MKT3jGy8l3SjaM_SRa-lG57MR5SRYocnKMyixoz4pP7FJefVK1r\\\"}]\",\"madeAt\":1700000004000,\"privacy\":\"trusting\"}"
+          ],
+          "lastSignature": "signature_z2fAscSgcfXExXGLLnvdYLnkja7jsNKrBJ3gDRa873LaKxFSEVMVd2yZyk2xVE19558oMaeVRukL97uZzPoKjg3B9"
+        }
+      ]
+    },
+    {
+      "coId": "co_zKreXms5Qn24Fnv9cuSk24jeybm",
+      "headerJson": "{\"createdAt\":\"2023-11-14T22:13:20.000Z\",\"meta\":null,\"ruleset\":{\"initialAdmin\":\"sealer_z86wRtf3PXp3GNtEJezxAxPyCb9L7iZxqGBJTPs6wxSdX/signer_zAsTRxudTbx2kxjukDb6ndC5NBZqmfFULMthLdScVdr3e\",\"type\":\"group\"},\"type\":\"comap\",\"uniqueness\":\"z25uuKKRqCuUD6PG3L\"}",
+      "sessions": [
+        {
+          "sessionId": "sealer_z86wRtf3PXp3GNtEJezxAxPyCb9L7iZxqGBJTPs6wxSdX/signer_zAsTRxudTbx2kxjukDb6ndC5NBZqmfFULMthLdScVdr3e_session_zD4h7Mxmjetx",
+          "signerId": "sealer_z86wRtf3PXp3GNtEJezxAxPyCb9L7iZxqGBJTPs6wxSdX/signer_zAsTRxudTbx2kxjukDb6ndC5NBZqmfFULMthLdScVdr3e",
+          "transactions": [
+            "{\"changes\":\"[{\\\"op\\\":\\\"set\\\",\\\"key\\\":\\\"sealer_z86wRtf3PXp3GNtEJezxAxPyCb9L7iZxqGBJTPs6wxSdX/signer_zAsTRxudTbx2kxjukDb6ndC5NBZqmfFULMthLdScVdr3e\\\",\\\"value\\\":\\\"admin\\\"}]\",\"madeAt\":1700000000000,\"privacy\":\"trusting\"}",
+            "{\"changes\":\"[{\\\"op\\\":\\\"set\\\",\\\"key\\\":\\\"key_z2Uj9c7gitYysPp1PD_for_sealer_z86wRtf3PXp3GNtEJezxAxPyCb9L7iZxqGBJTPs6wxSdX/signer_zAsTRxudTbx2kxjukDb6ndC5NBZqmfFULMthLdScVdr3e\\\",\\\"value\\\":\\\"sealed_UK8CqwucUG365VIbWzONmn_kDvFAdZyYqh-vsWROFUVuyIzaUTYbC-CamkNc6SVDhcM1ITKSsL3_VWR8Fbc93eV3lR777Bugp5A==\\\"}]\",\"madeAt\":1700000000000,\"privacy\":\"trusting\"}",
+            "{\"changes\":\"[{\\\"op\\\":\\\"set\\\",\\\"key\\\":\\\"readKey\\\",\\\"value\\\":\\\"key_z2Uj9c7gitYysPp1PD\\\"}]\",\"madeAt\":1700000000000,\"privacy\":\"trusting\"}",
+            "{\"changes\":\"[{\\\"op\\\":\\\"set\\\",\\\"key\\\":\\\"groupSealer\\\",\\\"value\\\":\\\"key_z2Uj9c7gitYysPp1PD@sealer_zET3YKKEPmXkDXLSSNAtvUzFn6gM1orLrUoGom7xkn2ic\\\"}]\",\"madeAt\":1700000000000,\"privacy\":\"trusting\"}",
+            "{\"changes\":\"[{\\\"op\\\":\\\"set\\\",\\\"key\\\":\\\"parent_co_zBdyBBH1AP3LCgDr72hKUKcwoh\\\",\\\"value\\\":\\\"extend\\\"}]\",\"madeAt\":1700000001000,\"privacy\":\"trusting\"}",
+            "{\"changes\":\"[{\\\"op\\\":\\\"set\\\",\\\"key\\\":\\\"key_z2Uj9c7gitYysPp1PD_for_key_z31dGbXwquQbo7Nzzt\\\",\\\"value\\\":\\\"encrypted_Un3BABt2cuzW_oBc96uPckp0q3rW8DMI56c2QI90rGW3dju-qHDImI33RfPau0H4OTepwTu9V-V8h\\\"}]\",\"madeAt\":1700000001000,\"privacy\":\"trusting\"}",
+            "{\"changes\":\"[{\\\"op\\\":\\\"set\\\",\\\"key\\\":\\\"co_zMp8tCa4inZv2Qws1DX4TXohj4k\\\",\\\"value\\\":\\\"reader\\\"}]\",\"madeAt\":1700000003000,\"privacy\":\"trusting\"}",
+            "{\"changes\":\"[{\\\"op\\\":\\\"set\\\",\\\"key\\\":\\\"key_z2Uj9c7gitYysPp1PD_for_co_zMp8tCa4inZv2Qws1DX4TXohj4k\\\",\\\"value\\\":\\\"sealed_Urzynb4pQKoQgIAmxPwALTQmXOT217kmE0iG8Krmhq8pNpEmuKvks92iINasZDRIxEWGd8qEe18-i33zYj0ZVqwwJ-RjYqRKGjQ==\\\"}]\",\"madeAt\":1700000003000,\"privacy\":\"trusting\"}",
+            "{\"changes\":\"[{\\\"op\\\":\\\"set\\\",\\\"key\\\":\\\"key_zFTXRM388DMmUs5A2_for_sealer_z86wRtf3PXp3GNtEJezxAxPyCb9L7iZxqGBJTPs6wxSdX/signer_zAsTRxudTbx2kxjukDb6ndC5NBZqmfFULMthLdScVdr3e\\\",\\\"value\\\":\\\"sealed_Ul0hfNXBdNJWQE9OpIZxXc_EKuq2b-ftwHyEXeiooGNJc_YyuWMNDbjuzHxt02EkCQJpgwgSDYSoFXCZsnlB3LURtca5FVWkZQQ==\\\"}]\",\"madeAt\":1700000004000,\"privacy\":\"trusting\"}",
+            "{\"changes\":\"[{\\\"op\\\":\\\"set\\\",\\\"key\\\":\\\"key_z2Uj9c7gitYysPp1PD_for_key_zFTXRM388DMmUs5A2\\\",\\\"value\\\":\\\"encrypted_Uy3X4ZcYsvr3qwp2yT6mMKtZWjcdeUaR22HgsTI9bBXKG0bQWrG4cDHwCfDjvrGr-rTh4BUOZRsxb\\\"}]\",\"madeAt\":1700000004000,\"privacy\":\"trusting\"}",
+            "{\"changes\":\"[{\\\"op\\\":\\\"set\\\",\\\"key\\\":\\\"readKey\\\",\\\"value\\\":\\\"key_zFTXRM388DMmUs5A2\\\"}]\",\"madeAt\":1700000004000,\"privacy\":\"trusting\"}",
+            "{\"changes\":\"[{\\\"op\\\":\\\"set\\\",\\\"key\\\":\\\"groupSealer\\\",\\\"value\\\":\\\"key_zFTXRM388DMmUs5A2@sealer_zHsALTCpx7GjXEX759ShsJxiP5ZPDA1DzLAwaLgMxd1Km\\\"}]\",\"madeAt\":1700000004000,\"privacy\":\"trusting\"}",
+            "{\"changes\":\"[{\\\"op\\\":\\\"set\\\",\\\"key\\\":\\\"key_zFTXRM388DMmUs5A2_for_key_z31dGbXwquQbo7Nzzt\\\",\\\"value\\\":\\\"encrypted_U6T0nvkQM-2DRMg3apWUBnI6kzigKw4LBV4bIfomfDQ4MZVXZOSVUwt0aA9UZCl5zPxI5jHO4qI0q\\\"}]\",\"madeAt\":1700000004000,\"privacy\":\"trusting\"}",
+            "{\"changes\":\"[{\\\"op\\\":\\\"set\\\",\\\"key\\\":\\\"co_zMp8tCa4inZv2Qws1DX4TXohj4k\\\",\\\"value\\\":\\\"revoked\\\"}]\",\"madeAt\":1700000004000,\"privacy\":\"trusting\"}"
+          ],
+          "lastSignature": "signature_z2HwzrHvtf3RKhPySqGkNSqBWXGzcn61U7pHgo4MHPeTBLHNAqcyeWynzQjtGSY6UgrgA91DAR4zbUsGYuSJ9eLUN"
+        }
+      ]
+    },
+    {
+      "coId": "co_zBdyBBH1AP3LCgDr72hKUKcwoh",
+      "headerJson": "{\"createdAt\":\"2023-11-14T22:13:20.000Z\",\"meta\":null,\"ruleset\":{\"initialAdmin\":\"sealer_z86wRtf3PXp3GNtEJezxAxPyCb9L7iZxqGBJTPs6wxSdX/signer_zAsTRxudTbx2kxjukDb6ndC5NBZqmfFULMthLdScVdr3e\",\"type\":\"group\"},\"type\":\"comap\",\"uniqueness\":\"z3nz9j1m3GZre5S2mk\"}",
+      "sessions": [
+        {
+          "sessionId": "sealer_z86wRtf3PXp3GNtEJezxAxPyCb9L7iZxqGBJTPs6wxSdX/signer_zAsTRxudTbx2kxjukDb6ndC5NBZqmfFULMthLdScVdr3e_session_zD4h7Mxmjetx",
+          "signerId": "sealer_z86wRtf3PXp3GNtEJezxAxPyCb9L7iZxqGBJTPs6wxSdX/signer_zAsTRxudTbx2kxjukDb6ndC5NBZqmfFULMthLdScVdr3e",
+          "transactions": [
+            "{\"changes\":\"[{\\\"op\\\":\\\"set\\\",\\\"key\\\":\\\"sealer_z86wRtf3PXp3GNtEJezxAxPyCb9L7iZxqGBJTPs6wxSdX/signer_zAsTRxudTbx2kxjukDb6ndC5NBZqmfFULMthLdScVdr3e\\\",\\\"value\\\":\\\"admin\\\"}]\",\"madeAt\":1700000000000,\"privacy\":\"trusting\"}",
+            "{\"changes\":\"[{\\\"op\\\":\\\"set\\\",\\\"key\\\":\\\"key_z31dGbXwquQbo7Nzzt_for_sealer_z86wRtf3PXp3GNtEJezxAxPyCb9L7iZxqGBJTPs6wxSdX/signer_zAsTRxudTbx2kxjukDb6ndC5NBZqmfFULMthLdScVdr3e\\\",\\\"value\\\":\\\"sealed_UFL2sboiBrsdSsbnKbrieHVFQAibWI3uExDSBQOvHzygQk7499NODFJmH1YnbjoBAbbTJELavdBAHbyMBA1tCTG3ex5Q2N8Hfhw==\\\"}]\",\"madeAt\":1700000000000,\"privacy\":\"trusting\"}",
+            "{\"changes\":\"[{\\\"op\\\":\\\"set\\\",\\\"key\\\":\\\"readKey\\\",\\\"value\\\":\\\"key_z31dGbXwquQbo7Nzzt\\\"}]\",\"madeAt\":1700000000000,\"privacy\":\"trusting\"}",
+            "{\"changes\":\"[{\\\"op\\\":\\\"set\\\",\\\"key\\\":\\\"groupSealer\\\",\\\"value\\\":\\\"key_z31dGbXwquQbo7Nzzt@sealer_z4zLpELfFe4fymwCZStxo4KWQAkL3cgbZND9S6GnJ35mM\\\"}]\",\"madeAt\":1700000000000,\"privacy\":\"trusting\"}",
+            "{\"changes\":\"[{\\\"op\\\":\\\"set\\\",\\\"key\\\":\\\"co_zMp8tCa4inZv2Qws1DX4TXohj4k\\\",\\\"value\\\":\\\"writer\\\"}]\",\"madeAt\":1700000002000,\"privacy\":\"trusting\"}",
+            "{\"changes\":\"[{\\\"op\\\":\\\"set\\\",\\\"key\\\":\\\"key_z31dGbXwquQbo7Nzzt_for_co_zMp8tCa4inZv2Qws1DX4TXohj4k\\\",\\\"value\\\":\\\"sealed_UI3vZSAV0P0GnytxtqqQGS9Jb6RVV3y35D1ULX05eva33RKaopz--Qcf9ExGubqugebFxlvebl5XZpNelnFetVtKWe7Xjeg9qgw==\\\"}]\",\"madeAt\":1700000002000,\"privacy\":\"trusting\"}"
+          ],
+          "lastSignature": "signature_z58pMZHFGgJbXJcYCMTUE5EfRXbGmTf5v4Kj7GvYMAXgkaVWfqmQthtyTm41gEYAgaiZ5GR6koAPC1Vvu5R6xkcpi"
+        }
+      ]
+    },
+    {
+      "coId": "co_zMp8tCa4inZv2Qws1DX4TXohj4k",
+      "headerJson": "{\"createdAt\":null,\"meta\":{\"type\":\"account\"},\"ruleset\":{\"initialAdmin\":\"sealer_z22vt7meFGvisvT5J1vJ9c8J6aWeWsLvKsKrz2vBz1h1Q/signer_zA2WjF4MRgNckHJg2SSoU3q4RcaPxxNuvKQfDJSXvwZRD\",\"type\":\"group\"},\"type\":\"comap\",\"uniqueness\":null}",
+      "sessions": [
+        {
+          "sessionId": "sealer_z22vt7meFGvisvT5J1vJ9c8J6aWeWsLvKsKrz2vBz1h1Q/signer_zA2WjF4MRgNckHJg2SSoU3q4RcaPxxNuvKQfDJSXvwZRD_session_z4WDmJW8jhFi",
+          "signerId": "signer_zA2WjF4MRgNckHJg2SSoU3q4RcaPxxNuvKQfDJSXvwZRD",
+          "transactions": [
+            "{\"changes\":\"[{\\\"op\\\":\\\"set\\\",\\\"key\\\":\\\"sealer_z22vt7meFGvisvT5J1vJ9c8J6aWeWsLvKsKrz2vBz1h1Q/signer_zA2WjF4MRgNckHJg2SSoU3q4RcaPxxNuvKQfDJSXvwZRD\\\",\\\"value\\\":\\\"admin\\\"}]\",\"madeAt\":1700000001000,\"privacy\":\"trusting\"}",
+            "{\"changes\":\"[{\\\"op\\\":\\\"set\\\",\\\"key\\\":\\\"key_z3KEHDoWgTvgCGUcda_for_sealer_z22vt7meFGvisvT5J1vJ9c8J6aWeWsLvKsKrz2vBz1h1Q/signer_zA2WjF4MRgNckHJg2SSoU3q4RcaPxxNuvKQfDJSXvwZRD\\\",\\\"value\\\":\\\"sealed_Ubwibh1fxyijqEHx3ir4dBqXKI3Qe6NC7M5KUwvqh9bJQBBiF4y82d8hMx95hd3lRfmOjWOABYatdzGY4TnGjJ9vAKIsM3_gHlQ==\\\"}]\",\"madeAt\":1700000001000,\"privacy\":\"trusting\"}",
+            "{\"changes\":\"[{\\\"op\\\":\\\"set\\\",\\\"key\\\":\\\"readKey\\\",\\\"value\\\":\\\"key_z3KEHDoWgTvgCGUcda\\\"}]\",\"madeAt\":1700000001000,\"privacy\":\"trusting\"}"
+          ],
+          "lastSignature": "signature_z5AACnSLkQq1WsE8qXzdJ54LfJNedV5hck1ERxR7qoeQy4EjCVKB1QxwhhD46zkzdaiDvu7fJg6JGVtriT2tpRTef"
+        }
+      ]
+    }
+  ],
+  "verdicts": {
+    "co_z76qaFotJb3Nbnar8k3Hk3CXCTg": [
+      {
+        "sessionId": "sealer_z86wRtf3PXp3GNtEJezxAxPyCb9L7iZxqGBJTPs6wxSdX/signer_zAsTRxudTbx2kxjukDb6ndC5NBZqmfFULMthLdScVdr3e_session_zD4h7Mxmjetx",
+        "txIndex": 0,
+        "valid": true,
+        "reason": null
+      },
+      {
+        "sessionId": "sealer_z86wRtf3PXp3GNtEJezxAxPyCb9L7iZxqGBJTPs6wxSdX/signer_zAsTRxudTbx2kxjukDb6ndC5NBZqmfFULMthLdScVdr3e_session_zD4h7Mxmjetx",
+        "txIndex": 1,
+        "valid": true,
+        "reason": null
+      },
+      {
+        "sessionId": "sealer_z86wRtf3PXp3GNtEJezxAxPyCb9L7iZxqGBJTPs6wxSdX/signer_zAsTRxudTbx2kxjukDb6ndC5NBZqmfFULMthLdScVdr3e_session_zD4h7Mxmjetx",
+        "txIndex": 2,
+        "valid": true,
+        "reason": null
+      },
+      {
+        "sessionId": "sealer_z86wRtf3PXp3GNtEJezxAxPyCb9L7iZxqGBJTPs6wxSdX/signer_zAsTRxudTbx2kxjukDb6ndC5NBZqmfFULMthLdScVdr3e_session_zD4h7Mxmjetx",
+        "txIndex": 3,
+        "valid": true,
+        "reason": null
+      },
+      {
+        "sessionId": "sealer_z86wRtf3PXp3GNtEJezxAxPyCb9L7iZxqGBJTPs6wxSdX/signer_zAsTRxudTbx2kxjukDb6ndC5NBZqmfFULMthLdScVdr3e_session_zD4h7Mxmjetx",
+        "txIndex": 4,
+        "valid": true,
+        "reason": null
+      },
+      {
+        "sessionId": "sealer_z86wRtf3PXp3GNtEJezxAxPyCb9L7iZxqGBJTPs6wxSdX/signer_zAsTRxudTbx2kxjukDb6ndC5NBZqmfFULMthLdScVdr3e_session_zD4h7Mxmjetx",
+        "txIndex": 5,
+        "valid": true,
+        "reason": null
+      },
+      {
+        "sessionId": "sealer_z86wRtf3PXp3GNtEJezxAxPyCb9L7iZxqGBJTPs6wxSdX/signer_zAsTRxudTbx2kxjukDb6ndC5NBZqmfFULMthLdScVdr3e_session_zD4h7Mxmjetx",
+        "txIndex": 6,
+        "valid": true,
+        "reason": null
+      },
+      {
+        "sessionId": "sealer_z86wRtf3PXp3GNtEJezxAxPyCb9L7iZxqGBJTPs6wxSdX/signer_zAsTRxudTbx2kxjukDb6ndC5NBZqmfFULMthLdScVdr3e_session_zD4h7Mxmjetx",
+        "txIndex": 7,
+        "valid": true,
+        "reason": null
+      },
+      {
+        "sessionId": "sealer_z86wRtf3PXp3GNtEJezxAxPyCb9L7iZxqGBJTPs6wxSdX/signer_zAsTRxudTbx2kxjukDb6ndC5NBZqmfFULMthLdScVdr3e_session_zD4h7Mxmjetx",
+        "txIndex": 8,
+        "valid": true,
+        "reason": null
+      },
+      {
+        "sessionId": "sealer_z86wRtf3PXp3GNtEJezxAxPyCb9L7iZxqGBJTPs6wxSdX/signer_zAsTRxudTbx2kxjukDb6ndC5NBZqmfFULMthLdScVdr3e_session_zD4h7Mxmjetx",
+        "txIndex": 9,
+        "valid": true,
+        "reason": null
+      },
+      {
+        "sessionId": "sealer_z86wRtf3PXp3GNtEJezxAxPyCb9L7iZxqGBJTPs6wxSdX/signer_zAsTRxudTbx2kxjukDb6ndC5NBZqmfFULMthLdScVdr3e_session_zD4h7Mxmjetx",
+        "txIndex": 10,
+        "valid": true,
+        "reason": null
+      }
+    ],
+    "co_zKreXms5Qn24Fnv9cuSk24jeybm": [
+      {
+        "sessionId": "sealer_z86wRtf3PXp3GNtEJezxAxPyCb9L7iZxqGBJTPs6wxSdX/signer_zAsTRxudTbx2kxjukDb6ndC5NBZqmfFULMthLdScVdr3e_session_zD4h7Mxmjetx",
+        "txIndex": 0,
+        "valid": true,
+        "reason": null
+      },
+      {
+        "sessionId": "sealer_z86wRtf3PXp3GNtEJezxAxPyCb9L7iZxqGBJTPs6wxSdX/signer_zAsTRxudTbx2kxjukDb6ndC5NBZqmfFULMthLdScVdr3e_session_zD4h7Mxmjetx",
+        "txIndex": 1,
+        "valid": true,
+        "reason": null
+      },
+      {
+        "sessionId": "sealer_z86wRtf3PXp3GNtEJezxAxPyCb9L7iZxqGBJTPs6wxSdX/signer_zAsTRxudTbx2kxjukDb6ndC5NBZqmfFULMthLdScVdr3e_session_zD4h7Mxmjetx",
+        "txIndex": 2,
+        "valid": true,
+        "reason": null
+      },
+      {
+        "sessionId": "sealer_z86wRtf3PXp3GNtEJezxAxPyCb9L7iZxqGBJTPs6wxSdX/signer_zAsTRxudTbx2kxjukDb6ndC5NBZqmfFULMthLdScVdr3e_session_zD4h7Mxmjetx",
+        "txIndex": 3,
+        "valid": true,
+        "reason": null
+      },
+      {
+        "sessionId": "sealer_z86wRtf3PXp3GNtEJezxAxPyCb9L7iZxqGBJTPs6wxSdX/signer_zAsTRxudTbx2kxjukDb6ndC5NBZqmfFULMthLdScVdr3e_session_zD4h7Mxmjetx",
+        "txIndex": 4,
+        "valid": true,
+        "reason": null
+      },
+      {
+        "sessionId": "sealer_z86wRtf3PXp3GNtEJezxAxPyCb9L7iZxqGBJTPs6wxSdX/signer_zAsTRxudTbx2kxjukDb6ndC5NBZqmfFULMthLdScVdr3e_session_zD4h7Mxmjetx",
+        "txIndex": 5,
+        "valid": true,
+        "reason": null
+      },
+      {
+        "sessionId": "sealer_z86wRtf3PXp3GNtEJezxAxPyCb9L7iZxqGBJTPs6wxSdX/signer_zAsTRxudTbx2kxjukDb6ndC5NBZqmfFULMthLdScVdr3e_session_zD4h7Mxmjetx",
+        "txIndex": 6,
+        "valid": true,
+        "reason": null
+      },
+      {
+        "sessionId": "sealer_z86wRtf3PXp3GNtEJezxAxPyCb9L7iZxqGBJTPs6wxSdX/signer_zAsTRxudTbx2kxjukDb6ndC5NBZqmfFULMthLdScVdr3e_session_zD4h7Mxmjetx",
+        "txIndex": 7,
+        "valid": true,
+        "reason": null
+      },
+      {
+        "sessionId": "sealer_z86wRtf3PXp3GNtEJezxAxPyCb9L7iZxqGBJTPs6wxSdX/signer_zAsTRxudTbx2kxjukDb6ndC5NBZqmfFULMthLdScVdr3e_session_zD4h7Mxmjetx",
+        "txIndex": 8,
+        "valid": true,
+        "reason": null
+      },
+      {
+        "sessionId": "sealer_z86wRtf3PXp3GNtEJezxAxPyCb9L7iZxqGBJTPs6wxSdX/signer_zAsTRxudTbx2kxjukDb6ndC5NBZqmfFULMthLdScVdr3e_session_zD4h7Mxmjetx",
+        "txIndex": 9,
+        "valid": true,
+        "reason": null
+      },
+      {
+        "sessionId": "sealer_z86wRtf3PXp3GNtEJezxAxPyCb9L7iZxqGBJTPs6wxSdX/signer_zAsTRxudTbx2kxjukDb6ndC5NBZqmfFULMthLdScVdr3e_session_zD4h7Mxmjetx",
+        "txIndex": 10,
+        "valid": true,
+        "reason": null
+      },
+      {
+        "sessionId": "sealer_z86wRtf3PXp3GNtEJezxAxPyCb9L7iZxqGBJTPs6wxSdX/signer_zAsTRxudTbx2kxjukDb6ndC5NBZqmfFULMthLdScVdr3e_session_zD4h7Mxmjetx",
+        "txIndex": 11,
+        "valid": true,
+        "reason": null
+      },
+      {
+        "sessionId": "sealer_z86wRtf3PXp3GNtEJezxAxPyCb9L7iZxqGBJTPs6wxSdX/signer_zAsTRxudTbx2kxjukDb6ndC5NBZqmfFULMthLdScVdr3e_session_zD4h7Mxmjetx",
+        "txIndex": 12,
+        "valid": true,
+        "reason": null
+      },
+      {
+        "sessionId": "sealer_z86wRtf3PXp3GNtEJezxAxPyCb9L7iZxqGBJTPs6wxSdX/signer_zAsTRxudTbx2kxjukDb6ndC5NBZqmfFULMthLdScVdr3e_session_zD4h7Mxmjetx",
+        "txIndex": 13,
+        "valid": true,
+        "reason": null
+      }
+    ],
+    "co_zBdyBBH1AP3LCgDr72hKUKcwoh": [
+      {
+        "sessionId": "sealer_z86wRtf3PXp3GNtEJezxAxPyCb9L7iZxqGBJTPs6wxSdX/signer_zAsTRxudTbx2kxjukDb6ndC5NBZqmfFULMthLdScVdr3e_session_zD4h7Mxmjetx",
+        "txIndex": 0,
+        "valid": true,
+        "reason": null
+      },
+      {
+        "sessionId": "sealer_z86wRtf3PXp3GNtEJezxAxPyCb9L7iZxqGBJTPs6wxSdX/signer_zAsTRxudTbx2kxjukDb6ndC5NBZqmfFULMthLdScVdr3e_session_zD4h7Mxmjetx",
+        "txIndex": 1,
+        "valid": true,
+        "reason": null
+      },
+      {
+        "sessionId": "sealer_z86wRtf3PXp3GNtEJezxAxPyCb9L7iZxqGBJTPs6wxSdX/signer_zAsTRxudTbx2kxjukDb6ndC5NBZqmfFULMthLdScVdr3e_session_zD4h7Mxmjetx",
+        "txIndex": 2,
+        "valid": true,
+        "reason": null
+      },
+      {
+        "sessionId": "sealer_z86wRtf3PXp3GNtEJezxAxPyCb9L7iZxqGBJTPs6wxSdX/signer_zAsTRxudTbx2kxjukDb6ndC5NBZqmfFULMthLdScVdr3e_session_zD4h7Mxmjetx",
+        "txIndex": 3,
+        "valid": true,
+        "reason": null
+      },
+      {
+        "sessionId": "sealer_z86wRtf3PXp3GNtEJezxAxPyCb9L7iZxqGBJTPs6wxSdX/signer_zAsTRxudTbx2kxjukDb6ndC5NBZqmfFULMthLdScVdr3e_session_zD4h7Mxmjetx",
+        "txIndex": 4,
+        "valid": true,
+        "reason": null
+      },
+      {
+        "sessionId": "sealer_z86wRtf3PXp3GNtEJezxAxPyCb9L7iZxqGBJTPs6wxSdX/signer_zAsTRxudTbx2kxjukDb6ndC5NBZqmfFULMthLdScVdr3e_session_zD4h7Mxmjetx",
+        "txIndex": 5,
+        "valid": true,
+        "reason": null
+      }
+    ]
+  },
+  "roleQueries": [
+    {
+      "groupId": "co_z76qaFotJb3Nbnar8k3Hk3CXCTg",
+      "member": "co_zMp8tCa4inZv2Qws1DX4TXohj4k",
+      "atTime": 1700000002000,
+      "expectedRole": "writer"
+    },
+    {
+      "groupId": "co_z76qaFotJb3Nbnar8k3Hk3CXCTg",
+      "member": "co_zMp8tCa4inZv2Qws1DX4TXohj4k",
+      "atTime": 1700000004000,
+      "expectedRole": "writer"
+    },
+    {
+      "groupId": "co_z76qaFotJb3Nbnar8k3Hk3CXCTg",
+      "member": "co_zMp8tCa4inZv2Qws1DX4TXohj4k",
+      "atTime": null,
+      "expectedRole": "writer"
+    },
+    {
+      "groupId": "co_zBdyBBH1AP3LCgDr72hKUKcwoh",
+      "member": "co_zMp8tCa4inZv2Qws1DX4TXohj4k",
+      "atTime": null,
+      "expectedRole": "writer"
+    }
+  ]
+}

--- a/crates/cojson-core/data/group_engine/everyone_roles.json
+++ b/crates/cojson-core/data/group_engine/everyone_roles.json
@@ -1,0 +1,133 @@
+{
+  "description": "everyone set to reader/writer/writeOnly/revoked (valid) and admin (invalid); everyone fallback for non-members",
+  "covalues": [
+    {
+      "coId": "co_z9xagpvf6qPANBBRC4sjEmh5wr1",
+      "headerJson": "{\"createdAt\":\"2023-11-14T22:13:20.000Z\",\"meta\":null,\"ruleset\":{\"initialAdmin\":\"sealer_zHfUEFixDbs5RwUiNikHZNtpr2TaNqwqXWc2f76sMu1V/signer_zHEMhz7XFQFy7Bj2Nz862Snw9xA7TLDdWRxhR6DQJLQCh\",\"type\":\"group\"},\"type\":\"comap\",\"uniqueness\":\"z5KU9UFP58riaz2b64\"}",
+      "sessions": [
+        {
+          "sessionId": "sealer_zHfUEFixDbs5RwUiNikHZNtpr2TaNqwqXWc2f76sMu1V/signer_zHEMhz7XFQFy7Bj2Nz862Snw9xA7TLDdWRxhR6DQJLQCh_session_zTJEJf7PYiSC",
+          "signerId": "sealer_zHfUEFixDbs5RwUiNikHZNtpr2TaNqwqXWc2f76sMu1V/signer_zHEMhz7XFQFy7Bj2Nz862Snw9xA7TLDdWRxhR6DQJLQCh",
+          "transactions": [
+            "{\"changes\":\"[{\\\"op\\\":\\\"set\\\",\\\"key\\\":\\\"sealer_zHfUEFixDbs5RwUiNikHZNtpr2TaNqwqXWc2f76sMu1V/signer_zHEMhz7XFQFy7Bj2Nz862Snw9xA7TLDdWRxhR6DQJLQCh\\\",\\\"value\\\":\\\"admin\\\"}]\",\"madeAt\":1700000000000,\"privacy\":\"trusting\"}",
+            "{\"changes\":\"[{\\\"op\\\":\\\"set\\\",\\\"key\\\":\\\"key_z3EnSWqdZ1AsLEhzQD_for_sealer_zHfUEFixDbs5RwUiNikHZNtpr2TaNqwqXWc2f76sMu1V/signer_zHEMhz7XFQFy7Bj2Nz862Snw9xA7TLDdWRxhR6DQJLQCh\\\",\\\"value\\\":\\\"sealed_UTXWV7hm1bWtzmmcgZ5eOL4VP_D0BKB1-CbZK3pWrAyi6d0cH5syHurLFx84Lwn6SFk9lxOEsluXMgP-_-vX5Qq90hABwaSmhWw==\\\"}]\",\"madeAt\":1700000000000,\"privacy\":\"trusting\"}",
+            "{\"changes\":\"[{\\\"op\\\":\\\"set\\\",\\\"key\\\":\\\"readKey\\\",\\\"value\\\":\\\"key_z3EnSWqdZ1AsLEhzQD\\\"}]\",\"madeAt\":1700000000000,\"privacy\":\"trusting\"}",
+            "{\"changes\":\"[{\\\"op\\\":\\\"set\\\",\\\"key\\\":\\\"groupSealer\\\",\\\"value\\\":\\\"key_z3EnSWqdZ1AsLEhzQD@sealer_zECeGrrSABYUMDJMREA4Q3dLhGSA2vnoX2MwUxYTAyDy5\\\"}]\",\"madeAt\":1700000000000,\"privacy\":\"trusting\"}",
+            "{\"changes\":\"[{\\\"op\\\":\\\"set\\\",\\\"key\\\":\\\"everyone\\\",\\\"value\\\":\\\"reader\\\"}]\",\"madeAt\":1700000001000,\"privacy\":\"trusting\"}",
+            "{\"changes\":\"[{\\\"op\\\":\\\"set\\\",\\\"key\\\":\\\"everyone\\\",\\\"value\\\":\\\"writer\\\"}]\",\"madeAt\":1700000002000,\"privacy\":\"trusting\"}",
+            "{\"changes\":\"[{\\\"op\\\":\\\"set\\\",\\\"key\\\":\\\"everyone\\\",\\\"value\\\":\\\"writeOnly\\\"}]\",\"madeAt\":1700000003000,\"privacy\":\"trusting\"}",
+            "{\"changes\":\"[{\\\"op\\\":\\\"set\\\",\\\"key\\\":\\\"everyone\\\",\\\"value\\\":\\\"revoked\\\"}]\",\"madeAt\":1700000004000,\"privacy\":\"trusting\"}",
+            "{\"changes\":\"[{\\\"op\\\":\\\"set\\\",\\\"key\\\":\\\"everyone\\\",\\\"value\\\":\\\"admin\\\"}]\",\"madeAt\":1700000005000,\"privacy\":\"trusting\"}"
+          ],
+          "lastSignature": "signature_z2RT5T2TCqbU458R76NwfK91VoiAwxVgr1aoGMmfgd5sy9cf8TrZC4qKU4h9PL23NpLwVhNHm6p2UDrVXtdhrtB5q"
+        }
+      ]
+    },
+    {
+      "coId": "co_zG2HeFQAR2LQNqBmJWtRHuFuApg",
+      "headerJson": "{\"createdAt\":null,\"meta\":{\"type\":\"account\"},\"ruleset\":{\"initialAdmin\":\"sealer_z3iF1F2t6ZhqETCXePheeKdjb1BFqZmEoj8NDsQqC1dks/signer_zAnKGYRSTUhx7DUZYp5XUWLEYoDpiE51HoNwfjwWL9aAN\",\"type\":\"group\"},\"type\":\"comap\",\"uniqueness\":null}",
+      "sessions": [
+        {
+          "sessionId": "sealer_z3iF1F2t6ZhqETCXePheeKdjb1BFqZmEoj8NDsQqC1dks/signer_zAnKGYRSTUhx7DUZYp5XUWLEYoDpiE51HoNwfjwWL9aAN_session_zYLiVJTT8DqC",
+          "signerId": "signer_zAnKGYRSTUhx7DUZYp5XUWLEYoDpiE51HoNwfjwWL9aAN",
+          "transactions": [
+            "{\"changes\":\"[{\\\"op\\\":\\\"set\\\",\\\"key\\\":\\\"sealer_z3iF1F2t6ZhqETCXePheeKdjb1BFqZmEoj8NDsQqC1dks/signer_zAnKGYRSTUhx7DUZYp5XUWLEYoDpiE51HoNwfjwWL9aAN\\\",\\\"value\\\":\\\"admin\\\"}]\",\"madeAt\":1700000000000,\"privacy\":\"trusting\"}",
+            "{\"changes\":\"[{\\\"op\\\":\\\"set\\\",\\\"key\\\":\\\"key_z2HTsrt3GrN414BeR9_for_sealer_z3iF1F2t6ZhqETCXePheeKdjb1BFqZmEoj8NDsQqC1dks/signer_zAnKGYRSTUhx7DUZYp5XUWLEYoDpiE51HoNwfjwWL9aAN\\\",\\\"value\\\":\\\"sealed_UfXYAkoKGfxoHwi2jLVEamL1DBvbIjE3QwJUXv-IfUMshsMjDb1_WbEW6JXERU_6YkQiuxuU5BGy4_TpyocWpt_kh7SxoWEWHVA==\\\"}]\",\"madeAt\":1700000000000,\"privacy\":\"trusting\"}",
+            "{\"changes\":\"[{\\\"op\\\":\\\"set\\\",\\\"key\\\":\\\"readKey\\\",\\\"value\\\":\\\"key_z2HTsrt3GrN414BeR9\\\"}]\",\"madeAt\":1700000000000,\"privacy\":\"trusting\"}"
+          ],
+          "lastSignature": "signature_z3DtutLmWg8xVybAQH8BJ9Fv9SwWsKT2uKSAWzds24Yhw1e1AKxB32YPtHm11xfGC1jGpN8wdQMLzWuW4wrayAvtw"
+        }
+      ]
+    }
+  ],
+  "verdicts": {
+    "co_z9xagpvf6qPANBBRC4sjEmh5wr1": [
+      {
+        "sessionId": "sealer_zHfUEFixDbs5RwUiNikHZNtpr2TaNqwqXWc2f76sMu1V/signer_zHEMhz7XFQFy7Bj2Nz862Snw9xA7TLDdWRxhR6DQJLQCh_session_zTJEJf7PYiSC",
+        "txIndex": 0,
+        "valid": true,
+        "reason": null
+      },
+      {
+        "sessionId": "sealer_zHfUEFixDbs5RwUiNikHZNtpr2TaNqwqXWc2f76sMu1V/signer_zHEMhz7XFQFy7Bj2Nz862Snw9xA7TLDdWRxhR6DQJLQCh_session_zTJEJf7PYiSC",
+        "txIndex": 1,
+        "valid": true,
+        "reason": null
+      },
+      {
+        "sessionId": "sealer_zHfUEFixDbs5RwUiNikHZNtpr2TaNqwqXWc2f76sMu1V/signer_zHEMhz7XFQFy7Bj2Nz862Snw9xA7TLDdWRxhR6DQJLQCh_session_zTJEJf7PYiSC",
+        "txIndex": 2,
+        "valid": true,
+        "reason": null
+      },
+      {
+        "sessionId": "sealer_zHfUEFixDbs5RwUiNikHZNtpr2TaNqwqXWc2f76sMu1V/signer_zHEMhz7XFQFy7Bj2Nz862Snw9xA7TLDdWRxhR6DQJLQCh_session_zTJEJf7PYiSC",
+        "txIndex": 3,
+        "valid": true,
+        "reason": null
+      },
+      {
+        "sessionId": "sealer_zHfUEFixDbs5RwUiNikHZNtpr2TaNqwqXWc2f76sMu1V/signer_zHEMhz7XFQFy7Bj2Nz862Snw9xA7TLDdWRxhR6DQJLQCh_session_zTJEJf7PYiSC",
+        "txIndex": 4,
+        "valid": true,
+        "reason": null
+      },
+      {
+        "sessionId": "sealer_zHfUEFixDbs5RwUiNikHZNtpr2TaNqwqXWc2f76sMu1V/signer_zHEMhz7XFQFy7Bj2Nz862Snw9xA7TLDdWRxhR6DQJLQCh_session_zTJEJf7PYiSC",
+        "txIndex": 5,
+        "valid": true,
+        "reason": null
+      },
+      {
+        "sessionId": "sealer_zHfUEFixDbs5RwUiNikHZNtpr2TaNqwqXWc2f76sMu1V/signer_zHEMhz7XFQFy7Bj2Nz862Snw9xA7TLDdWRxhR6DQJLQCh_session_zTJEJf7PYiSC",
+        "txIndex": 6,
+        "valid": true,
+        "reason": null
+      },
+      {
+        "sessionId": "sealer_zHfUEFixDbs5RwUiNikHZNtpr2TaNqwqXWc2f76sMu1V/signer_zHEMhz7XFQFy7Bj2Nz862Snw9xA7TLDdWRxhR6DQJLQCh_session_zTJEJf7PYiSC",
+        "txIndex": 7,
+        "valid": true,
+        "reason": null
+      },
+      {
+        "sessionId": "sealer_zHfUEFixDbs5RwUiNikHZNtpr2TaNqwqXWc2f76sMu1V/signer_zHEMhz7XFQFy7Bj2Nz862Snw9xA7TLDdWRxhR6DQJLQCh_session_zTJEJf7PYiSC",
+        "txIndex": 8,
+        "valid": false,
+        "reason": "Everyone can only be set to reader, writer, writeOnly or revoked"
+      }
+    ]
+  },
+  "roleQueries": [
+    {
+      "groupId": "co_z9xagpvf6qPANBBRC4sjEmh5wr1",
+      "member": "co_zG2HeFQAR2LQNqBmJWtRHuFuApg",
+      "atTime": 1700000001000,
+      "expectedRole": "reader"
+    },
+    {
+      "groupId": "co_z9xagpvf6qPANBBRC4sjEmh5wr1",
+      "member": "co_zG2HeFQAR2LQNqBmJWtRHuFuApg",
+      "atTime": 1700000002000,
+      "expectedRole": "writer"
+    },
+    {
+      "groupId": "co_z9xagpvf6qPANBBRC4sjEmh5wr1",
+      "member": "co_zG2HeFQAR2LQNqBmJWtRHuFuApg",
+      "atTime": 1700000004000,
+      "expectedRole": null
+    },
+    {
+      "groupId": "co_z9xagpvf6qPANBBRC4sjEmh5wr1",
+      "member": "everyone",
+      "atTime": 1700000002000,
+      "expectedRole": "writer"
+    },
+    {
+      "groupId": "co_z9xagpvf6qPANBBRC4sjEmh5wr1",
+      "member": "everyone",
+      "atTime": 1700000004000,
+      "expectedRole": null
+    }
+  ]
+}

--- a/crates/cojson-core/data/group_engine/initial_admin_self_promotion.json
+++ b/crates/cojson-core/data/group_engine/initial_admin_self_promotion.json
@@ -1,0 +1,57 @@
+{
+  "description": "fresh group whose first tx is the initial-admin self-promotion; a non-initialAdmin self-promotion is rejected",
+  "covalues": [
+    {
+      "coId": "co_zfhYqhutL2bEfQSw2WoLSa4kPA",
+      "headerJson": "{\"createdAt\":\"2026-07-03T23:11:06.968Z\",\"meta\":null,\"ruleset\":{\"initialAdmin\":\"sealer_z47ERcEzCiUxJXSLXvZpiRDxNE5m5m9dfdKYrCv1Ry49f/signer_z9dRyQrew2y9cMMJoEmDLrkRfwbJn7g1zRUkGCD7uZqDh\",\"type\":\"group\"},\"type\":\"comap\",\"uniqueness\":\"z2JSRSFmi57XrkyST4\"}",
+      "sessions": [
+        {
+          "sessionId": "sealer_z47ERcEzCiUxJXSLXvZpiRDxNE5m5m9dfdKYrCv1Ry49f/signer_z9dRyQrew2y9cMMJoEmDLrkRfwbJn7g1zRUkGCD7uZqDh_session_zUvhWcSNVyZE",
+          "signerId": "sealer_z47ERcEzCiUxJXSLXvZpiRDxNE5m5m9dfdKYrCv1Ry49f/signer_z9dRyQrew2y9cMMJoEmDLrkRfwbJn7g1zRUkGCD7uZqDh",
+          "transactions": [
+            "{\"changes\":\"[{\\\"op\\\":\\\"set\\\",\\\"key\\\":\\\"sealer_z47ERcEzCiUxJXSLXvZpiRDxNE5m5m9dfdKYrCv1Ry49f/signer_z9dRyQrew2y9cMMJoEmDLrkRfwbJn7g1zRUkGCD7uZqDh\\\",\\\"value\\\":\\\"admin\\\"}]\",\"madeAt\":1783120266968,\"privacy\":\"trusting\"}"
+          ],
+          "lastSignature": "signature_z3JadFiSTRicYqVdVSGercZYrughwoHRtymo7XZLS7pqdnrc8DQCRX25xTdD7yyvDX6GK3pKSKscA9ShF5h9hXbEc"
+        },
+        {
+          "sessionId": "sealer_zAondQcYX7Z9e8mdFaUbwv1FTAQSka55ZBA4dsjEWWzB9/signer_zGwgvdBgj1Gxr5hdFmfkU3sUvvgyypVSeLsmXSXE1pYrK_session_zETNiBG8WyPJ",
+          "signerId": "signer_zGwgvdBgj1Gxr5hdFmfkU3sUvvgyypVSeLsmXSXE1pYrK",
+          "transactions": [
+            "{\"changes\":\"[{\\\"op\\\":\\\"set\\\",\\\"key\\\":\\\"sealer_zAondQcYX7Z9e8mdFaUbwv1FTAQSka55ZBA4dsjEWWzB9/signer_zGwgvdBgj1Gxr5hdFmfkU3sUvvgyypVSeLsmXSXE1pYrK\\\",\\\"value\\\":\\\"admin\\\"}]\",\"madeAt\":1783120266969,\"privacy\":\"trusting\"}"
+          ],
+          "lastSignature": "signature_z4YWXh7Az3kb5WUNmk5SJfLSAh9ecBwjmfmpL4LWVcE7CUJo4MEDnnswnmw698R2UvLzBBNV31Z6RvADeoqfgb8Gc"
+        }
+      ]
+    }
+  ],
+  "verdicts": {
+    "co_zfhYqhutL2bEfQSw2WoLSa4kPA": [
+      {
+        "sessionId": "sealer_z47ERcEzCiUxJXSLXvZpiRDxNE5m5m9dfdKYrCv1Ry49f/signer_z9dRyQrew2y9cMMJoEmDLrkRfwbJn7g1zRUkGCD7uZqDh_session_zUvhWcSNVyZE",
+        "txIndex": 0,
+        "valid": true,
+        "reason": null
+      },
+      {
+        "sessionId": "sealer_zAondQcYX7Z9e8mdFaUbwv1FTAQSka55ZBA4dsjEWWzB9/signer_zGwgvdBgj1Gxr5hdFmfkU3sUvvgyypVSeLsmXSXE1pYrK_session_zETNiBG8WyPJ",
+        "txIndex": 0,
+        "valid": false,
+        "reason": "Group transaction must be made by current admin, manager, or invite"
+      }
+    ]
+  },
+  "roleQueries": [
+    {
+      "groupId": "co_zfhYqhutL2bEfQSw2WoLSa4kPA",
+      "member": "sealer_z47ERcEzCiUxJXSLXvZpiRDxNE5m5m9dfdKYrCv1Ry49f/signer_z9dRyQrew2y9cMMJoEmDLrkRfwbJn7g1zRUkGCD7uZqDh",
+      "atTime": null,
+      "expectedRole": "admin"
+    },
+    {
+      "groupId": "co_zfhYqhutL2bEfQSw2WoLSa4kPA",
+      "member": "sealer_zAondQcYX7Z9e8mdFaUbwv1FTAQSka55ZBA4dsjEWWzB9/signer_zGwgvdBgj1Gxr5hdFmfkU3sUvvgyypVSeLsmXSXE1pYrK",
+      "atTime": null,
+      "expectedRole": null
+    }
+  ]
+}

--- a/crates/cojson-core/data/group_engine/key_revelations.json
+++ b/crates/cojson-core/data/group_engine/key_revelations.json
@@ -1,0 +1,272 @@
+{
+  "description": "readKey/groupSealer/profile/root and key_for reveals: admin & invites allowed, writer rejected",
+  "covalues": [
+    {
+      "coId": "co_zF9TRSnEJckpS1pf2Rg2pg7Cca4",
+      "headerJson": "{\"createdAt\":\"2026-07-03T23:11:06.991Z\",\"meta\":null,\"ruleset\":{\"initialAdmin\":\"sealer_zEENFTAu5SD24wPzvYgHUjwyPzDaAJJ13Zsfz62SkmJgM/signer_z7w2FYPwuxJ7MbK9w8cRvezR2vAyQNoGE6knHbzji4hzm\",\"type\":\"group\"},\"type\":\"comap\",\"uniqueness\":\"z2TBFdfyWUWUPmxMQ\"}",
+      "sessions": [
+        {
+          "sessionId": "sealer_zEENFTAu5SD24wPzvYgHUjwyPzDaAJJ13Zsfz62SkmJgM/signer_z7w2FYPwuxJ7MbK9w8cRvezR2vAyQNoGE6knHbzji4hzm_session_z9RodzMybheA",
+          "signerId": "sealer_zEENFTAu5SD24wPzvYgHUjwyPzDaAJJ13Zsfz62SkmJgM/signer_z7w2FYPwuxJ7MbK9w8cRvezR2vAyQNoGE6knHbzji4hzm",
+          "transactions": [
+            "{\"changes\":\"[{\\\"op\\\":\\\"set\\\",\\\"key\\\":\\\"sealer_zEENFTAu5SD24wPzvYgHUjwyPzDaAJJ13Zsfz62SkmJgM/signer_z7w2FYPwuxJ7MbK9w8cRvezR2vAyQNoGE6knHbzji4hzm\\\",\\\"value\\\":\\\"admin\\\"}]\",\"madeAt\":1783120266991,\"privacy\":\"trusting\"}",
+            "{\"changes\":\"[{\\\"op\\\":\\\"set\\\",\\\"key\\\":\\\"key_zkjyd2gMFjkqofrx7_for_sealer_zEENFTAu5SD24wPzvYgHUjwyPzDaAJJ13Zsfz62SkmJgM/signer_z7w2FYPwuxJ7MbK9w8cRvezR2vAyQNoGE6knHbzji4hzm\\\",\\\"value\\\":\\\"sealed_UUT4GbXoKIp1tQYlMJD0qZk29T8hrt_MvCTxfoHzHBwQ0TiYtyBR8D9Dv2u0Cym14m_6Cl4YCci-bisP6EUd9V609yS5uf2DYxA==\\\"}]\",\"madeAt\":1783120266991,\"privacy\":\"trusting\"}",
+            "{\"changes\":\"[{\\\"op\\\":\\\"set\\\",\\\"key\\\":\\\"readKey\\\",\\\"value\\\":\\\"key_zkjyd2gMFjkqofrx7\\\"}]\",\"madeAt\":1783120266991,\"privacy\":\"trusting\"}",
+            "{\"changes\":\"[{\\\"op\\\":\\\"set\\\",\\\"key\\\":\\\"groupSealer\\\",\\\"value\\\":\\\"key_zkjyd2gMFjkqofrx7@sealer_z2nu6jQREcqmmUULcGjmR8s7EB69NP8ust1c88jJbhL3w\\\"}]\",\"madeAt\":1783120266991,\"privacy\":\"trusting\"}",
+            "{\"changes\":\"[{\\\"op\\\":\\\"set\\\",\\\"key\\\":\\\"co_zdsRpd6wW6ykcUc3BYSB4QsLTvH\\\",\\\"value\\\":\\\"writer\\\"}]\",\"madeAt\":1783120266992,\"privacy\":\"trusting\"}",
+            "{\"changes\":\"[{\\\"op\\\":\\\"set\\\",\\\"key\\\":\\\"key_zkjyd2gMFjkqofrx7_for_co_zdsRpd6wW6ykcUc3BYSB4QsLTvH\\\",\\\"value\\\":\\\"sealed_U8EQ5Ue53X3Lj9kUywnFPqc4wjMdXVWqqOEmuDLmGC29rXfZqLI0nCRk_UoThkiZILO2Y76tdjnjwa54nKWTncOHlCpLVRoI79A==\\\"}]\",\"madeAt\":1783120266992,\"privacy\":\"trusting\"}",
+            "{\"changes\":\"[{\\\"op\\\":\\\"set\\\",\\\"key\\\":\\\"readKey\\\",\\\"value\\\":\\\"key_z9AYKK62yg1TmUiyb\\\"}]\",\"madeAt\":1783120266992,\"privacy\":\"trusting\"}",
+            "{\"changes\":\"[{\\\"op\\\":\\\"set\\\",\\\"key\\\":\\\"groupSealer\\\",\\\"value\\\":\\\"sealer_zDUMMYGROUPSEALER\\\"}]\",\"madeAt\":1783120266993,\"privacy\":\"trusting\"}",
+            "{\"changes\":\"[{\\\"op\\\":\\\"set\\\",\\\"key\\\":\\\"profile\\\",\\\"value\\\":\\\"co_zDUMMYPROFILE\\\"}]\",\"madeAt\":1783120266993,\"privacy\":\"trusting\"}",
+            "{\"changes\":\"[{\\\"op\\\":\\\"set\\\",\\\"key\\\":\\\"root\\\",\\\"value\\\":\\\"co_zDUMMYROOT\\\"}]\",\"madeAt\":1783120266993,\"privacy\":\"trusting\"}",
+            "{\"changes\":\"[{\\\"op\\\":\\\"set\\\",\\\"key\\\":\\\"key_z9AYKK62yg1TmUiyb_for_co_zb8fv5RJrc3UjpZZr1Z2eMWBSMG\\\",\\\"value\\\":\\\"revelation_admin\\\"}]\",\"madeAt\":1783120266993,\"privacy\":\"trusting\"}",
+            "{\"changes\":\"[{\\\"op\\\":\\\"set\\\",\\\"key\\\":\\\"sealer_zFQcnaUH1XCRsU9KwQY7dFiTYfE2TkFoWkMNdBcwmTY7q/signer_zDQBM3X5S8EXyAscAVaq5FYPSChB5ryVcLrQossec9Nog\\\",\\\"value\\\":\\\"adminInvite\\\"}]\",\"madeAt\":1783120266993,\"privacy\":\"trusting\"}",
+            "{\"changes\":\"[{\\\"op\\\":\\\"set\\\",\\\"key\\\":\\\"sealer_z22U1ghP2YaagjbouzJvbtosKxppfXQ32cRhGTsb5wP8E/signer_z3d4vMqYtNqSzsFbvxtDEowYpATkWHfe36xSGXTcZsn3a\\\",\\\"value\\\":\\\"managerInvite\\\"}]\",\"madeAt\":1783120266994,\"privacy\":\"trusting\"}",
+            "{\"changes\":\"[{\\\"op\\\":\\\"set\\\",\\\"key\\\":\\\"sealer_z3xdSYXvYRGMvNyx9Z2FWaHsMEfbTLaRVXoh8q7VTzPQv/signer_z9QHQ77BM5B3CNkmUgHwokLhfsXWZuKeZVnzss5xL9CJA\\\",\\\"value\\\":\\\"writerInvite\\\"}]\",\"madeAt\":1783120266995,\"privacy\":\"trusting\"}",
+            "{\"changes\":\"[{\\\"op\\\":\\\"set\\\",\\\"key\\\":\\\"sealer_zCaArWH9TqqesKVrUK78Z8NGejhohLeLhjbRPDqcXrME/signer_zZf6LYwySxaqksCDErThdnDGLoqE95xws18KjZfSTAr8\\\",\\\"value\\\":\\\"readerInvite\\\"}]\",\"madeAt\":1783120266996,\"privacy\":\"trusting\"}",
+            "{\"changes\":\"[{\\\"op\\\":\\\"set\\\",\\\"key\\\":\\\"sealer_z8ucJDbzLDCxvxMnae4g1Lkxtjcbn5xYd6p2RDfXotz5v/signer_z5RH6uY5iDpjCcWJSyajfe8mnQ7bYFd2584YTp7yLTB6M\\\",\\\"value\\\":\\\"writeOnlyInvite\\\"}]\",\"madeAt\":1783120266997,\"privacy\":\"trusting\"}"
+          ],
+          "lastSignature": "signature_z3C4ut96aZgt33TLNKSjrHNHqKP6kMShH3KYHAgfYvXNF5UJxsvywfWcydz1dc8yXPySoMhfCg5iLRbiHxcyZTEXT"
+        },
+        {
+          "sessionId": "co_zdsRpd6wW6ykcUc3BYSB4QsLTvH_session_z8yqWH7P7CVs",
+          "signerId": "signer_zHGS9LqUuck1oQfSMvH9N8wD7WxkjW8gGUgEUdgVnEZdw",
+          "transactions": [
+            "{\"changes\":\"[{\\\"op\\\":\\\"set\\\",\\\"key\\\":\\\"readKey\\\",\\\"value\\\":\\\"key_zZYCD6zH5q9HsqXzh\\\"}]\",\"madeAt\":1783120266993,\"privacy\":\"trusting\"}",
+            "{\"changes\":\"[{\\\"op\\\":\\\"set\\\",\\\"key\\\":\\\"groupSealer\\\",\\\"value\\\":\\\"sealer_zDUMMY2\\\"}]\",\"madeAt\":1783120266993,\"privacy\":\"trusting\"}",
+            "{\"changes\":\"[{\\\"op\\\":\\\"set\\\",\\\"key\\\":\\\"profile\\\",\\\"value\\\":\\\"co_zDUMMY2\\\"}]\",\"madeAt\":1783120266993,\"privacy\":\"trusting\"}",
+            "{\"changes\":\"[{\\\"op\\\":\\\"set\\\",\\\"key\\\":\\\"root\\\",\\\"value\\\":\\\"co_zDUMMY2\\\"}]\",\"madeAt\":1783120266993,\"privacy\":\"trusting\"}"
+          ],
+          "lastSignature": "signature_z2PxS7SQ1eYkXWJbaXxLGjbdQFbJ1ZJaaZYB6jUxP4BQJbCa42Kz7SLsy4o6TKnwtM6FEfDqojEXmPwDuJWFWCVPJ"
+        },
+        {
+          "sessionId": "sealer_zFQcnaUH1XCRsU9KwQY7dFiTYfE2TkFoWkMNdBcwmTY7q/signer_zDQBM3X5S8EXyAscAVaq5FYPSChB5ryVcLrQossec9Nog_session_zgmvVJhY2eUF",
+          "signerId": "signer_zDQBM3X5S8EXyAscAVaq5FYPSChB5ryVcLrQossec9Nog",
+          "transactions": [
+            "{\"changes\":\"[{\\\"op\\\":\\\"set\\\",\\\"key\\\":\\\"key_z9AYKK62yg1TmUiyb_for_sealer_z5LaWj9qT5QD5nxZazGwvxVfjJqBMbspwY6jyFv4PhqgK/signer_z6c62Kn8iuU8jG96sJu2xjGT9FgiEtzNZVamVriCEVBh9\\\",\\\"value\\\":\\\"revelation_adminInvite\\\"}]\",\"madeAt\":1783120266994,\"privacy\":\"trusting\"}"
+          ],
+          "lastSignature": "signature_z5sbQjcjnG92Mq4e8Q3GUcYN7gNHUuKYKGV8y5KEeeSnYiDpaJNs1MQG75LsbaqZj3HdUB7Y9PA82Uu3cwT4su9Z3"
+        },
+        {
+          "sessionId": "sealer_z22U1ghP2YaagjbouzJvbtosKxppfXQ32cRhGTsb5wP8E/signer_z3d4vMqYtNqSzsFbvxtDEowYpATkWHfe36xSGXTcZsn3a_session_z7vEHCC2iZMJ",
+          "signerId": "signer_z3d4vMqYtNqSzsFbvxtDEowYpATkWHfe36xSGXTcZsn3a",
+          "transactions": [
+            "{\"changes\":\"[{\\\"op\\\":\\\"set\\\",\\\"key\\\":\\\"key_z9AYKK62yg1TmUiyb_for_sealer_zAL2JNh4BYguoxfxEHeDEsnurV87JZDuZKM5DnRhKqywr/signer_z3okmcSNFumREiuAJDE81NMke3rEtLF1ExLBq965bapPy\\\",\\\"value\\\":\\\"revelation_managerInvite\\\"}]\",\"madeAt\":1783120266995,\"privacy\":\"trusting\"}"
+          ],
+          "lastSignature": "signature_zna3ZiTX1dStnDpNNXwjTrmMu322GGDngHvozMQPnYDsEmedXKDQsJ4EUvjxvycEUajoCWESjx2XQuKtBMeLw4uN"
+        },
+        {
+          "sessionId": "sealer_z3xdSYXvYRGMvNyx9Z2FWaHsMEfbTLaRVXoh8q7VTzPQv/signer_z9QHQ77BM5B3CNkmUgHwokLhfsXWZuKeZVnzss5xL9CJA_session_zE4EULCZjypd",
+          "signerId": "signer_z9QHQ77BM5B3CNkmUgHwokLhfsXWZuKeZVnzss5xL9CJA",
+          "transactions": [
+            "{\"changes\":\"[{\\\"op\\\":\\\"set\\\",\\\"key\\\":\\\"key_z9AYKK62yg1TmUiyb_for_sealer_z7PV4EV1fzEA411ieXYgGMpo5wsRtuBDzBNn2Tj69i1uF/signer_z3XXZWFVxbrwnXcwixCV1hW6VZnS9yaJpthCXdL1aCz5F\\\",\\\"value\\\":\\\"revelation_writerInvite\\\"}]\",\"madeAt\":1783120266996,\"privacy\":\"trusting\"}"
+          ],
+          "lastSignature": "signature_z63DSzs1qyQJP1yAWnmyTanJC9AksyJFcHuGsRkXo5DtPzkZz53PNkCZJYNQxqsK4WypfLhy82PHMbUjGzMZ8gn6"
+        },
+        {
+          "sessionId": "sealer_zCaArWH9TqqesKVrUK78Z8NGejhohLeLhjbRPDqcXrME/signer_zZf6LYwySxaqksCDErThdnDGLoqE95xws18KjZfSTAr8_session_zHpstg7wQ2Lh",
+          "signerId": "signer_zZf6LYwySxaqksCDErThdnDGLoqE95xws18KjZfSTAr8",
+          "transactions": [
+            "{\"changes\":\"[{\\\"op\\\":\\\"set\\\",\\\"key\\\":\\\"key_z9AYKK62yg1TmUiyb_for_sealer_zAGFtTHYgpC8HP5D8EfKTyDZbTdSrAitcBmXj6HujPmmB/signer_z3tmoAD7SqEgXCUGqohpwC2tiPPuMzKdELGNeBWgVE5Gs\\\",\\\"value\\\":\\\"revelation_readerInvite\\\"}]\",\"madeAt\":1783120266997,\"privacy\":\"trusting\"}"
+          ],
+          "lastSignature": "signature_z3oqGuLXQarcJeuKmX4dWuNVoEkseYdn9MQAvZtjf34h7LyP9uqyxiP6yWNGGLzUgensYXpuFqfV47vkPMDsRzFid"
+        },
+        {
+          "sessionId": "sealer_z8ucJDbzLDCxvxMnae4g1Lkxtjcbn5xYd6p2RDfXotz5v/signer_z5RH6uY5iDpjCcWJSyajfe8mnQ7bYFd2584YTp7yLTB6M_session_zc2Tx6tMkxRk",
+          "signerId": "signer_z5RH6uY5iDpjCcWJSyajfe8mnQ7bYFd2584YTp7yLTB6M",
+          "transactions": [
+            "{\"changes\":\"[{\\\"op\\\":\\\"set\\\",\\\"key\\\":\\\"key_z9AYKK62yg1TmUiyb_for_sealer_z2URzyYBjfWX1kNmbVcUjT6ERTzybE15PKvb3gtrArcvC/signer_zBBwUXLZaMJMSioHniZQPMGzmYN7DukC9PyvLAJtZQ1AU\\\",\\\"value\\\":\\\"revelation_writeOnlyInvite\\\"}]\",\"madeAt\":1783120266998,\"privacy\":\"trusting\"}"
+          ],
+          "lastSignature": "signature_z3a42ePW8KyKa7KW7XF3uyUY3iLNSQFUAjfsUNTHQK6MNiGtPWge1ska5s1N7mkY2w9aqyUvzAF66QmNuNYggLBxh"
+        }
+      ]
+    },
+    {
+      "coId": "co_zdsRpd6wW6ykcUc3BYSB4QsLTvH",
+      "headerJson": "{\"createdAt\":null,\"meta\":{\"type\":\"account\"},\"ruleset\":{\"initialAdmin\":\"sealer_zCdx9ecyZUGc6JXQfPmagyUj8uZeWfjPG36kJYtcAVH1T/signer_zHGS9LqUuck1oQfSMvH9N8wD7WxkjW8gGUgEUdgVnEZdw\",\"type\":\"group\"},\"type\":\"comap\",\"uniqueness\":null}",
+      "sessions": [
+        {
+          "sessionId": "sealer_zCdx9ecyZUGc6JXQfPmagyUj8uZeWfjPG36kJYtcAVH1T/signer_zHGS9LqUuck1oQfSMvH9N8wD7WxkjW8gGUgEUdgVnEZdw_session_zd1uaBDWnm52",
+          "signerId": "signer_zHGS9LqUuck1oQfSMvH9N8wD7WxkjW8gGUgEUdgVnEZdw",
+          "transactions": [
+            "{\"changes\":\"[{\\\"op\\\":\\\"set\\\",\\\"key\\\":\\\"sealer_zCdx9ecyZUGc6JXQfPmagyUj8uZeWfjPG36kJYtcAVH1T/signer_zHGS9LqUuck1oQfSMvH9N8wD7WxkjW8gGUgEUdgVnEZdw\\\",\\\"value\\\":\\\"admin\\\"}]\",\"madeAt\":1783120266992,\"privacy\":\"trusting\"}",
+            "{\"changes\":\"[{\\\"op\\\":\\\"set\\\",\\\"key\\\":\\\"key_zR34nKMvf7UGx7WZS_for_sealer_zCdx9ecyZUGc6JXQfPmagyUj8uZeWfjPG36kJYtcAVH1T/signer_zHGS9LqUuck1oQfSMvH9N8wD7WxkjW8gGUgEUdgVnEZdw\\\",\\\"value\\\":\\\"sealed_UTGFkrHvy8RNnb8xkczqjfMyqKtbELNu4TNqYdVdYrtJ4RYvfKBIMjVsNgSLju4klTHvJrSNq0VLHfR9pcifF8rwXGlJDHCF2OQ==\\\"}]\",\"madeAt\":1783120266992,\"privacy\":\"trusting\"}",
+            "{\"changes\":\"[{\\\"op\\\":\\\"set\\\",\\\"key\\\":\\\"readKey\\\",\\\"value\\\":\\\"key_zR34nKMvf7UGx7WZS\\\"}]\",\"madeAt\":1783120266992,\"privacy\":\"trusting\"}"
+          ],
+          "lastSignature": "signature_z5CJwZTnJHvq28man6FmQ5FUGBqHvDPANiteWXDyiyfNMRE2U3zHxiNPA3Ey9JXxx2WeSuLy1yVqnNsr47e4jMsTu"
+        }
+      ]
+    },
+    {
+      "coId": "co_zb8fv5RJrc3UjpZZr1Z2eMWBSMG",
+      "headerJson": "{\"createdAt\":null,\"meta\":{\"type\":\"account\"},\"ruleset\":{\"initialAdmin\":\"sealer_zCi8xyJndgLm9yixffQQoKj7txxzW77tGQ3VeHheFVSM1/signer_zBUmv3i136mHjyUS1LWVQiLaFPREDhbMjQQKmeHGvWfr1\",\"type\":\"group\"},\"type\":\"comap\",\"uniqueness\":null}",
+      "sessions": [
+        {
+          "sessionId": "sealer_zCi8xyJndgLm9yixffQQoKj7txxzW77tGQ3VeHheFVSM1/signer_zBUmv3i136mHjyUS1LWVQiLaFPREDhbMjQQKmeHGvWfr1_session_zUp1tQxYLQiH",
+          "signerId": "signer_zBUmv3i136mHjyUS1LWVQiLaFPREDhbMjQQKmeHGvWfr1",
+          "transactions": [
+            "{\"changes\":\"[{\\\"op\\\":\\\"set\\\",\\\"key\\\":\\\"sealer_zCi8xyJndgLm9yixffQQoKj7txxzW77tGQ3VeHheFVSM1/signer_zBUmv3i136mHjyUS1LWVQiLaFPREDhbMjQQKmeHGvWfr1\\\",\\\"value\\\":\\\"admin\\\"}]\",\"madeAt\":1783120266992,\"privacy\":\"trusting\"}",
+            "{\"changes\":\"[{\\\"op\\\":\\\"set\\\",\\\"key\\\":\\\"key_z5TYhhT9teiEGSPizk_for_sealer_zCi8xyJndgLm9yixffQQoKj7txxzW77tGQ3VeHheFVSM1/signer_zBUmv3i136mHjyUS1LWVQiLaFPREDhbMjQQKmeHGvWfr1\\\",\\\"value\\\":\\\"sealed_UEW8gX18VYikgcm9PZb9Ic4_XtdBHKhqYd5u3U6z3MhAl9AZ8cJvkMx4paLRIER63SvGh40xFVqVBziyCdkxKLarpnEwzesG7rQ==\\\"}]\",\"madeAt\":1783120266992,\"privacy\":\"trusting\"}",
+            "{\"changes\":\"[{\\\"op\\\":\\\"set\\\",\\\"key\\\":\\\"readKey\\\",\\\"value\\\":\\\"key_z5TYhhT9teiEGSPizk\\\"}]\",\"madeAt\":1783120266992,\"privacy\":\"trusting\"}"
+          ],
+          "lastSignature": "signature_z2VbzL1iu7u19VuknsxwPXEHMnLyVxwBTDVy6psoriM7gGmwa7ox9enivhsuEnM14HgEB3neV5sWG1PWbGrgo6Yyr"
+        }
+      ]
+    }
+  ],
+  "verdicts": {
+    "co_zF9TRSnEJckpS1pf2Rg2pg7Cca4": [
+      {
+        "sessionId": "sealer_zEENFTAu5SD24wPzvYgHUjwyPzDaAJJ13Zsfz62SkmJgM/signer_z7w2FYPwuxJ7MbK9w8cRvezR2vAyQNoGE6knHbzji4hzm_session_z9RodzMybheA",
+        "txIndex": 0,
+        "valid": true,
+        "reason": null
+      },
+      {
+        "sessionId": "sealer_zEENFTAu5SD24wPzvYgHUjwyPzDaAJJ13Zsfz62SkmJgM/signer_z7w2FYPwuxJ7MbK9w8cRvezR2vAyQNoGE6knHbzji4hzm_session_z9RodzMybheA",
+        "txIndex": 1,
+        "valid": true,
+        "reason": null
+      },
+      {
+        "sessionId": "sealer_zEENFTAu5SD24wPzvYgHUjwyPzDaAJJ13Zsfz62SkmJgM/signer_z7w2FYPwuxJ7MbK9w8cRvezR2vAyQNoGE6knHbzji4hzm_session_z9RodzMybheA",
+        "txIndex": 2,
+        "valid": true,
+        "reason": null
+      },
+      {
+        "sessionId": "sealer_zEENFTAu5SD24wPzvYgHUjwyPzDaAJJ13Zsfz62SkmJgM/signer_z7w2FYPwuxJ7MbK9w8cRvezR2vAyQNoGE6knHbzji4hzm_session_z9RodzMybheA",
+        "txIndex": 3,
+        "valid": true,
+        "reason": null
+      },
+      {
+        "sessionId": "sealer_zEENFTAu5SD24wPzvYgHUjwyPzDaAJJ13Zsfz62SkmJgM/signer_z7w2FYPwuxJ7MbK9w8cRvezR2vAyQNoGE6knHbzji4hzm_session_z9RodzMybheA",
+        "txIndex": 4,
+        "valid": true,
+        "reason": null
+      },
+      {
+        "sessionId": "sealer_zEENFTAu5SD24wPzvYgHUjwyPzDaAJJ13Zsfz62SkmJgM/signer_z7w2FYPwuxJ7MbK9w8cRvezR2vAyQNoGE6knHbzji4hzm_session_z9RodzMybheA",
+        "txIndex": 5,
+        "valid": true,
+        "reason": null
+      },
+      {
+        "sessionId": "sealer_zEENFTAu5SD24wPzvYgHUjwyPzDaAJJ13Zsfz62SkmJgM/signer_z7w2FYPwuxJ7MbK9w8cRvezR2vAyQNoGE6knHbzji4hzm_session_z9RodzMybheA",
+        "txIndex": 6,
+        "valid": true,
+        "reason": null
+      },
+      {
+        "sessionId": "sealer_zEENFTAu5SD24wPzvYgHUjwyPzDaAJJ13Zsfz62SkmJgM/signer_z7w2FYPwuxJ7MbK9w8cRvezR2vAyQNoGE6knHbzji4hzm_session_z9RodzMybheA",
+        "txIndex": 7,
+        "valid": true,
+        "reason": null
+      },
+      {
+        "sessionId": "sealer_zEENFTAu5SD24wPzvYgHUjwyPzDaAJJ13Zsfz62SkmJgM/signer_z7w2FYPwuxJ7MbK9w8cRvezR2vAyQNoGE6knHbzji4hzm_session_z9RodzMybheA",
+        "txIndex": 8,
+        "valid": true,
+        "reason": null
+      },
+      {
+        "sessionId": "sealer_zEENFTAu5SD24wPzvYgHUjwyPzDaAJJ13Zsfz62SkmJgM/signer_z7w2FYPwuxJ7MbK9w8cRvezR2vAyQNoGE6knHbzji4hzm_session_z9RodzMybheA",
+        "txIndex": 9,
+        "valid": true,
+        "reason": null
+      },
+      {
+        "sessionId": "sealer_zEENFTAu5SD24wPzvYgHUjwyPzDaAJJ13Zsfz62SkmJgM/signer_z7w2FYPwuxJ7MbK9w8cRvezR2vAyQNoGE6knHbzji4hzm_session_z9RodzMybheA",
+        "txIndex": 10,
+        "valid": true,
+        "reason": null
+      },
+      {
+        "sessionId": "co_zdsRpd6wW6ykcUc3BYSB4QsLTvH_session_z8yqWH7P7CVs",
+        "txIndex": 0,
+        "valid": false,
+        "reason": "Only admins can set readKeys"
+      },
+      {
+        "sessionId": "co_zdsRpd6wW6ykcUc3BYSB4QsLTvH_session_z8yqWH7P7CVs",
+        "txIndex": 1,
+        "valid": false,
+        "reason": "Only admins can set groupSealer"
+      },
+      {
+        "sessionId": "co_zdsRpd6wW6ykcUc3BYSB4QsLTvH_session_z8yqWH7P7CVs",
+        "txIndex": 2,
+        "valid": false,
+        "reason": "Only admins can set profile"
+      },
+      {
+        "sessionId": "co_zdsRpd6wW6ykcUc3BYSB4QsLTvH_session_z8yqWH7P7CVs",
+        "txIndex": 3,
+        "valid": false,
+        "reason": "Only admins can set root"
+      },
+      {
+        "sessionId": "sealer_zEENFTAu5SD24wPzvYgHUjwyPzDaAJJ13Zsfz62SkmJgM/signer_z7w2FYPwuxJ7MbK9w8cRvezR2vAyQNoGE6knHbzji4hzm_session_z9RodzMybheA",
+        "txIndex": 11,
+        "valid": true,
+        "reason": null
+      },
+      {
+        "sessionId": "sealer_zFQcnaUH1XCRsU9KwQY7dFiTYfE2TkFoWkMNdBcwmTY7q/signer_zDQBM3X5S8EXyAscAVaq5FYPSChB5ryVcLrQossec9Nog_session_zgmvVJhY2eUF",
+        "txIndex": 0,
+        "valid": true,
+        "reason": null
+      },
+      {
+        "sessionId": "sealer_zEENFTAu5SD24wPzvYgHUjwyPzDaAJJ13Zsfz62SkmJgM/signer_z7w2FYPwuxJ7MbK9w8cRvezR2vAyQNoGE6knHbzji4hzm_session_z9RodzMybheA",
+        "txIndex": 12,
+        "valid": true,
+        "reason": null
+      },
+      {
+        "sessionId": "sealer_z22U1ghP2YaagjbouzJvbtosKxppfXQ32cRhGTsb5wP8E/signer_z3d4vMqYtNqSzsFbvxtDEowYpATkWHfe36xSGXTcZsn3a_session_z7vEHCC2iZMJ",
+        "txIndex": 0,
+        "valid": true,
+        "reason": null
+      },
+      {
+        "sessionId": "sealer_zEENFTAu5SD24wPzvYgHUjwyPzDaAJJ13Zsfz62SkmJgM/signer_z7w2FYPwuxJ7MbK9w8cRvezR2vAyQNoGE6knHbzji4hzm_session_z9RodzMybheA",
+        "txIndex": 13,
+        "valid": true,
+        "reason": null
+      },
+      {
+        "sessionId": "sealer_z3xdSYXvYRGMvNyx9Z2FWaHsMEfbTLaRVXoh8q7VTzPQv/signer_z9QHQ77BM5B3CNkmUgHwokLhfsXWZuKeZVnzss5xL9CJA_session_zE4EULCZjypd",
+        "txIndex": 0,
+        "valid": true,
+        "reason": null
+      },
+      {
+        "sessionId": "sealer_zEENFTAu5SD24wPzvYgHUjwyPzDaAJJ13Zsfz62SkmJgM/signer_z7w2FYPwuxJ7MbK9w8cRvezR2vAyQNoGE6knHbzji4hzm_session_z9RodzMybheA",
+        "txIndex": 14,
+        "valid": true,
+        "reason": null
+      },
+      {
+        "sessionId": "sealer_zCaArWH9TqqesKVrUK78Z8NGejhohLeLhjbRPDqcXrME/signer_zZf6LYwySxaqksCDErThdnDGLoqE95xws18KjZfSTAr8_session_zHpstg7wQ2Lh",
+        "txIndex": 0,
+        "valid": true,
+        "reason": null
+      },
+      {
+        "sessionId": "sealer_zEENFTAu5SD24wPzvYgHUjwyPzDaAJJ13Zsfz62SkmJgM/signer_z7w2FYPwuxJ7MbK9w8cRvezR2vAyQNoGE6knHbzji4hzm_session_z9RodzMybheA",
+        "txIndex": 15,
+        "valid": true,
+        "reason": null
+      },
+      {
+        "sessionId": "sealer_z8ucJDbzLDCxvxMnae4g1Lkxtjcbn5xYd6p2RDfXotz5v/signer_z5RH6uY5iDpjCcWJSyajfe8mnQ7bYFd2584YTp7yLTB6M_session_zc2Tx6tMkxRk",
+        "txIndex": 0,
+        "valid": true,
+        "reason": null
+      }
+    ]
+  },
+  "roleQueries": []
+}

--- a/crates/cojson-core/data/group_engine/malformed_changes.json
+++ b/crates/cojson-core/data/group_engine/malformed_changes.json
@@ -1,0 +1,79 @@
+{
+  "description": "malformed group transactions: multiple changes, non-set op, invalid role value, everyone with invalid role",
+  "covalues": [
+    {
+      "coId": "co_ziu6yhrdYUBTL6VCHfXJVqWnj5Y",
+      "headerJson": "{\"createdAt\":\"2026-07-03T23:11:07.016Z\",\"meta\":null,\"ruleset\":{\"initialAdmin\":\"sealer_z8C2ifhVc8njqJN5AeeBRu3d6P7MHkZV7afxNAubxS8ue/signer_z9UrGskTXJyRPD4qxzSWN69Kkdvxmddb6f5Pvaoa1zTm6\",\"type\":\"group\"},\"type\":\"comap\",\"uniqueness\":\"z3h8gvK9x5fncExQtj\"}",
+      "sessions": [
+        {
+          "sessionId": "sealer_z8C2ifhVc8njqJN5AeeBRu3d6P7MHkZV7afxNAubxS8ue/signer_z9UrGskTXJyRPD4qxzSWN69Kkdvxmddb6f5Pvaoa1zTm6_session_zjjRyRUss4fN",
+          "signerId": "sealer_z8C2ifhVc8njqJN5AeeBRu3d6P7MHkZV7afxNAubxS8ue/signer_z9UrGskTXJyRPD4qxzSWN69Kkdvxmddb6f5Pvaoa1zTm6",
+          "transactions": [
+            "{\"changes\":\"[{\\\"op\\\":\\\"set\\\",\\\"key\\\":\\\"sealer_z8C2ifhVc8njqJN5AeeBRu3d6P7MHkZV7afxNAubxS8ue/signer_z9UrGskTXJyRPD4qxzSWN69Kkdvxmddb6f5Pvaoa1zTm6\\\",\\\"value\\\":\\\"admin\\\"}]\",\"madeAt\":1783120267016,\"privacy\":\"trusting\"}",
+            "{\"changes\":\"[{\\\"op\\\":\\\"set\\\",\\\"key\\\":\\\"key_z2uVHKDQJrksBugPKd_for_sealer_z8C2ifhVc8njqJN5AeeBRu3d6P7MHkZV7afxNAubxS8ue/signer_z9UrGskTXJyRPD4qxzSWN69Kkdvxmddb6f5Pvaoa1zTm6\\\",\\\"value\\\":\\\"sealed_UWIKyeDrQosdL_3uRccw-sMcRY5Tt9dZAT4_rPYzJwKO6d27ve1d7LaHpsZjmuwq-nPs1sg0hUHBdeuDLtgoWkQVPv0cuA_NZJA==\\\"}]\",\"madeAt\":1783120267016,\"privacy\":\"trusting\"}",
+            "{\"changes\":\"[{\\\"op\\\":\\\"set\\\",\\\"key\\\":\\\"readKey\\\",\\\"value\\\":\\\"key_z2uVHKDQJrksBugPKd\\\"}]\",\"madeAt\":1783120267016,\"privacy\":\"trusting\"}",
+            "{\"changes\":\"[{\\\"op\\\":\\\"set\\\",\\\"key\\\":\\\"groupSealer\\\",\\\"value\\\":\\\"key_z2uVHKDQJrksBugPKd@sealer_z5iKfAdrRsUX59bPrhdYDcG7oEDgWKeTwk5qLL3RXqC1T\\\"}]\",\"madeAt\":1783120267016,\"privacy\":\"trusting\"}",
+            "{\"changes\":\"[{\\\"op\\\":\\\"set\\\",\\\"key\\\":\\\"sealer_zHCD8BQ6AwApDAMtAePFafpSGBrq5uwkAcp1XsTiVjdtt/signer_z9rYLyQkycYWE2hTkCtsiTtpbGewM9edbAqv3BSesr6ga\\\",\\\"value\\\":\\\"reader\\\"},{\\\"op\\\":\\\"set\\\",\\\"key\\\":\\\"sealer_zAz1DtidMzMSfbBy98PU9SB5GZSvKmLPrZvGsdpVcHWKo/signer_zCTLwyyagvhYs3TpmTfwJyvmxVfen1EY9HCvhm43fsSSr\\\",\\\"value\\\":\\\"reader\\\"}]\",\"madeAt\":1783120267017,\"privacy\":\"trusting\"}",
+            "{\"changes\":\"[{\\\"op\\\":\\\"del\\\",\\\"key\\\":\\\"sealer_zHCD8BQ6AwApDAMtAePFafpSGBrq5uwkAcp1XsTiVjdtt/signer_z9rYLyQkycYWE2hTkCtsiTtpbGewM9edbAqv3BSesr6ga\\\"}]\",\"madeAt\":1783120267017,\"privacy\":\"trusting\"}",
+            "{\"changes\":\"[{\\\"op\\\":\\\"set\\\",\\\"key\\\":\\\"sealer_zHCD8BQ6AwApDAMtAePFafpSGBrq5uwkAcp1XsTiVjdtt/signer_z9rYLyQkycYWE2hTkCtsiTtpbGewM9edbAqv3BSesr6ga\\\",\\\"value\\\":\\\"superadmin\\\"}]\",\"madeAt\":1783120267017,\"privacy\":\"trusting\"}",
+            "{\"changes\":\"[{\\\"op\\\":\\\"set\\\",\\\"key\\\":\\\"everyone\\\",\\\"value\\\":\\\"admin\\\"}]\",\"madeAt\":1783120267017,\"privacy\":\"trusting\"}"
+          ],
+          "lastSignature": "signature_zDvJcB38PwLmm1Rdq3xVaB6vYbUBHt4gpTTYBHCkmBdQJg7vrnH2eLvypmJzfCk6GD1dmQiXwrx2oQyqWMR7hccC"
+        }
+      ]
+    }
+  ],
+  "verdicts": {
+    "co_ziu6yhrdYUBTL6VCHfXJVqWnj5Y": [
+      {
+        "sessionId": "sealer_z8C2ifhVc8njqJN5AeeBRu3d6P7MHkZV7afxNAubxS8ue/signer_z9UrGskTXJyRPD4qxzSWN69Kkdvxmddb6f5Pvaoa1zTm6_session_zjjRyRUss4fN",
+        "txIndex": 0,
+        "valid": true,
+        "reason": null
+      },
+      {
+        "sessionId": "sealer_z8C2ifhVc8njqJN5AeeBRu3d6P7MHkZV7afxNAubxS8ue/signer_z9UrGskTXJyRPD4qxzSWN69Kkdvxmddb6f5Pvaoa1zTm6_session_zjjRyRUss4fN",
+        "txIndex": 1,
+        "valid": true,
+        "reason": null
+      },
+      {
+        "sessionId": "sealer_z8C2ifhVc8njqJN5AeeBRu3d6P7MHkZV7afxNAubxS8ue/signer_z9UrGskTXJyRPD4qxzSWN69Kkdvxmddb6f5Pvaoa1zTm6_session_zjjRyRUss4fN",
+        "txIndex": 2,
+        "valid": true,
+        "reason": null
+      },
+      {
+        "sessionId": "sealer_z8C2ifhVc8njqJN5AeeBRu3d6P7MHkZV7afxNAubxS8ue/signer_z9UrGskTXJyRPD4qxzSWN69Kkdvxmddb6f5Pvaoa1zTm6_session_zjjRyRUss4fN",
+        "txIndex": 3,
+        "valid": true,
+        "reason": null
+      },
+      {
+        "sessionId": "sealer_z8C2ifhVc8njqJN5AeeBRu3d6P7MHkZV7afxNAubxS8ue/signer_z9UrGskTXJyRPD4qxzSWN69Kkdvxmddb6f5Pvaoa1zTm6_session_zjjRyRUss4fN",
+        "txIndex": 4,
+        "valid": false,
+        "reason": "Group transaction must have exactly one change"
+      },
+      {
+        "sessionId": "sealer_z8C2ifhVc8njqJN5AeeBRu3d6P7MHkZV7afxNAubxS8ue/signer_z9UrGskTXJyRPD4qxzSWN69Kkdvxmddb6f5Pvaoa1zTm6_session_zjjRyRUss4fN",
+        "txIndex": 5,
+        "valid": false,
+        "reason": "Group transaction must set a role or readKey"
+      },
+      {
+        "sessionId": "sealer_z8C2ifhVc8njqJN5AeeBRu3d6P7MHkZV7afxNAubxS8ue/signer_z9UrGskTXJyRPD4qxzSWN69Kkdvxmddb6f5Pvaoa1zTm6_session_zjjRyRUss4fN",
+        "txIndex": 6,
+        "valid": false,
+        "reason": "Group transaction must set a valid role"
+      },
+      {
+        "sessionId": "sealer_z8C2ifhVc8njqJN5AeeBRu3d6P7MHkZV7afxNAubxS8ue/signer_z9UrGskTXJyRPD4qxzSWN69Kkdvxmddb6f5Pvaoa1zTm6_session_zjjRyRUss4fN",
+        "txIndex": 7,
+        "valid": false,
+        "reason": "Everyone can only be set to reader, writer, writeOnly or revoked"
+      }
+    ]
+  },
+  "roleQueries": []
+}

--- a/crates/cojson-core/data/group_engine/manager_rules.json
+++ b/crates/cojson-core/data/group_engine/manager_rules.json
@@ -1,0 +1,160 @@
+{
+  "description": "manager cannot demote admins, promote to admin, or invite admins/managers, but can add a writer",
+  "covalues": [
+    {
+      "coId": "co_zauZHdN3sH7gCmmfKH6464ekPJJ",
+      "headerJson": "{\"createdAt\":\"2026-07-03T23:11:06.984Z\",\"meta\":null,\"ruleset\":{\"initialAdmin\":\"sealer_zCW8f3fXvosKtiqRtJCFDMczYi8fRzbcvLLxcmkEiqkd3/signer_zD8vQ9RqKqJhmf4WK6si7zFuVbShr1iNWSWaWaovKcnBg\",\"type\":\"group\"},\"type\":\"comap\",\"uniqueness\":\"zyZoEacXzFv6rPsig\"}",
+      "sessions": [
+        {
+          "sessionId": "sealer_zCW8f3fXvosKtiqRtJCFDMczYi8fRzbcvLLxcmkEiqkd3/signer_zD8vQ9RqKqJhmf4WK6si7zFuVbShr1iNWSWaWaovKcnBg_session_ze2ZGE8c6p81",
+          "signerId": "sealer_zCW8f3fXvosKtiqRtJCFDMczYi8fRzbcvLLxcmkEiqkd3/signer_zD8vQ9RqKqJhmf4WK6si7zFuVbShr1iNWSWaWaovKcnBg",
+          "transactions": [
+            "{\"changes\":\"[{\\\"op\\\":\\\"set\\\",\\\"key\\\":\\\"sealer_zCW8f3fXvosKtiqRtJCFDMczYi8fRzbcvLLxcmkEiqkd3/signer_zD8vQ9RqKqJhmf4WK6si7zFuVbShr1iNWSWaWaovKcnBg\\\",\\\"value\\\":\\\"admin\\\"}]\",\"madeAt\":1783120266984,\"privacy\":\"trusting\"}",
+            "{\"changes\":\"[{\\\"op\\\":\\\"set\\\",\\\"key\\\":\\\"key_z2LwvVpni6ggvpxYEr_for_sealer_zCW8f3fXvosKtiqRtJCFDMczYi8fRzbcvLLxcmkEiqkd3/signer_zD8vQ9RqKqJhmf4WK6si7zFuVbShr1iNWSWaWaovKcnBg\\\",\\\"value\\\":\\\"sealed_U95YwO4GiMn51MieXL2bV29aFvRqtrMICb5G5kYxKFCLi0BdmLnD7H4k0Wm7_19ohIcKIMneZonEfp5VPnWT9TawASzsvX_w1FA==\\\"}]\",\"madeAt\":1783120266985,\"privacy\":\"trusting\"}",
+            "{\"changes\":\"[{\\\"op\\\":\\\"set\\\",\\\"key\\\":\\\"readKey\\\",\\\"value\\\":\\\"key_z2LwvVpni6ggvpxYEr\\\"}]\",\"madeAt\":1783120266985,\"privacy\":\"trusting\"}",
+            "{\"changes\":\"[{\\\"op\\\":\\\"set\\\",\\\"key\\\":\\\"groupSealer\\\",\\\"value\\\":\\\"key_z2LwvVpni6ggvpxYEr@sealer_z9LkfFL55RDFGTXfkBK5Wo5P8syaUkKpDqFDrVtQ3mRaJ\\\"}]\",\"madeAt\":1783120266985,\"privacy\":\"trusting\"}",
+            "{\"changes\":\"[{\\\"op\\\":\\\"set\\\",\\\"key\\\":\\\"co_zQWofMrhAAkVuaSeWXU3DpxTWU1\\\",\\\"value\\\":\\\"manager\\\"}]\",\"madeAt\":1783120266986,\"privacy\":\"trusting\"}",
+            "{\"changes\":\"[{\\\"op\\\":\\\"set\\\",\\\"key\\\":\\\"key_z2LwvVpni6ggvpxYEr_for_co_zQWofMrhAAkVuaSeWXU3DpxTWU1\\\",\\\"value\\\":\\\"sealed_UtkbCpQpgWPEtr1KMUufhlzIGwPYxMMhFVEu23GWAmEZOp0SxJtOjLQw3EL4e8HjsBjKpF8QFvkA4YtVcFwWLeRQQp3ZgBCRP4Q==\\\"}]\",\"madeAt\":1783120266986,\"privacy\":\"trusting\"}",
+            "{\"changes\":\"[{\\\"op\\\":\\\"set\\\",\\\"key\\\":\\\"co_z7X5EuzNiz8gKfR4fVWeSF1ebfY\\\",\\\"value\\\":\\\"admin\\\"}]\",\"madeAt\":1783120266986,\"privacy\":\"trusting\"}",
+            "{\"changes\":\"[{\\\"op\\\":\\\"set\\\",\\\"key\\\":\\\"key_z2LwvVpni6ggvpxYEr_for_co_z7X5EuzNiz8gKfR4fVWeSF1ebfY\\\",\\\"value\\\":\\\"sealed_U_jyDloXus3qO8_ytf9uEZiBaPQm26WPI8wd0eRXhjWcvNOnmIObx5w0WpG2-iEas5GivPTwpENYazq4PYuCEBRhi1bCyvJDNww==\\\"}]\",\"madeAt\":1783120266986,\"privacy\":\"trusting\"}"
+          ],
+          "lastSignature": "signature_z5WoNAYZxKEfdN7yTTP3Z2g7GWuLpoM9X4JzrfsjRr1Quxu3qS7B5U3YycBbj2AGZDBd5VXf3znUJ6Cg6K7NRLs9K"
+        },
+        {
+          "sessionId": "co_zQWofMrhAAkVuaSeWXU3DpxTWU1_session_zLf4X671bL8Y",
+          "signerId": "signer_z9vUWSHx2vStAq5qa9JAdAQDxDUh5NCUqUrvjXiUiHavD",
+          "transactions": [
+            "{\"changes\":\"[{\\\"op\\\":\\\"set\\\",\\\"key\\\":\\\"co_z7X5EuzNiz8gKfR4fVWeSF1ebfY\\\",\\\"value\\\":\\\"writer\\\"}]\",\"madeAt\":1783120266987,\"privacy\":\"trusting\"}",
+            "{\"changes\":\"[{\\\"op\\\":\\\"set\\\",\\\"key\\\":\\\"sealer_z9GrJ44zPD4s2rromKYt57aGXxT4npBHWeW16Udeo4CoQ/signer_zJ8QiHZRVeUryxFVo5zk26QGCiPx1cyZRiH6nqyirGEZQ\\\",\\\"value\\\":\\\"admin\\\"}]\",\"madeAt\":1783120266987,\"privacy\":\"trusting\"}",
+            "{\"changes\":\"[{\\\"op\\\":\\\"set\\\",\\\"key\\\":\\\"sealer_z2hozWu51b858Kr6HHanPPr8PYkTwAfmp9yQTcn7v4rSr/signer_zH1gQDmc6b9hkTHDzeruQbqUfm8yYLt5osWn473oEWqdj\\\",\\\"value\\\":\\\"adminInvite\\\"}]\",\"madeAt\":1783120266987,\"privacy\":\"trusting\"}",
+            "{\"changes\":\"[{\\\"op\\\":\\\"set\\\",\\\"key\\\":\\\"sealer_z9SUtx3gTf6YtdPbyMXmTZkM7JhyoG1iToZ72EPKGs2Xs/signer_z5qLBLD2NyrZfez198YiEsyASFX1JgMWA9qtyyvVEB5bP\\\",\\\"value\\\":\\\"managerInvite\\\"}]\",\"madeAt\":1783120266987,\"privacy\":\"trusting\"}",
+            "{\"changes\":\"[{\\\"op\\\":\\\"set\\\",\\\"key\\\":\\\"sealer_zAtAZpyuXzNAvygAnJQdhhVxYGY9usXhX8Tr8g5t7kUcB/signer_z5RLo2LadgonCjS7A2zXDeE5CwHK7WJYE9LYS8jjKMmX8\\\",\\\"value\\\":\\\"writer\\\"}]\",\"madeAt\":1783120266987,\"privacy\":\"trusting\"}"
+          ],
+          "lastSignature": "signature_z5yzNTssi9p9LF2BsGtdDiVeNTwW45NstTChoNvyR6GirJZVP1bZuEHkwA4uT9pgHBXD8dfKgj7f9e9hiMTFJUS9e"
+        }
+      ]
+    },
+    {
+      "coId": "co_zQWofMrhAAkVuaSeWXU3DpxTWU1",
+      "headerJson": "{\"createdAt\":null,\"meta\":{\"type\":\"account\"},\"ruleset\":{\"initialAdmin\":\"sealer_zGbqnXTrhM1sZzz2CGnt8cfjV8yMFpdmdmns8S25MXqw7/signer_z9vUWSHx2vStAq5qa9JAdAQDxDUh5NCUqUrvjXiUiHavD\",\"type\":\"group\"},\"type\":\"comap\",\"uniqueness\":null}",
+      "sessions": [
+        {
+          "sessionId": "sealer_zGbqnXTrhM1sZzz2CGnt8cfjV8yMFpdmdmns8S25MXqw7/signer_z9vUWSHx2vStAq5qa9JAdAQDxDUh5NCUqUrvjXiUiHavD_session_z3M5cLpDdgRf",
+          "signerId": "signer_z9vUWSHx2vStAq5qa9JAdAQDxDUh5NCUqUrvjXiUiHavD",
+          "transactions": [
+            "{\"changes\":\"[{\\\"op\\\":\\\"set\\\",\\\"key\\\":\\\"sealer_zGbqnXTrhM1sZzz2CGnt8cfjV8yMFpdmdmns8S25MXqw7/signer_z9vUWSHx2vStAq5qa9JAdAQDxDUh5NCUqUrvjXiUiHavD\\\",\\\"value\\\":\\\"admin\\\"}]\",\"madeAt\":1783120266985,\"privacy\":\"trusting\"}",
+            "{\"changes\":\"[{\\\"op\\\":\\\"set\\\",\\\"key\\\":\\\"key_z2dM49Ng6M898qoy9h_for_sealer_zGbqnXTrhM1sZzz2CGnt8cfjV8yMFpdmdmns8S25MXqw7/signer_z9vUWSHx2vStAq5qa9JAdAQDxDUh5NCUqUrvjXiUiHavD\\\",\\\"value\\\":\\\"sealed_Uy7Tezg-kQ3_ds6ARuLgKLwOBF3WOhW9T3LG6EZ8f0gJSKS1dJUy2pNclk7mfLJQICnGbqU9cV0SpRDSUKFh5Ypxlz-26PbJClw==\\\"}]\",\"madeAt\":1783120266985,\"privacy\":\"trusting\"}",
+            "{\"changes\":\"[{\\\"op\\\":\\\"set\\\",\\\"key\\\":\\\"readKey\\\",\\\"value\\\":\\\"key_z2dM49Ng6M898qoy9h\\\"}]\",\"madeAt\":1783120266985,\"privacy\":\"trusting\"}"
+          ],
+          "lastSignature": "signature_z5ji6auwoMZefdfYeMh4gRyXBW4JdJXxWAJxWHeudonCq5wzwuqiGqwiwuDNKcmXa7qEZnWrHPq6S4gGGYvFyMgLe"
+        }
+      ]
+    },
+    {
+      "coId": "co_z7X5EuzNiz8gKfR4fVWeSF1ebfY",
+      "headerJson": "{\"createdAt\":null,\"meta\":{\"type\":\"account\"},\"ruleset\":{\"initialAdmin\":\"sealer_z4t7RuydA2Wu4A3A9e811qU7UiM1X35UhJpWbDtj9pLNp/signer_ztMCUcBmCexvsjYTzFZpsWUZpf4DjHaZU2eKhSm5HSyh\",\"type\":\"group\"},\"type\":\"comap\",\"uniqueness\":null}",
+      "sessions": [
+        {
+          "sessionId": "sealer_z4t7RuydA2Wu4A3A9e811qU7UiM1X35UhJpWbDtj9pLNp/signer_ztMCUcBmCexvsjYTzFZpsWUZpf4DjHaZU2eKhSm5HSyh_session_zdkbh1uKuAM6",
+          "signerId": "signer_ztMCUcBmCexvsjYTzFZpsWUZpf4DjHaZU2eKhSm5HSyh",
+          "transactions": [
+            "{\"changes\":\"[{\\\"op\\\":\\\"set\\\",\\\"key\\\":\\\"sealer_z4t7RuydA2Wu4A3A9e811qU7UiM1X35UhJpWbDtj9pLNp/signer_ztMCUcBmCexvsjYTzFZpsWUZpf4DjHaZU2eKhSm5HSyh\\\",\\\"value\\\":\\\"admin\\\"}]\",\"madeAt\":1783120266985,\"privacy\":\"trusting\"}",
+            "{\"changes\":\"[{\\\"op\\\":\\\"set\\\",\\\"key\\\":\\\"key_z48pBxgLmPys6dHxkP_for_sealer_z4t7RuydA2Wu4A3A9e811qU7UiM1X35UhJpWbDtj9pLNp/signer_ztMCUcBmCexvsjYTzFZpsWUZpf4DjHaZU2eKhSm5HSyh\\\",\\\"value\\\":\\\"sealed_UGeRmNpzUkPzwKRRatuebege7qV2GcCpk8HlGuPiSandjoMcgSPZ7_8Tx0zWZS1J36kXxsRhvPd8uVg0IDXvjjMfqE1q0UEJc\\\"}]\",\"madeAt\":1783120266986,\"privacy\":\"trusting\"}",
+            "{\"changes\":\"[{\\\"op\\\":\\\"set\\\",\\\"key\\\":\\\"readKey\\\",\\\"value\\\":\\\"key_z48pBxgLmPys6dHxkP\\\"}]\",\"madeAt\":1783120266986,\"privacy\":\"trusting\"}"
+          ],
+          "lastSignature": "signature_z5QkdzDcPNjodWiZ5BmLr7fMk7F776w7CJWAHz5829KffYt13shY7GUN6R43P2QNSUsKzFxpQ7vZqDnsLni1QTTKB"
+        }
+      ]
+    }
+  ],
+  "verdicts": {
+    "co_zauZHdN3sH7gCmmfKH6464ekPJJ": [
+      {
+        "sessionId": "sealer_zCW8f3fXvosKtiqRtJCFDMczYi8fRzbcvLLxcmkEiqkd3/signer_zD8vQ9RqKqJhmf4WK6si7zFuVbShr1iNWSWaWaovKcnBg_session_ze2ZGE8c6p81",
+        "txIndex": 0,
+        "valid": true,
+        "reason": null
+      },
+      {
+        "sessionId": "sealer_zCW8f3fXvosKtiqRtJCFDMczYi8fRzbcvLLxcmkEiqkd3/signer_zD8vQ9RqKqJhmf4WK6si7zFuVbShr1iNWSWaWaovKcnBg_session_ze2ZGE8c6p81",
+        "txIndex": 1,
+        "valid": true,
+        "reason": null
+      },
+      {
+        "sessionId": "sealer_zCW8f3fXvosKtiqRtJCFDMczYi8fRzbcvLLxcmkEiqkd3/signer_zD8vQ9RqKqJhmf4WK6si7zFuVbShr1iNWSWaWaovKcnBg_session_ze2ZGE8c6p81",
+        "txIndex": 2,
+        "valid": true,
+        "reason": null
+      },
+      {
+        "sessionId": "sealer_zCW8f3fXvosKtiqRtJCFDMczYi8fRzbcvLLxcmkEiqkd3/signer_zD8vQ9RqKqJhmf4WK6si7zFuVbShr1iNWSWaWaovKcnBg_session_ze2ZGE8c6p81",
+        "txIndex": 3,
+        "valid": true,
+        "reason": null
+      },
+      {
+        "sessionId": "sealer_zCW8f3fXvosKtiqRtJCFDMczYi8fRzbcvLLxcmkEiqkd3/signer_zD8vQ9RqKqJhmf4WK6si7zFuVbShr1iNWSWaWaovKcnBg_session_ze2ZGE8c6p81",
+        "txIndex": 4,
+        "valid": true,
+        "reason": null
+      },
+      {
+        "sessionId": "sealer_zCW8f3fXvosKtiqRtJCFDMczYi8fRzbcvLLxcmkEiqkd3/signer_zD8vQ9RqKqJhmf4WK6si7zFuVbShr1iNWSWaWaovKcnBg_session_ze2ZGE8c6p81",
+        "txIndex": 5,
+        "valid": true,
+        "reason": null
+      },
+      {
+        "sessionId": "sealer_zCW8f3fXvosKtiqRtJCFDMczYi8fRzbcvLLxcmkEiqkd3/signer_zD8vQ9RqKqJhmf4WK6si7zFuVbShr1iNWSWaWaovKcnBg_session_ze2ZGE8c6p81",
+        "txIndex": 6,
+        "valid": true,
+        "reason": null
+      },
+      {
+        "sessionId": "sealer_zCW8f3fXvosKtiqRtJCFDMczYi8fRzbcvLLxcmkEiqkd3/signer_zD8vQ9RqKqJhmf4WK6si7zFuVbShr1iNWSWaWaovKcnBg_session_ze2ZGE8c6p81",
+        "txIndex": 7,
+        "valid": true,
+        "reason": null
+      },
+      {
+        "sessionId": "co_zQWofMrhAAkVuaSeWXU3DpxTWU1_session_zLf4X671bL8Y",
+        "txIndex": 0,
+        "valid": false,
+        "reason": "Managers can't demote admins."
+      },
+      {
+        "sessionId": "co_zQWofMrhAAkVuaSeWXU3DpxTWU1_session_zLf4X671bL8Y",
+        "txIndex": 1,
+        "valid": false,
+        "reason": "Managers can't promote to admin."
+      },
+      {
+        "sessionId": "co_zQWofMrhAAkVuaSeWXU3DpxTWU1_session_zLf4X671bL8Y",
+        "txIndex": 2,
+        "valid": false,
+        "reason": "Managers can't invite admins."
+      },
+      {
+        "sessionId": "co_zQWofMrhAAkVuaSeWXU3DpxTWU1_session_zLf4X671bL8Y",
+        "txIndex": 3,
+        "valid": false,
+        "reason": "Managers can't invite managers."
+      },
+      {
+        "sessionId": "co_zQWofMrhAAkVuaSeWXU3DpxTWU1_session_zLf4X671bL8Y",
+        "txIndex": 4,
+        "valid": true,
+        "reason": null
+      }
+    ]
+  },
+  "roleQueries": [
+    {
+      "groupId": "co_zauZHdN3sH7gCmmfKH6464ekPJJ",
+      "member": "sealer_zAtAZpyuXzNAvygAnJQdhhVxYGY9usXhX8Tr8g5t7kUcB/signer_z5RLo2LadgonCjS7A2zXDeE5CwHK7WJYE9LYS8jjKMmX8",
+      "atTime": null,
+      "expectedRole": "writer"
+    }
+  ]
+}

--- a/crates/cojson-core/data/group_engine/parent_capped.json
+++ b/crates/cojson-core/data/group_engine/parent_capped.json
@@ -1,0 +1,151 @@
+{
+  "description": "parent extension caps the inherited role: a parent admin is capped to writer in the child",
+  "covalues": [
+    {
+      "coId": "co_zWVAYLezoLqpZYT7g7KyNYoR3tj",
+      "headerJson": "{\"createdAt\":\"2026-07-03T23:11:07.004Z\",\"meta\":null,\"ruleset\":{\"initialAdmin\":\"sealer_zAUKM88fyfD7qVLTzVtiW3YgpHubj6DWj4muSjZnVHdt5/signer_zBfbrLXMdsAeo2roL2FA7EWfEgqAe9rVdPqk4hbxxeSap\",\"type\":\"group\"},\"type\":\"comap\",\"uniqueness\":\"z3sUbSnEr4Bzpu2AHr\"}",
+      "sessions": [
+        {
+          "sessionId": "sealer_zAUKM88fyfD7qVLTzVtiW3YgpHubj6DWj4muSjZnVHdt5/signer_zBfbrLXMdsAeo2roL2FA7EWfEgqAe9rVdPqk4hbxxeSap_session_zMm5S3FRH2yg",
+          "signerId": "sealer_zAUKM88fyfD7qVLTzVtiW3YgpHubj6DWj4muSjZnVHdt5/signer_zBfbrLXMdsAeo2roL2FA7EWfEgqAe9rVdPqk4hbxxeSap",
+          "transactions": [
+            "{\"changes\":\"[{\\\"op\\\":\\\"set\\\",\\\"key\\\":\\\"sealer_zAUKM88fyfD7qVLTzVtiW3YgpHubj6DWj4muSjZnVHdt5/signer_zBfbrLXMdsAeo2roL2FA7EWfEgqAe9rVdPqk4hbxxeSap\\\",\\\"value\\\":\\\"admin\\\"}]\",\"madeAt\":1783120267004,\"privacy\":\"trusting\"}",
+            "{\"changes\":\"[{\\\"op\\\":\\\"set\\\",\\\"key\\\":\\\"key_z2F6L2crjywLYLyQnD_for_sealer_zAUKM88fyfD7qVLTzVtiW3YgpHubj6DWj4muSjZnVHdt5/signer_zBfbrLXMdsAeo2roL2FA7EWfEgqAe9rVdPqk4hbxxeSap\\\",\\\"value\\\":\\\"sealed_UhNmgHpfewcaXwYo-jyDMm3Z4_VtmYCcLBunnBswgDTn8osoANoqARkCd0Dc4B6hGr_Jv1K1LvIOeYI8PnFwHBajLe1eiXvGxPg==\\\"}]\",\"madeAt\":1783120267005,\"privacy\":\"trusting\"}",
+            "{\"changes\":\"[{\\\"op\\\":\\\"set\\\",\\\"key\\\":\\\"readKey\\\",\\\"value\\\":\\\"key_z2F6L2crjywLYLyQnD\\\"}]\",\"madeAt\":1783120267005,\"privacy\":\"trusting\"}",
+            "{\"changes\":\"[{\\\"op\\\":\\\"set\\\",\\\"key\\\":\\\"groupSealer\\\",\\\"value\\\":\\\"key_z2F6L2crjywLYLyQnD@sealer_zFfpEJvbL1fpJEiC5gXJmqZZhuHCt77f3aLpmZJNG5PwC\\\"}]\",\"madeAt\":1783120267005,\"privacy\":\"trusting\"}",
+            "{\"changes\":\"[{\\\"op\\\":\\\"set\\\",\\\"key\\\":\\\"parent_co_zVsnsMtY74e4TTub5tzZQXbU21T\\\",\\\"value\\\":\\\"writer\\\"}]\",\"madeAt\":1783120267005,\"privacy\":\"trusting\"}",
+            "{\"changes\":\"[{\\\"op\\\":\\\"set\\\",\\\"key\\\":\\\"key_z2F6L2crjywLYLyQnD_for_key_z5KxbcFKvXoUNFqsWP\\\",\\\"value\\\":\\\"encrypted_UeC-FlcdW5-OR8-GtSctjOTKa7szT_kr5N8WPQFQnOGkiec-pGLehTu8NGEMWBj0wu5WL8IN4GJlv\\\"}]\",\"madeAt\":1783120267006,\"privacy\":\"trusting\"}"
+          ],
+          "lastSignature": "signature_z34MgJhAKLG9qS9Z5kGmCMThM9RKzqNPA7xjqJ5CgHWP8cXC4xMovcp6PRzJPawFMdqt916GitfjcWf1WGFgdvQyr"
+        }
+      ]
+    },
+    {
+      "coId": "co_zVsnsMtY74e4TTub5tzZQXbU21T",
+      "headerJson": "{\"createdAt\":\"2026-07-03T23:11:07.004Z\",\"meta\":null,\"ruleset\":{\"initialAdmin\":\"sealer_zAUKM88fyfD7qVLTzVtiW3YgpHubj6DWj4muSjZnVHdt5/signer_zBfbrLXMdsAeo2roL2FA7EWfEgqAe9rVdPqk4hbxxeSap\",\"type\":\"group\"},\"type\":\"comap\",\"uniqueness\":\"z2doJ1YgahoUhmJb3Q\"}",
+      "sessions": [
+        {
+          "sessionId": "sealer_zAUKM88fyfD7qVLTzVtiW3YgpHubj6DWj4muSjZnVHdt5/signer_zBfbrLXMdsAeo2roL2FA7EWfEgqAe9rVdPqk4hbxxeSap_session_zMm5S3FRH2yg",
+          "signerId": "sealer_zAUKM88fyfD7qVLTzVtiW3YgpHubj6DWj4muSjZnVHdt5/signer_zBfbrLXMdsAeo2roL2FA7EWfEgqAe9rVdPqk4hbxxeSap",
+          "transactions": [
+            "{\"changes\":\"[{\\\"op\\\":\\\"set\\\",\\\"key\\\":\\\"sealer_zAUKM88fyfD7qVLTzVtiW3YgpHubj6DWj4muSjZnVHdt5/signer_zBfbrLXMdsAeo2roL2FA7EWfEgqAe9rVdPqk4hbxxeSap\\\",\\\"value\\\":\\\"admin\\\"}]\",\"madeAt\":1783120267004,\"privacy\":\"trusting\"}",
+            "{\"changes\":\"[{\\\"op\\\":\\\"set\\\",\\\"key\\\":\\\"key_z5KxbcFKvXoUNFqsWP_for_sealer_zAUKM88fyfD7qVLTzVtiW3YgpHubj6DWj4muSjZnVHdt5/signer_zBfbrLXMdsAeo2roL2FA7EWfEgqAe9rVdPqk4hbxxeSap\\\",\\\"value\\\":\\\"sealed_USTbZURfXPzSXA0J-b2rdtIvcObggI2D_GJdo3X3wkEBe4VPvjbyTqmI5LabYb-K_kLcVvo2eUNjFb8vRTdenGRgwgIXyWQMKFQ==\\\"}]\",\"madeAt\":1783120267004,\"privacy\":\"trusting\"}",
+            "{\"changes\":\"[{\\\"op\\\":\\\"set\\\",\\\"key\\\":\\\"readKey\\\",\\\"value\\\":\\\"key_z5KxbcFKvXoUNFqsWP\\\"}]\",\"madeAt\":1783120267004,\"privacy\":\"trusting\"}",
+            "{\"changes\":\"[{\\\"op\\\":\\\"set\\\",\\\"key\\\":\\\"groupSealer\\\",\\\"value\\\":\\\"key_z5KxbcFKvXoUNFqsWP@sealer_z6sDEEYTPq5s42xefeBdCDcDRg9SWoah4vYdFuAu6BkiQ\\\"}]\",\"madeAt\":1783120267004,\"privacy\":\"trusting\"}",
+            "{\"changes\":\"[{\\\"op\\\":\\\"set\\\",\\\"key\\\":\\\"co_zm5EBfjfNvQLPjJYiDwf326voPM\\\",\\\"value\\\":\\\"admin\\\"}]\",\"madeAt\":1783120267005,\"privacy\":\"trusting\"}",
+            "{\"changes\":\"[{\\\"op\\\":\\\"set\\\",\\\"key\\\":\\\"key_z5KxbcFKvXoUNFqsWP_for_co_zm5EBfjfNvQLPjJYiDwf326voPM\\\",\\\"value\\\":\\\"sealed_UjFrQJiT6TmQHMKMa_A_DMWewAbhogec7T9Sv-xQLauEgkzCNC04oNNZZGHS7AZ1S51RaB3A-FD0ok5QdJa7Tol_ChCxHRpbD1w==\\\"}]\",\"madeAt\":1783120267005,\"privacy\":\"trusting\"}"
+          ],
+          "lastSignature": "signature_z2EYoFx32Ajj6fdasFPXpDkYv7Px2VBBbozmttQjJKyC8qAN8ZA9Sg8dXL7n9JnDjKjJSg9dT2NeK7uobGJ3jLwK"
+        }
+      ]
+    },
+    {
+      "coId": "co_zm5EBfjfNvQLPjJYiDwf326voPM",
+      "headerJson": "{\"createdAt\":null,\"meta\":{\"type\":\"account\"},\"ruleset\":{\"initialAdmin\":\"sealer_z61kWxyFjinVWWpg8jC8GQEWQ8zDvnSDeQcra9VHq4sMo/signer_z2qPDtAUcnW9ADhHeL6ZLNK6yxgJ6RZM819XXjt1djhWZ\",\"type\":\"group\"},\"type\":\"comap\",\"uniqueness\":null}",
+      "sessions": [
+        {
+          "sessionId": "sealer_z61kWxyFjinVWWpg8jC8GQEWQ8zDvnSDeQcra9VHq4sMo/signer_z2qPDtAUcnW9ADhHeL6ZLNK6yxgJ6RZM819XXjt1djhWZ_session_zFKiZBc49pw2",
+          "signerId": "signer_z2qPDtAUcnW9ADhHeL6ZLNK6yxgJ6RZM819XXjt1djhWZ",
+          "transactions": [
+            "{\"changes\":\"[{\\\"op\\\":\\\"set\\\",\\\"key\\\":\\\"sealer_z61kWxyFjinVWWpg8jC8GQEWQ8zDvnSDeQcra9VHq4sMo/signer_z2qPDtAUcnW9ADhHeL6ZLNK6yxgJ6RZM819XXjt1djhWZ\\\",\\\"value\\\":\\\"admin\\\"}]\",\"madeAt\":1783120267005,\"privacy\":\"trusting\"}",
+            "{\"changes\":\"[{\\\"op\\\":\\\"set\\\",\\\"key\\\":\\\"key_z4BD4mEeZMP57UesEq_for_sealer_z61kWxyFjinVWWpg8jC8GQEWQ8zDvnSDeQcra9VHq4sMo/signer_z2qPDtAUcnW9ADhHeL6ZLNK6yxgJ6RZM819XXjt1djhWZ\\\",\\\"value\\\":\\\"sealed_UDcpMzx-GsPCMz68pT36evLSOsg6wqpFlNU0wWUNx3_NMkFPh-EaG8im0bLHmDJq5FesHILzb0Q87L4-JWcSIZ6rVM-yUNllGFw==\\\"}]\",\"madeAt\":1783120267005,\"privacy\":\"trusting\"}",
+            "{\"changes\":\"[{\\\"op\\\":\\\"set\\\",\\\"key\\\":\\\"readKey\\\",\\\"value\\\":\\\"key_z4BD4mEeZMP57UesEq\\\"}]\",\"madeAt\":1783120267005,\"privacy\":\"trusting\"}"
+          ],
+          "lastSignature": "signature_zRWDCWMPweCD3s4yv3W4NWFvqqYjq1QF5QyL5BvZv5P5WRrLMJxFqHcYxaA9JX2HsLkRYXBeRNfgb8aKyk9e81be"
+        }
+      ]
+    }
+  ],
+  "verdicts": {
+    "co_zWVAYLezoLqpZYT7g7KyNYoR3tj": [
+      {
+        "sessionId": "sealer_zAUKM88fyfD7qVLTzVtiW3YgpHubj6DWj4muSjZnVHdt5/signer_zBfbrLXMdsAeo2roL2FA7EWfEgqAe9rVdPqk4hbxxeSap_session_zMm5S3FRH2yg",
+        "txIndex": 0,
+        "valid": true,
+        "reason": null
+      },
+      {
+        "sessionId": "sealer_zAUKM88fyfD7qVLTzVtiW3YgpHubj6DWj4muSjZnVHdt5/signer_zBfbrLXMdsAeo2roL2FA7EWfEgqAe9rVdPqk4hbxxeSap_session_zMm5S3FRH2yg",
+        "txIndex": 1,
+        "valid": true,
+        "reason": null
+      },
+      {
+        "sessionId": "sealer_zAUKM88fyfD7qVLTzVtiW3YgpHubj6DWj4muSjZnVHdt5/signer_zBfbrLXMdsAeo2roL2FA7EWfEgqAe9rVdPqk4hbxxeSap_session_zMm5S3FRH2yg",
+        "txIndex": 2,
+        "valid": true,
+        "reason": null
+      },
+      {
+        "sessionId": "sealer_zAUKM88fyfD7qVLTzVtiW3YgpHubj6DWj4muSjZnVHdt5/signer_zBfbrLXMdsAeo2roL2FA7EWfEgqAe9rVdPqk4hbxxeSap_session_zMm5S3FRH2yg",
+        "txIndex": 3,
+        "valid": true,
+        "reason": null
+      },
+      {
+        "sessionId": "sealer_zAUKM88fyfD7qVLTzVtiW3YgpHubj6DWj4muSjZnVHdt5/signer_zBfbrLXMdsAeo2roL2FA7EWfEgqAe9rVdPqk4hbxxeSap_session_zMm5S3FRH2yg",
+        "txIndex": 4,
+        "valid": true,
+        "reason": null
+      },
+      {
+        "sessionId": "sealer_zAUKM88fyfD7qVLTzVtiW3YgpHubj6DWj4muSjZnVHdt5/signer_zBfbrLXMdsAeo2roL2FA7EWfEgqAe9rVdPqk4hbxxeSap_session_zMm5S3FRH2yg",
+        "txIndex": 5,
+        "valid": true,
+        "reason": null
+      }
+    ],
+    "co_zVsnsMtY74e4TTub5tzZQXbU21T": [
+      {
+        "sessionId": "sealer_zAUKM88fyfD7qVLTzVtiW3YgpHubj6DWj4muSjZnVHdt5/signer_zBfbrLXMdsAeo2roL2FA7EWfEgqAe9rVdPqk4hbxxeSap_session_zMm5S3FRH2yg",
+        "txIndex": 0,
+        "valid": true,
+        "reason": null
+      },
+      {
+        "sessionId": "sealer_zAUKM88fyfD7qVLTzVtiW3YgpHubj6DWj4muSjZnVHdt5/signer_zBfbrLXMdsAeo2roL2FA7EWfEgqAe9rVdPqk4hbxxeSap_session_zMm5S3FRH2yg",
+        "txIndex": 1,
+        "valid": true,
+        "reason": null
+      },
+      {
+        "sessionId": "sealer_zAUKM88fyfD7qVLTzVtiW3YgpHubj6DWj4muSjZnVHdt5/signer_zBfbrLXMdsAeo2roL2FA7EWfEgqAe9rVdPqk4hbxxeSap_session_zMm5S3FRH2yg",
+        "txIndex": 2,
+        "valid": true,
+        "reason": null
+      },
+      {
+        "sessionId": "sealer_zAUKM88fyfD7qVLTzVtiW3YgpHubj6DWj4muSjZnVHdt5/signer_zBfbrLXMdsAeo2roL2FA7EWfEgqAe9rVdPqk4hbxxeSap_session_zMm5S3FRH2yg",
+        "txIndex": 3,
+        "valid": true,
+        "reason": null
+      },
+      {
+        "sessionId": "sealer_zAUKM88fyfD7qVLTzVtiW3YgpHubj6DWj4muSjZnVHdt5/signer_zBfbrLXMdsAeo2roL2FA7EWfEgqAe9rVdPqk4hbxxeSap_session_zMm5S3FRH2yg",
+        "txIndex": 4,
+        "valid": true,
+        "reason": null
+      },
+      {
+        "sessionId": "sealer_zAUKM88fyfD7qVLTzVtiW3YgpHubj6DWj4muSjZnVHdt5/signer_zBfbrLXMdsAeo2roL2FA7EWfEgqAe9rVdPqk4hbxxeSap_session_zMm5S3FRH2yg",
+        "txIndex": 5,
+        "valid": true,
+        "reason": null
+      }
+    ]
+  },
+  "roleQueries": [
+    {
+      "groupId": "co_zVsnsMtY74e4TTub5tzZQXbU21T",
+      "member": "co_zm5EBfjfNvQLPjJYiDwf326voPM",
+      "atTime": null,
+      "expectedRole": "admin"
+    },
+    {
+      "groupId": "co_zWVAYLezoLqpZYT7g7KyNYoR3tj",
+      "member": "co_zm5EBfjfNvQLPjJYiDwf326voPM",
+      "atTime": null,
+      "expectedRole": "writer"
+    }
+  ]
+}

--- a/crates/cojson-core/data/group_engine/parent_extend.json
+++ b/crates/cojson-core/data/group_engine/parent_extend.json
@@ -1,0 +1,163 @@
+{
+  "description": "child group extends a parent; a parent member inherits their role in the child",
+  "covalues": [
+    {
+      "coId": "co_z5DHhgf8AcC8m4SHj5GTjUhKqSW",
+      "headerJson": "{\"createdAt\":\"2023-11-14T22:13:20.000Z\",\"meta\":null,\"ruleset\":{\"initialAdmin\":\"sealer_zESjSTi1yYiUJFfk656cASqmbunMASbuirp4xhqPrSbRK/signer_zBcWTJdXbRNqh4iLqpvcGUxvyxceaHt2EC5oCWL9iZiox\",\"type\":\"group\"},\"type\":\"comap\",\"uniqueness\":\"z271wdMT8kaKaEMPew\"}",
+      "sessions": [
+        {
+          "sessionId": "sealer_zESjSTi1yYiUJFfk656cASqmbunMASbuirp4xhqPrSbRK/signer_zBcWTJdXbRNqh4iLqpvcGUxvyxceaHt2EC5oCWL9iZiox_session_zTyr8PzofJri",
+          "signerId": "sealer_zESjSTi1yYiUJFfk656cASqmbunMASbuirp4xhqPrSbRK/signer_zBcWTJdXbRNqh4iLqpvcGUxvyxceaHt2EC5oCWL9iZiox",
+          "transactions": [
+            "{\"changes\":\"[{\\\"op\\\":\\\"set\\\",\\\"key\\\":\\\"sealer_zESjSTi1yYiUJFfk656cASqmbunMASbuirp4xhqPrSbRK/signer_zBcWTJdXbRNqh4iLqpvcGUxvyxceaHt2EC5oCWL9iZiox\\\",\\\"value\\\":\\\"admin\\\"}]\",\"madeAt\":1700000000000,\"privacy\":\"trusting\"}",
+            "{\"changes\":\"[{\\\"op\\\":\\\"set\\\",\\\"key\\\":\\\"key_z2iHNV14VStEi3vLyE_for_sealer_zESjSTi1yYiUJFfk656cASqmbunMASbuirp4xhqPrSbRK/signer_zBcWTJdXbRNqh4iLqpvcGUxvyxceaHt2EC5oCWL9iZiox\\\",\\\"value\\\":\\\"sealed_UU8WlsPiGUG08_p8jqMgrVMWpW9dTQ8Ul12lePuFFjzrK5aVa4ScGR1Lj5CP36GZ60kzOUf_iHRHN5VSZJVlNIFXluZ-RGsL_YQ==\\\"}]\",\"madeAt\":1700000000000,\"privacy\":\"trusting\"}",
+            "{\"changes\":\"[{\\\"op\\\":\\\"set\\\",\\\"key\\\":\\\"readKey\\\",\\\"value\\\":\\\"key_z2iHNV14VStEi3vLyE\\\"}]\",\"madeAt\":1700000000000,\"privacy\":\"trusting\"}",
+            "{\"changes\":\"[{\\\"op\\\":\\\"set\\\",\\\"key\\\":\\\"groupSealer\\\",\\\"value\\\":\\\"key_z2iHNV14VStEi3vLyE@sealer_zC5hwyhU7u94maD3LFJiWcWe4K1hPdzJVYVhkjsMpyxNu\\\"}]\",\"madeAt\":1700000000000,\"privacy\":\"trusting\"}",
+            "{\"changes\":\"[{\\\"op\\\":\\\"set\\\",\\\"key\\\":\\\"parent_co_zcsomTZP9rEDbhYyqGzHvb1vC24\\\",\\\"value\\\":\\\"extend\\\"}]\",\"madeAt\":1700000001000,\"privacy\":\"trusting\"}",
+            "{\"changes\":\"[{\\\"op\\\":\\\"set\\\",\\\"key\\\":\\\"key_z2iHNV14VStEi3vLyE_for_key_z4nse3CyTChiMxmBbm\\\",\\\"value\\\":\\\"encrypted_UjWq9xplrNw_h9beTNTzhv5FisyOT2N_aFQWbC9x02XGqWYbU9HrJYB5n1FIL0geFRT5fmXSyFVtO\\\"}]\",\"madeAt\":1700000001000,\"privacy\":\"trusting\"}"
+          ],
+          "lastSignature": "signature_z2uUvpxJPr2y7cNTDz5CE6R8snzmV7ZydWSRVm3HEyeqTDW64JEgKVrExKvQcLPAd6NfwNADXaBgf9bfeDkAgpUvC"
+        }
+      ]
+    },
+    {
+      "coId": "co_zcsomTZP9rEDbhYyqGzHvb1vC24",
+      "headerJson": "{\"createdAt\":\"2023-11-14T22:13:20.000Z\",\"meta\":null,\"ruleset\":{\"initialAdmin\":\"sealer_zESjSTi1yYiUJFfk656cASqmbunMASbuirp4xhqPrSbRK/signer_zBcWTJdXbRNqh4iLqpvcGUxvyxceaHt2EC5oCWL9iZiox\",\"type\":\"group\"},\"type\":\"comap\",\"uniqueness\":\"z3d882SxPS1LTRf3SQ\"}",
+      "sessions": [
+        {
+          "sessionId": "sealer_zESjSTi1yYiUJFfk656cASqmbunMASbuirp4xhqPrSbRK/signer_zBcWTJdXbRNqh4iLqpvcGUxvyxceaHt2EC5oCWL9iZiox_session_zTyr8PzofJri",
+          "signerId": "sealer_zESjSTi1yYiUJFfk656cASqmbunMASbuirp4xhqPrSbRK/signer_zBcWTJdXbRNqh4iLqpvcGUxvyxceaHt2EC5oCWL9iZiox",
+          "transactions": [
+            "{\"changes\":\"[{\\\"op\\\":\\\"set\\\",\\\"key\\\":\\\"sealer_zESjSTi1yYiUJFfk656cASqmbunMASbuirp4xhqPrSbRK/signer_zBcWTJdXbRNqh4iLqpvcGUxvyxceaHt2EC5oCWL9iZiox\\\",\\\"value\\\":\\\"admin\\\"}]\",\"madeAt\":1700000000000,\"privacy\":\"trusting\"}",
+            "{\"changes\":\"[{\\\"op\\\":\\\"set\\\",\\\"key\\\":\\\"key_z4nse3CyTChiMxmBbm_for_sealer_zESjSTi1yYiUJFfk656cASqmbunMASbuirp4xhqPrSbRK/signer_zBcWTJdXbRNqh4iLqpvcGUxvyxceaHt2EC5oCWL9iZiox\\\",\\\"value\\\":\\\"sealed_Ug-1jjnLUP2Hokxzq4QferELREVo53WA5MCMFJ41X198aOEK5qi0fQI1ig1NXXZM70_2a-_8t89VdGHj26Gsep5TLmgXHG5t7yA==\\\"}]\",\"madeAt\":1700000000000,\"privacy\":\"trusting\"}",
+            "{\"changes\":\"[{\\\"op\\\":\\\"set\\\",\\\"key\\\":\\\"readKey\\\",\\\"value\\\":\\\"key_z4nse3CyTChiMxmBbm\\\"}]\",\"madeAt\":1700000000000,\"privacy\":\"trusting\"}",
+            "{\"changes\":\"[{\\\"op\\\":\\\"set\\\",\\\"key\\\":\\\"groupSealer\\\",\\\"value\\\":\\\"key_z4nse3CyTChiMxmBbm@sealer_zGbd4fAdSEEsuBbwgJvcKpmuesLo65FKm9JYQ7w5pASAa\\\"}]\",\"madeAt\":1700000000000,\"privacy\":\"trusting\"}",
+            "{\"changes\":\"[{\\\"op\\\":\\\"set\\\",\\\"key\\\":\\\"co_zA3vtQiNneawkmxzmrhvqVhz18o\\\",\\\"value\\\":\\\"writer\\\"}]\",\"madeAt\":1700000002000,\"privacy\":\"trusting\"}",
+            "{\"changes\":\"[{\\\"op\\\":\\\"set\\\",\\\"key\\\":\\\"key_z4nse3CyTChiMxmBbm_for_co_zA3vtQiNneawkmxzmrhvqVhz18o\\\",\\\"value\\\":\\\"sealed_UgVlGklPoj7OOwQFnKxCdeYx74G__seurPMV3kjC2Hnz12FcJKmtY1nxtiYxW3BCDEokQhNQ4hAwRmNjZI-by4cOPiQ8vOe_8Ew==\\\"}]\",\"madeAt\":1700000002000,\"privacy\":\"trusting\"}"
+          ],
+          "lastSignature": "signature_z5nSfFTJui1VYagTDa4YNeETtkZmSDkfsRibmfpi6DXxpDqhr8Qk8XsHYaYYzUDWQMUWMMxd8u3SMpdFPf55rFYNc"
+        }
+      ]
+    },
+    {
+      "coId": "co_zA3vtQiNneawkmxzmrhvqVhz18o",
+      "headerJson": "{\"createdAt\":null,\"meta\":{\"type\":\"account\"},\"ruleset\":{\"initialAdmin\":\"sealer_zHKHriimkJ1ukGVkpbxzPwTa3mxJF5duV48SPDF6ZBZpH/signer_zAcsfQJWmciERXYaXMAnwhMWKvyidunAt9sSkCzK8ZvUR\",\"type\":\"group\"},\"type\":\"comap\",\"uniqueness\":null}",
+      "sessions": [
+        {
+          "sessionId": "sealer_zHKHriimkJ1ukGVkpbxzPwTa3mxJF5duV48SPDF6ZBZpH/signer_zAcsfQJWmciERXYaXMAnwhMWKvyidunAt9sSkCzK8ZvUR_session_zhYU2wop9WWW",
+          "signerId": "signer_zAcsfQJWmciERXYaXMAnwhMWKvyidunAt9sSkCzK8ZvUR",
+          "transactions": [
+            "{\"changes\":\"[{\\\"op\\\":\\\"set\\\",\\\"key\\\":\\\"sealer_zHKHriimkJ1ukGVkpbxzPwTa3mxJF5duV48SPDF6ZBZpH/signer_zAcsfQJWmciERXYaXMAnwhMWKvyidunAt9sSkCzK8ZvUR\\\",\\\"value\\\":\\\"admin\\\"}]\",\"madeAt\":1700000001000,\"privacy\":\"trusting\"}",
+            "{\"changes\":\"[{\\\"op\\\":\\\"set\\\",\\\"key\\\":\\\"key_z4cvgmZ3nT8157HBzv_for_sealer_zHKHriimkJ1ukGVkpbxzPwTa3mxJF5duV48SPDF6ZBZpH/signer_zAcsfQJWmciERXYaXMAnwhMWKvyidunAt9sSkCzK8ZvUR\\\",\\\"value\\\":\\\"sealed_Uu-AfWN8PB2AmgPDnEs7kUVhMjhWtFg34ci3xD9D45A7cZPH7B4VjWykL8bhbvmXuvPj8LcqzlO2YSLnfN9lX4sX2gKkjAz15xA==\\\"}]\",\"madeAt\":1700000001000,\"privacy\":\"trusting\"}",
+            "{\"changes\":\"[{\\\"op\\\":\\\"set\\\",\\\"key\\\":\\\"readKey\\\",\\\"value\\\":\\\"key_z4cvgmZ3nT8157HBzv\\\"}]\",\"madeAt\":1700000001000,\"privacy\":\"trusting\"}"
+          ],
+          "lastSignature": "signature_z3svXcA3GWkhJaggApNdL2UMUrvwu5tVN6K4EBoQ2mNmCBEHmsQUcJBDGiQREsDMyjMcrpgcPJdrZ9cxGsTuEJked"
+        }
+      ]
+    }
+  ],
+  "verdicts": {
+    "co_z5DHhgf8AcC8m4SHj5GTjUhKqSW": [
+      {
+        "sessionId": "sealer_zESjSTi1yYiUJFfk656cASqmbunMASbuirp4xhqPrSbRK/signer_zBcWTJdXbRNqh4iLqpvcGUxvyxceaHt2EC5oCWL9iZiox_session_zTyr8PzofJri",
+        "txIndex": 0,
+        "valid": true,
+        "reason": null
+      },
+      {
+        "sessionId": "sealer_zESjSTi1yYiUJFfk656cASqmbunMASbuirp4xhqPrSbRK/signer_zBcWTJdXbRNqh4iLqpvcGUxvyxceaHt2EC5oCWL9iZiox_session_zTyr8PzofJri",
+        "txIndex": 1,
+        "valid": true,
+        "reason": null
+      },
+      {
+        "sessionId": "sealer_zESjSTi1yYiUJFfk656cASqmbunMASbuirp4xhqPrSbRK/signer_zBcWTJdXbRNqh4iLqpvcGUxvyxceaHt2EC5oCWL9iZiox_session_zTyr8PzofJri",
+        "txIndex": 2,
+        "valid": true,
+        "reason": null
+      },
+      {
+        "sessionId": "sealer_zESjSTi1yYiUJFfk656cASqmbunMASbuirp4xhqPrSbRK/signer_zBcWTJdXbRNqh4iLqpvcGUxvyxceaHt2EC5oCWL9iZiox_session_zTyr8PzofJri",
+        "txIndex": 3,
+        "valid": true,
+        "reason": null
+      },
+      {
+        "sessionId": "sealer_zESjSTi1yYiUJFfk656cASqmbunMASbuirp4xhqPrSbRK/signer_zBcWTJdXbRNqh4iLqpvcGUxvyxceaHt2EC5oCWL9iZiox_session_zTyr8PzofJri",
+        "txIndex": 4,
+        "valid": true,
+        "reason": null
+      },
+      {
+        "sessionId": "sealer_zESjSTi1yYiUJFfk656cASqmbunMASbuirp4xhqPrSbRK/signer_zBcWTJdXbRNqh4iLqpvcGUxvyxceaHt2EC5oCWL9iZiox_session_zTyr8PzofJri",
+        "txIndex": 5,
+        "valid": true,
+        "reason": null
+      }
+    ],
+    "co_zcsomTZP9rEDbhYyqGzHvb1vC24": [
+      {
+        "sessionId": "sealer_zESjSTi1yYiUJFfk656cASqmbunMASbuirp4xhqPrSbRK/signer_zBcWTJdXbRNqh4iLqpvcGUxvyxceaHt2EC5oCWL9iZiox_session_zTyr8PzofJri",
+        "txIndex": 0,
+        "valid": true,
+        "reason": null
+      },
+      {
+        "sessionId": "sealer_zESjSTi1yYiUJFfk656cASqmbunMASbuirp4xhqPrSbRK/signer_zBcWTJdXbRNqh4iLqpvcGUxvyxceaHt2EC5oCWL9iZiox_session_zTyr8PzofJri",
+        "txIndex": 1,
+        "valid": true,
+        "reason": null
+      },
+      {
+        "sessionId": "sealer_zESjSTi1yYiUJFfk656cASqmbunMASbuirp4xhqPrSbRK/signer_zBcWTJdXbRNqh4iLqpvcGUxvyxceaHt2EC5oCWL9iZiox_session_zTyr8PzofJri",
+        "txIndex": 2,
+        "valid": true,
+        "reason": null
+      },
+      {
+        "sessionId": "sealer_zESjSTi1yYiUJFfk656cASqmbunMASbuirp4xhqPrSbRK/signer_zBcWTJdXbRNqh4iLqpvcGUxvyxceaHt2EC5oCWL9iZiox_session_zTyr8PzofJri",
+        "txIndex": 3,
+        "valid": true,
+        "reason": null
+      },
+      {
+        "sessionId": "sealer_zESjSTi1yYiUJFfk656cASqmbunMASbuirp4xhqPrSbRK/signer_zBcWTJdXbRNqh4iLqpvcGUxvyxceaHt2EC5oCWL9iZiox_session_zTyr8PzofJri",
+        "txIndex": 4,
+        "valid": true,
+        "reason": null
+      },
+      {
+        "sessionId": "sealer_zESjSTi1yYiUJFfk656cASqmbunMASbuirp4xhqPrSbRK/signer_zBcWTJdXbRNqh4iLqpvcGUxvyxceaHt2EC5oCWL9iZiox_session_zTyr8PzofJri",
+        "txIndex": 5,
+        "valid": true,
+        "reason": null
+      }
+    ]
+  },
+  "roleQueries": [
+    {
+      "groupId": "co_z5DHhgf8AcC8m4SHj5GTjUhKqSW",
+      "member": "co_zA3vtQiNneawkmxzmrhvqVhz18o",
+      "atTime": 1700000001000,
+      "expectedRole": null
+    },
+    {
+      "groupId": "co_z5DHhgf8AcC8m4SHj5GTjUhKqSW",
+      "member": "co_zA3vtQiNneawkmxzmrhvqVhz18o",
+      "atTime": 1700000002000,
+      "expectedRole": "writer"
+    },
+    {
+      "groupId": "co_z5DHhgf8AcC8m4SHj5GTjUhKqSW",
+      "member": "co_zA3vtQiNneawkmxzmrhvqVhz18o",
+      "atTime": null,
+      "expectedRole": "writer"
+    },
+    {
+      "groupId": "co_zcsomTZP9rEDbhYyqGzHvb1vC24",
+      "member": "co_zA3vtQiNneawkmxzmrhvqVhz18o",
+      "atTime": null,
+      "expectedRole": "writer"
+    }
+  ]
+}

--- a/crates/cojson-core/data/group_engine/parent_revoked_inheritance.json
+++ b/crates/cojson-core/data/group_engine/parent_revoked_inheritance.json
@@ -1,0 +1,235 @@
+{
+  "description": "member is reader in child and revoked in parent (extend mapping); pins the read-side override behaviour",
+  "covalues": [
+    {
+      "coId": "co_zRZMUa44hGFZ8e9RPKysQsviUie",
+      "headerJson": "{\"createdAt\":\"2026-07-03T23:11:07.007Z\",\"meta\":null,\"ruleset\":{\"initialAdmin\":\"sealer_zHQxXTMfd828qkFQNaDk7GggcQGkgaK43WNtw237bq4oZ/signer_z25RxRwkMpqnZC7wmctKSBphwzpBAW4LDVHgn3TDuj1UJ\",\"type\":\"group\"},\"type\":\"comap\",\"uniqueness\":\"z2AgwfNbJF4y88zEDE\"}",
+      "sessions": [
+        {
+          "sessionId": "sealer_zHQxXTMfd828qkFQNaDk7GggcQGkgaK43WNtw237bq4oZ/signer_z25RxRwkMpqnZC7wmctKSBphwzpBAW4LDVHgn3TDuj1UJ_session_zgn6itg7PE3X",
+          "signerId": "sealer_zHQxXTMfd828qkFQNaDk7GggcQGkgaK43WNtw237bq4oZ/signer_z25RxRwkMpqnZC7wmctKSBphwzpBAW4LDVHgn3TDuj1UJ",
+          "transactions": [
+            "{\"changes\":\"[{\\\"op\\\":\\\"set\\\",\\\"key\\\":\\\"sealer_zHQxXTMfd828qkFQNaDk7GggcQGkgaK43WNtw237bq4oZ/signer_z25RxRwkMpqnZC7wmctKSBphwzpBAW4LDVHgn3TDuj1UJ\\\",\\\"value\\\":\\\"admin\\\"}]\",\"madeAt\":1783120267007,\"privacy\":\"trusting\"}",
+            "{\"changes\":\"[{\\\"op\\\":\\\"set\\\",\\\"key\\\":\\\"key_zDoEcBMhL5kieDZG7_for_sealer_zHQxXTMfd828qkFQNaDk7GggcQGkgaK43WNtw237bq4oZ/signer_z25RxRwkMpqnZC7wmctKSBphwzpBAW4LDVHgn3TDuj1UJ\\\",\\\"value\\\":\\\"sealed_UuLh-3qMQeW70l7BgOk1UG4zy8GXEbDL33mktyylBpN6wWw3Fpf9PRcUPj1GWODddUjXidFlOoCIsxKtCfaik6ufxfzarXf27Bg==\\\"}]\",\"madeAt\":1783120267007,\"privacy\":\"trusting\"}",
+            "{\"changes\":\"[{\\\"op\\\":\\\"set\\\",\\\"key\\\":\\\"readKey\\\",\\\"value\\\":\\\"key_zDoEcBMhL5kieDZG7\\\"}]\",\"madeAt\":1783120267007,\"privacy\":\"trusting\"}",
+            "{\"changes\":\"[{\\\"op\\\":\\\"set\\\",\\\"key\\\":\\\"groupSealer\\\",\\\"value\\\":\\\"key_zDoEcBMhL5kieDZG7@sealer_zDRuFoWJG92Jhxb1UneJvn46ZbzuyYdfnEpHL8n5cfAWD\\\"}]\",\"madeAt\":1783120267007,\"privacy\":\"trusting\"}",
+            "{\"changes\":\"[{\\\"op\\\":\\\"set\\\",\\\"key\\\":\\\"parent_co_zReFPKwRN7T1f8N3GrG7sBFopBW\\\",\\\"value\\\":\\\"extend\\\"}]\",\"madeAt\":1783120267007,\"privacy\":\"trusting\"}",
+            "{\"changes\":\"[{\\\"op\\\":\\\"set\\\",\\\"key\\\":\\\"key_zDoEcBMhL5kieDZG7_for_key_z4CYHbNe4No63nPuwT\\\",\\\"value\\\":\\\"encrypted_UDcsJbhbKW4YBxxdoBLTVJ5Pdx-wzKvXPOClRWYfv719cr4ISimeJmzip4ay79OBFtMM8h0L3zcGO\\\"}]\",\"madeAt\":1783120267007,\"privacy\":\"trusting\"}",
+            "{\"changes\":\"[{\\\"op\\\":\\\"set\\\",\\\"key\\\":\\\"co_zWnf1uvxKUbBtFuQ6wJ7Esiavcd\\\",\\\"value\\\":\\\"reader\\\"}]\",\"madeAt\":1783120267008,\"privacy\":\"trusting\"}",
+            "{\"changes\":\"[{\\\"op\\\":\\\"set\\\",\\\"key\\\":\\\"key_zDoEcBMhL5kieDZG7_for_co_zWnf1uvxKUbBtFuQ6wJ7Esiavcd\\\",\\\"value\\\":\\\"sealed_UWCafi-AAwOc0B4NGFM6ZoJRysdmmIht-0kgH5H6_YYmnUbPT4Vl_RiY7U7f06mqNWAfKsCWK0rGJkwvZdbjU7XYtenzUVTFN1g==\\\"}]\",\"madeAt\":1783120267008,\"privacy\":\"trusting\"}",
+            "{\"changes\":\"[{\\\"op\\\":\\\"set\\\",\\\"key\\\":\\\"key_z4cRsMcrPXHDM3Fxu8_for_sealer_zHQxXTMfd828qkFQNaDk7GggcQGkgaK43WNtw237bq4oZ/signer_z25RxRwkMpqnZC7wmctKSBphwzpBAW4LDVHgn3TDuj1UJ\\\",\\\"value\\\":\\\"sealed_UbEkFx55xN6YUk-1R8GbRdczUxOiwbYARlMlekYnGONXbrOIna0Cj2_KAqMV6DYiiWtZelibKgiuIpGw_yJuR-YxpCrNmGDGCXg==\\\"}]\",\"madeAt\":1783120267008,\"privacy\":\"trusting\"}",
+            "{\"changes\":\"[{\\\"op\\\":\\\"set\\\",\\\"key\\\":\\\"key_zDoEcBMhL5kieDZG7_for_key_z4cRsMcrPXHDM3Fxu8\\\",\\\"value\\\":\\\"encrypted_UmaDmno_TcpnAvfepPwcRNej-52qacEFmfpIrwEW54aKq2VqjBuh8CDqadB4RWcgcrkd1pOgVWIgC\\\"}]\",\"madeAt\":1783120267008,\"privacy\":\"trusting\"}",
+            "{\"changes\":\"[{\\\"op\\\":\\\"set\\\",\\\"key\\\":\\\"readKey\\\",\\\"value\\\":\\\"key_z4cRsMcrPXHDM3Fxu8\\\"}]\",\"madeAt\":1783120267009,\"privacy\":\"trusting\"}",
+            "{\"changes\":\"[{\\\"op\\\":\\\"set\\\",\\\"key\\\":\\\"groupSealer\\\",\\\"value\\\":\\\"key_z4cRsMcrPXHDM3Fxu8@sealer_z3m9d261mUC5mzvJQEaVFwrrtAGvBaMAFHxJTmGsBxZLC\\\"}]\",\"madeAt\":1783120267009,\"privacy\":\"trusting\"}",
+            "{\"changes\":\"[{\\\"op\\\":\\\"set\\\",\\\"key\\\":\\\"key_z4cRsMcrPXHDM3Fxu8_for_key_z5jyoD9CwadPCxNhEJ\\\",\\\"value\\\":\\\"encrypted_UBDgr684S9EiGUXSSxUKVO7qmRFWeUKZ15eCQl5f9r9xFkuo0Y9b2HhCquJ_vvNYe-IuKFLfYlEhf\\\"}]\",\"madeAt\":1783120267009,\"privacy\":\"trusting\"}"
+          ],
+          "lastSignature": "signature_z5GR8p7fkL2cvr28cveJFceUjZcqB4hwehhBKbyFx2CRiUsG3EyN88h5a8AX5Ez4zD4CjoSsLwaYAZFzW5edFmwc6"
+        }
+      ]
+    },
+    {
+      "coId": "co_zReFPKwRN7T1f8N3GrG7sBFopBW",
+      "headerJson": "{\"createdAt\":\"2026-07-03T23:11:07.006Z\",\"meta\":null,\"ruleset\":{\"initialAdmin\":\"sealer_zHQxXTMfd828qkFQNaDk7GggcQGkgaK43WNtw237bq4oZ/signer_z25RxRwkMpqnZC7wmctKSBphwzpBAW4LDVHgn3TDuj1UJ\",\"type\":\"group\"},\"type\":\"comap\",\"uniqueness\":\"z4rcH9NJcDUCdKNsHq\"}",
+      "sessions": [
+        {
+          "sessionId": "sealer_zHQxXTMfd828qkFQNaDk7GggcQGkgaK43WNtw237bq4oZ/signer_z25RxRwkMpqnZC7wmctKSBphwzpBAW4LDVHgn3TDuj1UJ_session_zgn6itg7PE3X",
+          "signerId": "sealer_zHQxXTMfd828qkFQNaDk7GggcQGkgaK43WNtw237bq4oZ/signer_z25RxRwkMpqnZC7wmctKSBphwzpBAW4LDVHgn3TDuj1UJ",
+          "transactions": [
+            "{\"changes\":\"[{\\\"op\\\":\\\"set\\\",\\\"key\\\":\\\"sealer_zHQxXTMfd828qkFQNaDk7GggcQGkgaK43WNtw237bq4oZ/signer_z25RxRwkMpqnZC7wmctKSBphwzpBAW4LDVHgn3TDuj1UJ\\\",\\\"value\\\":\\\"admin\\\"}]\",\"madeAt\":1783120267006,\"privacy\":\"trusting\"}",
+            "{\"changes\":\"[{\\\"op\\\":\\\"set\\\",\\\"key\\\":\\\"key_z4CYHbNe4No63nPuwT_for_sealer_zHQxXTMfd828qkFQNaDk7GggcQGkgaK43WNtw237bq4oZ/signer_z25RxRwkMpqnZC7wmctKSBphwzpBAW4LDVHgn3TDuj1UJ\\\",\\\"value\\\":\\\"sealed_UrwjavYbI3hhGZpV5_2Zbn0nXZKQplJtId5P72ZgacV1Vd0mvFtnVsYANjf3Fbmihqg7M1uWMaTo_MyMvdRhbygribH81Ns17pg==\\\"}]\",\"madeAt\":1783120267007,\"privacy\":\"trusting\"}",
+            "{\"changes\":\"[{\\\"op\\\":\\\"set\\\",\\\"key\\\":\\\"readKey\\\",\\\"value\\\":\\\"key_z4CYHbNe4No63nPuwT\\\"}]\",\"madeAt\":1783120267007,\"privacy\":\"trusting\"}",
+            "{\"changes\":\"[{\\\"op\\\":\\\"set\\\",\\\"key\\\":\\\"groupSealer\\\",\\\"value\\\":\\\"key_z4CYHbNe4No63nPuwT@sealer_z4WqHLiWihdxXuUEcVYm7ReoPQDuPifbesd7r6Bfvd8BY\\\"}]\",\"madeAt\":1783120267007,\"privacy\":\"trusting\"}",
+            "{\"changes\":\"[{\\\"op\\\":\\\"set\\\",\\\"key\\\":\\\"co_zWnf1uvxKUbBtFuQ6wJ7Esiavcd\\\",\\\"value\\\":\\\"reader\\\"}]\",\"madeAt\":1783120267008,\"privacy\":\"trusting\"}",
+            "{\"changes\":\"[{\\\"op\\\":\\\"set\\\",\\\"key\\\":\\\"key_z4CYHbNe4No63nPuwT_for_co_zWnf1uvxKUbBtFuQ6wJ7Esiavcd\\\",\\\"value\\\":\\\"sealed_UMQQJ1ya2q9aUuABxmBq4La3Z41RrMnvc0kpB6BOEQCVMZW4TMluQtBzwAPXefNigGUkQ2EN5EKq4u6wSYsJzGb-y-dQlE3Rogg==\\\"}]\",\"madeAt\":1783120267008,\"privacy\":\"trusting\"}",
+            "{\"changes\":\"[{\\\"op\\\":\\\"set\\\",\\\"key\\\":\\\"key_z5jyoD9CwadPCxNhEJ_for_sealer_zHQxXTMfd828qkFQNaDk7GggcQGkgaK43WNtw237bq4oZ/signer_z25RxRwkMpqnZC7wmctKSBphwzpBAW4LDVHgn3TDuj1UJ\\\",\\\"value\\\":\\\"sealed_UeAPuuRTgzXhZ-6nU4gWaiOgP6rGJ1-J6vCdNSMZsjE8ThHCZrlE00DTPO35zvVnvEACBOr8Wy9bQEa8UHKPY_fML6KFtBh9dxQ==\\\"}]\",\"madeAt\":1783120267008,\"privacy\":\"trusting\"}",
+            "{\"changes\":\"[{\\\"op\\\":\\\"set\\\",\\\"key\\\":\\\"key_z4CYHbNe4No63nPuwT_for_key_z5jyoD9CwadPCxNhEJ\\\",\\\"value\\\":\\\"encrypted_Us9HSG4qSwawsKwnxOyEac1-LGUOB4LallNyW0Z4aOy_kWAoGXblgNSkM_PPRlGHtgc2n5bjv0j0J\\\"}]\",\"madeAt\":1783120267008,\"privacy\":\"trusting\"}",
+            "{\"changes\":\"[{\\\"op\\\":\\\"set\\\",\\\"key\\\":\\\"readKey\\\",\\\"value\\\":\\\"key_z5jyoD9CwadPCxNhEJ\\\"}]\",\"madeAt\":1783120267008,\"privacy\":\"trusting\"}",
+            "{\"changes\":\"[{\\\"op\\\":\\\"set\\\",\\\"key\\\":\\\"groupSealer\\\",\\\"value\\\":\\\"key_z5jyoD9CwadPCxNhEJ@sealer_z262WxUvGvut5bJgRND47q6h7AJf8dSYJBMs6CmQDYL2a\\\"}]\",\"madeAt\":1783120267008,\"privacy\":\"trusting\"}",
+            "{\"changes\":\"[{\\\"op\\\":\\\"set\\\",\\\"key\\\":\\\"co_zWnf1uvxKUbBtFuQ6wJ7Esiavcd\\\",\\\"value\\\":\\\"revoked\\\"}]\",\"madeAt\":1783120267009,\"privacy\":\"trusting\"}"
+          ],
+          "lastSignature": "signature_zkHTPL9WKA9um9ZEGgp3gHPxjThie23YGiKEP4c8qhN1ykPBMS9Q7A32cj9m4Y861Q5nncAhxBKoAdJoPZLYx3dn"
+        }
+      ]
+    },
+    {
+      "coId": "co_zWnf1uvxKUbBtFuQ6wJ7Esiavcd",
+      "headerJson": "{\"createdAt\":null,\"meta\":{\"type\":\"account\"},\"ruleset\":{\"initialAdmin\":\"sealer_zDfhE3GNukAnW1GvEyoRY4GkYtmx5qV27TAnNSzpek4kD/signer_z9k81ce9YvL8LfQ6ZzdPYpjfHypJP418zrdRBHPJA2xZ2\",\"type\":\"group\"},\"type\":\"comap\",\"uniqueness\":null}",
+      "sessions": [
+        {
+          "sessionId": "sealer_zDfhE3GNukAnW1GvEyoRY4GkYtmx5qV27TAnNSzpek4kD/signer_z9k81ce9YvL8LfQ6ZzdPYpjfHypJP418zrdRBHPJA2xZ2_session_zDkrxxpYgqNw",
+          "signerId": "signer_z9k81ce9YvL8LfQ6ZzdPYpjfHypJP418zrdRBHPJA2xZ2",
+          "transactions": [
+            "{\"changes\":\"[{\\\"op\\\":\\\"set\\\",\\\"key\\\":\\\"sealer_zDfhE3GNukAnW1GvEyoRY4GkYtmx5qV27TAnNSzpek4kD/signer_z9k81ce9YvL8LfQ6ZzdPYpjfHypJP418zrdRBHPJA2xZ2\\\",\\\"value\\\":\\\"admin\\\"}]\",\"madeAt\":1783120267007,\"privacy\":\"trusting\"}",
+            "{\"changes\":\"[{\\\"op\\\":\\\"set\\\",\\\"key\\\":\\\"key_z4NW5JNd1PWyF7KM6M_for_sealer_zDfhE3GNukAnW1GvEyoRY4GkYtmx5qV27TAnNSzpek4kD/signer_z9k81ce9YvL8LfQ6ZzdPYpjfHypJP418zrdRBHPJA2xZ2\\\",\\\"value\\\":\\\"sealed_UmC-GvC679Vl2D7pjFGYFzUlCq6PWyFBuADtHHtVk0nyT3Pb1UkQfRx5cSKiiFQah0H6fq2-VlI_M_0p_bvJr6xxj5NPScUvhow==\\\"}]\",\"madeAt\":1783120267007,\"privacy\":\"trusting\"}",
+            "{\"changes\":\"[{\\\"op\\\":\\\"set\\\",\\\"key\\\":\\\"readKey\\\",\\\"value\\\":\\\"key_z4NW5JNd1PWyF7KM6M\\\"}]\",\"madeAt\":1783120267007,\"privacy\":\"trusting\"}"
+          ],
+          "lastSignature": "signature_z4ujvJ8No3qZ5FkaXLDEdazMhLu8Wge6NL4iRWL3J1nHxsGYdRTNk6TNoMN4N5rqThQBq4BZrsKgzr6K3LZpufett"
+        }
+      ]
+    }
+  ],
+  "verdicts": {
+    "co_zRZMUa44hGFZ8e9RPKysQsviUie": [
+      {
+        "sessionId": "sealer_zHQxXTMfd828qkFQNaDk7GggcQGkgaK43WNtw237bq4oZ/signer_z25RxRwkMpqnZC7wmctKSBphwzpBAW4LDVHgn3TDuj1UJ_session_zgn6itg7PE3X",
+        "txIndex": 0,
+        "valid": true,
+        "reason": null
+      },
+      {
+        "sessionId": "sealer_zHQxXTMfd828qkFQNaDk7GggcQGkgaK43WNtw237bq4oZ/signer_z25RxRwkMpqnZC7wmctKSBphwzpBAW4LDVHgn3TDuj1UJ_session_zgn6itg7PE3X",
+        "txIndex": 1,
+        "valid": true,
+        "reason": null
+      },
+      {
+        "sessionId": "sealer_zHQxXTMfd828qkFQNaDk7GggcQGkgaK43WNtw237bq4oZ/signer_z25RxRwkMpqnZC7wmctKSBphwzpBAW4LDVHgn3TDuj1UJ_session_zgn6itg7PE3X",
+        "txIndex": 2,
+        "valid": true,
+        "reason": null
+      },
+      {
+        "sessionId": "sealer_zHQxXTMfd828qkFQNaDk7GggcQGkgaK43WNtw237bq4oZ/signer_z25RxRwkMpqnZC7wmctKSBphwzpBAW4LDVHgn3TDuj1UJ_session_zgn6itg7PE3X",
+        "txIndex": 3,
+        "valid": true,
+        "reason": null
+      },
+      {
+        "sessionId": "sealer_zHQxXTMfd828qkFQNaDk7GggcQGkgaK43WNtw237bq4oZ/signer_z25RxRwkMpqnZC7wmctKSBphwzpBAW4LDVHgn3TDuj1UJ_session_zgn6itg7PE3X",
+        "txIndex": 4,
+        "valid": true,
+        "reason": null
+      },
+      {
+        "sessionId": "sealer_zHQxXTMfd828qkFQNaDk7GggcQGkgaK43WNtw237bq4oZ/signer_z25RxRwkMpqnZC7wmctKSBphwzpBAW4LDVHgn3TDuj1UJ_session_zgn6itg7PE3X",
+        "txIndex": 5,
+        "valid": true,
+        "reason": null
+      },
+      {
+        "sessionId": "sealer_zHQxXTMfd828qkFQNaDk7GggcQGkgaK43WNtw237bq4oZ/signer_z25RxRwkMpqnZC7wmctKSBphwzpBAW4LDVHgn3TDuj1UJ_session_zgn6itg7PE3X",
+        "txIndex": 6,
+        "valid": true,
+        "reason": null
+      },
+      {
+        "sessionId": "sealer_zHQxXTMfd828qkFQNaDk7GggcQGkgaK43WNtw237bq4oZ/signer_z25RxRwkMpqnZC7wmctKSBphwzpBAW4LDVHgn3TDuj1UJ_session_zgn6itg7PE3X",
+        "txIndex": 7,
+        "valid": true,
+        "reason": null
+      },
+      {
+        "sessionId": "sealer_zHQxXTMfd828qkFQNaDk7GggcQGkgaK43WNtw237bq4oZ/signer_z25RxRwkMpqnZC7wmctKSBphwzpBAW4LDVHgn3TDuj1UJ_session_zgn6itg7PE3X",
+        "txIndex": 8,
+        "valid": true,
+        "reason": null
+      },
+      {
+        "sessionId": "sealer_zHQxXTMfd828qkFQNaDk7GggcQGkgaK43WNtw237bq4oZ/signer_z25RxRwkMpqnZC7wmctKSBphwzpBAW4LDVHgn3TDuj1UJ_session_zgn6itg7PE3X",
+        "txIndex": 9,
+        "valid": true,
+        "reason": null
+      },
+      {
+        "sessionId": "sealer_zHQxXTMfd828qkFQNaDk7GggcQGkgaK43WNtw237bq4oZ/signer_z25RxRwkMpqnZC7wmctKSBphwzpBAW4LDVHgn3TDuj1UJ_session_zgn6itg7PE3X",
+        "txIndex": 10,
+        "valid": true,
+        "reason": null
+      },
+      {
+        "sessionId": "sealer_zHQxXTMfd828qkFQNaDk7GggcQGkgaK43WNtw237bq4oZ/signer_z25RxRwkMpqnZC7wmctKSBphwzpBAW4LDVHgn3TDuj1UJ_session_zgn6itg7PE3X",
+        "txIndex": 11,
+        "valid": true,
+        "reason": null
+      },
+      {
+        "sessionId": "sealer_zHQxXTMfd828qkFQNaDk7GggcQGkgaK43WNtw237bq4oZ/signer_z25RxRwkMpqnZC7wmctKSBphwzpBAW4LDVHgn3TDuj1UJ_session_zgn6itg7PE3X",
+        "txIndex": 12,
+        "valid": true,
+        "reason": null
+      }
+    ],
+    "co_zReFPKwRN7T1f8N3GrG7sBFopBW": [
+      {
+        "sessionId": "sealer_zHQxXTMfd828qkFQNaDk7GggcQGkgaK43WNtw237bq4oZ/signer_z25RxRwkMpqnZC7wmctKSBphwzpBAW4LDVHgn3TDuj1UJ_session_zgn6itg7PE3X",
+        "txIndex": 0,
+        "valid": true,
+        "reason": null
+      },
+      {
+        "sessionId": "sealer_zHQxXTMfd828qkFQNaDk7GggcQGkgaK43WNtw237bq4oZ/signer_z25RxRwkMpqnZC7wmctKSBphwzpBAW4LDVHgn3TDuj1UJ_session_zgn6itg7PE3X",
+        "txIndex": 1,
+        "valid": true,
+        "reason": null
+      },
+      {
+        "sessionId": "sealer_zHQxXTMfd828qkFQNaDk7GggcQGkgaK43WNtw237bq4oZ/signer_z25RxRwkMpqnZC7wmctKSBphwzpBAW4LDVHgn3TDuj1UJ_session_zgn6itg7PE3X",
+        "txIndex": 2,
+        "valid": true,
+        "reason": null
+      },
+      {
+        "sessionId": "sealer_zHQxXTMfd828qkFQNaDk7GggcQGkgaK43WNtw237bq4oZ/signer_z25RxRwkMpqnZC7wmctKSBphwzpBAW4LDVHgn3TDuj1UJ_session_zgn6itg7PE3X",
+        "txIndex": 3,
+        "valid": true,
+        "reason": null
+      },
+      {
+        "sessionId": "sealer_zHQxXTMfd828qkFQNaDk7GggcQGkgaK43WNtw237bq4oZ/signer_z25RxRwkMpqnZC7wmctKSBphwzpBAW4LDVHgn3TDuj1UJ_session_zgn6itg7PE3X",
+        "txIndex": 4,
+        "valid": true,
+        "reason": null
+      },
+      {
+        "sessionId": "sealer_zHQxXTMfd828qkFQNaDk7GggcQGkgaK43WNtw237bq4oZ/signer_z25RxRwkMpqnZC7wmctKSBphwzpBAW4LDVHgn3TDuj1UJ_session_zgn6itg7PE3X",
+        "txIndex": 5,
+        "valid": true,
+        "reason": null
+      },
+      {
+        "sessionId": "sealer_zHQxXTMfd828qkFQNaDk7GggcQGkgaK43WNtw237bq4oZ/signer_z25RxRwkMpqnZC7wmctKSBphwzpBAW4LDVHgn3TDuj1UJ_session_zgn6itg7PE3X",
+        "txIndex": 6,
+        "valid": true,
+        "reason": null
+      },
+      {
+        "sessionId": "sealer_zHQxXTMfd828qkFQNaDk7GggcQGkgaK43WNtw237bq4oZ/signer_z25RxRwkMpqnZC7wmctKSBphwzpBAW4LDVHgn3TDuj1UJ_session_zgn6itg7PE3X",
+        "txIndex": 7,
+        "valid": true,
+        "reason": null
+      },
+      {
+        "sessionId": "sealer_zHQxXTMfd828qkFQNaDk7GggcQGkgaK43WNtw237bq4oZ/signer_z25RxRwkMpqnZC7wmctKSBphwzpBAW4LDVHgn3TDuj1UJ_session_zgn6itg7PE3X",
+        "txIndex": 8,
+        "valid": true,
+        "reason": null
+      },
+      {
+        "sessionId": "sealer_zHQxXTMfd828qkFQNaDk7GggcQGkgaK43WNtw237bq4oZ/signer_z25RxRwkMpqnZC7wmctKSBphwzpBAW4LDVHgn3TDuj1UJ_session_zgn6itg7PE3X",
+        "txIndex": 9,
+        "valid": true,
+        "reason": null
+      },
+      {
+        "sessionId": "sealer_zHQxXTMfd828qkFQNaDk7GggcQGkgaK43WNtw237bq4oZ/signer_z25RxRwkMpqnZC7wmctKSBphwzpBAW4LDVHgn3TDuj1UJ_session_zgn6itg7PE3X",
+        "txIndex": 10,
+        "valid": true,
+        "reason": null
+      }
+    ]
+  },
+  "roleQueries": [
+    {
+      "groupId": "co_zReFPKwRN7T1f8N3GrG7sBFopBW",
+      "member": "co_zWnf1uvxKUbBtFuQ6wJ7Esiavcd",
+      "atTime": null,
+      "expectedRole": null
+    },
+    {
+      "groupId": "co_zRZMUa44hGFZ8e9RPKysQsviUie",
+      "member": "co_zWnf1uvxKUbBtFuQ6wJ7Esiavcd",
+      "atTime": null,
+      "expectedRole": "reader"
+    }
+  ]
+}

--- a/crates/cojson-core/data/group_engine/private_tx_in_group.json
+++ b/crates/cojson-core/data/group_engine/private_tx_in_group.json
@@ -1,0 +1,108 @@
+{
+  "description": "a private transaction on a group is rejected; on an account it takes the account/private branch (pinned)",
+  "covalues": [
+    {
+      "coId": "co_z2dhDRz85jdtEnof1tWHHZxxZw8",
+      "headerJson": "{\"createdAt\":\"2026-07-03T23:11:07.021Z\",\"meta\":null,\"ruleset\":{\"initialAdmin\":\"co_zEjVr6wFSTU3tmsiVKK9Nco94Sj\",\"type\":\"group\"},\"type\":\"comap\",\"uniqueness\":\"z387DN2nD2gepXmRcT\"}",
+      "sessions": [
+        {
+          "sessionId": "co_zEjVr6wFSTU3tmsiVKK9Nco94Sj_session_z17bJJ4g4iST",
+          "signerId": "co_zEjVr6wFSTU3tmsiVKK9Nco94Sj",
+          "transactions": [
+            "{\"changes\":\"[{\\\"op\\\":\\\"set\\\",\\\"key\\\":\\\"co_zEjVr6wFSTU3tmsiVKK9Nco94Sj\\\",\\\"value\\\":\\\"admin\\\"}]\",\"madeAt\":1783120267021,\"privacy\":\"trusting\"}",
+            "{\"changes\":\"[{\\\"op\\\":\\\"set\\\",\\\"key\\\":\\\"key_zrVbjZywBMMdpWWMU_for_co_zEjVr6wFSTU3tmsiVKK9Nco94Sj\\\",\\\"value\\\":\\\"sealed_UN6OhmMKe_ZwoRt68ISCJH0WyAP2f-FBXb7H7zuuXOwBj4lsJExA-vJiMa5Ox4vutezo_EPjCNv2GWO7YFdZdwjabEjMKxqwjAw==\\\"}]\",\"madeAt\":1783120267021,\"privacy\":\"trusting\"}",
+            "{\"changes\":\"[{\\\"op\\\":\\\"set\\\",\\\"key\\\":\\\"readKey\\\",\\\"value\\\":\\\"key_zrVbjZywBMMdpWWMU\\\"}]\",\"madeAt\":1783120267021,\"privacy\":\"trusting\"}",
+            "{\"changes\":\"[{\\\"op\\\":\\\"set\\\",\\\"key\\\":\\\"groupSealer\\\",\\\"value\\\":\\\"key_zrVbjZywBMMdpWWMU@sealer_zHSjafBZGXCqSQGQ1bGjERcN5febeka1CtFACPnMaZWLa\\\"}]\",\"madeAt\":1783120267021,\"privacy\":\"trusting\"}",
+            "{\"encryptedChanges\":\"encrypted_UkDhx-CTL_NJFQ1faZAP69-FcPkuv_6SofePfCzmWR_dvSphawymsUFsCSTP2qkoq82Y3BM6UKG0V7n1D_H2Dq4d2dTV5xBFtnviTlLvO9rWguffEp6I89TbfL1zJ89n7WhPB1c6ewvh0FGyZIi5ZrGBl2BndMZJB9Ca8p6lzVzhdHsvb_pAhUCkAivj-uoO8jg==\",\"keyUsed\":\"key_zrVbjZywBMMdpWWMU\",\"madeAt\":1783120267022,\"privacy\":\"private\"}"
+          ],
+          "lastSignature": "signature_z4MSp3CEH2JcAFSSZe6zmGRQ6UbF91ALdR724ChmAU2MmST46PS7cpea55QCw4DhLBJjEHiu2D7hcTJ2mPwxtHMao"
+        }
+      ]
+    },
+    {
+      "coId": "co_zEjVr6wFSTU3tmsiVKK9Nco94Sj",
+      "headerJson": "{\"createdAt\":null,\"meta\":{\"type\":\"account\"},\"ruleset\":{\"initialAdmin\":\"sealer_z9xYwKbdsPWMdCy5tbHaj5oaTXTjjZj3AJFZ4m4CfKumY/signer_zC61GV4S8wtSQFNsQBMptfpN7xt2sDSpegp5pvEu9AX6h\",\"type\":\"group\"},\"type\":\"comap\",\"uniqueness\":null}",
+      "sessions": [
+        {
+          "sessionId": "sealer_z9xYwKbdsPWMdCy5tbHaj5oaTXTjjZj3AJFZ4m4CfKumY/signer_zC61GV4S8wtSQFNsQBMptfpN7xt2sDSpegp5pvEu9AX6h_session_z17bJJ4g4iST",
+          "signerId": "co_zEjVr6wFSTU3tmsiVKK9Nco94Sj",
+          "transactions": [
+            "{\"changes\":\"[{\\\"op\\\":\\\"set\\\",\\\"key\\\":\\\"sealer_z9xYwKbdsPWMdCy5tbHaj5oaTXTjjZj3AJFZ4m4CfKumY/signer_zC61GV4S8wtSQFNsQBMptfpN7xt2sDSpegp5pvEu9AX6h\\\",\\\"value\\\":\\\"admin\\\"}]\",\"madeAt\":1783120267020,\"privacy\":\"trusting\"}",
+            "{\"changes\":\"[{\\\"op\\\":\\\"set\\\",\\\"key\\\":\\\"key_z2TFRFNZ8xFLT686Ar_for_sealer_z9xYwKbdsPWMdCy5tbHaj5oaTXTjjZj3AJFZ4m4CfKumY/signer_zC61GV4S8wtSQFNsQBMptfpN7xt2sDSpegp5pvEu9AX6h\\\",\\\"value\\\":\\\"sealed_UFCt78JNBICVRvLttipFgY8796sU2MbrB6KVp2v_7GV1HDFAms7AXkEfibJufpQMmAPz0SW_SHkEQRUC0jeN0qjVFWLjFsZ0kbw==\\\"}]\",\"madeAt\":1783120267020,\"privacy\":\"trusting\"}",
+            "{\"changes\":\"[{\\\"op\\\":\\\"set\\\",\\\"key\\\":\\\"readKey\\\",\\\"value\\\":\\\"key_z2TFRFNZ8xFLT686Ar\\\"}]\",\"madeAt\":1783120267021,\"privacy\":\"trusting\"}",
+            "{\"changes\":\"[{\\\"op\\\":\\\"set\\\",\\\"key\\\":\\\"profile\\\",\\\"value\\\":\\\"co_zcturcTSDYbFD2px8hSfE3Lfd24\\\"}]\",\"madeAt\":1783120267021,\"privacy\":\"trusting\"}",
+            "{\"encryptedChanges\":\"encrypted_UeXUAV8IpkU3esn---D2Gxrii3kJJtkgIAbcJfM0vI2kPT4NhNtNfWl7e4y8PaC15ZVn5gKNlOWdi\",\"keyUsed\":\"key_z2TFRFNZ8xFLT686Ar\",\"madeAt\":1783120267022,\"privacy\":\"private\"}"
+          ],
+          "lastSignature": "signature_z2YjZdyUuqMLAYwTDXLzKEAfGYPAXhdFQS1raboVrsKaKejuBbZ4Z8VN3u5kphvBufjT92VaTfx84bvPXa1xfeKVe"
+        }
+      ]
+    }
+  ],
+  "verdicts": {
+    "co_z2dhDRz85jdtEnof1tWHHZxxZw8": [
+      {
+        "sessionId": "co_zEjVr6wFSTU3tmsiVKK9Nco94Sj_session_z17bJJ4g4iST",
+        "txIndex": 0,
+        "valid": true,
+        "reason": null
+      },
+      {
+        "sessionId": "co_zEjVr6wFSTU3tmsiVKK9Nco94Sj_session_z17bJJ4g4iST",
+        "txIndex": 1,
+        "valid": true,
+        "reason": null
+      },
+      {
+        "sessionId": "co_zEjVr6wFSTU3tmsiVKK9Nco94Sj_session_z17bJJ4g4iST",
+        "txIndex": 2,
+        "valid": true,
+        "reason": null
+      },
+      {
+        "sessionId": "co_zEjVr6wFSTU3tmsiVKK9Nco94Sj_session_z17bJJ4g4iST",
+        "txIndex": 3,
+        "valid": true,
+        "reason": null
+      },
+      {
+        "sessionId": "co_zEjVr6wFSTU3tmsiVKK9Nco94Sj_session_z17bJJ4g4iST",
+        "txIndex": 4,
+        "valid": false,
+        "reason": "Can't make private transactions in groups"
+      }
+    ],
+    "co_zEjVr6wFSTU3tmsiVKK9Nco94Sj": [
+      {
+        "sessionId": "sealer_z9xYwKbdsPWMdCy5tbHaj5oaTXTjjZj3AJFZ4m4CfKumY/signer_zC61GV4S8wtSQFNsQBMptfpN7xt2sDSpegp5pvEu9AX6h_session_z17bJJ4g4iST",
+        "txIndex": 0,
+        "valid": true,
+        "reason": null
+      },
+      {
+        "sessionId": "sealer_z9xYwKbdsPWMdCy5tbHaj5oaTXTjjZj3AJFZ4m4CfKumY/signer_zC61GV4S8wtSQFNsQBMptfpN7xt2sDSpegp5pvEu9AX6h_session_z17bJJ4g4iST",
+        "txIndex": 1,
+        "valid": true,
+        "reason": null
+      },
+      {
+        "sessionId": "sealer_z9xYwKbdsPWMdCy5tbHaj5oaTXTjjZj3AJFZ4m4CfKumY/signer_zC61GV4S8wtSQFNsQBMptfpN7xt2sDSpegp5pvEu9AX6h_session_z17bJJ4g4iST",
+        "txIndex": 2,
+        "valid": true,
+        "reason": null
+      },
+      {
+        "sessionId": "sealer_z9xYwKbdsPWMdCy5tbHaj5oaTXTjjZj3AJFZ4m4CfKumY/signer_zC61GV4S8wtSQFNsQBMptfpN7xt2sDSpegp5pvEu9AX6h_session_z17bJJ4g4iST",
+        "txIndex": 3,
+        "valid": true,
+        "reason": null
+      },
+      {
+        "sessionId": "sealer_z9xYwKbdsPWMdCy5tbHaj5oaTXTjjZj3AJFZ4m4CfKumY/signer_zC61GV4S8wtSQFNsQBMptfpN7xt2sDSpegp5pvEu9AX6h_session_z17bJJ4g4iST",
+        "txIndex": 4,
+        "valid": true,
+        "reason": null
+      }
+    ]
+  },
+  "roleQueries": []
+}

--- a/crates/cojson-core/data/group_engine/self_extension_cycle.json
+++ b/crates/cojson-core/data/group_engine/self_extension_cycle.json
@@ -1,0 +1,58 @@
+{
+  "description": "a group cannot extend itself (circular dependency)",
+  "covalues": [
+    {
+      "coId": "co_zn1grrqdX3CmYbvC3Jrvaaeiy7D",
+      "headerJson": "{\"createdAt\":\"2026-07-03T23:11:07.013Z\",\"meta\":null,\"ruleset\":{\"initialAdmin\":\"sealer_zDLrz3jaRxTbWRF5zcNLAiPFmp6zktoYbiHCZuGJvrgdQ/signer_z2x9ijaZrsNaZCuMAh6DisRSRNVtnxCy2LyHU6nDvt4FD\",\"type\":\"group\"},\"type\":\"comap\",\"uniqueness\":\"z4HJaT8UpFV25UFQ83\"}",
+      "sessions": [
+        {
+          "sessionId": "sealer_zDLrz3jaRxTbWRF5zcNLAiPFmp6zktoYbiHCZuGJvrgdQ/signer_z2x9ijaZrsNaZCuMAh6DisRSRNVtnxCy2LyHU6nDvt4FD_session_zwCnmTa9UoU",
+          "signerId": "sealer_zDLrz3jaRxTbWRF5zcNLAiPFmp6zktoYbiHCZuGJvrgdQ/signer_z2x9ijaZrsNaZCuMAh6DisRSRNVtnxCy2LyHU6nDvt4FD",
+          "transactions": [
+            "{\"changes\":\"[{\\\"op\\\":\\\"set\\\",\\\"key\\\":\\\"sealer_zDLrz3jaRxTbWRF5zcNLAiPFmp6zktoYbiHCZuGJvrgdQ/signer_z2x9ijaZrsNaZCuMAh6DisRSRNVtnxCy2LyHU6nDvt4FD\\\",\\\"value\\\":\\\"admin\\\"}]\",\"madeAt\":1783120267013,\"privacy\":\"trusting\"}",
+            "{\"changes\":\"[{\\\"op\\\":\\\"set\\\",\\\"key\\\":\\\"key_z5e6VJc1oEK13vUHNR_for_sealer_zDLrz3jaRxTbWRF5zcNLAiPFmp6zktoYbiHCZuGJvrgdQ/signer_z2x9ijaZrsNaZCuMAh6DisRSRNVtnxCy2LyHU6nDvt4FD\\\",\\\"value\\\":\\\"sealed_Ui9aZreENMCw3HyvoW6un8HmBn_5FE9wgpUbZcWOG_Pgw37jvrnGF6jZ1kP10NMfk_TSqpCxWjbNouimarIyPmOHZ62VUpZhsCA==\\\"}]\",\"madeAt\":1783120267014,\"privacy\":\"trusting\"}",
+            "{\"changes\":\"[{\\\"op\\\":\\\"set\\\",\\\"key\\\":\\\"readKey\\\",\\\"value\\\":\\\"key_z5e6VJc1oEK13vUHNR\\\"}]\",\"madeAt\":1783120267014,\"privacy\":\"trusting\"}",
+            "{\"changes\":\"[{\\\"op\\\":\\\"set\\\",\\\"key\\\":\\\"groupSealer\\\",\\\"value\\\":\\\"key_z5e6VJc1oEK13vUHNR@sealer_z3Dhw9y4FRimHfTj84R7KcnbymBY8Wq3mTKbRhHhZ2ZZT\\\"}]\",\"madeAt\":1783120267014,\"privacy\":\"trusting\"}",
+            "{\"changes\":\"[{\\\"op\\\":\\\"set\\\",\\\"key\\\":\\\"parent_co_zn1grrqdX3CmYbvC3Jrvaaeiy7D\\\",\\\"value\\\":\\\"extend\\\"}]\",\"madeAt\":1783120267014,\"privacy\":\"trusting\"}"
+          ],
+          "lastSignature": "signature_z2ZTHVwxtjaMfy9T5nmJkVVR3ddSuwwoQXink8fFqF33FFce9yL42dzJ7bUAf7ec7zUpCWE5TkUhXWFvX3wHAEEcs"
+        }
+      ]
+    }
+  ],
+  "verdicts": {
+    "co_zn1grrqdX3CmYbvC3Jrvaaeiy7D": [
+      {
+        "sessionId": "sealer_zDLrz3jaRxTbWRF5zcNLAiPFmp6zktoYbiHCZuGJvrgdQ/signer_z2x9ijaZrsNaZCuMAh6DisRSRNVtnxCy2LyHU6nDvt4FD_session_zwCnmTa9UoU",
+        "txIndex": 0,
+        "valid": true,
+        "reason": null
+      },
+      {
+        "sessionId": "sealer_zDLrz3jaRxTbWRF5zcNLAiPFmp6zktoYbiHCZuGJvrgdQ/signer_z2x9ijaZrsNaZCuMAh6DisRSRNVtnxCy2LyHU6nDvt4FD_session_zwCnmTa9UoU",
+        "txIndex": 1,
+        "valid": true,
+        "reason": null
+      },
+      {
+        "sessionId": "sealer_zDLrz3jaRxTbWRF5zcNLAiPFmp6zktoYbiHCZuGJvrgdQ/signer_z2x9ijaZrsNaZCuMAh6DisRSRNVtnxCy2LyHU6nDvt4FD_session_zwCnmTa9UoU",
+        "txIndex": 2,
+        "valid": true,
+        "reason": null
+      },
+      {
+        "sessionId": "sealer_zDLrz3jaRxTbWRF5zcNLAiPFmp6zktoYbiHCZuGJvrgdQ/signer_z2x9ijaZrsNaZCuMAh6DisRSRNVtnxCy2LyHU6nDvt4FD_session_zwCnmTa9UoU",
+        "txIndex": 3,
+        "valid": true,
+        "reason": null
+      },
+      {
+        "sessionId": "sealer_zDLrz3jaRxTbWRF5zcNLAiPFmp6zktoYbiHCZuGJvrgdQ/signer_z2x9ijaZrsNaZCuMAh6DisRSRNVtnxCy2LyHU6nDvt4FD_session_zwCnmTa9UoU",
+        "txIndex": 4,
+        "valid": false,
+        "reason": "Parent group is a circular dependency"
+      }
+    ]
+  },
+  "roleQueries": []
+}

--- a/crates/cojson-core/data/group_engine/self_revoke.json
+++ b/crates/cojson-core/data/group_engine/self_revoke.json
@@ -1,0 +1,102 @@
+{
+  "description": "a member revokes their own access (valid without admin role)",
+  "covalues": [
+    {
+      "coId": "co_zKoDosrALeLFn77PXATB7g5va4L",
+      "headerJson": "{\"createdAt\":\"2026-07-03T23:11:06.970Z\",\"meta\":null,\"ruleset\":{\"initialAdmin\":\"sealer_zBGKneqCbMKguf6BbpcHxursv2kMwUSrPDMMt9gwwuATQ/signer_zBTceB5LcDC9oKYX1F57498MGjugvMsUXwpkzNefc2aL9\",\"type\":\"group\"},\"type\":\"comap\",\"uniqueness\":\"zrzhaNGWrgc3NgaCh\"}",
+      "sessions": [
+        {
+          "sessionId": "sealer_zBGKneqCbMKguf6BbpcHxursv2kMwUSrPDMMt9gwwuATQ/signer_zBTceB5LcDC9oKYX1F57498MGjugvMsUXwpkzNefc2aL9_session_zh5ujuUo45ZQ",
+          "signerId": "sealer_zBGKneqCbMKguf6BbpcHxursv2kMwUSrPDMMt9gwwuATQ/signer_zBTceB5LcDC9oKYX1F57498MGjugvMsUXwpkzNefc2aL9",
+          "transactions": [
+            "{\"changes\":\"[{\\\"op\\\":\\\"set\\\",\\\"key\\\":\\\"sealer_zBGKneqCbMKguf6BbpcHxursv2kMwUSrPDMMt9gwwuATQ/signer_zBTceB5LcDC9oKYX1F57498MGjugvMsUXwpkzNefc2aL9\\\",\\\"value\\\":\\\"admin\\\"}]\",\"madeAt\":1783120266970,\"privacy\":\"trusting\"}",
+            "{\"changes\":\"[{\\\"op\\\":\\\"set\\\",\\\"key\\\":\\\"key_zS3X7oED7qn8JMMxB_for_sealer_zBGKneqCbMKguf6BbpcHxursv2kMwUSrPDMMt9gwwuATQ/signer_zBTceB5LcDC9oKYX1F57498MGjugvMsUXwpkzNefc2aL9\\\",\\\"value\\\":\\\"sealed_UAU2bnz3wKMdbrdE_rFKHvk4WYc_z6CIY7-_LUe5Tb7ciuBcKelE9Wxcrm1Cyv1C18d0ynMMmrqgRPWdT0ldBAk87BEKq0I0nFw==\\\"}]\",\"madeAt\":1783120266970,\"privacy\":\"trusting\"}",
+            "{\"changes\":\"[{\\\"op\\\":\\\"set\\\",\\\"key\\\":\\\"readKey\\\",\\\"value\\\":\\\"key_zS3X7oED7qn8JMMxB\\\"}]\",\"madeAt\":1783120266970,\"privacy\":\"trusting\"}",
+            "{\"changes\":\"[{\\\"op\\\":\\\"set\\\",\\\"key\\\":\\\"groupSealer\\\",\\\"value\\\":\\\"key_zS3X7oED7qn8JMMxB@sealer_zGhy45SejMhWt2qB3CwSJUNWNcNMQSY8d8hpCU2DtB5av\\\"}]\",\"madeAt\":1783120266970,\"privacy\":\"trusting\"}",
+            "{\"changes\":\"[{\\\"op\\\":\\\"set\\\",\\\"key\\\":\\\"co_z17a733hH4xUnu1PcYXh9iRufbk\\\",\\\"value\\\":\\\"reader\\\"}]\",\"madeAt\":1783120266971,\"privacy\":\"trusting\"}",
+            "{\"changes\":\"[{\\\"op\\\":\\\"set\\\",\\\"key\\\":\\\"key_zS3X7oED7qn8JMMxB_for_co_z17a733hH4xUnu1PcYXh9iRufbk\\\",\\\"value\\\":\\\"sealed_UMb2NcJHd0jZdoWKeM5-jp-UYqkTvgo7kN1vcD8MXU8ABY5yzFIH6CGwMJcE5Usq5BlhnQEFUoyU-Mrt2qxuKPBr6MJJf76FQqA==\\\"}]\",\"madeAt\":1783120266971,\"privacy\":\"trusting\"}"
+          ],
+          "lastSignature": "signature_z3muDHFpSod7Xra1V3gEP1fc9Abx2HKzcQy1NsitbT3fBzVtE7vtAEX4SbqAmPySQKZ5vpZMNHCVwvqhisuuygJGa"
+        },
+        {
+          "sessionId": "co_z17a733hH4xUnu1PcYXh9iRufbk_session_zX2WiWTgBJrd",
+          "signerId": "signer_zFukaBairw7GjGBY53yNihZKvbDTB9bUsoVkEjkzrFdsP",
+          "transactions": [
+            "{\"changes\":\"[{\\\"op\\\":\\\"set\\\",\\\"key\\\":\\\"co_z17a733hH4xUnu1PcYXh9iRufbk\\\",\\\"value\\\":\\\"revoked\\\"}]\",\"madeAt\":1783120266972,\"privacy\":\"trusting\"}"
+          ],
+          "lastSignature": "signature_z4amshx8MVFZRLwzj6iBzuGcxiSqk4v1vnApgJkMKjquGVZY9Ms6j9AbAPYUVV8movrzuow1KXeMg2b9tMGHCugc8"
+        }
+      ]
+    },
+    {
+      "coId": "co_z17a733hH4xUnu1PcYXh9iRufbk",
+      "headerJson": "{\"createdAt\":null,\"meta\":{\"type\":\"account\"},\"ruleset\":{\"initialAdmin\":\"sealer_zB3Ag2GfFMLV4wGHR5PBdHQrW2QMSY9CFtL7v4TLJGnDD/signer_zFukaBairw7GjGBY53yNihZKvbDTB9bUsoVkEjkzrFdsP\",\"type\":\"group\"},\"type\":\"comap\",\"uniqueness\":null}",
+      "sessions": [
+        {
+          "sessionId": "sealer_zB3Ag2GfFMLV4wGHR5PBdHQrW2QMSY9CFtL7v4TLJGnDD/signer_zFukaBairw7GjGBY53yNihZKvbDTB9bUsoVkEjkzrFdsP_session_zB83f8Ym5AZf",
+          "signerId": "signer_zFukaBairw7GjGBY53yNihZKvbDTB9bUsoVkEjkzrFdsP",
+          "transactions": [
+            "{\"changes\":\"[{\\\"op\\\":\\\"set\\\",\\\"key\\\":\\\"sealer_zB3Ag2GfFMLV4wGHR5PBdHQrW2QMSY9CFtL7v4TLJGnDD/signer_zFukaBairw7GjGBY53yNihZKvbDTB9bUsoVkEjkzrFdsP\\\",\\\"value\\\":\\\"admin\\\"}]\",\"madeAt\":1783120266971,\"privacy\":\"trusting\"}",
+            "{\"changes\":\"[{\\\"op\\\":\\\"set\\\",\\\"key\\\":\\\"key_z36AqJ6GUBNGtBrJsA_for_sealer_zB3Ag2GfFMLV4wGHR5PBdHQrW2QMSY9CFtL7v4TLJGnDD/signer_zFukaBairw7GjGBY53yNihZKvbDTB9bUsoVkEjkzrFdsP\\\",\\\"value\\\":\\\"sealed_U4Kw_piPX4G2iBwz7rLPA--T_QKVSjaLa1RT9-zxX6nJgE2b0ftIyy0ineL6loLW9sZ8Zgohq8M3ZroiIg5M3db0t79t1PnwzOw==\\\"}]\",\"madeAt\":1783120266971,\"privacy\":\"trusting\"}",
+            "{\"changes\":\"[{\\\"op\\\":\\\"set\\\",\\\"key\\\":\\\"readKey\\\",\\\"value\\\":\\\"key_z36AqJ6GUBNGtBrJsA\\\"}]\",\"madeAt\":1783120266971,\"privacy\":\"trusting\"}"
+          ],
+          "lastSignature": "signature_z2zT6FNCg78xVrAECpyEqgZCTHGsEW46KuNqdgqZYX4G3T4U7o36Fv2qJRGgN9htVTLspRqh7554KmsfaEAggfVtE"
+        }
+      ]
+    }
+  ],
+  "verdicts": {
+    "co_zKoDosrALeLFn77PXATB7g5va4L": [
+      {
+        "sessionId": "sealer_zBGKneqCbMKguf6BbpcHxursv2kMwUSrPDMMt9gwwuATQ/signer_zBTceB5LcDC9oKYX1F57498MGjugvMsUXwpkzNefc2aL9_session_zh5ujuUo45ZQ",
+        "txIndex": 0,
+        "valid": true,
+        "reason": null
+      },
+      {
+        "sessionId": "sealer_zBGKneqCbMKguf6BbpcHxursv2kMwUSrPDMMt9gwwuATQ/signer_zBTceB5LcDC9oKYX1F57498MGjugvMsUXwpkzNefc2aL9_session_zh5ujuUo45ZQ",
+        "txIndex": 1,
+        "valid": true,
+        "reason": null
+      },
+      {
+        "sessionId": "sealer_zBGKneqCbMKguf6BbpcHxursv2kMwUSrPDMMt9gwwuATQ/signer_zBTceB5LcDC9oKYX1F57498MGjugvMsUXwpkzNefc2aL9_session_zh5ujuUo45ZQ",
+        "txIndex": 2,
+        "valid": true,
+        "reason": null
+      },
+      {
+        "sessionId": "sealer_zBGKneqCbMKguf6BbpcHxursv2kMwUSrPDMMt9gwwuATQ/signer_zBTceB5LcDC9oKYX1F57498MGjugvMsUXwpkzNefc2aL9_session_zh5ujuUo45ZQ",
+        "txIndex": 3,
+        "valid": true,
+        "reason": null
+      },
+      {
+        "sessionId": "sealer_zBGKneqCbMKguf6BbpcHxursv2kMwUSrPDMMt9gwwuATQ/signer_zBTceB5LcDC9oKYX1F57498MGjugvMsUXwpkzNefc2aL9_session_zh5ujuUo45ZQ",
+        "txIndex": 4,
+        "valid": true,
+        "reason": null
+      },
+      {
+        "sessionId": "sealer_zBGKneqCbMKguf6BbpcHxursv2kMwUSrPDMMt9gwwuATQ/signer_zBTceB5LcDC9oKYX1F57498MGjugvMsUXwpkzNefc2aL9_session_zh5ujuUo45ZQ",
+        "txIndex": 5,
+        "valid": true,
+        "reason": null
+      },
+      {
+        "sessionId": "co_z17a733hH4xUnu1PcYXh9iRufbk_session_zX2WiWTgBJrd",
+        "txIndex": 0,
+        "valid": true,
+        "reason": null
+      }
+    ]
+  },
+  "roleQueries": [
+    {
+      "groupId": "co_zKoDosrALeLFn77PXATB7g5va4L",
+      "member": "co_z17a733hH4xUnu1PcYXh9iRufbk",
+      "atTime": null,
+      "expectedRole": null
+    }
+  ]
+}

--- a/crates/cojson-core/data/group_engine/write_only_keys.json
+++ b/crates/cojson-core/data/group_engine/write_only_keys.json
@@ -1,0 +1,121 @@
+{
+  "description": "writeOnly member sets own write key (valid); invite override (invalid); admin override (valid); own write-key revelation (valid)",
+  "covalues": [
+    {
+      "coId": "co_zC7uB7wqSteBqsbxtMit21u3dGN",
+      "headerJson": "{\"createdAt\":\"2023-11-14T22:13:20.000Z\",\"meta\":null,\"ruleset\":{\"initialAdmin\":\"sealer_z9LZQd9286cbcxQPPY7gSQfKfoUhXa2GDrfQEuvzomwAS/signer_zB4QGLjJPRvuZhHGKXngmomkjvb84QkLfErPPLudPShJF\",\"type\":\"group\"},\"type\":\"comap\",\"uniqueness\":\"z4gf5QxtpS3DxCiUrq\"}",
+      "sessions": [
+        {
+          "sessionId": "sealer_z9LZQd9286cbcxQPPY7gSQfKfoUhXa2GDrfQEuvzomwAS/signer_zB4QGLjJPRvuZhHGKXngmomkjvb84QkLfErPPLudPShJF_session_z2MW97iS5DPX",
+          "signerId": "sealer_z9LZQd9286cbcxQPPY7gSQfKfoUhXa2GDrfQEuvzomwAS/signer_zB4QGLjJPRvuZhHGKXngmomkjvb84QkLfErPPLudPShJF",
+          "transactions": [
+            "{\"changes\":\"[{\\\"op\\\":\\\"set\\\",\\\"key\\\":\\\"sealer_z9LZQd9286cbcxQPPY7gSQfKfoUhXa2GDrfQEuvzomwAS/signer_zB4QGLjJPRvuZhHGKXngmomkjvb84QkLfErPPLudPShJF\\\",\\\"value\\\":\\\"admin\\\"}]\",\"madeAt\":1700000000000,\"privacy\":\"trusting\"}",
+            "{\"changes\":\"[{\\\"op\\\":\\\"set\\\",\\\"key\\\":\\\"key_z2gX1BJsBNJAvksaev_for_sealer_z9LZQd9286cbcxQPPY7gSQfKfoUhXa2GDrfQEuvzomwAS/signer_zB4QGLjJPRvuZhHGKXngmomkjvb84QkLfErPPLudPShJF\\\",\\\"value\\\":\\\"sealed_U3Jx2VEHtiMGR2NGVdwnAWERxojlGp9rMYzzKD5AD85fiHC1ookb4-po4vs1fC5-COSkRDW4WbI1irnv4482--TMHe_N_NwXtJw==\\\"}]\",\"madeAt\":1700000000000,\"privacy\":\"trusting\"}",
+            "{\"changes\":\"[{\\\"op\\\":\\\"set\\\",\\\"key\\\":\\\"readKey\\\",\\\"value\\\":\\\"key_z2gX1BJsBNJAvksaev\\\"}]\",\"madeAt\":1700000000000,\"privacy\":\"trusting\"}",
+            "{\"changes\":\"[{\\\"op\\\":\\\"set\\\",\\\"key\\\":\\\"groupSealer\\\",\\\"value\\\":\\\"key_z2gX1BJsBNJAvksaev@sealer_zDfvyH67JpZFMBMAezq29phbCSzDupQwuSGmvWoeKQGBX\\\"}]\",\"madeAt\":1700000000000,\"privacy\":\"trusting\"}",
+            "{\"changes\":\"[{\\\"op\\\":\\\"set\\\",\\\"key\\\":\\\"sealer_zFBdmxo1bQvhv7wkXr5yyGkPG4Hsda4qs4pCJFArwh8Ga/signer_zBQyvZD4DzbLhQADvsag2otoZ69JWS35AARyvWjoPghfZ\\\",\\\"value\\\":\\\"writeOnly\\\"}]\",\"madeAt\":1700000001000,\"privacy\":\"trusting\"}",
+            "{\"changes\":\"[{\\\"op\\\":\\\"set\\\",\\\"key\\\":\\\"sealer_zEsdgbLovywsz46P62HtkihTdZ5yXpAfAAcaHBtUiRU2L/signer_zNBPyFnmNuBLvMow7zoNM1WHnszBViwC1BowEbGj1eL6\\\",\\\"value\\\":\\\"writeOnlyInvite\\\"}]\",\"madeAt\":1700000002000,\"privacy\":\"trusting\"}",
+            "{\"changes\":\"[{\\\"op\\\":\\\"set\\\",\\\"key\\\":\\\"writeKeyFor_sealer_zFBdmxo1bQvhv7wkXr5yyGkPG4Hsda4qs4pCJFArwh8Ga/signer_zBQyvZD4DzbLhQADvsag2otoZ69JWS35AARyvWjoPghfZ\\\",\\\"value\\\":\\\"key_z4F9FaP6jGDsL3qa5v\\\"}]\",\"madeAt\":1700000005000,\"privacy\":\"trusting\"}"
+          ],
+          "lastSignature": "signature_z4p5SWVHpC2oSmGymsV4qAjXRNnkpQEYuneVQ1GwfQ4sZNVieQCCTGAvaTgqQXWokbR1Qy1bMkru3U54dqvG62M1R"
+        },
+        {
+          "sessionId": "sealer_zFBdmxo1bQvhv7wkXr5yyGkPG4Hsda4qs4pCJFArwh8Ga/signer_zBQyvZD4DzbLhQADvsag2otoZ69JWS35AARyvWjoPghfZ_session_zhHcTsuY9xtd",
+          "signerId": "signer_zBQyvZD4DzbLhQADvsag2otoZ69JWS35AARyvWjoPghfZ",
+          "transactions": [
+            "{\"changes\":\"[{\\\"op\\\":\\\"set\\\",\\\"key\\\":\\\"writeKeyFor_sealer_zFBdmxo1bQvhv7wkXr5yyGkPG4Hsda4qs4pCJFArwh8Ga/signer_zBQyvZD4DzbLhQADvsag2otoZ69JWS35AARyvWjoPghfZ\\\",\\\"value\\\":\\\"key_zEwcE1fw4PDLMTeBR\\\"}]\",\"madeAt\":1700000003000,\"privacy\":\"trusting\"}"
+          ],
+          "lastSignature": "signature_z5iYUfddMDBisrxsEPkpuhTGgcGEXupK5fiKbsCL7ggXa1qvADrQpYRs9ZjUyhECwJVAvNkHwZTAWTrgAUqhQnHyc"
+        },
+        {
+          "sessionId": "sealer_zEsdgbLovywsz46P62HtkihTdZ5yXpAfAAcaHBtUiRU2L/signer_zNBPyFnmNuBLvMow7zoNM1WHnszBViwC1BowEbGj1eL6_session_zKiNbJcdV1MA",
+          "signerId": "signer_zNBPyFnmNuBLvMow7zoNM1WHnszBViwC1BowEbGj1eL6",
+          "transactions": [
+            "{\"changes\":\"[{\\\"op\\\":\\\"set\\\",\\\"key\\\":\\\"writeKeyFor_sealer_zFBdmxo1bQvhv7wkXr5yyGkPG4Hsda4qs4pCJFArwh8Ga/signer_zBQyvZD4DzbLhQADvsag2otoZ69JWS35AARyvWjoPghfZ\\\",\\\"value\\\":\\\"key_z4uKmCKwixLXB3RptB\\\"}]\",\"madeAt\":1700000004000,\"privacy\":\"trusting\"}"
+          ],
+          "lastSignature": "signature_z2h54RZWUhPeN9TC2NQE8jJiE8D2r1p6PgyetJoR3ZbJ1gP56wZ5wHQV8tWwbH4Muu54sZRcQsRnJErPSU2usmpmp"
+        },
+        {
+          "sessionId": "sealer_zFBdmxo1bQvhv7wkXr5yyGkPG4Hsda4qs4pCJFArwh8Ga/signer_zBQyvZD4DzbLhQADvsag2otoZ69JWS35AARyvWjoPghfZ_session_zdmitwYKxBZe",
+          "signerId": "signer_zBQyvZD4DzbLhQADvsag2otoZ69JWS35AARyvWjoPghfZ",
+          "transactions": [
+            "{\"changes\":\"[{\\\"op\\\":\\\"set\\\",\\\"key\\\":\\\"key_z4F9FaP6jGDsL3qa5v_for_sealer_zFBdmxo1bQvhv7wkXr5yyGkPG4Hsda4qs4pCJFArwh8Ga/signer_zBQyvZD4DzbLhQADvsag2otoZ69JWS35AARyvWjoPghfZ\\\",\\\"value\\\":\\\"revelation_dummy\\\"}]\",\"madeAt\":1700000006000,\"privacy\":\"trusting\"}"
+          ],
+          "lastSignature": "signature_z3BzGqwaRWFRTUGVKLCY7iE6pFmdyM2rzHiysUNvF4jtr13A8RNMmLEbyzoCFvAomuornpNmgjhGUXDSBUTKu6Hsi"
+        }
+      ]
+    }
+  ],
+  "verdicts": {
+    "co_zC7uB7wqSteBqsbxtMit21u3dGN": [
+      {
+        "sessionId": "sealer_z9LZQd9286cbcxQPPY7gSQfKfoUhXa2GDrfQEuvzomwAS/signer_zB4QGLjJPRvuZhHGKXngmomkjvb84QkLfErPPLudPShJF_session_z2MW97iS5DPX",
+        "txIndex": 0,
+        "valid": true,
+        "reason": null
+      },
+      {
+        "sessionId": "sealer_z9LZQd9286cbcxQPPY7gSQfKfoUhXa2GDrfQEuvzomwAS/signer_zB4QGLjJPRvuZhHGKXngmomkjvb84QkLfErPPLudPShJF_session_z2MW97iS5DPX",
+        "txIndex": 1,
+        "valid": true,
+        "reason": null
+      },
+      {
+        "sessionId": "sealer_z9LZQd9286cbcxQPPY7gSQfKfoUhXa2GDrfQEuvzomwAS/signer_zB4QGLjJPRvuZhHGKXngmomkjvb84QkLfErPPLudPShJF_session_z2MW97iS5DPX",
+        "txIndex": 2,
+        "valid": true,
+        "reason": null
+      },
+      {
+        "sessionId": "sealer_z9LZQd9286cbcxQPPY7gSQfKfoUhXa2GDrfQEuvzomwAS/signer_zB4QGLjJPRvuZhHGKXngmomkjvb84QkLfErPPLudPShJF_session_z2MW97iS5DPX",
+        "txIndex": 3,
+        "valid": true,
+        "reason": null
+      },
+      {
+        "sessionId": "sealer_z9LZQd9286cbcxQPPY7gSQfKfoUhXa2GDrfQEuvzomwAS/signer_zB4QGLjJPRvuZhHGKXngmomkjvb84QkLfErPPLudPShJF_session_z2MW97iS5DPX",
+        "txIndex": 4,
+        "valid": true,
+        "reason": null
+      },
+      {
+        "sessionId": "sealer_z9LZQd9286cbcxQPPY7gSQfKfoUhXa2GDrfQEuvzomwAS/signer_zB4QGLjJPRvuZhHGKXngmomkjvb84QkLfErPPLudPShJF_session_z2MW97iS5DPX",
+        "txIndex": 5,
+        "valid": true,
+        "reason": null
+      },
+      {
+        "sessionId": "sealer_zFBdmxo1bQvhv7wkXr5yyGkPG4Hsda4qs4pCJFArwh8Ga/signer_zBQyvZD4DzbLhQADvsag2otoZ69JWS35AARyvWjoPghfZ_session_zhHcTsuY9xtd",
+        "txIndex": 0,
+        "valid": true,
+        "reason": null
+      },
+      {
+        "sessionId": "sealer_zEsdgbLovywsz46P62HtkihTdZ5yXpAfAAcaHBtUiRU2L/signer_zNBPyFnmNuBLvMow7zoNM1WHnszBViwC1BowEbGj1eL6_session_zKiNbJcdV1MA",
+        "txIndex": 0,
+        "valid": false,
+        "reason": "Write key already exists and can't be overridden by invite"
+      },
+      {
+        "sessionId": "sealer_z9LZQd9286cbcxQPPY7gSQfKfoUhXa2GDrfQEuvzomwAS/signer_zB4QGLjJPRvuZhHGKXngmomkjvb84QkLfErPPLudPShJF_session_z2MW97iS5DPX",
+        "txIndex": 6,
+        "valid": true,
+        "reason": null
+      },
+      {
+        "sessionId": "sealer_zFBdmxo1bQvhv7wkXr5yyGkPG4Hsda4qs4pCJFArwh8Ga/signer_zBQyvZD4DzbLhQADvsag2otoZ69JWS35AARyvWjoPghfZ_session_zdmitwYKxBZe",
+        "txIndex": 0,
+        "valid": true,
+        "reason": null
+      }
+    ]
+  },
+  "roleQueries": [
+    {
+      "groupId": "co_zC7uB7wqSteBqsbxtMit21u3dGN",
+      "member": "sealer_zFBdmxo1bQvhv7wkXr5yyGkPG4Hsda4qs4pCJFArwh8Ga/signer_zBQyvZD4DzbLhQADvsag2otoZ69JWS35AARyvWjoPghfZ",
+      "atTime": null,
+      "expectedRole": "writeOnly"
+    }
+  ]
+}

--- a/crates/cojson-core/src/core/group_engine/classify.rs
+++ b/crates/cojson-core/src/core/group_engine/classify.rs
@@ -1,0 +1,191 @@
+//! CoValue key-shape classifiers.
+//!
+//! Ported from `packages/cojson/src/permissions.ts:583-642`
+//! (`isWriteKeyForMember`, `isKeyForKeyField`, `isKeyForAccountField`,
+//! `isKeySealedForGroupField`, `isParentExtension`, `isChildExtension`,
+//! `isOwnWriteKeyRevelation`), plus:
+//! - `packages/cojson/src/typeUtils/accountOrAgentIDfromSessionID.ts`
+//!   (`accountOrAgentIDfromSessionID`)
+//! - `packages/cojson/src/ids.ts:57-59` (`getParentGroupId`)
+
+use std::collections::HashMap;
+
+/// `isWriteKeyForMember` — permissions.ts:583-587.
+pub fn is_write_key_for_member(co: &str) -> bool {
+    co.starts_with("writeKeyFor_")
+}
+
+/// `getAccountOrAgentFromWriteKeyForMember` — permissions.ts:589-593.
+pub fn account_or_agent_from_write_key_for_member(co: &str) -> &str {
+    &co["writeKeyFor_".len()..]
+}
+
+/// `isKeyForKeyField` — permissions.ts:595-597.
+pub fn is_key_for_key_field(co: &str) -> bool {
+    co.starts_with("key_") && co.contains("_for_key")
+}
+
+/// `isKeyForAccountField` — permissions.ts:599-607. NOTE the odd `||`
+/// grouping: `(starts "key_" && (contains "_for_sealer" || "_for_co"))
+/// || contains "_for_everyone"` — the `_for_everyone` disjunct is NOT gated
+/// by the `key_` prefix check.
+pub fn is_key_for_account_field(co: &str) -> bool {
+    (co.starts_with("key_") && (co.contains("_for_sealer") || co.contains("_for_co")))
+        || co.contains("_for_everyone")
+}
+
+/// `isKeySealedForGroupField` — permissions.ts:609-613.
+pub fn is_key_sealed_for_group_field(co: &str) -> bool {
+    co.starts_with("key_") && co.contains("_sealedFor_sealer")
+}
+
+/// `isParentExtension` — permissions.ts:615-617 / `isParentGroupReference`, ids.ts:51-55.
+pub fn is_parent_extension(key: &str) -> bool {
+    key.starts_with("parent_")
+}
+
+/// `isChildExtension` — permissions.ts:619-621 / `isChildGroupReference`, ids.ts:61-63.
+pub fn is_child_extension(key: &str) -> bool {
+    key.starts_with("child_")
+}
+
+/// `isOwnWriteKeyRevelation` — permissions.ts:623-642.
+///
+/// `key` is either a `${KeyID}_for_${...}` or `${KeyID}_sealedFor_${...}`
+/// shape; find the first of `_for_` / `_sealedFor_`, take the prefix as the
+/// candidate keyID, and check it against the member's recorded write-only
+/// key.
+pub fn is_own_write_key_revelation(
+    key: &str,
+    member_key: &str,
+    write_only_keys: &HashMap<String, String>,
+) -> bool {
+    let idx = match key.find("_for_") {
+        Some(i) => Some(i),
+        None => key.find("_sealedFor_"),
+    };
+
+    let Some(i) = idx else {
+        return false;
+    };
+
+    let key_id = &key[..i];
+
+    if key_id.is_empty() {
+        return false;
+    }
+
+    write_only_keys.get(member_key).map(|s| s.as_str()) == Some(key_id)
+}
+
+/// Substring before `"_session"` — `accountOrAgentIDfromSessionID.ts`.
+pub fn author_from_session_id(session_id: &str) -> &str {
+    match session_id.find("_session") {
+        Some(i) => &session_id[..i],
+        None => session_id,
+    }
+}
+
+/// Strip the `"parent_"` prefix — `getParentGroupId`, ids.ts:57-59.
+pub fn parent_group_id_from_key(key: &str) -> &str {
+    &key["parent_".len()..]
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn write_key_for_member() {
+        assert!(is_write_key_for_member("writeKeyFor_co_z1"));
+        assert!(!is_write_key_for_member("key_z1_for_key_z2"));
+        assert_eq!(
+            account_or_agent_from_write_key_for_member("writeKeyFor_co_z1"),
+            "co_z1"
+        );
+    }
+
+    #[test]
+    fn key_for_key_field() {
+        assert!(is_key_for_key_field("key_z1_for_key_z2"));
+        assert!(!is_key_for_key_field("key_z1_for_sealer_z1"));
+        assert!(!is_key_for_key_field("writeKeyFor_co_z1"));
+    }
+
+    #[test]
+    fn key_for_account_field() {
+        assert!(is_key_for_account_field("key_z1_for_sealer_z1"));
+        assert!(is_key_for_account_field("key_z1_for_co_z1"));
+        assert!(is_key_for_account_field("key_z1_for_everyone"));
+        // the `_for_everyone` disjunct is not gated by the `key_` prefix
+        assert!(is_key_for_account_field("anything_for_everyone"));
+        assert!(!is_key_for_account_field("key_z1_for_key_z2"));
+        assert!(!is_key_for_account_field("writeKeyFor_co_z1"));
+    }
+
+    #[test]
+    fn key_sealed_for_group_field() {
+        assert!(is_key_sealed_for_group_field("key_z1_sealedFor_sealer_z1"));
+        assert!(!is_key_sealed_for_group_field("key_z1_for_sealer_z1"));
+        assert!(!is_key_sealed_for_group_field("z1_sealedFor_sealer_z1"));
+    }
+
+    #[test]
+    fn parent_and_child_extension() {
+        assert!(is_parent_extension("parent_co_z1"));
+        assert!(!is_parent_extension("child_co_z1"));
+        assert!(is_child_extension("child_co_z1"));
+        assert!(!is_child_extension("parent_co_z1"));
+        assert_eq!(parent_group_id_from_key("parent_co_z1"), "co_z1");
+    }
+
+    #[test]
+    fn own_write_key_revelation() {
+        let mut write_only_keys = HashMap::new();
+        write_only_keys.insert("co_zMember".to_string(), "key_z1".to_string());
+
+        assert!(is_own_write_key_revelation(
+            "key_z1_for_co_zOther",
+            "co_zMember",
+            &write_only_keys,
+        ));
+        assert!(is_own_write_key_revelation(
+            "key_z1_sealedFor_sealer_zOther",
+            "co_zMember",
+            &write_only_keys,
+        ));
+        // wrong keyID
+        assert!(!is_own_write_key_revelation(
+            "key_z2_for_co_zOther",
+            "co_zMember",
+            &write_only_keys,
+        ));
+        // member has no recorded write-only key
+        assert!(!is_own_write_key_revelation(
+            "key_z1_for_co_zOther",
+            "co_zUnknown",
+            &write_only_keys,
+        ));
+        // no `_for_`/`_sealedFor_` marker at all
+        assert!(!is_own_write_key_revelation(
+            "key_z1",
+            "co_zMember",
+            &write_only_keys,
+        ));
+        // empty keyID prefix (marker at position 0)
+        assert!(!is_own_write_key_revelation(
+            "_for_co_zOther",
+            "co_zMember",
+            &write_only_keys,
+        ));
+    }
+
+    #[test]
+    fn author_from_session_id_strips_suffix() {
+        assert_eq!(author_from_session_id("co_zA_session_z123"), "co_zA");
+        assert_eq!(
+            author_from_session_id("sealer_zA/signer_zB_session_z1"),
+            "sealer_zA/signer_zB"
+        );
+    }
+}

--- a/crates/cojson-core/src/core/group_engine/classify.rs
+++ b/crates/cojson-core/src/core/group_engine/classify.rs
@@ -55,6 +55,11 @@ pub fn is_child_extension(key: &str) -> bool {
 /// shape; find the first of `_for_` / `_sealedFor_`, take the prefix as the
 /// candidate keyID, and check it against the member's recorded write-only
 /// key.
+///
+/// Deliberate deviation: TS falls through to comparing `key.slice(0, -1)`
+/// when neither `_for_` nor `_sealedFor_` is present; this port returns
+/// false instead — behaviorally identical for all real key shapes, do not
+/// "fix" back.
 pub fn is_own_write_key_revelation(
     key: &str,
     member_key: &str,

--- a/crates/cojson-core/src/core/group_engine/engine.rs
+++ b/crates/cojson-core/src/core/group_engine/engine.rs
@@ -51,11 +51,15 @@ use crate::core::group_engine::classify::{
     is_key_for_key_field, is_key_sealed_for_group_field, is_own_write_key_revelation,
     is_parent_extension, is_write_key_for_member, parent_group_id_from_key,
 };
-use crate::core::group_engine::tx_view::{collect_group_txs, sort_for_validation, PendingTxIn, Privacy};
+use crate::core::group_engine::tx_view::{
+    collect_group_txs, sort_for_validation, PendingTxIn, Privacy,
+};
 use crate::core::group_engine::types::{
     is_higher_role, is_more_permissive_and_should_inherit, ParentRoleMapping, Role, TimeBasedEntry,
 };
-use crate::core::session_map::{CoValueHeader, JsonValue, RulesetDef, SessionMapError, SessionMapImpl};
+use crate::core::session_map::{
+    CoValueHeader, JsonValue, RulesetDef, SessionMapError, SessionMapImpl,
+};
 
 /// The `"everyone"` pseudo-member key (`EVERYONE`, group.ts:49).
 const EVERYONE: &str = "everyone";
@@ -301,13 +305,7 @@ pub fn build_group_engine(
         }
         RulesetKind::OwnedByGroup(group_id) => {
             build_owned_by_group(
-                covalues,
-                engines,
-                &mut state,
-                sm,
-                &group_id,
-                pending,
-                visited,
+                covalues, engines, &mut state, sm, &group_id, pending, visited,
             )?;
         }
         RulesetKind::UnsafeAllowAll => {
@@ -506,7 +504,9 @@ fn build_group_ruleset(
                         .add_change(effective, ParentRoleMapping::Revoked);
                 }
                 Some(mapping) => {
-                    resolver.parent_groups.insert(parent_group_id.clone(), mapping);
+                    resolver
+                        .parent_groups
+                        .insert(parent_group_id.clone(), mapping);
                     state
                         .parent_history
                         .entry(parent_group_id.clone())
@@ -579,7 +579,9 @@ fn build_group_ruleset(
             && affected_member == transactor
             && assigned_role == Role::Admin
         {
-            resolver.member_roles.insert(affected_member.clone(), assigned_role);
+            resolver
+                .member_roles
+                .insert(affected_member.clone(), assigned_role);
             state
                 .role_history
                 .entry(affected_member.clone())
@@ -591,7 +593,9 @@ fn build_group_ruleset(
 
         // self revoke is always valid (permissions.ts:478-482)
         if transactor == affected_member && assigned_role == Role::Revoked {
-            resolver.member_roles.insert(affected_member.clone(), assigned_role);
+            resolver
+                .member_roles
+                .insert(affected_member.clone(), assigned_role);
             state
                 .role_history
                 .entry(affected_member.clone())
@@ -619,7 +623,9 @@ fn build_group_ruleset(
                 verdict!(invalid "Admins can't demote admins.");
                 continue;
             }
-            resolver.member_roles.insert(affected_member.clone(), assigned_role);
+            resolver
+                .member_roles
+                .insert(affected_member.clone(), assigned_role);
             state
                 .role_history
                 .entry(affected_member.clone())
@@ -647,7 +653,9 @@ fn build_group_ruleset(
                 verdict!(invalid "Managers can't invite managers.");
                 continue;
             }
-            resolver.member_roles.insert(affected_member.clone(), assigned_role);
+            resolver
+                .member_roles
+                .insert(affected_member.clone(), assigned_role);
             state
                 .role_history
                 .entry(affected_member.clone())
@@ -702,7 +710,9 @@ fn build_group_ruleset(
             continue;
         }
 
-        resolver.member_roles.insert(affected_member.clone(), assigned_role);
+        resolver
+            .member_roles
+            .insert(affected_member.clone(), assigned_role);
         state
             .role_history
             .entry(affected_member.clone())
@@ -745,7 +755,9 @@ fn build_owned_by_group(
         // used as-is (so the "Transactor not found in group" branch is
         // unreachable — this helper never returns undefined).
         let effective_transactor = if tx.author == group_id && group_is_account {
-            group_initial_admin.clone().unwrap_or_else(|| tx.author.clone())
+            group_initial_admin
+                .clone()
+                .unwrap_or_else(|| tx.author.clone())
         } else {
             tx.author.clone()
         };
@@ -1062,7 +1074,13 @@ mod tests {
                 let txs_json = format!("[{}]", session.transactions.join(","));
                 node.get_mut(&cov.co_id)
                     .unwrap()
-                    .add_transactions(&session.session_id, None, &txs_json, &session.last_signature, true)
+                    .add_transactions(
+                        &session.session_id,
+                        None,
+                        &txs_json,
+                        &session.last_signature,
+                        true,
+                    )
                     .unwrap_or_else(|e| panic!("[{name}] add txs {}: {e}", session.session_id));
             }
         }
@@ -1240,7 +1258,13 @@ mod tests {
             let txs_json = format!("[{}]", session.transactions.join(","));
             node.get_mut(&child.co_id)
                 .unwrap()
-                .add_transactions(&session.session_id, None, &txs_json, &session.last_signature, true)
+                .add_transactions(
+                    &session.session_id,
+                    None,
+                    &txs_json,
+                    &session.last_signature,
+                    true,
+                )
                 .unwrap_or_else(|e| panic!("[parent_extend] add txs {}: {e}", session.session_id));
         }
 

--- a/crates/cojson-core/src/core/group_engine/engine.rs
+++ b/crates/cojson-core/src/core/group_engine/engine.rs
@@ -1165,4 +1165,88 @@ mod tests {
     fixture_test!(self_extension_cycle, "self_extension_cycle");
     fixture_test!(self_revoke, "self_revoke");
     fixture_test!(write_only_keys, "write_only_keys");
+
+    // =====================================================================
+    // Error taxonomy: UnknownCoValue (primary) vs CoValueNotLoaded (dependency)
+    // =====================================================================
+
+    /// An unregistered PRIMARY coId passed directly to a coId-first entry point
+    /// is API misuse — `UnknownCoValue` — matching every other `NodeCore`
+    /// method (e.g. `get`/`get_mut`). It must NOT surface as
+    /// `CoValueNotLoaded`, which is reserved for dependencies (parent groups /
+    /// owning accounts) discovered missing during a recursive build.
+    #[test]
+    fn validate_group_unknown_primary_errors() {
+        use crate::core::session_map::SessionMapError;
+
+        let mut node = NodeCore::new();
+
+        match node.validate_group("co_zNope", &[]) {
+            Err(SessionMapError::UnknownCoValue(id)) => assert_eq!(id, "co_zNope"),
+            other => panic!("expected UnknownCoValue, got {other:?}"),
+        }
+
+        match node.role_of("co_zNope", "co_zX", None) {
+            Err(SessionMapError::UnknownCoValue(id)) => assert_eq!(id, "co_zNope"),
+            other => panic!("expected UnknownCoValue, got {other:?}"),
+        }
+    }
+
+    /// A missing DEPENDENCY discovered while recursively building the primary
+    /// coId's engine (here: the parent group referenced by a
+    /// `parent_<id>` extension) must still surface as `CoValueNotLoaded`, not
+    /// `UnknownCoValue` — only the primary coId gets the API-misuse treatment.
+    #[test]
+    fn missing_parent_dependency_is_covalue_not_loaded() {
+        use crate::core::session_map::SessionMapError;
+
+        let fix = FixtureFile::load("parent_extend");
+
+        // The child references `parent_co_zcsomTZP9rEDbhYyqGzHvb1vC24` in its
+        // transactions; find it (and its parent id) generically off the
+        // fixture rather than hardcoding which covalue is "first".
+        let child = fix
+            .covalues
+            .iter()
+            .find(|cov| {
+                cov.sessions.iter().any(|s| {
+                    s.transactions
+                        .iter()
+                        .any(|raw| raw.contains("\\\"key\\\":\\\"parent_"))
+                })
+            })
+            .expect("[parent_extend] fixture should contain a child with a parent_ extension");
+
+        let parent_id = child
+            .sessions
+            .iter()
+            .find_map(|s| {
+                s.transactions.iter().find_map(|raw| {
+                    let v: serde_json::Value = serde_json::from_str(raw).ok()?;
+                    let changes_str = v.get("changes")?.as_str()?;
+                    let changes: serde_json::Value = serde_json::from_str(changes_str).ok()?;
+                    let key = changes.get(0)?.get("key")?.as_str()?;
+                    key.strip_prefix("parent_").map(|id| id.to_string())
+                })
+            })
+            .expect("[parent_extend] child should have a parent_<id> extension key");
+
+        // Load ONLY the child covalue — the parent is never registered.
+        let mut node = NodeCore::new();
+        let _ = build_session_map(child); // sanity: header + txs parse under skip_verify
+        node.create_co_value(&child.co_id, &child.header_json, None, true)
+            .unwrap_or_else(|e| panic!("[parent_extend] create {}: {e}", child.co_id));
+        for session in &child.sessions {
+            let txs_json = format!("[{}]", session.transactions.join(","));
+            node.get_mut(&child.co_id)
+                .unwrap()
+                .add_transactions(&session.session_id, None, &txs_json, &session.last_signature, true)
+                .unwrap_or_else(|e| panic!("[parent_extend] add txs {}: {e}", session.session_id));
+        }
+
+        match node.validate_group(&child.co_id, &[]) {
+            Err(SessionMapError::CoValueNotLoaded(id)) => assert_eq!(id, parent_id),
+            other => panic!("expected CoValueNotLoaded({parent_id}), got {other:?}"),
+        }
+    }
 }

--- a/crates/cojson-core/src/core/group_engine/engine.rs
+++ b/crates/cojson-core/src/core/group_engine/engine.rs
@@ -16,7 +16,7 @@
 //! Two role structures are kept, and they are deliberately different (spec:
 //! "TWO role structures"):
 //!
-//! - The **validation-order plain map** ([`ResolverState::member_roles`]) mirrors
+//! - The **validation-order plain map** (`ResolverState::member_roles`) mirrors
 //!   `MemberRoleResolver.memberRoles`. Direct-role lookups here IGNORE time
 //!   (`permissions.ts:207-212`); only the parent walk is time-based.
 //! - The **time-indexed histories** ([`GroupEngineState::role_history`],
@@ -762,6 +762,9 @@ fn build_owned_by_group(
         // The reader branch-pointer special case (permissions.ts:124-137)
         // requires `tx.meta.branch`, which no fixture exercises and which the
         // transaction view does not surface; it is intentionally not ported.
+        // Stage 3 ports it: `validateTransactions`' PendingTx will carry
+        // decrypted meta and the verdict gains a `validBranchPointerOnly`
+        // outcome.
         let has_write = matches!(
             role,
             Some(Role::Admin) | Some(Role::Manager) | Some(Role::Writer) | Some(Role::WriteOnly)

--- a/crates/cojson-core/src/core/group_engine/engine.rs
+++ b/crates/cojson-core/src/core/group_engine/engine.rs
@@ -1,0 +1,1165 @@
+//! Group validation and read-side role resolution over the `NodeCore` registry.
+//!
+//! This is the Rust port of cojson's permission engine. Two TypeScript
+//! algorithms are fused here, exactly as the spec mandates, because they share
+//! one accumulation pass:
+//!
+//! - **Validation** — `determineValidTransactions` /
+//!   `determineValidTransactionsForGroup` (`packages/cojson/src/permissions.ts`):
+//!   walks a CoValue's transactions in validation order and produces a
+//!   [`Verdict`] (valid flag + verbatim TS reason) for every one of them.
+//! - **Read-side role resolution** — `RawGroup.roleOfInternal` /
+//!   `RawAccount.roleOfInternal` (`packages/cojson/src/coValues/group.ts`,
+//!   `account.ts`): answers "what role does `member` have in this group at
+//!   time `t`", following time-based parent inheritance.
+//!
+//! Two role structures are kept, and they are deliberately different (spec:
+//! "TWO role structures"):
+//!
+//! - The **validation-order plain map** ([`ResolverState::member_roles`]) mirrors
+//!   `MemberRoleResolver.memberRoles`. Direct-role lookups here IGNORE time
+//!   (`permissions.ts:207-212`); only the parent walk is time-based.
+//! - The **time-indexed histories** ([`GroupEngineState::role_history`],
+//!   [`GroupEngineState::parent_history`]) mirror the CoMap content /
+//!   `parentGroupsChanges` that `roleOfInternal` reads, and are built from
+//!   VALIDATED set-role / parent ops only.
+//!
+//! Builds are always FULL RECOMPUTE (never incremental); a built
+//! [`GroupEngineState`] is cached per CoValue and reused only while its
+//! per-session transaction counts are unchanged.
+//!
+//! ## Borrow strategy
+//!
+//! Recursive engine builds walk from a child group into its parents, and a
+//! build must both read many session maps (immutably) and store the engines it
+//! computes (mutably). To keep those two borrows disjoint, the engine store
+//! lives in a `HashMap<String, GroupEngineState>` that is a SEPARATE field of
+//! `NodeCore` from the `covalues: HashMap<String, SessionMapImpl>` map. The
+//! algorithms are free functions taking `(&covalues, &mut engines)`, so a
+//! `NodeCore` method destructures `self` into its two fields and passes disjoint
+//! borrows in. No session map is ever cloned. A single `visited` set guards
+//! against build/read re-entrancy on cyclic data (impossible for valid data,
+//! since `isSelfExtension` rejects cycles at validation time, but guarded
+//! anyway).
+
+use std::collections::{HashMap, HashSet};
+
+use indexmap::IndexMap;
+
+use crate::core::group_engine::classify::{
+    account_or_agent_from_write_key_for_member, is_child_extension, is_key_for_account_field,
+    is_key_for_key_field, is_key_sealed_for_group_field, is_own_write_key_revelation,
+    is_parent_extension, is_write_key_for_member, parent_group_id_from_key,
+};
+use crate::core::group_engine::tx_view::{collect_group_txs, sort_for_validation, PendingTxIn, Privacy};
+use crate::core::group_engine::types::{
+    is_higher_role, is_more_permissive_and_should_inherit, ParentRoleMapping, Role, TimeBasedEntry,
+};
+use crate::core::session_map::{CoValueHeader, JsonValue, RulesetDef, SessionMapError, SessionMapImpl};
+
+/// The `"everyone"` pseudo-member key (`EVERYONE`, group.ts:49).
+const EVERYONE: &str = "everyone";
+
+/// A per-transaction validation verdict, in validation order.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Verdict {
+    pub session_id: String,
+    pub tx_index: u32,
+    pub valid: bool,
+    /// Verbatim TS reason string when invalid; `None` when valid.
+    pub reason: Option<String>,
+}
+
+/// The ruleset kind of a CoValue header, plus the facts the engine needs.
+enum RulesetKind {
+    Group,
+    OwnedByGroup(String),
+    UnsafeAllowAll,
+}
+
+/// Built by one full validation pass; cached per CoValue keyed by session
+/// tx-counts.
+pub struct GroupEngineState {
+    /// `(session_id, tx_count)` snapshot at build time — the cache-validity key.
+    pub session_counts: Vec<(String, u32)>,
+    pub verdicts: Vec<Verdict>,
+    /// READ state (time-indexed), built from VALIDATED set-role ops only:
+    /// member -> role over time (`madeAt` = effective made-at of the op).
+    pub role_history: HashMap<String, TimeBasedEntry<Role>>,
+    /// parent coId -> mapping over time. `IndexMap` (not the plain `HashMap`
+    /// the task sketch shows) so the parent walk iterates in first-appearance
+    /// order, matching TS `parentGroupsChanges` Map iteration.
+    pub parent_history: IndexMap<String, TimeBasedEntry<ParentRoleMapping>>,
+    /// Header ruleset `initialAdmin` (the static agent id for accounts).
+    pub initial_admin: Option<String>,
+    /// Header `meta.type == "account"` — mirrors `CoValueCore.isGroup()`
+    /// distinguishing accounts from plain groups.
+    pub is_account: bool,
+}
+
+/// Function-local validation state (NOT stored) — mirrors `MemberRoleResolver`
+/// being rebuilt per `determineValidTransactionsForGroup` call.
+struct ResolverState {
+    /// Plain, time-ignoring direct roles (permissions.ts:184-185).
+    member_roles: HashMap<String, Role>,
+    /// Current non-revoked parent mappings in validation order
+    /// (`MemberRoleResolver.parentGroups`); `IndexMap` preserves the TS Map's
+    /// insertion order for the parent walk.
+    parent_groups: IndexMap<String, ParentRoleMapping>,
+    /// member -> KeyID recorded from `writeKeyFor_` ops (last write wins).
+    write_only_keys: HashMap<String, String>,
+    /// The set of `writeKeyFor_` change keys already seen.
+    write_keys: HashSet<String>,
+}
+
+impl ResolverState {
+    fn new() -> Self {
+        ResolverState {
+            member_roles: HashMap::new(),
+            parent_groups: IndexMap::new(),
+            write_only_keys: HashMap::new(),
+            write_keys: HashSet::new(),
+        }
+    }
+}
+
+// =====================================================================
+// Header facts
+// =====================================================================
+
+fn ruleset_kind(header: &CoValueHeader) -> RulesetKind {
+    match &header.ruleset {
+        RulesetDef::Group(_) => RulesetKind::Group,
+        RulesetDef::OwnedByGroup(o) => RulesetKind::OwnedByGroup(o.group.clone()),
+        RulesetDef::UnsafeAllowAll(_) => RulesetKind::UnsafeAllowAll,
+    }
+}
+
+fn initial_admin_of(header: &CoValueHeader) -> Option<String> {
+    match &header.ruleset {
+        RulesetDef::Group(g) => Some(g.initial_admin.clone()),
+        _ => None,
+    }
+}
+
+/// `header.meta?.type === "account"`.
+fn header_meta_is_account(header: &CoValueHeader) -> bool {
+    match &header.meta {
+        Some(JsonValue::Object(obj)) => {
+            matches!(obj.get("type"), Some(JsonValue::String(s)) if s == "account")
+        }
+        _ => false,
+    }
+}
+
+/// `CoValueCore.isGroup()` — ruleset is `group` AND not an account
+/// (coValueCore.ts:1758-1772).
+fn header_is_group(header: &CoValueHeader) -> bool {
+    matches!(header.ruleset, RulesetDef::Group(_)) && !header_meta_is_account(header)
+}
+
+/// Snapshot of `(session_id, tx_count)` in session-insertion order.
+fn session_counts_of(sm: &SessionMapImpl) -> Vec<(String, u32)> {
+    sm.get_session_ids()
+        .into_iter()
+        .map(|sid| {
+            let count = sm.get_transaction_count(&sid).unwrap_or(0);
+            (sid, count)
+        })
+        .collect()
+}
+
+// =====================================================================
+// Change parsing helpers
+// =====================================================================
+
+fn change_op(change: &serde_json::Value) -> Option<&str> {
+    change.get("op").and_then(|v| v.as_str())
+}
+
+fn change_key(change: &serde_json::Value) -> &str {
+    change.get("key").and_then(|v| v.as_str()).unwrap_or("")
+}
+
+fn change_value_str(change: &serde_json::Value) -> Option<&str> {
+    change.get("value").and_then(|v| v.as_str())
+}
+
+/// Parse a `parent_<id>` change value into a [`ParentRoleMapping`].
+/// `"extend"`/`"revoked"`/a capped role string. Unrecognized values (never
+/// produced by real cojson) yield `None` and are dropped from the read/resolver
+/// state while the transaction still validates — see the deviation note in the
+/// parent-extension branch.
+fn parse_parent_mapping(value: Option<&str>) -> Option<ParentRoleMapping> {
+    match value {
+        Some("extend") => Some(ParentRoleMapping::Extend),
+        Some("revoked") => Some(ParentRoleMapping::Revoked),
+        Some(other) => Role::parse(other).map(ParentRoleMapping::Capped),
+        None => None,
+    }
+}
+
+/// Every string the validator accepts as a role value (permissions.ts:424-436).
+fn is_valid_role_value(v: Option<&str>) -> bool {
+    matches!(
+        v,
+        Some(
+            "admin"
+                | "manager"
+                | "writer"
+                | "reader"
+                | "writeOnly"
+                | "revoked"
+                | "managerInvite"
+                | "adminInvite"
+                | "writerInvite"
+                | "readerInvite"
+                | "writeOnlyInvite"
+        )
+    )
+}
+
+// =====================================================================
+// Engine freshness / build entry point
+// =====================================================================
+
+/// Rebuild `co_id`'s engine into `engines` iff its per-session tx-counts changed
+/// since the last build (full recompute). No-op when a fresh engine exists or
+/// when `co_id` is already mid-build (`visited` guard, cyclic data only).
+fn ensure_engine(
+    covalues: &HashMap<String, SessionMapImpl>,
+    engines: &mut HashMap<String, GroupEngineState>,
+    co_id: &str,
+    pending: &[PendingTxIn],
+    visited: &mut HashSet<String>,
+) -> Result<(), SessionMapError> {
+    let sm = covalues
+        .get(co_id)
+        .ok_or_else(|| SessionMapError::CoValueNotLoaded(co_id.to_string()))?;
+
+    if let Some(existing) = engines.get(co_id) {
+        if existing.session_counts == session_counts_of(sm) {
+            return Ok(());
+        }
+    }
+
+    // Re-entrant build (only reachable on cyclic parent graphs, which valid data
+    // never forms): leave the engine absent; readers treat a missing engine as
+    // "no roles", breaking the cycle.
+    if visited.contains(co_id) {
+        return Ok(());
+    }
+
+    visited.insert(co_id.to_string());
+    let state = build_group_engine(covalues, engines, co_id, pending, visited);
+    visited.remove(co_id);
+    let state = state?;
+    engines.insert(co_id.to_string(), state);
+    Ok(())
+}
+
+/// Full recompute of one CoValue's engine. Dispatches on ruleset type exactly as
+/// `determineValidTransactions` (permissions.ts:73-169) does.
+pub fn build_group_engine(
+    covalues: &HashMap<String, SessionMapImpl>,
+    engines: &mut HashMap<String, GroupEngineState>,
+    co_id: &str,
+    pending: &[PendingTxIn],
+    visited: &mut HashSet<String>,
+) -> Result<GroupEngineState, SessionMapError> {
+    let sm = covalues
+        .get(co_id)
+        .ok_or_else(|| SessionMapError::CoValueNotLoaded(co_id.to_string()))?;
+    let header = sm.header();
+    let kind = ruleset_kind(header);
+    let initial_admin = initial_admin_of(header);
+    let is_account = header_meta_is_account(header);
+    let session_counts = session_counts_of(sm);
+
+    let mut state = GroupEngineState {
+        session_counts,
+        verdicts: Vec::new(),
+        role_history: HashMap::new(),
+        parent_history: IndexMap::new(),
+        initial_admin: initial_admin.clone(),
+        is_account,
+    };
+
+    match kind {
+        RulesetKind::Group => {
+            build_group_ruleset(
+                covalues,
+                engines,
+                co_id,
+                &mut state,
+                sm,
+                initial_admin,
+                is_account,
+                pending,
+                visited,
+            )?;
+        }
+        RulesetKind::OwnedByGroup(group_id) => {
+            build_owned_by_group(
+                covalues,
+                engines,
+                &mut state,
+                sm,
+                &group_id,
+                pending,
+                visited,
+            )?;
+        }
+        RulesetKind::UnsafeAllowAll => {
+            // permissions.ts:157-163 — every transaction is valid.
+            let mut txs = collect_group_txs(sm, pending);
+            sort_for_validation(&mut txs);
+            for tx in &txs {
+                state.verdicts.push(Verdict {
+                    session_id: tx.session_id.clone(),
+                    tx_index: tx.tx_index,
+                    valid: true,
+                    reason: None,
+                });
+            }
+        }
+    }
+
+    Ok(state)
+}
+
+// =====================================================================
+// Group ruleset validation (determineValidTransactionsForGroup)
+// =====================================================================
+
+#[allow(clippy::too_many_arguments)]
+fn build_group_ruleset(
+    covalues: &HashMap<String, SessionMapImpl>,
+    engines: &mut HashMap<String, GroupEngineState>,
+    co_id: &str,
+    state: &mut GroupEngineState,
+    sm: &SessionMapImpl,
+    initial_admin: Option<String>,
+    is_account: bool,
+    pending: &[PendingTxIn],
+    visited: &mut HashSet<String>,
+) -> Result<(), SessionMapError> {
+    let mut txs = collect_group_txs(sm, pending);
+    sort_for_validation(&mut txs);
+
+    // `coValue.isGroup()` — a plain group (not an account).
+    let is_group = !is_account;
+    let initial_admin = initial_admin.unwrap_or_default();
+
+    let mut resolver = ResolverState::new();
+
+    for tx in &txs {
+        let transactor = tx.author.clone();
+        let made_at = tx.current_made_at;
+        let effective = tx.effective_made_at;
+
+        let transactor_role =
+            resolver_role_at(covalues, engines, &resolver, &transactor, made_at, visited)?;
+
+        macro_rules! verdict {
+            (valid) => {{
+                state.verdicts.push(Verdict {
+                    session_id: tx.session_id.clone(),
+                    tx_index: tx.tx_index,
+                    valid: true,
+                    reason: None,
+                });
+            }};
+            (invalid $reason:expr) => {{
+                state.verdicts.push(Verdict {
+                    session_id: tx.session_id.clone(),
+                    tx_index: tx.tx_index,
+                    valid: false,
+                    reason: Some($reason.to_string()),
+                });
+            }};
+        }
+
+        // --- privacy branch (permissions.ts:250-265) ---
+        if tx.privacy == Privacy::Private {
+            if is_group {
+                verdict!(invalid "Can't make private transactions in groups");
+            } else if transactor_role == Some(Role::Admin) {
+                verdict!(valid);
+            } else {
+                verdict!(invalid "Only admins can make private transactions in groups");
+            }
+            continue;
+        }
+
+        // `if (!changes) continue;` (permissions.ts:269-271). Only reachable for
+        // a trusting tx whose changes failed to parse (never produced by cojson);
+        // no verdict is emitted, matching TS leaving the tx in its prior state.
+        let changes = match &tx.changes {
+            Some(c) => c,
+            None => continue,
+        };
+
+        // `change = changes[0]` is read before the length check in TS, but only
+        // used afterwards (permissions.ts:273-285).
+        if changes.len() != 1 {
+            verdict!(invalid "Group transaction must have exactly one change");
+            continue;
+        }
+        let change = &changes[0];
+
+        if change_op(change) != Some("set") {
+            verdict!(invalid "Group transaction must set a role or readKey");
+            continue;
+        }
+
+        let key = change_key(change);
+
+        // --- fixed-key admin-only fields (permissions.ts:292-323) ---
+        if key == "readKey" {
+            if !Role::can_admin(transactor_role) {
+                verdict!(invalid "Only admins can set readKeys");
+                continue;
+            }
+            verdict!(valid);
+            continue;
+        } else if key == "groupSealer" {
+            if !Role::can_admin(transactor_role) {
+                verdict!(invalid "Only admins can set groupSealer");
+                continue;
+            }
+            verdict!(valid);
+            continue;
+        } else if key == "profile" {
+            if !Role::can_admin(transactor_role) {
+                verdict!(invalid "Only admins can set profile");
+                continue;
+            }
+            verdict!(valid);
+            continue;
+        } else if key == "root" {
+            if !Role::can_admin(transactor_role) {
+                verdict!(invalid "Only admins can set root");
+                continue;
+            }
+            verdict!(valid);
+            continue;
+        } else if is_key_for_key_field(key)
+            || is_key_for_account_field(key)
+            || is_key_sealed_for_group_field(key)
+        {
+            // key revelation (permissions.ts:324-344): admins, managers and any
+            // invite may reveal; anyone else only their own write key.
+            let allowed = matches!(
+                transactor_role,
+                Some(Role::Admin)
+                    | Some(Role::AdminInvite)
+                    | Some(Role::Manager)
+                    | Some(Role::ManagerInvite)
+                    | Some(Role::WriterInvite)
+                    | Some(Role::ReaderInvite)
+                    | Some(Role::WriteOnlyInvite)
+            );
+            if !allowed && !is_own_write_key_revelation(key, &transactor, &resolver.write_only_keys)
+            {
+                verdict!(invalid "Only admins and managers can reveal keys");
+                continue;
+            }
+            verdict!(valid);
+            continue;
+        } else if is_parent_extension(key) {
+            // parent extension (permissions.ts:345-381)
+            if !Role::can_admin(transactor_role) {
+                verdict!(invalid "Only admins and managers can set parent extensions");
+                continue;
+            }
+
+            let parent_group_id = parent_group_id_from_key(key).to_string();
+
+            // `expectCoValueLoaded` throwing -> CoValueNotLoaded.
+            let parent_sm = covalues
+                .get(&parent_group_id)
+                .ok_or_else(|| SessionMapError::CoValueNotLoaded(parent_group_id.clone()))?;
+
+            if !header_is_group(parent_sm.header()) {
+                verdict!(invalid "Parent group is not a group");
+                continue;
+            }
+
+            if is_self_extension(covalues, engines, co_id, &parent_group_id, visited)? {
+                verdict!(invalid "Parent group is a circular dependency");
+                continue;
+            }
+
+            // The change value is NOT validated in TS; unrecognized values are
+            // stored verbatim. This port drops values it can't map to a
+            // `ParentRoleMapping` (extend / revoked / capped role) from both the
+            // resolver and the read history, but still marks the tx valid —
+            // behaviorally identical for every value real cojson produces.
+            match parse_parent_mapping(change_value_str(change)) {
+                Some(ParentRoleMapping::Revoked) => {
+                    resolver.parent_groups.shift_remove(&parent_group_id);
+                    state
+                        .parent_history
+                        .entry(parent_group_id.clone())
+                        .or_default()
+                        .add_change(effective, ParentRoleMapping::Revoked);
+                }
+                Some(mapping) => {
+                    resolver.parent_groups.insert(parent_group_id.clone(), mapping);
+                    state
+                        .parent_history
+                        .entry(parent_group_id.clone())
+                        .or_default()
+                        .add_change(effective, mapping);
+                }
+                None => {}
+            }
+
+            verdict!(valid);
+            continue;
+        } else if is_child_extension(key) {
+            verdict!(invalid "Child extensions are not allowed anymore");
+            continue;
+        } else if is_write_key_for_member(key) {
+            // writeKeyFor_ (permissions.ts:385-418)
+            let member_key = account_or_agent_from_write_key_for_member(key).to_string();
+
+            let first_check_fails = transactor_role != Some(Role::Admin)
+                && transactor_role != Some(Role::Manager)
+                && transactor_role != Some(Role::WriteOnlyInvite)
+                && member_key != transactor;
+            if first_check_fails {
+                verdict!(invalid "Only admins and managers can set writeKeys");
+                continue;
+            }
+
+            // Assigned on EVERY writeKeyFor_ tx that passes the first check,
+            // BEFORE the override check — even for txs the override check then
+            // rejects (porter note 6).
+            if let Some(v) = change_value_str(change) {
+                resolver
+                    .write_only_keys
+                    .insert(member_key.clone(), v.to_string());
+            }
+
+            if resolver.write_keys.contains(key) && !Role::can_admin(transactor_role) {
+                verdict!(invalid "Write key already exists and can't be overridden by invite");
+                continue;
+            }
+
+            resolver.write_keys.insert(key.to_string());
+            verdict!(valid);
+            continue;
+        }
+
+        // --- role assignment (permissions.ts:421-570) ---
+        let affected_member = key.to_string();
+        let assigned_role_str = change_value_str(change);
+
+        if !is_valid_role_value(assigned_role_str) {
+            verdict!(invalid "Group transaction must set a valid role");
+            continue;
+        }
+        let assigned_role = Role::parse(assigned_role_str.unwrap()).unwrap();
+
+        if affected_member == EVERYONE
+            && !matches!(
+                assigned_role,
+                Role::Reader | Role::Writer | Role::WriteOnly | Role::Revoked
+            )
+        {
+            verdict!(invalid "Everyone can only be set to reader, writer, writeOnly or revoked");
+            continue;
+        }
+
+        // is first self promotion to admin (permissions.ts:468-476)
+        if transactor_role.is_none()
+            && transactor == initial_admin
+            && affected_member == transactor
+            && assigned_role == Role::Admin
+        {
+            resolver.member_roles.insert(affected_member.clone(), assigned_role);
+            state
+                .role_history
+                .entry(affected_member.clone())
+                .or_default()
+                .add_change(effective, assigned_role);
+            verdict!(valid);
+            continue;
+        }
+
+        // self revoke is always valid (permissions.ts:478-482)
+        if transactor == affected_member && assigned_role == Role::Revoked {
+            resolver.member_roles.insert(affected_member.clone(), assigned_role);
+            state
+                .role_history
+                .entry(affected_member.clone())
+                .or_default()
+                .add_change(effective, assigned_role);
+            verdict!(valid);
+            continue;
+        }
+
+        let affected_member_role = resolver_role_at(
+            covalues,
+            engines,
+            &resolver,
+            &affected_member,
+            made_at,
+            visited,
+        )?;
+
+        // admins (permissions.ts:493-505)
+        if transactor_role == Some(Role::Admin) {
+            if affected_member_role == Some(Role::Admin)
+                && assigned_role != Role::Admin
+                && affected_member != transactor
+            {
+                verdict!(invalid "Admins can't demote admins.");
+                continue;
+            }
+            resolver.member_roles.insert(affected_member.clone(), assigned_role);
+            state
+                .role_history
+                .entry(affected_member.clone())
+                .or_default()
+                .add_change(effective, assigned_role);
+            verdict!(valid);
+            continue;
+        }
+
+        // managers (permissions.ts:513-534)
+        if transactor_role == Some(Role::Manager) {
+            if affected_member_role == Some(Role::Admin) {
+                verdict!(invalid "Managers can't demote admins.");
+                continue;
+            }
+            if assigned_role == Role::Admin {
+                verdict!(invalid "Managers can't promote to admin.");
+                continue;
+            }
+            if assigned_role == Role::AdminInvite {
+                verdict!(invalid "Managers can't invite admins.");
+                continue;
+            }
+            if assigned_role == Role::ManagerInvite {
+                verdict!(invalid "Managers can't invite managers.");
+                continue;
+            }
+            resolver.member_roles.insert(affected_member.clone(), assigned_role);
+            state
+                .role_history
+                .entry(affected_member.clone())
+                .or_default()
+                .add_change(effective, assigned_role);
+            verdict!(valid);
+            continue;
+        }
+
+        // invites (permissions.ts:536-566)
+        let invite_ok = match transactor_role {
+            Some(Role::AdminInvite) => {
+                if assigned_role != Role::Admin {
+                    verdict!(invalid "AdminInvites can only create admins.");
+                    continue;
+                }
+                true
+            }
+            Some(Role::ManagerInvite) => {
+                if assigned_role != Role::Manager {
+                    verdict!(invalid "managerInvite can only create managers.");
+                    continue;
+                }
+                true
+            }
+            Some(Role::WriterInvite) => {
+                if assigned_role != Role::Writer {
+                    verdict!(invalid "WriterInvites can only create writers.");
+                    continue;
+                }
+                true
+            }
+            Some(Role::ReaderInvite) => {
+                if assigned_role != Role::Reader {
+                    verdict!(invalid "ReaderInvites can only create reader.");
+                    continue;
+                }
+                true
+            }
+            Some(Role::WriteOnlyInvite) => {
+                if assigned_role != Role::WriteOnly {
+                    verdict!(invalid "WriteOnlyInvites can only create writeOnly.");
+                    continue;
+                }
+                true
+            }
+            _ => false,
+        };
+
+        if !invite_ok {
+            verdict!(invalid "Group transaction must be made by current admin, manager, or invite");
+            continue;
+        }
+
+        resolver.member_roles.insert(affected_member.clone(), assigned_role);
+        state
+            .role_history
+            .entry(affected_member.clone())
+            .or_default()
+            .add_change(effective, assigned_role);
+        verdict!(valid);
+    }
+
+    Ok(())
+}
+
+// =====================================================================
+// ownedByGroup validation (determineValidTransactions, permissions.ts:90-155)
+// =====================================================================
+
+#[allow(clippy::too_many_arguments)]
+fn build_owned_by_group(
+    covalues: &HashMap<String, SessionMapImpl>,
+    engines: &mut HashMap<String, GroupEngineState>,
+    state: &mut GroupEngineState,
+    sm: &SessionMapImpl,
+    group_id: &str,
+    pending: &[PendingTxIn],
+    visited: &mut HashSet<String>,
+) -> Result<(), SessionMapError> {
+    // The owning group must be loaded (expectCoValueLoaded, permissions.ts:92-98).
+    ensure_engine(covalues, engines, group_id, &[], visited)?;
+    let (group_is_account, group_initial_admin) = engines
+        .get(group_id)
+        .map(|e| (e.is_account, e.initial_admin.clone()))
+        .unwrap_or((false, None));
+
+    // The ownedByGroup branch iterates transactions without the group-validation
+    // sort; use collection order (session-insertion, txIndex ascending).
+    let txs = collect_group_txs(sm, pending);
+
+    for tx in &txs {
+        // agentInAccountOrMemberInGroup (permissions.ts:573-581): an account's
+        // own id resolves to its static header agent; every other transactor is
+        // used as-is (so the "Transactor not found in group" branch is
+        // unreachable — this helper never returns undefined).
+        let effective_transactor = if tx.author == group_id && group_is_account {
+            group_initial_admin.clone().unwrap_or_else(|| tx.author.clone())
+        } else {
+            tx.author.clone()
+        };
+
+        let role = role_of_internal(
+            covalues,
+            engines,
+            group_id,
+            &effective_transactor,
+            Some(tx.current_made_at),
+            visited,
+        )?;
+
+        // The reader branch-pointer special case (permissions.ts:124-137)
+        // requires `tx.meta.branch`, which no fixture exercises and which the
+        // transaction view does not surface; it is intentionally not ported.
+        let has_write = matches!(
+            role,
+            Some(Role::Admin) | Some(Role::Manager) | Some(Role::Writer) | Some(Role::WriteOnly)
+        );
+
+        if has_write {
+            state.verdicts.push(Verdict {
+                session_id: tx.session_id.clone(),
+                tx_index: tx.tx_index,
+                valid: true,
+                reason: None,
+            });
+        } else {
+            state.verdicts.push(Verdict {
+                session_id: tx.session_id.clone(),
+                tx_index: tx.tx_index,
+                valid: false,
+                reason: Some("Transactor has no write permissions".to_string()),
+            });
+        }
+    }
+
+    Ok(())
+}
+
+// =====================================================================
+// Validation-side role resolution (MemberRoleResolver.getRoleAtTime)
+// =====================================================================
+
+/// `MemberRoleResolver.getRoleAtTime` (permissions.ts:207-226). The direct role
+/// comes from the plain, time-ignoring map; each parent contributes its
+/// time-based read-side role, capped/extended per its mapping and upgraded via
+/// the validation comparator.
+fn resolver_role_at(
+    covalues: &HashMap<String, SessionMapImpl>,
+    engines: &mut HashMap<String, GroupEngineState>,
+    resolver: &ResolverState,
+    member: &str,
+    time: u64,
+    visited: &mut HashSet<String>,
+) -> Result<Option<Role>, SessionMapError> {
+    let mut role = resolver.member_roles.get(member).copied();
+
+    for (parent_id, mapping) in &resolver.parent_groups {
+        // Cyclic-data guard: an in-progress parent contributes nothing.
+        if visited.contains(parent_id) {
+            continue;
+        }
+        let parent_role =
+            role_of_internal(covalues, engines, parent_id, member, Some(time), visited)?;
+
+        if !Role::is_inheritable(parent_role) {
+            continue;
+        }
+
+        let resolved = match mapping {
+            ParentRoleMapping::Extend => parent_role.unwrap(),
+            ParentRoleMapping::Capped(r) => *r,
+            // Revoked mappings are never present in `parent_groups` (removed on
+            // revoke); listed for exhaustiveness.
+            ParentRoleMapping::Revoked => continue,
+        };
+
+        if is_higher_role(resolved, role) {
+            role = Some(resolved);
+        }
+    }
+
+    Ok(role)
+}
+
+// =====================================================================
+// Read-side role resolution (RawGroup/RawAccount.roleOfInternal)
+// =====================================================================
+
+/// Read-side role of `member` in `group_id` at `at_time` (`None` = latest).
+///
+/// Port of `RawGroup.roleOfInternal` (group.ts:451-488) plus the `RawAccount`
+/// overrides (account.ts:68-75). Builds the group's engine (and, recursively,
+/// its parents') on demand.
+pub fn role_of_internal(
+    covalues: &HashMap<String, SessionMapImpl>,
+    engines: &mut HashMap<String, GroupEngineState>,
+    group_id: &str,
+    member: &str,
+    at_time: Option<u64>,
+    visited: &mut HashSet<String>,
+) -> Result<Option<Role>, SessionMapError> {
+    ensure_engine(covalues, engines, group_id, &[], visited)?;
+
+    // Missing engine == cyclic build in progress: treat as no roles.
+    let engine = match engines.get(group_id) {
+        Some(e) => e,
+        None => return Ok(None),
+    };
+
+    // RawAccount override (account.ts:68-75): self is always admin.
+    if engine.is_account && member == group_id {
+        return Ok(Some(Role::Admin));
+    }
+
+    // Direct role; a direct `revoked` collapses to `undefined` here
+    // (group.ts:454-458).
+    let mut role_info = match engine.role_history.get(member) {
+        Some(hist) => match hist.get_at_time(at_time) {
+            Some(Role::Revoked) | None => None,
+            Some(r) => Some(*r),
+        },
+        None => None,
+    };
+
+    // Parent walk (group.ts:462-479). Collect the parent edges first so the
+    // engines map is free to be mutated by the recursion.
+    let parent_edges: Vec<(String, ParentRoleMapping)> = engine
+        .parent_history
+        .iter()
+        .filter_map(|(pid, hist)| match hist.get_at_time(at_time) {
+            Some(ParentRoleMapping::Revoked) | None => None,
+            Some(mapping) => Some((pid.clone(), *mapping)),
+        })
+        .collect();
+
+    for (parent_id, mapping) in parent_edges {
+        // Cycle guard: skip an edge back into a group we are already resolving.
+        if visited.contains(&parent_id) {
+            continue;
+        }
+        let parent_role =
+            role_of_internal(covalues, engines, &parent_id, member, at_time, visited)?;
+
+        if !Role::is_inheritable(parent_role) {
+            continue;
+        }
+
+        let role_to_inherit = match mapping {
+            ParentRoleMapping::Extend => parent_role.unwrap(),
+            ParentRoleMapping::Capped(r) => r,
+            ParentRoleMapping::Revoked => continue,
+        };
+
+        if is_more_permissive_and_should_inherit(role_to_inherit, role_info) {
+            role_info = Some(role_to_inherit);
+        }
+    }
+
+    // Everyone fallback (group.ts:481-485) — only when no role resolved and the
+    // query itself is not for "everyone".
+    if role_info.is_none() && member != EVERYONE {
+        // Re-borrow: the recursion above may have rebuilt/replaced the engine.
+        if let Some(engine) = engines.get(group_id) {
+            if let Some(hist) = engine.role_history.get(EVERYONE) {
+                match hist.get_at_time(at_time) {
+                    Some(Role::Revoked) | None => {}
+                    Some(r) => return Ok(Some(*r)),
+                }
+            }
+        }
+    }
+
+    Ok(role_info)
+}
+
+// =====================================================================
+// isSelfExtension (group.ts:1766-1791)
+// =====================================================================
+
+/// `isSelfExtension` (group.ts:1766-1791): stack walk from the candidate
+/// `parent_id` over each group's CURRENT (latest, non-revoked) parent mappings;
+/// returns true if the child's own id is reached (including `parent_id ==
+/// child_id`, a direct self-reference).
+fn is_self_extension(
+    covalues: &HashMap<String, SessionMapImpl>,
+    engines: &mut HashMap<String, GroupEngineState>,
+    child_id: &str,
+    parent_id: &str,
+    visited: &mut HashSet<String>,
+) -> Result<bool, SessionMapError> {
+    let mut checked: HashSet<String> = HashSet::new();
+    let mut queue: Vec<String> = vec![parent_id.to_string()];
+
+    while let Some(current) = queue.pop() {
+        if current == child_id {
+            return Ok(true);
+        }
+        if !checked.insert(current.clone()) {
+            continue;
+        }
+
+        // getParentGroups() on `current` requires it loaded and needs its engine
+        // for the current parent mappings.
+        ensure_engine(covalues, engines, &current, &[], visited)?;
+        let parents: Vec<String> = match engines.get(&current) {
+            Some(e) => e
+                .parent_history
+                .iter()
+                .filter_map(|(pid, hist)| match hist.get_at_time(None) {
+                    Some(ParentRoleMapping::Revoked) | None => None,
+                    Some(_) => Some(pid.clone()),
+                })
+                .collect(),
+            None => Vec::new(),
+        };
+
+        for pid in parents {
+            if !checked.contains(&pid) {
+                queue.push(pid);
+            }
+        }
+    }
+
+    Ok(false)
+}
+
+// =====================================================================
+// NodeCore-facing entry points
+// =====================================================================
+
+/// Validate every transaction of `co_id` and return the verdicts in validation
+/// order. Operates on `NodeCore`'s disjoint field borrows.
+pub fn validate_group(
+    covalues: &HashMap<String, SessionMapImpl>,
+    engines: &mut HashMap<String, GroupEngineState>,
+    co_id: &str,
+    pending: &[PendingTxIn],
+) -> Result<Vec<Verdict>, SessionMapError> {
+    let mut visited = HashSet::new();
+    ensure_engine(covalues, engines, co_id, pending, &mut visited)?;
+    Ok(engines
+        .get(co_id)
+        .map(|e| e.verdicts.clone())
+        .unwrap_or_default())
+}
+
+/// Read-side role of `member` in `group_id` at `at_time`.
+pub fn role_of(
+    covalues: &HashMap<String, SessionMapImpl>,
+    engines: &mut HashMap<String, GroupEngineState>,
+    group_id: &str,
+    member: &str,
+    at_time: Option<u64>,
+) -> Result<Option<Role>, SessionMapError> {
+    let mut visited = HashSet::new();
+    role_of_internal(covalues, engines, group_id, member, at_time, &mut visited)
+}
+
+// =====================================================================
+// Fixture tests — the main gate. One test per `data/group_engine/*.json`.
+// =====================================================================
+
+#[cfg(test)]
+mod tests {
+    use super::Verdict;
+    use crate::core::group_engine::tx_view::fixtures::{build_session_map, FixtureFile};
+    use crate::core::node::NodeCore;
+
+    /// `(session_id, tx_index) -> madeAt` from a fixture's raw transactions.
+    fn made_at_index(fix: &FixtureFile) -> std::collections::HashMap<(String, u32), u64> {
+        let mut m = std::collections::HashMap::new();
+        for cov in &fix.covalues {
+            for s in &cov.sessions {
+                for (i, raw) in s.transactions.iter().enumerate() {
+                    let v: serde_json::Value = serde_json::from_str(raw).unwrap();
+                    let made = v.get("madeAt").and_then(|x| x.as_u64()).unwrap_or(0);
+                    m.insert((s.session_id.clone(), i as u32), made);
+                }
+            }
+        }
+        m
+    }
+
+    /// Load a fixture into a `NodeCore`, then assert every verdict list and every
+    /// role query matches EXACTLY (valid flag + verbatim reason string + role).
+    ///
+    /// Verdict ORDER is asserted up to the comparator's own ambiguity: cross-session
+    /// transactions sharing a `madeAt` are `Equal` under `compareTransactions`
+    /// (coValueCore.ts:1851-1855), so their relative order is unspecified. The check
+    /// therefore requires (a) an identical `madeAt` sequence and (b) an identical set
+    /// of verdicts within each equal-`madeAt` group — pinning validity, reason, and
+    /// the fully-ordered part of the sequence, while allowing equal-`madeAt`
+    /// cross-session ties to differ. See the report's ordering note.
+    fn run_fixture(name: &str) {
+        let fix = FixtureFile::load(name);
+        let made_at = made_at_index(&fix);
+
+        // Build each covalue's session map exactly as the standalone fixture
+        // helper does, but inside the node's registry.
+        let mut node = NodeCore::new();
+        for cov in &fix.covalues {
+            // Reuse the shared builder to stay identical to the tx_view tests,
+            // then splice it in via a fresh create + transaction replay.
+            let _ = build_session_map(cov); // sanity: header + txs parse under skip_verify
+            node.create_co_value(&cov.co_id, &cov.header_json, None, true)
+                .unwrap_or_else(|e| panic!("[{name}] create {}: {e}", cov.co_id));
+            for session in &cov.sessions {
+                let txs_json = format!("[{}]", session.transactions.join(","));
+                node.get_mut(&cov.co_id)
+                    .unwrap()
+                    .add_transactions(&session.session_id, None, &txs_json, &session.last_signature, true)
+                    .unwrap_or_else(|e| panic!("[{name}] add txs {}: {e}", session.session_id));
+            }
+        }
+
+        // Verdicts: one validate_group call per verdict-bearing covalue.
+        for (co_id, expected) in &fix.verdicts {
+            let got = node
+                .validate_group(co_id, &[])
+                .unwrap_or_else(|e| panic!("[{name}] validate_group {co_id}: {e}"));
+            assert_eq!(
+                got.len(),
+                expected.len(),
+                "[{name}] verdict count mismatch for {co_id}\n got: {got:#?}"
+            );
+
+            // (a) identical madeAt sequence (the fully-ordered part of the order).
+            for (i, (g, e)) in got.iter().zip(expected.iter()).enumerate() {
+                let gm = made_at[&(g.session_id.clone(), g.tx_index)];
+                let em = made_at[&(e.session_id.clone(), e.tx_index)];
+                assert!(
+                    gm == em,
+                    "[{name}] verdict madeAt-sequence mismatch at #{i} for {co_id}: \
+                     got {gm} ({} #{}), expected {em} ({} #{})",
+                    g.session_id,
+                    g.tx_index,
+                    e.session_id,
+                    e.tx_index
+                );
+            }
+
+            // (b) identical verdict set within each equal-madeAt group.
+            let key = |v: &Verdict| {
+                (
+                    made_at[&(v.session_id.clone(), v.tx_index)],
+                    v.session_id.clone(),
+                    v.tx_index,
+                    v.valid,
+                    v.reason.clone(),
+                )
+            };
+            let mut gs: Vec<_> = got.iter().map(key).collect();
+            let mut es: Vec<_> = expected
+                .iter()
+                .map(|e| {
+                    (
+                        made_at[&(e.session_id.clone(), e.tx_index)],
+                        e.session_id.clone(),
+                        e.tx_index,
+                        e.valid,
+                        e.reason.clone(),
+                    )
+                })
+                .collect();
+            gs.sort();
+            es.sort();
+            assert_eq!(gs, es, "[{name}] verdict set mismatch for {co_id}");
+        }
+
+        // Role queries.
+        for q in &fix.role_queries {
+            let got = node
+                .role_of(&q.group_id, &q.member, q.at_time)
+                .unwrap_or_else(|e| panic!("[{name}] role_of {} {}: {e}", q.group_id, q.member));
+            let got_str = got.map(|r| r.as_str().to_string());
+            assert_eq!(
+                got_str.as_deref(),
+                q.expected_role.as_deref(),
+                "[{name}] role query group={} member={} atTime={:?}",
+                q.group_id,
+                q.member,
+                q.at_time
+            );
+        }
+    }
+
+    macro_rules! fixture_test {
+        ($fn_name:ident, $file:literal) => {
+            #[test]
+            fn $fn_name() {
+                run_fixture($file);
+            }
+        };
+    }
+
+    fixture_test!(account_agent_resolution, "account_agent_resolution");
+    fixture_test!(admin_demotion_rules, "admin_demotion_rules");
+    fixture_test!(all_invites, "all_invites");
+    fixture_test!(basic_roles, "basic_roles");
+    fixture_test!(cross_session_ties, "cross_session_ties");
+    fixture_test!(deep_parent_chain, "deep_parent_chain");
+    fixture_test!(everyone_roles, "everyone_roles");
+    fixture_test!(initial_admin_self_promotion, "initial_admin_self_promotion");
+    fixture_test!(key_revelations, "key_revelations");
+    fixture_test!(malformed_changes, "malformed_changes");
+    fixture_test!(manager_rules, "manager_rules");
+    fixture_test!(parent_capped, "parent_capped");
+    fixture_test!(parent_extend, "parent_extend");
+    fixture_test!(parent_revoked_inheritance, "parent_revoked_inheritance");
+    fixture_test!(private_tx_in_group, "private_tx_in_group");
+    fixture_test!(self_extension_cycle, "self_extension_cycle");
+    fixture_test!(self_revoke, "self_revoke");
+    fixture_test!(write_only_keys, "write_only_keys");
+}

--- a/crates/cojson-core/src/core/group_engine/mod.rs
+++ b/crates/cojson-core/src/core/group_engine/mod.rs
@@ -1,0 +1,12 @@
+//! Group engine: role model, permission comparators, and CoValue key
+//! classifiers ported from `packages/cojson/src/permissions.ts` and
+//! `packages/cojson/src/coValues/group.ts`.
+//!
+//! `engine` (validation/read-side algorithms) is added in a later task; this
+//! module currently only exposes the foundation types and key classifiers.
+
+pub mod classify;
+pub mod types;
+
+pub use classify::*;
+pub use types::*;

--- a/crates/cojson-core/src/core/group_engine/mod.rs
+++ b/crates/cojson-core/src/core/group_engine/mod.rs
@@ -2,13 +2,15 @@
 //! classifiers ported from `packages/cojson/src/permissions.ts` and
 //! `packages/cojson/src/coValues/group.ts`.
 //!
-//! `engine` (validation/read-side algorithms) is added in a later task; this
-//! module currently only exposes the foundation types and key classifiers.
+//! `engine` fuses group validation and read-side role resolution over the
+//! `NodeCore` registry; `classify`, `tx_view` and `types` are its foundation.
 
 pub mod classify;
+pub mod engine;
 pub mod tx_view;
 pub mod types;
 
 pub use classify::*;
+pub use engine::*;
 pub use tx_view::*;
 pub use types::*;

--- a/crates/cojson-core/src/core/group_engine/mod.rs
+++ b/crates/cojson-core/src/core/group_engine/mod.rs
@@ -6,7 +6,9 @@
 //! module currently only exposes the foundation types and key classifiers.
 
 pub mod classify;
+pub mod tx_view;
 pub mod types;
 
 pub use classify::*;
+pub use tx_view::*;
 pub use types::*;

--- a/crates/cojson-core/src/core/group_engine/tx_view.rs
+++ b/crates/cojson-core/src/core/group_engine/tx_view.rs
@@ -1,0 +1,432 @@
+//! Group transaction views and validation ordering.
+//!
+//! Builds [`GroupTxView`]s from a [`SessionMapImpl`] — iterating sessions in
+//! insertion order, transactions by index within a session, parsing each
+//! transaction JSON exactly once — and sorts them with the validation
+//! comparator ported from `coValueCore.ts:1842-1855` (`compareTransactions`).
+//!
+//! The comparator orders by `effective_made_at` ascending; ties are broken by
+//! `tx_index` only WITHIN a session, and across sessions the original
+//! (session-insertion) order is preserved: Rust's [`Vec::sort_by`] is stable, so
+//! returning [`Equal`](core::cmp::Ordering::Equal) for cross-session ties keeps
+//! the iteration order established by [`collect_group_txs`]. The
+//! `cross_session_ties` fixture exists precisely to pin this outcome.
+
+use crate::core::group_engine::classify::author_from_session_id;
+use crate::core::session_log::Transaction;
+use crate::core::SessionMapImpl;
+use std::collections::HashMap;
+
+/// Extra per-transaction info the sync/merge layer supplies (merge-meta
+/// derived source times). Looked up by `(session_id, tx_index)` inside
+/// [`collect_group_txs`].
+#[derive(Debug, Clone, serde::Deserialize)]
+pub struct PendingTxIn {
+    pub session_id: String,
+    pub tx_index: u32,
+    pub source_made_at: Option<u64>,
+}
+
+/// Privacy class of a transaction, derived from the wire [`Transaction`] variant.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Privacy {
+    Private,
+    Trusting,
+}
+
+/// A flattened, parsed view of one group transaction, ready for the validation
+/// pass. Built by [`collect_group_txs`].
+#[derive(Debug, Clone)]
+pub struct GroupTxView {
+    pub session_id: String,
+    pub tx_index: u32,
+    /// `accountOrAgentIDfromSessionID(session_id)` — the transaction author.
+    pub author: String,
+    /// The transaction's own `madeAt` — used for permission checks.
+    pub current_made_at: u64,
+    /// `source_made_at.unwrap_or(current_made_at)` — the merge-meta-derived time
+    /// used for ORDERING. Falls back to [`GroupTxView::current_made_at`] when no
+    /// pending info is supplied for this transaction.
+    pub effective_made_at: u64,
+    pub privacy: Privacy,
+    /// Parsed `changes` array for trusting transactions. `None` for private
+    /// transactions (their changes are encrypted/opaque at this layer) and,
+    /// defensively, for trusting transactions whose `changes` string is not a
+    /// valid JSON array — valid cojson producers always stringify a real array,
+    /// so the latter does not occur for stored state.
+    pub changes: Option<Vec<serde_json::Value>>,
+}
+
+/// Collect every transaction of `sm` into views, in session-insertion order,
+/// `tx_index` ascending within each session. Each transaction JSON is parsed
+/// exactly once. `pending_info` supplies optional source times keyed by
+/// `(session_id, tx_index)`; see [`GroupTxView::effective_made_at`].
+pub fn collect_group_txs(sm: &SessionMapImpl, pending_info: &[PendingTxIn]) -> Vec<GroupTxView> {
+    // Keyed source-time lookup. Only entries that carry a source time
+    // participate; their absence falls back to the tx's own madeAt — matching
+    // `source_made_at.unwrap_or(current_made_at)`.
+    let source_times: HashMap<(&str, u32), u64> = pending_info
+        .iter()
+        .filter_map(|p| {
+            p.source_made_at
+                .map(|t| ((p.session_id.as_str(), p.tx_index), t))
+        })
+        .collect();
+
+    let mut views = Vec::new();
+    for (session_id, tx_jsons) in sm.iter_session_transactions() {
+        for (tx_index, tx_json) in tx_jsons.iter().enumerate() {
+            // SessionMapImpl stores only transactions it serialized itself, so
+            // every entry re-parses as a Transaction; a failure here would
+            // indicate storage corruption (and would silently change the
+            // validation set, so we surface it loudly rather than skip).
+            let tx: Transaction = serde_json::from_str(tx_json)
+                .expect("stored transaction JSON must re-parse as Transaction");
+
+            let (privacy, current_made_at, changes) = match tx {
+                Transaction::Trusting(t) => {
+                    // Cojson producers always stringify a valid JSON array; a
+                    // parse failure is defensive only (treated as no usable
+                    // changes, which downstream validation will reject).
+                    let changes = serde_json::from_str(&t.changes).ok();
+                    let made_at = t.made_at.as_u64().unwrap_or(0);
+                    (Privacy::Trusting, made_at, changes)
+                }
+                Transaction::Private(p) => {
+                    let made_at = p.made_at.as_u64().unwrap_or(0);
+                    (Privacy::Private, made_at, None)
+                }
+            };
+
+            let effective_made_at = source_times
+                .get(&(session_id, tx_index as u32))
+                .copied()
+                .unwrap_or(current_made_at);
+
+            views.push(GroupTxView {
+                session_id: session_id.to_string(),
+                tx_index: tx_index as u32,
+                author: author_from_session_id(session_id).to_string(),
+                current_made_at,
+                effective_made_at,
+                privacy,
+                changes,
+            });
+        }
+    }
+    views
+}
+
+/// `compareTransactions` port (`coValueCore.ts:1842-1855`) + STABLE sort.
+///
+/// `effective_made_at` ascending; on ties, same-session pairs order by
+/// `tx_index`, cross-session pairs compare [`Equal`](core::cmp::Ordering::Equal)
+/// so the stable sort preserves the session-insertion order built by
+/// [`collect_group_txs`].
+pub fn sort_for_validation(txs: &mut [GroupTxView]) {
+    txs.sort_by(|a, b| {
+        match a.effective_made_at.cmp(&b.effective_made_at) {
+            core::cmp::Ordering::Equal if a.session_id == b.session_id => {
+                a.tx_index.cmp(&b.tx_index)
+            }
+            core::cmp::Ordering::Equal => core::cmp::Ordering::Equal,
+            other => other,
+        }
+    });
+}
+
+// =====================================================================
+// Test-support: fixture serde structs (reused by later group-engine tasks)
+// =====================================================================
+
+#[cfg(test)]
+pub(crate) mod fixtures {
+    use serde::Deserialize;
+    use std::collections::HashMap;
+
+    use crate::core::SessionMapImpl;
+
+    /// One session's raw transaction wire JSON plus its commit signature, as
+    /// stored in a fixture file.
+    #[allow(dead_code)]
+    #[derive(Debug, Clone, Deserialize)]
+    pub struct FixtureSession {
+        #[serde(rename = "sessionId")]
+        pub session_id: String,
+        #[serde(rename = "signerId", default)]
+        pub signer_id: Option<String>,
+        /// Raw wire-JSON transaction strings; each parses to a `Transaction`.
+        pub transactions: Vec<String>,
+        #[serde(rename = "lastSignature")]
+        pub last_signature: String,
+    }
+
+    #[derive(Debug, Clone, Deserialize)]
+    pub struct FixtureCovalue {
+        #[serde(rename = "coId")]
+        pub co_id: String,
+        #[serde(rename = "headerJson")]
+        pub header_json: String,
+        pub sessions: Vec<FixtureSession>,
+    }
+
+    /// A per-transaction validation verdict, keyed by coId in
+    /// [`FixtureFile::verdicts`]. The ORDER of a coId's verdict list is the
+    /// expected validation order — `collect_group_txs` + `sort_for_validation`
+    /// must reproduce it.
+    /// Read by Task 4 (validation); kept here so the fixture parses fully.
+    #[allow(dead_code)]
+    #[derive(Debug, Clone, Deserialize)]
+    pub struct FixtureVerdict {
+        #[serde(rename = "sessionId")]
+        pub session_id: String,
+        #[serde(rename = "txIndex")]
+        pub tx_index: u32,
+        pub valid: bool,
+        pub reason: Option<String>,
+    }
+
+    /// Read by Task 4 (role resolution); kept here so the fixture parses fully.
+    #[allow(dead_code)]
+    #[derive(Debug, Clone, Deserialize)]
+    pub struct FixtureRoleQuery {
+        #[serde(rename = "groupId")]
+        pub group_id: String,
+        pub member: String,
+        #[serde(rename = "atTime")]
+        pub at_time: Option<u64>,
+        // `null` in fixtures means "the member has no role at this time".
+        #[serde(rename = "expectedRole")]
+        pub expected_role: Option<String>,
+    }
+
+    /// Parsed shape of a `data/group_engine/*.json` fixture file.
+    #[allow(dead_code)]
+    #[derive(Debug, Clone, Deserialize)]
+    pub struct FixtureFile {
+        #[serde(default)]
+        pub description: Option<String>,
+        pub covalues: Vec<FixtureCovalue>,
+        #[serde(default)]
+        pub verdicts: HashMap<String, Vec<FixtureVerdict>>,
+        #[serde(default, rename = "roleQueries")]
+        pub role_queries: Vec<FixtureRoleQuery>,
+    }
+
+    impl FixtureFile {
+        /// Load a fixture from `data/group_engine/<name>.json` relative to the
+        /// crate root (where `cargo test` runs).
+        pub fn load(name: &str) -> Self {
+            let path = format!("data/group_engine/{name}.json");
+            let text =
+                std::fs::read_to_string(&path).unwrap_or_else(|e| panic!("read {path}: {e}"));
+            serde_json::from_str(&text)
+                .unwrap_or_else(|e| panic!("parse {path}: {e}"))
+        }
+    }
+
+    /// Build a `SessionMapImpl` from a fixture covalue, loading every session's
+    /// transactions with signature verification skipped. The group engine reads
+    /// already-stored state; it does not re-verify session signatures here, and
+    /// the tx views it builds are independent of the signer id.
+    pub fn build_session_map(cov: &FixtureCovalue) -> SessionMapImpl {
+        let mut sm = SessionMapImpl::new_with_skip_verify(&cov.co_id, &cov.header_json, None, true)
+            .expect("fixture header should parse under skip_verify");
+        for session in &cov.sessions {
+            // `add_transactions` takes a JSON array of transaction OBJECTS; the
+            // fixture stores one object per string, so splice them into an array
+            // (no re-serialization that could reorder fields).
+            let txs_json = format!("[{}]", session.transactions.join(","));
+            // signer_id left as None: fixture `signerId`s are account/session
+            // ids, not raw verifying keys, and signature verification is skipped
+            // anyway — the group engine does not need a public key here.
+            sm.add_transactions(
+                &session.session_id,
+                None,
+                &txs_json,
+                &session.last_signature,
+                true,
+            )
+            .expect("fixture transactions load under skip_verify");
+        }
+        sm
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// `cross_session_ties` (group covalue `co_zfF4FnTK4hX5gj2Lzss8Zxp2HTh`):
+    /// three sessions, all transactions at the SAME `madeAt`. Extraction must be
+    /// session-insertion / txIndex-ascending, and because every effective time is
+    /// equal, the stable sort must be a no-op — both reproducing the fixture's
+    /// verdict order (8 admin-session txs, then one tx each from the two
+    /// conflicting sessions).
+    #[test]
+    fn cross_session_ties_extraction_and_order_match_verdicts() {
+        let fix = fixtures::FixtureFile::load("cross_session_ties");
+        let cov = fix
+            .covalues
+            .iter()
+            .find(|c| c.co_id == "co_zfF4FnTK4hX5gj2Lzss8Zxp2HTh")
+            .expect("ties group covalue present");
+
+        let sm = fixtures::build_session_map(cov);
+        let collected = collect_group_txs(&sm, &[]);
+
+        let verdicts = fix
+            .verdicts
+            .get("co_zfF4FnTK4hX5gj2Lzss8Zxp2HTh")
+            .expect("ties verdicts present");
+
+        // Extraction order already equals the verdict (validation) order.
+        assert_eq!(collected.len(), verdicts.len(), "tx count");
+        for (v, vd) in collected.iter().zip(verdicts.iter()) {
+            assert_eq!(v.session_id, vd.session_id, "session order");
+            assert_eq!(v.tx_index, vd.tx_index, "tx_index order");
+            // All equal madeAt, no pending info -> effective == current.
+            assert_eq!(v.current_made_at, 1_700_000_000_000, "current_made_at");
+            assert_eq!(v.effective_made_at, v.current_made_at, "effective_made_at");
+            assert_eq!(v.privacy, Privacy::Trusting, "privacy");
+            assert!(v.changes.is_some(), "trusting tx must parse changes");
+        }
+
+        // Stable sort of an all-equal set is a no-op.
+        let mut sorted = collected.clone();
+        sort_for_validation(&mut sorted);
+        let key = |v: &GroupTxView| (v.session_id.clone(), v.tx_index);
+        assert_eq!(
+            sorted.iter().map(key).collect::<Vec<_>>(),
+            collected.iter().map(key).collect::<Vec<_>>(),
+            "stable sort must preserve insertion order on equal madeAt"
+        );
+    }
+
+    /// `basic_roles` (group covalue, single session, 20 trusting txs with
+    /// monotonically non-decreasing `madeAt` in txIndex order). Pins: same-session
+    /// ties break by txIndex, and a single session's txIndex order is already the
+    /// sorted order.
+    #[test]
+    fn basic_roles_single_session_order() {
+        let fix = fixtures::FixtureFile::load("basic_roles");
+        let cov = &fix.covalues[0];
+        assert_eq!(cov.co_id, "co_zSwsoHJ9ytViWJyoLeMwG8GLJ3T");
+
+        let sm = fixtures::build_session_map(cov);
+        let mut views = collect_group_txs(&sm, &[]);
+
+        assert_eq!(views.len(), 20, "20 trusting txs in the admin session");
+        for (i, v) in views.iter().enumerate() {
+            assert_eq!(v.tx_index, i as u32, "tx_index ascending");
+            assert_eq!(v.privacy, Privacy::Trusting);
+            assert!(v.changes.is_some());
+            assert_eq!(v.effective_made_at, v.current_made_at, "no pending info");
+        }
+
+        // madeAt is non-decreasing in txIndex order in this fixture, so the
+        // single-session sort (ties -> txIndex) is a no-op.
+        let before: Vec<u32> = views.iter().map(|v| v.tx_index).collect();
+        sort_for_validation(&mut views);
+        let after: Vec<u32> = views.iter().map(|v| v.tx_index).collect();
+        assert_eq!(before, after, "single-session sort preserves txIndex order");
+    }
+
+    /// `private_tx_in_group` (group covalue): 4 trusting txs followed by one
+    /// private tx. A private tx must yield `Privacy::Private` with `changes`
+    /// `None` (changes are encrypted/opaque here); trusting txs parse changes.
+    #[test]
+    fn private_tx_view_has_no_changes() {
+        let fix = fixtures::FixtureFile::load("private_tx_in_group");
+        let cov = &fix.covalues[0];
+        let sm = fixtures::build_session_map(cov);
+        let views = collect_group_txs(&sm, &[]);
+
+        assert_eq!(views.len(), 5);
+        for v in &views[0..4] {
+            assert_eq!(v.privacy, Privacy::Trusting);
+            assert!(v.changes.is_some(), "trusting tx parses changes");
+        }
+        let private = &views[4];
+        assert_eq!(private.privacy, Privacy::Private);
+        assert!(private.changes.is_none(), "private tx changes must be None");
+        assert_eq!(private.current_made_at, 1_783_120_267_022);
+    }
+
+    /// Synthetic test pinning all three comparator branches directly:
+    /// different `madeAt` orders ascending; equal `madeAt` within a session
+    /// orders by txIndex; equal `madeAt` across sessions preserves insertion
+    /// order (stable).
+    #[test]
+    fn sort_for_validation_pins_three_branches() {
+        fn view(session: &str, tx_index: u32, effective_made_at: u64) -> GroupTxView {
+            GroupTxView {
+                session_id: session.to_string(),
+                tx_index,
+                author: author_from_session_id(session).to_string(),
+                current_made_at: effective_made_at,
+                effective_made_at,
+                privacy: Privacy::Trusting,
+                changes: Some(vec![]),
+            }
+        }
+
+        // Insertion order: s1/0, s2/0, s1/1, s3/0
+        let mut txs = vec![
+            view("co_a_session_x", 0, 200),
+            view("co_b_session_y", 0, 100), // earlier madeAt -> sorts first
+            view("co_a_session_x", 1, 200),
+            view("co_c_session_z", 0, 200),
+        ];
+        sort_for_validation(&mut txs);
+
+        let order: Vec<(String, u32)> = txs
+            .iter()
+            .map(|t| (t.session_id.clone(), t.tx_index))
+            .collect();
+        assert_eq!(
+            order,
+            vec![
+                ("co_b_session_y".to_string(), 0), // madeAt 100 ascending
+                ("co_a_session_x".to_string(), 0), // madeAt 200, same session -> txIndex
+                ("co_a_session_x".to_string(), 1),
+                ("co_c_session_z".to_string(), 0), // madeAt 200, cross-session -> stable
+            ]
+        );
+    }
+
+    /// `pending_info` source times override `current_made_at` for ORDERING only:
+    /// `effective_made_at = source_made_at.unwrap_or(current_made_at)`, while
+    /// `current_made_at` is unchanged.
+    #[test]
+    fn pending_source_made_at_drives_ordering() {
+        let fix = fixtures::FixtureFile::load("cross_session_ties");
+        let cov = fix
+            .covalues
+            .iter()
+            .find(|c| c.co_id == "co_zfF4FnTK4hX5gj2Lzss8Zxp2HTh")
+            .unwrap();
+        let sm = fixtures::build_session_map(cov);
+
+        // Push session B's single tx to a much later source time so it lands last.
+        let b_session = "co_zUGQrkaYiZrjKaNgqQgARcDd54d_session_zG8MqseX8L3A";
+        let pending = vec![PendingTxIn {
+            session_id: b_session.to_string(),
+            tx_index: 0,
+            source_made_at: Some(1_800_000_000_000),
+        }];
+        let mut views = collect_group_txs(&sm, &pending);
+        sort_for_validation(&mut views);
+
+        let b = views
+            .iter()
+            .find(|v| v.session_id == b_session)
+            .expect("session B present");
+        assert_eq!(b.current_made_at, 1_700_000_000_000, "current unchanged");
+        assert_eq!(b.effective_made_at, 1_800_000_000_000, "effective overridden");
+        assert_eq!(
+            views.last().unwrap().session_id, b_session,
+            "later effective time sorts last"
+        );
+    }
+}

--- a/crates/cojson-core/src/core/group_engine/tx_view.rs
+++ b/crates/cojson-core/src/core/group_engine/tx_view.rs
@@ -124,14 +124,10 @@ pub fn collect_group_txs(sm: &SessionMapImpl, pending_info: &[PendingTxIn]) -> V
 /// so the stable sort preserves the session-insertion order built by
 /// [`collect_group_txs`].
 pub fn sort_for_validation(txs: &mut [GroupTxView]) {
-    txs.sort_by(|a, b| {
-        match a.effective_made_at.cmp(&b.effective_made_at) {
-            core::cmp::Ordering::Equal if a.session_id == b.session_id => {
-                a.tx_index.cmp(&b.tx_index)
-            }
-            core::cmp::Ordering::Equal => core::cmp::Ordering::Equal,
-            other => other,
-        }
+    txs.sort_by(|a, b| match a.effective_made_at.cmp(&b.effective_made_at) {
+        core::cmp::Ordering::Equal if a.session_id == b.session_id => a.tx_index.cmp(&b.tx_index),
+        core::cmp::Ordering::Equal => core::cmp::Ordering::Equal,
+        other => other,
     });
 }
 
@@ -220,8 +216,7 @@ pub(crate) mod fixtures {
             let path = format!("data/group_engine/{name}.json");
             let text =
                 std::fs::read_to_string(&path).unwrap_or_else(|e| panic!("read {path}: {e}"));
-            serde_json::from_str(&text)
-                .unwrap_or_else(|e| panic!("parse {path}: {e}"))
+            serde_json::from_str(&text).unwrap_or_else(|e| panic!("parse {path}: {e}"))
         }
     }
 
@@ -423,9 +418,13 @@ mod tests {
             .find(|v| v.session_id == b_session)
             .expect("session B present");
         assert_eq!(b.current_made_at, 1_700_000_000_000, "current unchanged");
-        assert_eq!(b.effective_made_at, 1_800_000_000_000, "effective overridden");
         assert_eq!(
-            views.last().unwrap().session_id, b_session,
+            b.effective_made_at, 1_800_000_000_000,
+            "effective overridden"
+        );
+        assert_eq!(
+            views.last().unwrap().session_id,
+            b_session,
             "later effective time sorts last"
         );
     }

--- a/crates/cojson-core/src/core/group_engine/tx_view.rs
+++ b/crates/cojson-core/src/core/group_engine/tx_view.rs
@@ -7,7 +7,7 @@
 //!
 //! The comparator orders by `effective_made_at` ascending; ties are broken by
 //! `tx_index` only WITHIN a session, and across sessions the original
-//! (session-insertion) order is preserved: Rust's [`Vec::sort_by`] is stable, so
+//! (session-insertion) order is preserved: Rust's `Vec::sort_by` is stable, so
 //! returning [`Equal`](core::cmp::Ordering::Equal) for cross-session ties keeps
 //! the iteration order established by [`collect_group_txs`]. The
 //! `cross_session_ties` fixture exists precisely to pin this outcome.

--- a/crates/cojson-core/src/core/group_engine/types.rs
+++ b/crates/cojson-core/src/core/group_engine/types.rs
@@ -10,7 +10,7 @@
 use serde::{Deserialize, Serialize};
 
 /// A member's role in a group. Mirrors TS `Role` (permissions.ts:28-57).
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub enum Role {
     #[serde(rename = "admin")]
     Admin,
@@ -179,7 +179,7 @@ pub fn is_more_permissive_and_should_inherit(
 /// A parent-group reference role — `ParentGroupReferenceRole`, group.ts:92-98.
 /// Parsed from the `parent_<id>` change value: `"extend"` | a capped role
 /// string | `"revoked"`.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum ParentRoleMapping {
     Extend,
     Capped(Role),
@@ -391,6 +391,10 @@ mod tests {
         assert!(is_higher_role(Role::Writer, Some(Role::Reader)));
         assert!(!is_higher_role(Role::Reader, Some(Role::Writer)));
         assert!(!is_higher_role(Role::Writer, Some(Role::WriteOnly)));
+
+        // Literal, TS-derived spot check independent of `expected`: b ==
+        // manager falls through to the `false` branch (permissions.ts:171-181).
+        assert!(!is_higher_role(Role::Writer, Some(Role::Manager)));
     }
 
     // Table-driven test of is_more_permissive_and_should_inherit over every
@@ -485,6 +489,23 @@ mod tests {
         assert!(!is_more_permissive_and_should_inherit(
             Role::WriteOnly,
             None
+        ));
+
+        // Literal, TS-derived spot checks independent of `expected`, pinning
+        // group.ts:1693-1727 branch by branch.
+        assert!(is_more_permissive_and_should_inherit(
+            Role::Manager,
+            Some(Role::Writer)
+        ));
+        assert!(is_more_permissive_and_should_inherit(
+            Role::Admin,
+            Some(Role::Writer)
+        ));
+        assert!(is_more_permissive_and_should_inherit(Role::Reader, None));
+        // invite fallthrough -> false
+        assert!(!is_more_permissive_and_should_inherit(
+            Role::AdminInvite,
+            Some(Role::Reader)
         ));
     }
 

--- a/crates/cojson-core/src/core/group_engine/types.rs
+++ b/crates/cojson-core/src/core/group_engine/types.rs
@@ -1,0 +1,514 @@
+//! Role model, permission comparators, and time-indexed entries.
+//!
+//! Ported from:
+//! - `packages/cojson/src/permissions.ts:171-181` (`isHigherRole`)
+//! - `packages/cojson/src/coValues/group.ts:1681-1727`
+//!   (`isInheritableRole`, `isMorePermissiveAndShouldInherit`)
+//! - `packages/cojson/src/coValues/group.ts:254-286` (`TimeBasedEntry`)
+//! - `packages/cojson/src/coValues/group.ts:92-98` (`ParentGroupReferenceRole`)
+
+use serde::{Deserialize, Serialize};
+
+/// A member's role in a group. Mirrors TS `Role` (permissions.ts:28-57).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum Role {
+    #[serde(rename = "admin")]
+    Admin,
+    #[serde(rename = "manager")]
+    Manager,
+    #[serde(rename = "writer")]
+    Writer,
+    #[serde(rename = "reader")]
+    Reader,
+    #[serde(rename = "writeOnly")]
+    WriteOnly,
+    #[serde(rename = "revoked")]
+    Revoked,
+    #[serde(rename = "adminInvite")]
+    AdminInvite,
+    #[serde(rename = "managerInvite")]
+    ManagerInvite,
+    #[serde(rename = "writerInvite")]
+    WriterInvite,
+    #[serde(rename = "readerInvite")]
+    ReaderInvite,
+    #[serde(rename = "writeOnlyInvite")]
+    WriteOnlyInvite,
+}
+
+impl Role {
+    /// Parse the exact TS string form of a role. Returns `None` for anything else.
+    pub fn parse(s: &str) -> Option<Role> {
+        match s {
+            "admin" => Some(Role::Admin),
+            "manager" => Some(Role::Manager),
+            "writer" => Some(Role::Writer),
+            "reader" => Some(Role::Reader),
+            "writeOnly" => Some(Role::WriteOnly),
+            "revoked" => Some(Role::Revoked),
+            "adminInvite" => Some(Role::AdminInvite),
+            "managerInvite" => Some(Role::ManagerInvite),
+            "writerInvite" => Some(Role::WriterInvite),
+            "readerInvite" => Some(Role::ReaderInvite),
+            "writeOnlyInvite" => Some(Role::WriteOnlyInvite),
+            _ => None,
+        }
+    }
+
+    /// The exact TS string form of this role (inverse of [`Role::parse`]).
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Role::Admin => "admin",
+            Role::Manager => "manager",
+            Role::Writer => "writer",
+            Role::Reader => "reader",
+            Role::WriteOnly => "writeOnly",
+            Role::Revoked => "revoked",
+            Role::AdminInvite => "adminInvite",
+            Role::ManagerInvite => "managerInvite",
+            Role::WriterInvite => "writerInvite",
+            Role::ReaderInvite => "readerInvite",
+            Role::WriteOnlyInvite => "writeOnlyInvite",
+        }
+    }
+
+    /// `isAccountRole` — permissions.ts:59-67. True for the five non-invite,
+    /// non-revoked "concrete account" roles.
+    pub fn is_account_role(role: Option<Role>) -> bool {
+        matches!(
+            role,
+            Some(Role::Manager)
+                | Some(Role::Admin)
+                | Some(Role::Writer)
+                | Some(Role::Reader)
+                | Some(Role::WriteOnly)
+        )
+    }
+
+    /// `canAdmin` — permissions.ts:69-71.
+    pub fn can_admin(role: Option<Role>) -> bool {
+        matches!(role, Some(Role::Admin) | Some(Role::Manager))
+    }
+
+    /// `isInheritableRole` — group.ts:1681-1691.
+    pub fn is_inheritable(role: Option<Role>) -> bool {
+        matches!(
+            role,
+            Some(Role::Revoked)
+                | Some(Role::Admin)
+                | Some(Role::Manager)
+                | Some(Role::Writer)
+                | Some(Role::Reader)
+        )
+    }
+}
+
+/// Validation-side comparator — `isHigherRole`, permissions.ts:171-181.
+///
+/// Is `a` higher than `b`? `revoked` is never higher than anything (including
+/// another `revoked`/`undefined`).
+///
+/// NOTE: TS also has a leading `a === undefined` check; `a` is not optional
+/// here (the TS signature takes `Role`, not `Role | undefined`, for `a`), so
+/// that branch is dropped as unreachable — everything else is a literal,
+/// branch-for-branch port.
+pub fn is_higher_role(a: Role, b: Option<Role>) -> bool {
+    if a == Role::Revoked {
+        return false;
+    }
+    if b.is_none() || b == Some(Role::Revoked) {
+        return true;
+    }
+    if b == Some(Role::Admin) {
+        return false;
+    }
+    if a == Role::Admin {
+        return true;
+    }
+    if b == Some(Role::Manager) {
+        return false;
+    }
+    if a == Role::Manager {
+        return true;
+    }
+    a == Role::Writer && b == Some(Role::Reader)
+}
+
+/// Read-side comparator — `isMorePermissiveAndShouldInherit`, group.ts:1693-1727.
+///
+/// NOTE: a `revoked` role in the parent returns `true` — an inherited
+/// `revoked` OVERRIDES the child role. This differs from the validation-side
+/// comparator above, where `revoked` is never higher. Callers rarely reach
+/// this branch (see porter notes), but the table is ported exactly as
+/// written.
+pub fn is_more_permissive_and_should_inherit(
+    role_in_parent: Role,
+    role_in_child: Option<Role>,
+) -> bool {
+    if role_in_parent == Role::Revoked {
+        return true;
+    }
+
+    if role_in_parent == Role::Manager {
+        return role_in_child.is_none()
+            || (role_in_child != Some(Role::Manager) && role_in_child != Some(Role::Admin));
+    }
+
+    if role_in_parent == Role::Admin {
+        return role_in_child.is_none() || role_in_child != Some(Role::Admin);
+    }
+
+    if role_in_parent == Role::Writer {
+        return role_in_child.is_none()
+            || role_in_child == Some(Role::Reader)
+            || role_in_child == Some(Role::WriteOnly);
+    }
+
+    if role_in_parent == Role::Reader {
+        return role_in_child.is_none();
+    }
+
+    // writeOnly can't be inherited
+    if role_in_parent == Role::WriteOnly {
+        return false;
+    }
+
+    false
+}
+
+/// A parent-group reference role — `ParentGroupReferenceRole`, group.ts:92-98.
+/// Parsed from the `parent_<id>` change value: `"extend"` | a capped role
+/// string | `"revoked"`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ParentRoleMapping {
+    Extend,
+    Capped(Role),
+    Revoked,
+}
+
+/// A time-indexed history of values, keyed by `madeAt` timestamp.
+/// Ported from `TimeBasedEntry`, group.ts:254-286.
+#[derive(Debug, Clone)]
+pub struct TimeBasedEntry<T> {
+    changes: Vec<(u64, T)>,
+}
+
+impl<T> TimeBasedEntry<T> {
+    pub fn new() -> Self {
+        TimeBasedEntry {
+            changes: Vec::new(),
+        }
+    }
+
+    /// Insert a change in chronological order. Search backwards from the end
+    /// so that an equal `made_at` inserts AFTER existing equals (TS scans
+    /// `> madeAt`, stopping — and thus inserting — at the first entry that is
+    /// not strictly greater).
+    pub fn add_change(&mut self, made_at: u64, value: T) {
+        let mut idx = self.changes.len();
+        while idx > 0 && self.changes[idx - 1].0 > made_at {
+            idx -= 1;
+        }
+        self.changes.insert(idx, (made_at, value));
+    }
+
+    pub fn get_latest(&self) -> Option<&T> {
+        self.changes.last().map(|(_, v)| v)
+    }
+
+    /// `getAtTime` — `None` (TS `undefined`) means "latest"; otherwise the
+    /// last change with `made_at <= at_time` (TS `findLast`).
+    pub fn get_at_time(&self, at_time: Option<u64>) -> Option<&T> {
+        match at_time {
+            None => self.get_latest(),
+            Some(t) => self
+                .changes
+                .iter()
+                .rev()
+                .find(|(m, _)| *m <= t)
+                .map(|(_, v)| v),
+        }
+    }
+}
+
+impl<T> Default for TimeBasedEntry<T> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn role_round_trips_every_ts_string() {
+        let cases = [
+            (Role::Admin, "admin"),
+            (Role::Manager, "manager"),
+            (Role::Writer, "writer"),
+            (Role::Reader, "reader"),
+            (Role::WriteOnly, "writeOnly"),
+            (Role::Revoked, "revoked"),
+            (Role::AdminInvite, "adminInvite"),
+            (Role::ManagerInvite, "managerInvite"),
+            (Role::WriterInvite, "writerInvite"),
+            (Role::ReaderInvite, "readerInvite"),
+            (Role::WriteOnlyInvite, "writeOnlyInvite"),
+        ];
+        for (role, s) in cases {
+            assert_eq!(Role::parse(s), Some(role), "parse({s:?})");
+            assert_eq!(role.as_str(), s, "as_str({role:?})");
+            // serde round trip too
+            let json = serde_json::to_string(&role).unwrap();
+            assert_eq!(json, format!("\"{s}\""));
+            let back: Role = serde_json::from_str(&json).unwrap();
+            assert_eq!(back, role);
+        }
+        assert_eq!(Role::parse("nonsense"), None);
+    }
+
+    #[test]
+    fn is_account_role_matches_ts_table() {
+        assert!(Role::is_account_role(Some(Role::Manager)));
+        assert!(Role::is_account_role(Some(Role::Admin)));
+        assert!(Role::is_account_role(Some(Role::Writer)));
+        assert!(Role::is_account_role(Some(Role::Reader)));
+        assert!(Role::is_account_role(Some(Role::WriteOnly)));
+        assert!(!Role::is_account_role(Some(Role::Revoked)));
+        assert!(!Role::is_account_role(Some(Role::AdminInvite)));
+        assert!(!Role::is_account_role(Some(Role::ManagerInvite)));
+        assert!(!Role::is_account_role(Some(Role::WriterInvite)));
+        assert!(!Role::is_account_role(Some(Role::ReaderInvite)));
+        assert!(!Role::is_account_role(Some(Role::WriteOnlyInvite)));
+        assert!(!Role::is_account_role(None));
+    }
+
+    #[test]
+    fn can_admin_matches_ts_table() {
+        assert!(Role::can_admin(Some(Role::Admin)));
+        assert!(Role::can_admin(Some(Role::Manager)));
+        for role in [
+            Role::Writer,
+            Role::Reader,
+            Role::WriteOnly,
+            Role::Revoked,
+            Role::AdminInvite,
+            Role::ManagerInvite,
+            Role::WriterInvite,
+            Role::ReaderInvite,
+            Role::WriteOnlyInvite,
+        ] {
+            assert!(!Role::can_admin(Some(role)), "{role:?}");
+        }
+        assert!(!Role::can_admin(None));
+    }
+
+    #[test]
+    fn is_inheritable_role_matches_ts_table() {
+        for role in [
+            Role::Revoked,
+            Role::Admin,
+            Role::Manager,
+            Role::Writer,
+            Role::Reader,
+        ] {
+            assert!(Role::is_inheritable(Some(role)), "{role:?}");
+        }
+        for role in [
+            Role::WriteOnly,
+            Role::AdminInvite,
+            Role::ManagerInvite,
+            Role::WriterInvite,
+            Role::ReaderInvite,
+            Role::WriteOnlyInvite,
+        ] {
+            assert!(!Role::is_inheritable(Some(role)), "{role:?}");
+        }
+        assert!(!Role::is_inheritable(None));
+    }
+
+    // Table-driven test of is_higher_role over every (a, b) role pair plus
+    // b = None, mirroring permissions.ts:171-181 branch by branch.
+    #[test]
+    fn is_higher_role_covers_every_branch() {
+        const ALL: [Role; 11] = [
+            Role::Admin,
+            Role::Manager,
+            Role::Writer,
+            Role::Reader,
+            Role::WriteOnly,
+            Role::Revoked,
+            Role::AdminInvite,
+            Role::ManagerInvite,
+            Role::WriterInvite,
+            Role::ReaderInvite,
+            Role::WriteOnlyInvite,
+        ];
+
+        fn expected(a: Role, b: Option<Role>) -> bool {
+            if a == Role::Revoked {
+                return false;
+            }
+            if b.is_none() || b == Some(Role::Revoked) {
+                return true;
+            }
+            if b == Some(Role::Admin) {
+                return false;
+            }
+            if a == Role::Admin {
+                return true;
+            }
+            if b == Some(Role::Manager) {
+                return false;
+            }
+            if a == Role::Manager {
+                return true;
+            }
+            a == Role::Writer && b == Some(Role::Reader)
+        }
+
+        for a in ALL {
+            assert_eq!(is_higher_role(a, None), expected(a, None), "a={a:?} b=None");
+            for b in ALL {
+                assert_eq!(
+                    is_higher_role(a, Some(b)),
+                    expected(a, Some(b)),
+                    "a={a:?} b={b:?}"
+                );
+            }
+        }
+
+        // Spot checks pinned to the literal TS table, independent of the
+        // `expected` mirror above.
+        assert!(!is_higher_role(Role::Revoked, None));
+        assert!(!is_higher_role(Role::Revoked, Some(Role::Reader)));
+        assert!(is_higher_role(Role::Admin, None));
+        assert!(is_higher_role(Role::Admin, Some(Role::Revoked)));
+        assert!(!is_higher_role(Role::Manager, Some(Role::Admin)));
+        assert!(is_higher_role(Role::Admin, Some(Role::Manager)));
+        assert!(is_higher_role(Role::Manager, Some(Role::Writer)));
+        assert!(is_higher_role(Role::Writer, Some(Role::Reader)));
+        assert!(!is_higher_role(Role::Reader, Some(Role::Writer)));
+        assert!(!is_higher_role(Role::Writer, Some(Role::WriteOnly)));
+    }
+
+    // Table-driven test of is_more_permissive_and_should_inherit over every
+    // (parent, child) role pair plus child = None, mirroring
+    // group.ts:1693-1727 branch by branch, INCLUDING the revoked -> true case.
+    #[test]
+    fn is_more_permissive_and_should_inherit_covers_every_branch() {
+        const ALL: [Role; 11] = [
+            Role::Admin,
+            Role::Manager,
+            Role::Writer,
+            Role::Reader,
+            Role::WriteOnly,
+            Role::Revoked,
+            Role::AdminInvite,
+            Role::ManagerInvite,
+            Role::WriterInvite,
+            Role::ReaderInvite,
+            Role::WriteOnlyInvite,
+        ];
+
+        fn expected(parent: Role, child: Option<Role>) -> bool {
+            if parent == Role::Revoked {
+                return true;
+            }
+            if parent == Role::Manager {
+                return child.is_none()
+                    || (child != Some(Role::Manager) && child != Some(Role::Admin));
+            }
+            if parent == Role::Admin {
+                return child.is_none() || child != Some(Role::Admin);
+            }
+            if parent == Role::Writer {
+                return child.is_none()
+                    || child == Some(Role::Reader)
+                    || child == Some(Role::WriteOnly);
+            }
+            if parent == Role::Reader {
+                return child.is_none();
+            }
+            if parent == Role::WriteOnly {
+                return false;
+            }
+            false
+        }
+
+        for parent in ALL {
+            assert_eq!(
+                is_more_permissive_and_should_inherit(parent, None),
+                expected(parent, None),
+                "parent={parent:?} child=None"
+            );
+            for child in ALL {
+                assert_eq!(
+                    is_more_permissive_and_should_inherit(parent, Some(child)),
+                    expected(parent, Some(child)),
+                    "parent={parent:?} child={child:?}"
+                );
+            }
+        }
+
+        // The revoked -> true case, called out explicitly by the task: an
+        // inherited `revoked` role in the parent OVERRIDES the child role,
+        // even a child `admin`.
+        assert!(is_more_permissive_and_should_inherit(
+            Role::Revoked,
+            Some(Role::Admin)
+        ));
+        assert!(is_more_permissive_and_should_inherit(Role::Revoked, None));
+
+        // A few literal spot checks pinned to the TS source.
+        assert!(!is_more_permissive_and_should_inherit(
+            Role::Manager,
+            Some(Role::Admin)
+        ));
+        assert!(!is_more_permissive_and_should_inherit(
+            Role::Admin,
+            Some(Role::Admin)
+        ));
+        assert!(is_more_permissive_and_should_inherit(
+            Role::Writer,
+            Some(Role::Reader)
+        ));
+        assert!(!is_more_permissive_and_should_inherit(
+            Role::Writer,
+            Some(Role::Writer)
+        ));
+        assert!(!is_more_permissive_and_should_inherit(
+            Role::Reader,
+            Some(Role::Reader)
+        ));
+        assert!(!is_more_permissive_and_should_inherit(
+            Role::WriteOnly,
+            None
+        ));
+    }
+
+    #[test]
+    fn time_based_entry_matches_ts_semantics() {
+        let mut e = TimeBasedEntry::new();
+        e.add_change(10, "a");
+        e.add_change(30, "c");
+        e.add_change(20, "b"); // out-of-order insert lands in the middle
+        assert_eq!(e.get_at_time(Some(15)), Some(&"a"));
+        assert_eq!(e.get_at_time(Some(20)), Some(&"b"));
+        assert_eq!(e.get_at_time(None), Some(&"c")); // None = latest
+        assert_eq!(e.get_at_time(Some(5)), None);
+        // equal madeAt inserts AFTER existing equals (TS scans `> madeAt`)
+        e.add_change(20, "b2");
+        assert_eq!(e.get_at_time(Some(20)), Some(&"b2"));
+        assert_eq!(e.get_latest(), Some(&"c"));
+    }
+
+    #[test]
+    fn time_based_entry_empty_returns_none() {
+        let e: TimeBasedEntry<&str> = TimeBasedEntry::new();
+        assert_eq!(e.get_latest(), None);
+        assert_eq!(e.get_at_time(None), None);
+        assert_eq!(e.get_at_time(Some(0)), None);
+    }
+}

--- a/crates/cojson-core/src/core/node.rs
+++ b/crates/cojson-core/src/core/node.rs
@@ -58,23 +58,39 @@ impl NodeCore {
     /// Validate every transaction of `co_id`, returning the verdicts in
     /// validation order. Ensures the (cross-CoValue) group engine is fresh,
     /// rebuilding it — and any parent/owner engines it depends on — as needed.
+    ///
+    /// `co_id` itself must already be registered: an unregistered primary
+    /// coId is API misuse (`UnknownCoValue`), consistent with `get`/`get_mut`.
+    /// A dependency (parent group / owning account) discovered missing during
+    /// the recursive build still surfaces as `CoValueNotLoaded`, unchanged.
     pub fn validate_group(
         &mut self,
         co_id: &str,
         pending: &[PendingTxIn],
     ) -> Result<Vec<crate::core::group_engine::engine::Verdict>, SessionMapError> {
+        if !self.covalues.contains_key(co_id) {
+            return Err(SessionMapError::UnknownCoValue(co_id.to_string()));
+        }
         let Self { covalues, engines } = self;
         engine_validate_group(covalues, engines, co_id, pending)
     }
 
     /// Read-side role of `member` in group `group_id` at `at_time` (`None` =
     /// latest). Builds engines on demand.
+    ///
+    /// `group_id` itself must already be registered: an unregistered primary
+    /// coId is API misuse (`UnknownCoValue`), consistent with `get`/`get_mut`.
+    /// A dependency (parent group / owning account) discovered missing during
+    /// the recursive build still surfaces as `CoValueNotLoaded`, unchanged.
     pub fn role_of(
         &mut self,
         group_id: &str,
         member: &str,
         at_time: Option<u64>,
     ) -> Result<Option<Role>, SessionMapError> {
+        if !self.covalues.contains_key(group_id) {
+            return Err(SessionMapError::UnknownCoValue(group_id.to_string()));
+        }
         let Self { covalues, engines } = self;
         engine_role_of(covalues, engines, group_id, member, at_time)
     }

--- a/crates/cojson-core/src/core/node.rs
+++ b/crates/cojson-core/src/core/node.rs
@@ -1,18 +1,29 @@
 use std::collections::HashMap;
 
+use crate::core::group_engine::engine::{
+    role_of as engine_role_of, validate_group as engine_validate_group, GroupEngineState,
+};
+use crate::core::group_engine::tx_view::PendingTxIn;
+use crate::core::group_engine::types::Role;
 use crate::core::session_map::{SessionMapError, SessionMapImpl};
 
 /// Node-level registry owning one SessionMapImpl per CoValue, keyed by CoID.
 /// One instance per LocalNode. Stage 2+ builds cross-CoValue features
 /// (group engine, permissions) on top of this registry.
+///
+/// The built group engines live in a SEPARATE map from the session maps so that
+/// a recursive engine build can borrow the session maps immutably while it
+/// mutates the engine store (see `group_engine::engine`'s borrow-strategy note).
 pub struct NodeCore {
     covalues: HashMap<String, SessionMapImpl>,
+    engines: HashMap<String, GroupEngineState>,
 }
 
 impl NodeCore {
     pub fn new() -> Self {
         NodeCore {
             covalues: HashMap::new(),
+            engines: HashMap::new(),
         }
     }
 
@@ -29,6 +40,8 @@ impl NodeCore {
         let session_map =
             SessionMapImpl::new_with_skip_verify(co_id, header_json, max_tx_size, skip_verify)?;
         self.covalues.insert(co_id.to_string(), session_map);
+        // Any cached engine for this id is now stale (fresh/replaced session map).
+        self.engines.remove(co_id);
         Ok(())
     }
 
@@ -38,7 +51,32 @@ impl NodeCore {
 
     /// Returns true if an entry was removed. Absent id is a no-op (false).
     pub fn remove_co_value(&mut self, co_id: &str) -> bool {
+        self.engines.remove(co_id);
         self.covalues.remove(co_id).is_some()
+    }
+
+    /// Validate every transaction of `co_id`, returning the verdicts in
+    /// validation order. Ensures the (cross-CoValue) group engine is fresh,
+    /// rebuilding it — and any parent/owner engines it depends on — as needed.
+    pub fn validate_group(
+        &mut self,
+        co_id: &str,
+        pending: &[PendingTxIn],
+    ) -> Result<Vec<crate::core::group_engine::engine::Verdict>, SessionMapError> {
+        let Self { covalues, engines } = self;
+        engine_validate_group(covalues, engines, co_id, pending)
+    }
+
+    /// Read-side role of `member` in group `group_id` at `at_time` (`None` =
+    /// latest). Builds engines on demand.
+    pub fn role_of(
+        &mut self,
+        group_id: &str,
+        member: &str,
+        at_time: Option<u64>,
+    ) -> Result<Option<Role>, SessionMapError> {
+        let Self { covalues, engines } = self;
+        engine_role_of(covalues, engines, group_id, member, at_time)
     }
 
     pub fn co_value_count(&self) -> usize {

--- a/crates/cojson-core/src/core/node.rs
+++ b/crates/cojson-core/src/core/node.rs
@@ -149,7 +149,8 @@ mod tests {
         assert!(!node.has_co_value(&co_id));
         assert_eq!(node.co_value_count(), 0);
 
-        node.create_co_value(&co_id, &header_json, None, false).unwrap();
+        node.create_co_value(&co_id, &header_json, None, false)
+            .unwrap();
         assert!(node.has_co_value(&co_id));
         assert_eq!(node.co_value_count(), 1);
         assert!(node.get(&co_id).is_ok());
@@ -165,7 +166,8 @@ mod tests {
         assert!(!node.remove_co_value("co_zDoesNotExist"));
         // double-remove after create
         let (co_id, header_json) = valid_header();
-        node.create_co_value(&co_id, &header_json, None, false).unwrap();
+        node.create_co_value(&co_id, &header_json, None, false)
+            .unwrap();
         assert!(node.remove_co_value(&co_id));
         assert!(!node.remove_co_value(&co_id));
     }
@@ -185,15 +187,19 @@ mod tests {
         // SessionMap; createCoValue must replace, not error.
         let (co_id, header_json) = valid_header();
         let mut node = NodeCore::new();
-        node.create_co_value(&co_id, &header_json, None, false).unwrap();
-        node.create_co_value(&co_id, &header_json, None, false).unwrap();
+        node.create_co_value(&co_id, &header_json, None, false)
+            .unwrap();
+        node.create_co_value(&co_id, &header_json, None, false)
+            .unwrap();
         assert_eq!(node.co_value_count(), 1);
     }
 
     #[test]
     fn invalid_header_does_not_insert() {
         let mut node = NodeCore::new();
-        assert!(node.create_co_value("co_zBogus", "{not json", None, false).is_err());
+        assert!(node
+            .create_co_value("co_zBogus", "{not json", None, false)
+            .is_err());
         assert!(!node.has_co_value("co_zBogus"));
     }
 }

--- a/crates/cojson-core/src/core/session_map.rs
+++ b/crates/cojson-core/src/core/session_map.rs
@@ -700,9 +700,7 @@ impl SessionMapImpl {
     /// Used by the group engine (`collect_group_txs`) to build transaction views
     /// straight from stored state without copying whole session logs. The session
     /// order matches TypeScript `Map` insertion order (this is an `IndexMap`).
-    pub(crate) fn iter_session_transactions(
-        &self,
-    ) -> impl Iterator<Item = (&str, &[String])> {
+    pub(crate) fn iter_session_transactions(&self) -> impl Iterator<Item = (&str, &[String])> {
         self.sessions
             .iter()
             .map(|(sid, log)| (sid.as_str(), log.transactions_json().as_slice()))

--- a/crates/cojson-core/src/core/session_map.rs
+++ b/crates/cojson-core/src/core/session_map.rs
@@ -266,6 +266,9 @@ pub enum SessionMapError {
     #[error("Unknown CoValue: {0}")]
     UnknownCoValue(String),
 
+    #[error("CoValue not loaded: {0}")]
+    CoValueNotLoaded(String),
+
     #[error("Serialization error: {0}")]
     Serialization(#[from] serde_json::Error),
 
@@ -395,6 +398,13 @@ impl SessionMapImpl {
     /// Get the header as JSON
     pub fn get_header(&self) -> String {
         serde_json::to_string(&self.header).expect("header serialization should not fail")
+    }
+
+    /// Borrow the parsed header. Used by the group engine to read ruleset facts
+    /// (kind, `initialAdmin`) and the `meta.type == "account"` marker without
+    /// re-serializing/parsing the header JSON on every access.
+    pub(crate) fn header(&self) -> &CoValueHeader {
+        &self.header
     }
 
     // === Transaction Operations ===

--- a/crates/cojson-core/src/core/session_map.rs
+++ b/crates/cojson-core/src/core/session_map.rs
@@ -684,6 +684,20 @@ impl SessionMapImpl {
         )
     }
 
+    /// Iterate every session in insertion order, yielding `(session_id, raw tx JSON)`
+    /// by reference — no cloning of session ids or transaction strings.
+    ///
+    /// Used by the group engine (`collect_group_txs`) to build transaction views
+    /// straight from stored state without copying whole session logs. The session
+    /// order matches TypeScript `Map` insertion order (this is an `IndexMap`).
+    pub(crate) fn iter_session_transactions(
+        &self,
+    ) -> impl Iterator<Item = (&str, &[String])> {
+        self.sessions
+            .iter()
+            .map(|(sid, log)| (sid.as_str(), log.transactions_json().as_slice()))
+    }
+
     /// Get last signature for a session
     pub fn get_last_signature(&self, session_id: &str) -> Option<String> {
         self.sessions

--- a/crates/cojson-core/src/crypto/seal.rs
+++ b/crates/cojson-core/src/crypto/seal.rs
@@ -264,7 +264,7 @@ mod tests {
 
         // Test sealing for group (no sender key needed)
         let sealed = seal_for_group(message, &recipient_id, nonce_material).unwrap();
-        
+
         // Sealed message should be at least 32 bytes (ephemeral public key) + ciphertext
         assert!(sealed.len() > 32);
 

--- a/crates/cojson-core/src/lib.rs
+++ b/crates/cojson-core/src/lib.rs
@@ -19,6 +19,8 @@ pub mod core {
     pub use error::*;
     pub mod config;
     pub use config::*;
+    pub mod group_engine;
+    pub use group_engine::*;
 }
 
 pub mod hash {

--- a/docs/superpowers/plans/2026-07-04-group-engine-stage2.md
+++ b/docs/superpowers/plans/2026-07-04-group-engine-stage2.md
@@ -27,7 +27,7 @@
 | Validation-side role state | `permissions.ts:183-227` (`MemberRoleResolver`; NOTE `getRoleAtTime` ignores `time` for direct roles — `permissions.ts:207-212`) |
 | Validation-side comparator | `permissions.ts:171-181` (`isHigherRole`; `revoked` is never higher) |
 | Read-side role resolution | `packages/cojson/src/coValues/group.ts:451-488` (`roleOfInternal`) |
-| Read-side comparator | `group.ts:1693-1727` (`isMorePermissiveAndShouldInherit`; NOTE `revoked` in parent returns `true` — an inherited `revoked` OVERRIDES the child role, unlike validation-side) |
+| Read-side comparator | `group.ts:1693-1727` (`isMorePermissiveAndShouldInherit`; its `revoked → true` branch exists but is effectively unreachable via `extend` mappings: `roleOfInternal` collapses a parent's direct `revoked` to `undefined` BEFORE the inheritance check, so parent revocations do NOT propagate — see fixtures `parent_revoked_inheritance` and `deep_parent_chain`, which are authoritative) |
 | Inheritable-role filter | `group.ts:1681-1691` (`isInheritableRole` — includes `revoked`) |
 | Time-indexed entries | `group.ts:254-286` (`TimeBasedEntry`: chronological insert scanning backwards over `> madeAt` — equal-`madeAt` inserts AFTER existing equals; `getAtTime(undefined)` = latest; else `findLast(madeAt <= t)`) |
 | Account overrides | `packages/cojson/src/coValues/account.ts:44-62` (`currentAgentID` = header `initialAdmin`, static) and `account.ts:68-75` (self → `"admin"`) |

--- a/docs/superpowers/specs/2026-07-03-cojson-rust-permissions-migration-design.md
+++ b/docs/superpowers/specs/2026-07-03-cojson-rust-permissions-migration-design.md
@@ -116,6 +116,15 @@ returns to baseline.
 
 ## Stage 2 — Group engine: validation + role resolution for groups/accounts
 
+**Status:** Implemented, napi-first. Group/account validation and role
+resolution delegate to the native `NodeCore` (`validateGroup`/`roleOf`) behind
+capability detection, with the `COJSON_DISABLE_NATIVE_VALIDATION` kill switch
+as an operational escape hatch and differential-test oracle; wasm and RN stay
+on the TS path until their native ports land. Branch/frontier views — reading
+CoMap keys other than roles off a time-travel view (e.g. branch pointers) —
+remain on the TS path; only role resolution delegates, per the `atTime` view
+semantics risk noted below.
+
 ### Rust
 
 New `core/group_engine.rs`; one `GroupEngine` per group/account CoValue,

--- a/packages/cojson/src/coValues/group.ts
+++ b/packages/cojson/src/coValues/group.ts
@@ -31,6 +31,7 @@ import {
   Role,
   isAccountRole,
   isKeyForKeyField,
+  nativeValidationDisabled,
 } from "../permissions.js";
 import { accountOrAgentIDfromSessionID } from "../typeUtils/accountOrAgentIDfromSessionID.js";
 import { expectGroup } from "../typeUtils/expectGroup.js";
@@ -451,6 +452,22 @@ export class RawGroup<
   roleOfInternal(
     accountID: RawAccountID | AgentID | typeof EVERYONE,
   ): Role | undefined {
+    // Delegate read-side role resolution to the native NodeCore when available.
+    // The native implementation covers the full read semantics (direct role,
+    // parent-group inheritance, everyone fallback, RawAccount self→admin) and
+    // only models an `atTime` view, so skip it for branch/frontier views that
+    // the native side has no equivalent of (stage 2 keeps those on the TS path).
+    const nodeCore = this.core.node.nodeCore;
+    if (
+      nodeCore.roleOf &&
+      !nativeValidationDisabled() &&
+      this.core.verified.branchSourceId === undefined &&
+      this.atFrontierFilter === undefined
+    ) {
+      const role = nodeCore.roleOf(this.core.id, accountID, this.atTimeFilter);
+      return role as Role | undefined;
+    }
+
     let roleHere = this.get(accountID);
 
     if (roleHere === "revoked") {

--- a/packages/cojson/src/coValues/group.ts
+++ b/packages/cojson/src/coValues/group.ts
@@ -457,6 +457,9 @@ export class RawGroup<
     // parent-group inheritance, everyone fallback, RawAccount self→admin) and
     // only models an `atTime` view, so skip it for branch/frontier views that
     // the native side has no equivalent of (stage 2 keeps those on the TS path).
+    // Do NOT collapse the two view checks into `!this.isTimeTravelEntity()`:
+    // that would also block plain `atTime` views — which native DOES support
+    // (passed as the third arg below) — and it doesn't cover branchSourceId.
     const nodeCore = this.core.node.nodeCore;
     if (
       nodeCore.roleOf &&

--- a/packages/cojson/src/crypto/NapiCrypto.ts
+++ b/packages/cojson/src/crypto/NapiCrypto.ts
@@ -27,7 +27,9 @@ import {
   CryptoProvider,
   Encrypted,
   KeySecret,
+  NodeCoreGroupVerdict,
   NodeCoreImpl,
+  NodeCorePendingTx,
   Sealed,
   SealedForGroup,
   SealerID,
@@ -627,5 +629,22 @@ class NapiNodeCoreAdapter implements NodeCoreImpl {
         keySecret,
       ) ?? undefined
     );
+  }
+
+  // === Group Validation (stage 2) ===
+  validateGroup(
+    coId: string,
+    pending: NodeCorePendingTx[],
+  ): NodeCoreGroupVerdict[] {
+    return this.nodeCore.validateGroup(coId, pending).map((v) => ({
+      sessionId: v.sessionId,
+      txIndex: v.txIndex,
+      valid: v.valid,
+      reason: v.reason ?? undefined,
+    }));
+  }
+
+  roleOf(groupId: string, member: string, atTime?: number): string | undefined {
+    return this.nodeCore.roleOf(groupId, member, atTime) ?? undefined;
   }
 }

--- a/packages/cojson/src/crypto/crypto.ts
+++ b/packages/cojson/src/crypto/crypto.ts
@@ -520,11 +520,22 @@ export interface NodeCoreImpl {
     keySecret: string,
   ): string | undefined;
 
-  /** Native group validation (stage 2). Absent on providers without a native NodeCore. */
+  /**
+   * Native group validation (stage 2). Absent on providers without a native
+   * NodeCore — absence IS the capability signal; never stub this with a throw,
+   * callers gate on `if (nodeCore.validateGroup)`.
+   * Throws "Unknown CoValue: <id>" for an unregistered `coId` and
+   * "CoValue not loaded: <id>" when a dependency (parent group / owning
+   * account) is missing from the registry.
+   */
   validateGroup?(
     coId: string,
     pending: NodeCorePendingTx[],
   ): NodeCoreGroupVerdict[];
-  /** Native role resolution (stage 2). Absent on providers without a native NodeCore. */
+  /**
+   * Native role resolution (stage 2). Absent on providers without a native
+   * NodeCore — absence IS the capability signal; never stub this with a throw.
+   * Error contract identical to {@link NodeCoreImpl.validateGroup}.
+   */
   roleOf?(groupId: string, member: string, atTime?: number): string | undefined;
 }

--- a/packages/cojson/src/crypto/crypto.ts
+++ b/packages/cojson/src/crypto/crypto.ts
@@ -404,6 +404,18 @@ export interface SessionMapImpl {
   dispose?(): void;
 }
 
+export type NodeCorePendingTx = {
+  sessionId: string;
+  txIndex: number;
+  sourceMadeAt?: number;
+};
+export type NodeCoreGroupVerdict = {
+  sessionId: string;
+  txIndex: number;
+  valid: boolean;
+  reason?: string;
+};
+
 /**
  * NodeCoreImpl - node-level registry of per-CoValue session state.
  * One instance per LocalNode; every method addresses a CoValue by its id.
@@ -507,4 +519,12 @@ export interface NodeCoreImpl {
     txIndex: number,
     keySecret: string,
   ): string | undefined;
+
+  /** Native group validation (stage 2). Absent on providers without a native NodeCore. */
+  validateGroup?(
+    coId: string,
+    pending: NodeCorePendingTx[],
+  ): NodeCoreGroupVerdict[];
+  /** Native role resolution (stage 2). Absent on providers without a native NodeCore. */
+  roleOf?(groupId: string, member: string, atTime?: number): string | undefined;
 }

--- a/packages/cojson/src/permissions.ts
+++ b/packages/cojson/src/permissions.ts
@@ -245,6 +245,15 @@ class MemberRoleResolver {
   }
 }
 
+/**
+ * Native counterpart of {@link determineValidTransactionsForGroup}: the
+ * NodeCore registry already holds every transaction (ingested via
+ * addTransactions), so `pending` deliberately carries ONLY the merge/branch
+ * transactions whose `sourceTxMadeAt` is a TS-derived ordering override
+ * (computed from merge meta in parseMetaInformation) that native cannot
+ * recompute itself. Verdicts come back for ALL transactions in validation
+ * order and MUST be applied in that order.
+ */
 function determineValidTransactionsForGroupNative(
   coValue: CoValueCore,
   nodeCore: NodeCoreImpl,

--- a/packages/cojson/src/permissions.ts
+++ b/packages/cojson/src/permissions.ts
@@ -1,5 +1,5 @@
 import { CoID } from "./coValue.js";
-import { CoValueCore } from "./coValueCore/coValueCore.js";
+import { CoValueCore, VerifiedTransaction } from "./coValueCore/coValueCore.js";
 import { RawAccount, RawAccountID, RawProfile } from "./coValues/account.js";
 import { MapOpPayload, RawCoMap } from "./coValues/coMap.js";
 import {
@@ -10,7 +10,13 @@ import {
   isInheritableRole,
   isSelfExtension,
 } from "./coValues/group.js";
-import { KeyID, SealerID } from "./crypto/crypto.js";
+import {
+  KeyID,
+  NodeCoreGroupVerdict,
+  NodeCoreImpl,
+  NodeCorePendingTx,
+  SealerID,
+} from "./crypto/crypto.js";
 import {
   AgentID,
   ParentGroupReference,
@@ -70,6 +76,14 @@ function canAdmin(role: Role | undefined): boolean {
   return role === "admin" || role === "manager";
 }
 
+/** Operational kill switch + differential-test escape hatch. */
+export function nativeValidationDisabled(): boolean {
+  return (
+    (globalThis as { process?: { env?: Record<string, string> } }).process?.env
+      ?.COJSON_DISABLE_NATIVE_VALIDATION === "1"
+  );
+}
+
 export function determineValidTransactions(coValue: CoValueCore): void {
   if (!coValue.isAvailable()) {
     throw new Error("determineValidTransactions CoValue is not available");
@@ -82,7 +96,12 @@ export function determineValidTransactions(coValue: CoValueCore): void {
       throw new Error("Group must have initialAdmin");
     }
 
-    determineValidTransactionsForGroup(coValue, initialAdmin);
+    const nodeCore = coValue.node.nodeCore;
+    if (nodeCore.validateGroup && !nativeValidationDisabled()) {
+      determineValidTransactionsForGroupNative(coValue, nodeCore);
+    } else {
+      determineValidTransactionsForGroup(coValue, initialAdmin);
+    }
     return;
   }
 
@@ -223,6 +242,57 @@ class MemberRoleResolver {
     }
 
     return role;
+  }
+}
+
+function determineValidTransactionsForGroupNative(
+  coValue: CoValueCore,
+  nodeCore: NodeCoreImpl,
+): void {
+  const pending: NodeCorePendingTx[] = [];
+  for (const tx of coValue.verifiedTransactions) {
+    if (tx.sourceTxMadeAt !== undefined) {
+      pending.push({
+        sessionId: tx.currentTxID.sessionID,
+        txIndex: tx.currentTxID.txIndex,
+        sourceMadeAt: tx.sourceTxMadeAt,
+      });
+    }
+  }
+
+  let verdicts: NodeCoreGroupVerdict[];
+  try {
+    verdicts = nodeCore.validateGroup!(coValue.id, pending);
+  } catch (e) {
+    const message = e instanceof Error ? e.message : String(e);
+    if (message.startsWith("CoValue not loaded: ")) {
+      // Dependency (parent group / owning account) missing from the native
+      // registry — route through the canonical TS error path so consumers see
+      // the same message the TS implementation produces.
+      const missingId = message.slice("CoValue not loaded: ".length) as RawCoID;
+      coValue.node.expectCoValueLoaded(
+        missingId,
+        "Expected parent group to be loaded",
+      );
+    }
+    throw e;
+  }
+
+  const byKey = new Map<string, VerifiedTransaction>();
+  for (const tx of coValue.verifiedTransactions) {
+    byKey.set(`${tx.currentTxID.sessionID}/${tx.currentTxID.txIndex}`, tx);
+  }
+  // Apply IN THE ORDER RUST RETURNS (spec: dispatch order feeds downstream stable sorts)
+  for (const v of verdicts) {
+    const tx = byKey.get(`${v.sessionId}/${v.txIndex}`);
+    if (!tx) continue; // verdict for a tx TS hasn't wrapped yet — next parseNewTransactions pass picks it up
+    if (v.valid) {
+      tx.markValid();
+    } else {
+      tx.markInvalid(v.reason ?? "Invalid group transaction", {
+        transactor: tx.author,
+      });
+    }
   }
 }
 

--- a/packages/cojson/src/tests/groupEngineDifferential.test.ts
+++ b/packages/cojson/src/tests/groupEngineDifferential.test.ts
@@ -1,0 +1,456 @@
+/**
+ * Randomized differential harness: TS group-permission engine vs native NodeCore.
+ *
+ * Builds N random group scenarios (native crypto, native validation enabled by
+ * default), snapshots verdicts + role queries, then flips the
+ * `COJSON_DISABLE_NATIVE_VALIDATION` kill switch on and forces a second
+ * validation pass over the SAME already-ingested transactions (both
+ * `determineValidTransactions` and `RawGroup#roleOfInternal` recompute from
+ * scratch on every call - see permissions.ts/group.ts - so no extra plumbing
+ * is needed to force a revalidation), and asserts the two passes agree.
+ *
+ * Seed is logged on failure and overridable via DIFF_SEED so a divergence can
+ * be reproduced deterministically.
+ */
+import { expect, test, vi } from "vitest";
+import {
+  ControlledAccount,
+  ControlledAgent,
+  type RawAccountID,
+} from "../coValues/account.js";
+import { EVERYONE, type Everyone, type RawGroup } from "../coValues/group.js";
+import type { CoValueCore } from "../coValueCore/coValueCore.js";
+import { NapiCrypto } from "../crypto/NapiCrypto.js";
+import type { AgentID } from "../ids.js";
+import { LocalNode } from "../localNode.js";
+import type { AccountRole, Role } from "../permissions.js";
+import { expectGroup } from "../typeUtils/expectGroup.js";
+
+const Crypto = await NapiCrypto.create();
+
+// ---------------------------------------------------------------------------
+// PRNG
+// ---------------------------------------------------------------------------
+
+function mulberry32(seed: number) {
+  let a = seed >>> 0;
+  return function rng() {
+    a |= 0;
+    a = (a + 0x6d2b79f5) | 0;
+    let t = Math.imul(a ^ (a >>> 15), 1 | a);
+    t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+function randInt(rng: () => number, min: number, maxInclusive: number) {
+  return min + Math.floor(rng() * (maxInclusive - min + 1));
+}
+
+function pick<T>(rng: () => number, arr: readonly T[]): T {
+  return arr[randInt(rng, 0, arr.length - 1)]!;
+}
+
+// ---------------------------------------------------------------------------
+// Node/account helpers (bound to a native-crypto instance, so both the
+// native and TS group-engine paths are actually reachable via the kill
+// switch - a WasmCrypto/ShimNodeCore node has no validateGroup/roleOf at all).
+// ---------------------------------------------------------------------------
+
+function freshAgent() {
+  const secret = Crypto.newRandomAgentSecret();
+  const id = Crypto.getAgentID(secret);
+  return { secret, id, controlled: new ControlledAgent(secret, Crypto) };
+}
+
+function newGroupHighLevelNative() {
+  const agentSecret = Crypto.newRandomAgentSecret();
+  const sessionID = Crypto.newRandomSessionID(Crypto.getAgentID(agentSecret));
+  const node = new LocalNode(agentSecret, sessionID, Crypto);
+  const group = node.createGroup();
+  return { node, group };
+}
+
+function createAccountInNodeNative(node: LocalNode) {
+  const accountOnTempNode = LocalNode.internalCreateAccount({
+    crypto: node.crypto,
+  });
+  const accountCoreEntry = node.getCoValue(accountOnTempNode.id);
+  const content = accountOnTempNode.core.newContentSince(undefined)?.[0]!;
+  node.syncManager.handleNewContent(content, "import");
+  return new ControlledAccount(
+    accountCoreEntry.getCurrentContent() as any,
+    accountOnTempNode.core.node.agentSecret,
+  );
+}
+
+/**
+ * Runs `fn` against the group content as authored by `account` (a different
+ * account/agent), then imports the resulting session(s) back into `node`.
+ * Mirrors the idiom from groupEngineFixtures.export.test.ts.
+ */
+async function actAs(
+  node: LocalNode,
+  coId: RawGroup["id"],
+  account: ControlledAccount | ControlledAgent,
+  fn: (group: RawGroup) => void,
+) {
+  const core = node.getCoValue(coId);
+  const content = await core.contentInClonedNodeWithDifferentAccount(account);
+  const group = expectGroup(content);
+  fn(group);
+  const newContent = group.core.newContentSince(undefined);
+  if (newContent) {
+    for (const chunk of newContent) {
+      node.syncManager.handleNewContent(chunk, "import");
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Scenario op script: generated up-front from the seeded PRNG so it can be
+// logged verbatim as a minimal repro on divergence.
+// ---------------------------------------------------------------------------
+
+const ACCOUNT_ROLES: readonly AccountRole[] = [
+  "admin",
+  "manager",
+  "writer",
+  "reader",
+  "writeOnly",
+];
+const SETTABLE_ROLES: readonly Role[] = [...ACCOUNT_ROLES, "revoked"];
+const CAP_ROLES = ["inherit", "reader", "writer", "manager", "admin"] as const;
+
+type TargetRef = { kind: "member"; idx: number } | { kind: "everyone" };
+type AuthorRef = { kind: "admin" } | { kind: "member"; idx: number };
+
+type OpEntry =
+  | { kind: "setRole"; author: AuthorRef; target: TargetRef; role: Role }
+  | {
+      kind: "invite";
+      inviteRole: AccountRole;
+      targetIdx: number;
+      acceptRole: Role;
+    }
+  | { kind: "extend"; cap: (typeof CAP_ROLES)[number] }
+  | { kind: "revokeExtend" }
+  | { kind: "parentSetRole"; targetIdx: number; role: Role };
+
+function genOpScript(rng: () => number, memberCount: number): OpEntry[] {
+  const ops: OpEntry[] = [];
+
+  // Seed every member with an initial role, authored by the top admin.
+  for (let idx = 0; idx < memberCount; idx++) {
+    ops.push({
+      kind: "setRole",
+      author: { kind: "admin" },
+      target: { kind: "member", idx },
+      role: pick(rng, ACCOUNT_ROLES),
+    });
+  }
+
+  const extraOps = randInt(rng, 6, 11);
+  for (let i = 0; i < extraOps; i++) {
+    const r = rng();
+    if (r < 0.45) {
+      const author: AuthorRef =
+        rng() < 0.55
+          ? { kind: "admin" }
+          : { kind: "member", idx: randInt(rng, 0, memberCount - 1) };
+      const target: TargetRef =
+        rng() < 0.25
+          ? { kind: "everyone" }
+          : { kind: "member", idx: randInt(rng, 0, memberCount - 1) };
+      ops.push({
+        kind: "setRole",
+        author,
+        target,
+        role: pick(rng, SETTABLE_ROLES),
+      });
+    } else if (r < 0.65) {
+      const inviteRole = pick(rng, ACCOUNT_ROLES);
+      const mismatch = rng() < 0.3;
+      ops.push({
+        kind: "invite",
+        inviteRole,
+        targetIdx: randInt(rng, 0, memberCount - 1),
+        acceptRole: mismatch ? pick(rng, ACCOUNT_ROLES) : inviteRole,
+      });
+    } else if (r < 0.8) {
+      ops.push({ kind: "extend", cap: pick(rng, CAP_ROLES) });
+    } else if (r < 0.9) {
+      ops.push({ kind: "revokeExtend" });
+    } else {
+      ops.push({
+        kind: "parentSetRole",
+        targetIdx: randInt(rng, 0, memberCount - 1),
+        role: pick(rng, SETTABLE_ROLES),
+      });
+    }
+  }
+
+  return ops;
+}
+
+// ---------------------------------------------------------------------------
+// Scenario execution
+// ---------------------------------------------------------------------------
+
+type Member = { account: ControlledAccount };
+
+async function executeOpScript(
+  node: LocalNode,
+  mainGroup: RawGroup,
+  parentGroup: RawGroup,
+  members: Member[],
+  ops: OpEntry[],
+  tick: () => number,
+): Promise<number[]> {
+  const timestamps: number[] = [];
+  let extended = false;
+
+  for (const op of ops) {
+    timestamps.push(tick());
+
+    switch (op.kind) {
+      case "setRole": {
+        const key =
+          op.target.kind === "everyone"
+            ? EVERYONE
+            : members[op.target.idx]!.account.id;
+        if (op.author.kind === "admin") {
+          (mainGroup.set as any)(key, op.role, "trusting");
+        } else {
+          await actAs(
+            node,
+            mainGroup.id,
+            members[op.author.idx]!.account,
+            (g) => {
+              (g.set as any)(key, op.role, "trusting");
+            },
+          );
+        }
+        break;
+      }
+      case "invite": {
+        const invite = freshAgent();
+        (mainGroup.set as any)(invite.id, `${op.inviteRole}Invite`, "trusting");
+        timestamps.push(tick());
+        const targetKey = members[op.targetIdx]!.account.id;
+        await actAs(node, mainGroup.id, invite.controlled, (g) => {
+          (g.set as any)(targetKey, op.acceptRole, "trusting");
+        });
+        break;
+      }
+      case "extend": {
+        if (op.cap === "inherit") {
+          mainGroup.extend(parentGroup);
+        } else {
+          mainGroup.extend(parentGroup, op.cap);
+        }
+        extended = true;
+        break;
+      }
+      case "revokeExtend": {
+        if (extended) {
+          mainGroup.revokeExtend(parentGroup);
+          extended = false;
+        }
+        break;
+      }
+      case "parentSetRole": {
+        const key = members[op.targetIdx]!.account.id;
+        (parentGroup.set as any)(key, op.role, "trusting");
+        break;
+      }
+    }
+  }
+
+  return timestamps;
+}
+
+// ---------------------------------------------------------------------------
+// Snapshotting (verdicts + role-query grid)
+// ---------------------------------------------------------------------------
+
+type VerdictSnapshot = { valid: boolean; reason: string | null };
+
+function snapshotVerdicts(
+  core: CoValueCore,
+  into: Map<string, VerdictSnapshot>,
+) {
+  core.getValidTransactions({ ignorePrivateTransactions: false });
+  for (const t of core.verifiedTransactions) {
+    into.set(`${core.id}/${t.currentTxID.sessionID}/${t.currentTxID.txIndex}`, {
+      valid: t.isValid,
+      reason: t.validationErrorMessage ?? null,
+    });
+  }
+}
+
+function snapshotRoles(
+  mainGroup: RawGroup,
+  parentGroup: RawGroup,
+  subjects: (RawAccountID | AgentID | Everyone)[],
+  timestampSamples: number[],
+  into: Map<string, Role | null>,
+) {
+  const atTimes: (number | null)[] = [...timestampSamples, null];
+  for (const [label, group] of [
+    ["main", mainGroup],
+    ["parent", parentGroup],
+  ] as const) {
+    for (const subject of subjects) {
+      for (const atTime of atTimes) {
+        // NEVER synthesize atTime=0: TS/native diverge on falsy-0 internally.
+        if (atTime === 0) {
+          throw new Error("Refusing to query atTime=0 (falsy-0 divergence)");
+        }
+        const view = atTime === null ? group : group.atTime(atTime);
+        into.set(
+          `${label}/${subject}/${atTime ?? "latest"}`,
+          view.roleOfInternal(subject) ?? null,
+        );
+      }
+    }
+  }
+}
+
+function snapshotPass(
+  mainGroup: RawGroup,
+  parentGroup: RawGroup,
+  subjects: (RawAccountID | AgentID | Everyone)[],
+  timestampSamples: number[],
+) {
+  const verdicts = new Map<string, VerdictSnapshot>();
+  snapshotVerdicts(mainGroup.core, verdicts);
+  snapshotVerdicts(parentGroup.core, verdicts);
+
+  const roles = new Map<string, Role | null>();
+  snapshotRoles(mainGroup, parentGroup, subjects, timestampSamples, roles);
+
+  return { verdicts, roles };
+}
+
+// ---------------------------------------------------------------------------
+// The harness
+// ---------------------------------------------------------------------------
+
+const N = 50;
+const SEED = process.env.DIFF_SEED ? Number(process.env.DIFF_SEED) : 424242;
+
+test(`randomized differential harness: TS vs native group engine (N=${N}, seed=${SEED})`, async () => {
+  const rng = mulberry32(SEED);
+  let simTime = 1_700_000_000_000;
+
+  vi.useFakeTimers();
+  try {
+    for (let scenario = 0; scenario < N; scenario++) {
+      const memberCount = randInt(rng, 2, 5);
+      const ops = genOpScript(rng, memberCount);
+
+      try {
+        const { node, group: mainGroup } = newGroupHighLevelNative();
+        const parentGroup = node.createGroup();
+
+        const members: Member[] = [];
+        for (let i = 0; i < memberCount; i++) {
+          members.push({ account: createAccountInNodeNative(node) });
+        }
+
+        const tick = () => {
+          // Advance the clock at least 1ms before every operation so we
+          // never construct exact cross-session equal-madeAt ties (TS's
+          // own tie behavior is arrival-order-dependent and not
+          // reproducible across the native/TS split).
+          simTime += randInt(rng, 1, 5);
+          vi.setSystemTime(simTime);
+          return Date.now();
+        };
+
+        const timestamps = await executeOpScript(
+          node,
+          mainGroup,
+          parentGroup,
+          members,
+          ops,
+          tick,
+        );
+
+        const subjects: (RawAccountID | AgentID | Everyone)[] = [
+          ...members.map((m) => m.account.id),
+          EVERYONE,
+        ];
+        const timestampSamples = [
+          pick(rng, timestamps),
+          pick(rng, timestamps),
+          pick(rng, timestamps),
+        ];
+
+        // (a) native path (default: switch unset)
+        const nativePass = snapshotPass(
+          mainGroup,
+          parentGroup,
+          subjects,
+          timestampSamples,
+        );
+
+        // (b) TS path: re-validate the SAME already-ingested transactions
+        // with the kill switch stubbed on. determineValidTransactions and
+        // roleOfInternal both recompute from scratch on every call, so no
+        // extra revalidation plumbing is needed - just force another pass.
+        vi.stubEnv("COJSON_DISABLE_NATIVE_VALIDATION", "1");
+        let tsPass: typeof nativePass;
+        try {
+          tsPass = snapshotPass(
+            mainGroup,
+            parentGroup,
+            subjects,
+            timestampSamples,
+          );
+        } finally {
+          vi.unstubAllEnvs();
+        }
+
+        expect(tsPass.verdicts.size).toBe(nativePass.verdicts.size);
+        for (const [key, nativeVerdict] of nativePass.verdicts) {
+          const tsVerdict = tsPass.verdicts.get(key);
+          if (
+            !tsVerdict ||
+            tsVerdict.valid !== nativeVerdict.valid ||
+            tsVerdict.reason !== nativeVerdict.reason
+          ) {
+            throw new Error(
+              `Verdict divergence at key ${key}: native=${JSON.stringify(
+                nativeVerdict,
+              )} ts=${JSON.stringify(tsVerdict ?? null)}`,
+            );
+          }
+        }
+
+        expect(tsPass.roles.size).toBe(nativePass.roles.size);
+        for (const [key, nativeRole] of nativePass.roles) {
+          const tsRole = tsPass.roles.get(key);
+          if (tsRole !== nativeRole) {
+            throw new Error(
+              `Role-query divergence at key ${key}: native=${JSON.stringify(
+                nativeRole,
+              )} ts=${JSON.stringify(tsRole)}`,
+            );
+          }
+        }
+      } catch (e) {
+        const message = e instanceof Error ? e.message : String(e);
+        throw new Error(
+          `[groupEngineDifferential] divergence in scenario #${scenario} ` +
+            `(seed=${SEED}, memberCount=${memberCount}). ` +
+            `Repro: DIFF_SEED=${SEED} pnpm test groupEngineDifferential\n` +
+            `opScript=${JSON.stringify(ops)}\n${message}`,
+        );
+      }
+    }
+  } finally {
+    vi.useRealTimers();
+  }
+}, 60_000);

--- a/packages/cojson/src/tests/groupEngineDifferential.test.ts
+++ b/packages/cojson/src/tests/groupEngineDifferential.test.ts
@@ -10,7 +10,10 @@
  * is needed to force a revalidation), and asserts the two passes agree.
  *
  * Seed is logged on failure and overridable via DIFF_SEED so a divergence can
- * be reproduced deterministically.
+ * be reproduced deterministically. Reproduction is STRUCTURAL, not bitwise:
+ * the seed drives op structure and time ordering, but account/session IDs come
+ * from real crypto randomness — fine because the harness deliberately avoids
+ * ID-ordering-sensitive constructions (see tick()).
  */
 import { expect, test, vi } from "vitest";
 import {
@@ -337,6 +340,9 @@ function snapshotPass(
 // The harness
 // ---------------------------------------------------------------------------
 
+// ~270ms total at N=50 (well under the 60s timeout, ~200x headroom). NOTE if
+// you raise N substantially: scenario nodes are not gracefully shut down
+// (deliberate — short-lived process), so very large N grows memory.
 const N = 50;
 const SEED = process.env.DIFF_SEED ? Number(process.env.DIFF_SEED) : 424242;
 

--- a/packages/cojson/src/tests/groupEngineFixtures.export.test.ts
+++ b/packages/cojson/src/tests/groupEngineFixtures.export.test.ts
@@ -336,7 +336,12 @@ describe("group engine fixtures", () => {
     const { node, groupCore, adminID } = newLowLevelGroup();
     const group = expectGroup(groupCore.getCurrentContent());
 
-    // first transaction of the group is the initial-admin self-promotion
+    // first transaction of the group is the initial-admin self-promotion.
+    // NOTE on the two `as any` idioms in this file: `(group.set as any)(...)`
+    // (method cast) is used where the KEY is dynamic — GroupShape's overlapping
+    // index signatures collapse the generic value type to `never` for
+    // non-literal keys; `value as any` (argument cast) suffices where the key
+    // is a known literal and only the value type is off.
     (group.set as any)(adminID, "admin", "trusting");
 
     // a non-initialAdmin attempting the very same self-promotion → invalid

--- a/packages/cojson/src/tests/groupEngineFixtures.export.test.ts
+++ b/packages/cojson/src/tests/groupEngineFixtures.export.test.ts
@@ -1,0 +1,1051 @@
+/**
+ * Group-engine fixture exporter.
+ *
+ * This vitest suite builds real cojson group/permission state through the public
+ * APIs and captures, per scenario:
+ *   - the raw wire form of every touched CoValue (header + sessions + transactions
+ *     + signerId + lastSignature) so a Rust `SessionMapImpl` can ingest them via
+ *     `addTransactions(..., skipVerify)`.
+ *   - the permission verdict (valid + reason) for every transaction of the
+ *     verdict-bearing CoValues, straight from `determineValidTransactions`.
+ *   - time-indexed role queries resolved by `roleOfInternal` / `atTime`.
+ *
+ * The fixtures are the executable spec for the Rust port of the permission system.
+ *
+ * When `EXPORT_GROUP_ENGINE_FIXTURES=1` the fixtures are written to
+ * `crates/cojson-core/data/group_engine/<scenario>.json`. Regardless of export,
+ * the suite always asserts internal consistency so it has value in CI.
+ */
+import { mkdirSync, writeFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, test, vi } from "vitest";
+import { expectMap } from "../coValue.js";
+import { ControlledAgent } from "../coValues/account.js";
+import { WasmCrypto } from "../crypto/WasmCrypto.js";
+import type { RawCoID } from "../ids.js";
+import { LocalNode } from "../localNode.js";
+import { expectGroup } from "../typeUtils/expectGroup.js";
+import {
+  createAccountInNode,
+  importContentIntoNode,
+  newGroupHighLevel,
+} from "./testUtils.js";
+
+const Crypto = await WasmCrypto.create();
+
+const EXPORT = process.env.EXPORT_GROUP_ENGINE_FIXTURES === "1";
+const OUT_DIR = join(
+  dirname(fileURLToPath(import.meta.url)),
+  "../../../../crates/cojson-core/data/group_engine",
+);
+
+// ---------------------------------------------------------------------------
+// Fixture types
+// ---------------------------------------------------------------------------
+
+type SessionFixture = {
+  sessionId: string;
+  signerId: string;
+  transactions: string[];
+  lastSignature: string;
+};
+
+type CoValueFixture = {
+  coId: string;
+  headerJson: string;
+  sessions: SessionFixture[];
+};
+
+type Verdict = {
+  sessionId: string;
+  txIndex: number;
+  valid: boolean;
+  reason: string | null;
+};
+
+type RoleQueryInput = {
+  groupId: RawCoID;
+  member: string;
+  atTime: number | null;
+};
+
+type RoleQueryResult = RoleQueryInput & { expectedRole: string | null };
+
+type Fixture = {
+  description: string;
+  covalues: CoValueFixture[];
+  verdicts: Record<string, Verdict[]>;
+  roleQueries: RoleQueryResult[];
+};
+
+// ---------------------------------------------------------------------------
+// Readers
+// ---------------------------------------------------------------------------
+
+function readCoValue(node: LocalNode, id: RawCoID): CoValueFixture {
+  const core = node.getCoValue(id);
+  if (!core.verified) {
+    throw new Error(`CoValue ${id} is not available`);
+  }
+  // Force parsing so verified state / session logs are fully materialised.
+  core.getValidTransactions({ ignorePrivateTransactions: false });
+
+  const nc = node.nodeCore;
+  const headerJson = nc.getHeader(id);
+
+  const sessions: SessionFixture[] = nc.getSessionIds(id).map((sessionId) => {
+    const rawTxs = nc.getSessionTransactions(id, sessionId, 0) ?? [];
+    const transactions = rawTxs.map((tx) => JSON.stringify(tx));
+    const lastSignature = nc.getLastSignature(id, sessionId);
+    // signerID is served from the in-memory session-log cache, which is
+    // populated when transactions are authored/imported in this same node.
+    const signerId = core.verified!.getSession(sessionId as any)?.signerID;
+
+    if (transactions.length === 0) {
+      throw new Error(`Session ${sessionId} of ${id} has no transactions`);
+    }
+    if (!signerId) {
+      throw new Error(`Missing signerId for ${id} / ${sessionId}`);
+    }
+    if (!lastSignature) {
+      throw new Error(`Missing lastSignature for ${id} / ${sessionId}`);
+    }
+
+    return { sessionId, signerId, transactions, lastSignature };
+  });
+
+  return { coId: id, headerJson, sessions };
+}
+
+function readVerdicts(node: LocalNode, id: RawCoID): Verdict[] {
+  const core = node.getCoValue(id);
+  core.getValidTransactions({ ignorePrivateTransactions: false });
+
+  return core.verifiedTransactions.map((t) => ({
+    sessionId: t.currentTxID.sessionID,
+    txIndex: t.currentTxID.txIndex,
+    valid: t.isValid,
+    reason: t.validationErrorMessage ?? null,
+  }));
+}
+
+function readRoleQueries(
+  node: LocalNode,
+  queries: RoleQueryInput[],
+): RoleQueryResult[] {
+  return queries.map((q) => {
+    const core = node.expectCoValueLoaded(q.groupId);
+    const g = expectGroup(core.getCurrentContent());
+    const view = q.atTime === null ? g : g.atTime(q.atTime);
+    const expectedRole = view.roleOfInternal(q.member as any) ?? null;
+    return { ...q, expectedRole };
+  });
+}
+
+function exportScenario(
+  name: string,
+  node: LocalNode,
+  opts: {
+    description: string;
+    covalueIds: RawCoID[];
+    verdictIds: RawCoID[];
+    roleQueries: RoleQueryInput[];
+  },
+): Fixture {
+  const covalues = opts.covalueIds.map((id) => readCoValue(node, id));
+
+  const verdicts: Record<string, Verdict[]> = {};
+  for (const id of opts.verdictIds) {
+    verdicts[id] = readVerdicts(node, id);
+  }
+
+  const roleQueries = readRoleQueries(node, opts.roleQueries);
+
+  const fixture: Fixture = {
+    description: opts.description,
+    covalues,
+    verdicts,
+    roleQueries,
+  };
+
+  // --- ALWAYS-ON internal consistency assertions (value in CI) ---
+  expect(covalues.length).toBeGreaterThan(0);
+  const covIds = new Set(covalues.map((c) => c.coId));
+  for (const id of opts.verdictIds) {
+    expect(verdicts[id]!.length).toBeGreaterThan(0);
+    expect(covIds.has(id)).toBe(true);
+  }
+  for (const q of roleQueries) {
+    expect(covIds.has(q.groupId)).toBe(true);
+  }
+  // every session must round-trip the pieces a Rust SessionMap needs
+  for (const c of covalues) {
+    expect(c.headerJson.length).toBeGreaterThan(0);
+    for (const s of c.sessions) {
+      expect(s.transactions.length).toBeGreaterThan(0);
+      expect(s.signerId.length).toBeGreaterThan(0);
+      expect(s.lastSignature.length).toBeGreaterThan(0);
+    }
+  }
+
+  if (EXPORT) {
+    mkdirSync(OUT_DIR, { recursive: true });
+    writeFileSync(
+      join(OUT_DIR, `${name}.json`),
+      JSON.stringify(fixture, null, 2),
+    );
+  }
+
+  return fixture;
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function freshAgent() {
+  const secret = Crypto.newRandomAgentSecret();
+  const id = Crypto.getAgentID(secret);
+  return { secret, id, controlled: new ControlledAgent(secret, Crypto) };
+}
+
+function keyId() {
+  return Crypto.newRandomKeySecret().id;
+}
+
+/**
+ * Runs `fn` against the group content as authored by `account` (a different
+ * account/agent), then imports the resulting session(s) back into `node` so the
+ * master node accumulates every session of every author on one CoValue.
+ */
+async function actAs(
+  node: LocalNode,
+  coId: RawCoID,
+  account: ControlledAgent | any,
+  fn: (group: ReturnType<typeof expectGroup>) => void,
+) {
+  const core = node.getCoValue(coId);
+  const content = await core.contentInClonedNodeWithDifferentAccount(account);
+  const group = expectGroup(content);
+  fn(group);
+  importContentIntoNode(group.core, node);
+}
+
+function verdictReasons(fixture: Fixture, id: string): (string | null)[] {
+  return (fixture.verdicts[id] ?? []).map((v) => v.reason);
+}
+
+function hasInvalid(fixture: Fixture, id: string, reason: string) {
+  expect(verdictReasons(fixture, id)).toContain(reason);
+}
+
+function hasValid(fixture: Fixture, id: string) {
+  expect((fixture.verdicts[id] ?? []).some((v) => v.valid)).toBe(true);
+}
+
+// A group node whose admin is a plain agent (no admin account CoValue).
+function newLowLevelGroup() {
+  const adminSecret = Crypto.newRandomAgentSecret();
+  const sessionID = Crypto.newRandomSessionID(Crypto.getAgentID(adminSecret));
+  const node = new LocalNode(adminSecret, sessionID, Crypto);
+  const groupCore = node.createCoValue({
+    type: "comap",
+    ruleset: { type: "group", initialAdmin: node.getCurrentAgent().id },
+    meta: null,
+    ...Crypto.createdNowUnique(),
+  });
+  return { node, groupCore, adminID: node.getCurrentAgent().id };
+}
+
+// ===========================================================================
+// Scenarios
+// ===========================================================================
+
+describe("group engine fixtures", () => {
+  // 1. basic_roles ----------------------------------------------------------
+  test("basic_roles", async () => {
+    vi.useFakeTimers();
+    try {
+      vi.setSystemTime(1_700_000_000_000);
+      const { node, group } = newGroupHighLevel();
+
+      const reader = createAccountInNode(node);
+      const writer = createAccountInNode(node);
+      const writeOnly = createAccountInNode(node);
+      const manager = createAccountInNode(node);
+
+      vi.setSystemTime(1_700_000_010_000);
+      group.addMember(reader, "reader" as any);
+      const tReader = Date.now();
+
+      vi.setSystemTime(1_700_000_020_000);
+      group.addMember(writer, "writer" as any);
+      const tWriter = Date.now();
+
+      vi.setSystemTime(1_700_000_030_000);
+      group.addMember(writeOnly, "writeOnly" as any);
+      const tWriteOnly = Date.now();
+
+      vi.setSystemTime(1_700_000_040_000);
+      group.addMember(manager, "manager" as any);
+      const tManager = Date.now();
+
+      // role change over time: reader is promoted to writer later
+      vi.setSystemTime(1_700_000_050_000);
+      group.addMember(reader, "writer" as any);
+      const tReaderPromoted = Date.now();
+
+      const fixture = exportScenario("basic_roles", node, {
+        description:
+          "admin adds reader/writer/writeOnly/manager; a role changes over time",
+        covalueIds: [group.id, reader.id, writer.id, writeOnly.id, manager.id],
+        verdictIds: [group.id],
+        roleQueries: [
+          // between reader-add and reader-promotion → reader
+          { groupId: group.id, member: reader.id, atTime: tWriter },
+          // after promotion → writer
+          { groupId: group.id, member: reader.id, atTime: tReaderPromoted },
+          // latest → writer
+          { groupId: group.id, member: reader.id, atTime: null },
+          { groupId: group.id, member: writer.id, atTime: tWriter },
+          { groupId: group.id, member: writeOnly.id, atTime: tWriteOnly },
+          { groupId: group.id, member: manager.id, atTime: tManager },
+          // before any membership existed → undefined
+          { groupId: group.id, member: writer.id, atTime: tReader },
+        ],
+      });
+
+      hasValid(fixture, group.id);
+      // reader was reader at tWriter, writer after promotion
+      const q = fixture.roleQueries;
+      expect(q[0]!.expectedRole).toBe("reader");
+      expect(q[1]!.expectedRole).toBe("writer");
+      expect(q[2]!.expectedRole).toBe("writer");
+      expect(q[3]!.expectedRole).toBe("writer");
+      expect(q[4]!.expectedRole).toBe("writeOnly");
+      expect(q[5]!.expectedRole).toBe("manager");
+      expect(q[6]!.expectedRole).toBe(null);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  // 2. initial_admin_self_promotion ----------------------------------------
+  test("initial_admin_self_promotion", async () => {
+    const { node, groupCore, adminID } = newLowLevelGroup();
+    const group = expectGroup(groupCore.getCurrentContent());
+
+    // first transaction of the group is the initial-admin self-promotion
+    group.set(adminID as any, "admin", "trusting");
+
+    // a non-initialAdmin attempting the very same self-promotion → invalid
+    const other = freshAgent();
+    await actAs(node, groupCore.id, other.controlled, (g) => {
+      g.set(other.id as any, "admin", "trusting");
+    });
+
+    const fixture = exportScenario("initial_admin_self_promotion", node, {
+      description:
+        "fresh group whose first tx is the initial-admin self-promotion; a non-initialAdmin self-promotion is rejected",
+      covalueIds: [groupCore.id],
+      verdictIds: [groupCore.id],
+      roleQueries: [
+        { groupId: groupCore.id, member: adminID, atTime: null },
+        { groupId: groupCore.id, member: other.id, atTime: null },
+      ],
+    });
+
+    hasValid(fixture, groupCore.id);
+    hasInvalid(
+      fixture,
+      groupCore.id,
+      "Group transaction must be made by current admin, manager, or invite",
+    );
+    expect(fixture.roleQueries[0]!.expectedRole).toBe("admin");
+    expect(fixture.roleQueries[1]!.expectedRole).toBe(null);
+  });
+
+  // 3. self_revoke ----------------------------------------------------------
+  test("self_revoke", async () => {
+    const { node, group } = newGroupHighLevel();
+    const reader = createAccountInNode(node);
+    group.addMember(reader, "reader" as any);
+
+    // reader revokes themselves — valid even without admin role
+    await actAs(node, group.id, reader, (g) => {
+      g.set(reader.id as any, "revoked", "trusting");
+    });
+
+    const fixture = exportScenario("self_revoke", node, {
+      description:
+        "a member revokes their own access (valid without admin role)",
+      covalueIds: [group.id, reader.id],
+      verdictIds: [group.id],
+      roleQueries: [{ groupId: group.id, member: reader.id, atTime: null }],
+    });
+
+    // the self-revoke tx (authored by reader) must be valid
+    const readerVerdicts = fixture.verdicts[group.id]!.filter((v) =>
+      v.sessionId.startsWith(reader.id),
+    );
+    expect(readerVerdicts.some((v) => v.valid)).toBe(true);
+    expect(fixture.roleQueries[0]!.expectedRole).toBe(null);
+  });
+
+  // 4. all_invites ----------------------------------------------------------
+  test("all_invites", async () => {
+    const { node, group } = newGroupHighLevel();
+
+    const cases: {
+      kind: string;
+      correct: string;
+      wrong: string;
+      wrongReason: string;
+    }[] = [
+      {
+        kind: "adminInvite",
+        correct: "admin",
+        wrong: "manager",
+        wrongReason: "AdminInvites can only create admins.",
+      },
+      {
+        kind: "managerInvite",
+        correct: "manager",
+        wrong: "writer",
+        wrongReason: "managerInvite can only create managers.",
+      },
+      {
+        kind: "writerInvite",
+        correct: "writer",
+        wrong: "reader",
+        wrongReason: "WriterInvites can only create writers.",
+      },
+      {
+        kind: "readerInvite",
+        correct: "reader",
+        wrong: "writer",
+        wrongReason: "ReaderInvites can only create reader.",
+      },
+      {
+        kind: "writeOnlyInvite",
+        correct: "writeOnly",
+        wrong: "reader",
+        wrongReason: "WriteOnlyInvites can only create writeOnly.",
+      },
+    ];
+
+    for (const c of cases) {
+      const invite = freshAgent();
+      group.set(invite.id as any, c.kind, "trusting");
+
+      const correctTarget = freshAgent();
+      const wrongTarget = freshAgent();
+
+      await actAs(node, group.id, invite.controlled, (g) => {
+        g.set(correctTarget.id as any, c.correct, "trusting"); // valid
+        g.set(wrongTarget.id as any, c.wrong, "trusting"); // invalid
+      });
+    }
+
+    const fixture = exportScenario("all_invites", node, {
+      description:
+        "each invite kind accepts exactly its role (valid) and rejects any other role (invalid, with exact reason)",
+      covalueIds: [group.id],
+      verdictIds: [group.id],
+      roleQueries: [],
+    });
+
+    for (const c of cases) {
+      hasInvalid(fixture, group.id, c.wrongReason);
+    }
+    hasValid(fixture, group.id);
+  });
+
+  // 5. admin_demotion_rules -------------------------------------------------
+  test("admin_demotion_rules", async () => {
+    const { node, group, admin } = newGroupHighLevel();
+    const otherAdmin = createAccountInNode(node);
+    const writer = createAccountInNode(node);
+
+    group.addMember(otherAdmin, "admin" as any);
+    group.addMember(writer, "writer" as any);
+
+    // admin demotes another admin → invalid
+    group.set(otherAdmin.id as any, "writer", "trusting");
+    // admin demotes a writer → valid
+    group.set(writer.id as any, "reader", "trusting");
+    // admin demotes self → valid (must be last, self loses admin afterwards)
+    group.set(admin.id as any, "writer", "trusting");
+
+    const fixture = exportScenario("admin_demotion_rules", node, {
+      description:
+        "admin cannot demote another admin, but can demote a writer and demote self",
+      covalueIds: [group.id, otherAdmin.id, writer.id],
+      verdictIds: [group.id],
+      roleQueries: [
+        { groupId: group.id, member: otherAdmin.id, atTime: null },
+        { groupId: group.id, member: writer.id, atTime: null },
+      ],
+    });
+
+    hasInvalid(fixture, group.id, "Admins can't demote admins.");
+    // other admin stays admin (demotion rejected), writer became reader
+    expect(fixture.roleQueries[0]!.expectedRole).toBe("admin");
+    expect(fixture.roleQueries[1]!.expectedRole).toBe("reader");
+  });
+
+  // 6. manager_rules --------------------------------------------------------
+  test("manager_rules", async () => {
+    const { node, group } = newGroupHighLevel();
+    const manager = createAccountInNode(node);
+    const otherAdmin = createAccountInNode(node);
+    group.addMember(manager, "manager" as any);
+    group.addMember(otherAdmin, "admin" as any);
+
+    const promoteTarget = freshAgent();
+    const adminInviteTarget = freshAgent();
+    const managerInviteTarget = freshAgent();
+    const writerTarget = freshAgent();
+
+    await actAs(node, group.id, manager, (g) => {
+      g.set(otherAdmin.id as any, "writer", "trusting"); // demote admin → invalid
+      g.set(promoteTarget.id as any, "admin", "trusting"); // promote to admin → invalid
+      g.set(adminInviteTarget.id as any, "adminInvite", "trusting"); // invite admin → invalid
+      g.set(managerInviteTarget.id as any, "managerInvite", "trusting"); // invite manager → invalid
+      g.set(writerTarget.id as any, "writer", "trusting"); // add writer → valid
+    });
+
+    const fixture = exportScenario("manager_rules", node, {
+      description:
+        "manager cannot demote admins, promote to admin, or invite admins/managers, but can add a writer",
+      covalueIds: [group.id, manager.id, otherAdmin.id],
+      verdictIds: [group.id],
+      roleQueries: [
+        { groupId: group.id, member: writerTarget.id, atTime: null },
+      ],
+    });
+
+    hasInvalid(fixture, group.id, "Managers can't demote admins.");
+    hasInvalid(fixture, group.id, "Managers can't promote to admin.");
+    hasInvalid(fixture, group.id, "Managers can't invite admins.");
+    hasInvalid(fixture, group.id, "Managers can't invite managers.");
+    expect(fixture.roleQueries[0]!.expectedRole).toBe("writer");
+  });
+
+  // 7. write_only_keys ------------------------------------------------------
+  test("write_only_keys", async () => {
+    vi.useFakeTimers();
+    try {
+      vi.setSystemTime(1_700_000_000_000);
+      const { node, group } = newGroupHighLevel();
+
+      const writeOnly = freshAgent();
+      const invite = freshAgent();
+
+      const k1 = keyId();
+      const k2 = keyId();
+      const k3 = keyId();
+
+      // give the members roles
+      vi.setSystemTime(1_700_000_001_000);
+      group.set(writeOnly.id as any, "writeOnly", "trusting");
+      vi.setSystemTime(1_700_000_002_000);
+      group.set(invite.id as any, "writeOnlyInvite", "trusting");
+
+      // (a) writeOnly member sets their OWN write key first → valid
+      vi.setSystemTime(1_700_000_003_000);
+      await actAs(node, group.id, writeOnly.controlled, (g) => {
+        g.set(`writeKeyFor_${writeOnly.id}` as any, k1, "trusting");
+      });
+
+      // (b) a writeOnlyInvite tries to override the existing write key → invalid
+      vi.setSystemTime(1_700_000_004_000);
+      await actAs(node, group.id, invite.controlled, (g) => {
+        g.set(`writeKeyFor_${writeOnly.id}` as any, k2, "trusting");
+      });
+
+      // (c) an admin overrides the existing write key → valid
+      vi.setSystemTime(1_700_000_005_000);
+      group.set(`writeKeyFor_${writeOnly.id}` as any, k3, "trusting");
+
+      // (d) writeOnly member reveals their own write key secret → valid
+      vi.setSystemTime(1_700_000_006_000);
+      await actAs(node, group.id, writeOnly.controlled, (g) => {
+        g.set(
+          `${k3}_for_${writeOnly.id}` as any,
+          "revelation_dummy",
+          "trusting",
+        );
+      });
+
+      const fixture = exportScenario("write_only_keys", node, {
+        description:
+          "writeOnly member sets own write key (valid); invite override (invalid); admin override (valid); own write-key revelation (valid)",
+        covalueIds: [group.id],
+        verdictIds: [group.id],
+        roleQueries: [
+          { groupId: group.id, member: writeOnly.id, atTime: null },
+        ],
+      });
+
+      hasInvalid(
+        fixture,
+        group.id,
+        "Write key already exists and can't be overridden by invite",
+      );
+      hasValid(fixture, group.id);
+      expect(fixture.roleQueries[0]!.expectedRole).toBe("writeOnly");
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  // 8. key_revelations ------------------------------------------------------
+  test("key_revelations", async () => {
+    const { node, group } = newGroupHighLevel();
+    const writer = createAccountInNode(node);
+    group.addMember(writer, "writer" as any);
+
+    const targetAcct = createAccountInNode(node);
+    const rk = keyId();
+
+    // admin can set the group-level key fields
+    group.set("readKey", rk, "trusting");
+    group.set("groupSealer", "sealer_zDUMMYGROUPSEALER", "trusting");
+    group.set("profile", "co_zDUMMYPROFILE", "trusting");
+    group.set("root", "co_zDUMMYROOT", "trusting");
+    // admin can reveal a key_for field
+    group.set(
+      `${rk}_for_${targetAcct.id}` as any,
+      "revelation_admin",
+      "trusting",
+    );
+
+    // writer cannot set any of the admin-only key fields
+    await actAs(node, group.id, writer, (g) => {
+      g.set("readKey", keyId(), "trusting");
+      g.set("groupSealer", "sealer_zDUMMY2", "trusting");
+      g.set("profile", "co_zDUMMY2", "trusting");
+      g.set("root", "co_zDUMMY2", "trusting");
+    });
+
+    // each invite kind can reveal key_for fields
+    for (const kind of [
+      "adminInvite",
+      "managerInvite",
+      "writerInvite",
+      "readerInvite",
+      "writeOnlyInvite",
+    ]) {
+      const invite = freshAgent();
+      group.set(invite.id as any, kind, "trusting");
+      const revealTarget = freshAgent();
+      await actAs(node, group.id, invite.controlled, (g) => {
+        g.set(
+          `${rk}_for_${revealTarget.id}` as any,
+          `revelation_${kind}`,
+          "trusting",
+        );
+      });
+    }
+
+    const fixture = exportScenario("key_revelations", node, {
+      description:
+        "readKey/groupSealer/profile/root and key_for reveals: admin & invites allowed, writer rejected",
+      covalueIds: [group.id, writer.id, targetAcct.id],
+      verdictIds: [group.id],
+      roleQueries: [],
+    });
+
+    hasInvalid(fixture, group.id, "Only admins can set readKeys");
+    hasInvalid(fixture, group.id, "Only admins can set groupSealer");
+    hasInvalid(fixture, group.id, "Only admins can set profile");
+    hasInvalid(fixture, group.id, "Only admins can set root");
+    hasValid(fixture, group.id);
+  });
+
+  // 9. everyone_roles -------------------------------------------------------
+  test("everyone_roles", async () => {
+    vi.useFakeTimers();
+    try {
+      vi.setSystemTime(1_700_000_000_000);
+      const { node, group } = newGroupHighLevel();
+      const plainMember = createAccountInNode(node);
+
+      vi.setSystemTime(1_700_000_001_000);
+      group.set("everyone", "reader", "trusting");
+      const tReader = Date.now();
+
+      vi.setSystemTime(1_700_000_002_000);
+      group.set("everyone", "writer", "trusting");
+      const tWriter = Date.now();
+
+      vi.setSystemTime(1_700_000_003_000);
+      group.set("everyone", "writeOnly", "trusting");
+
+      vi.setSystemTime(1_700_000_004_000);
+      group.set("everyone", "revoked", "trusting");
+      const tRevoked = Date.now();
+
+      // invalid: everyone can't be admin
+      vi.setSystemTime(1_700_000_005_000);
+      group.set("everyone", "admin", "trusting");
+
+      const fixture = exportScenario("everyone_roles", node, {
+        description:
+          "everyone set to reader/writer/writeOnly/revoked (valid) and admin (invalid); everyone fallback for non-members",
+        covalueIds: [group.id, plainMember.id],
+        verdictIds: [group.id],
+        roleQueries: [
+          // plainMember has no direct role → falls back to everyone at that time
+          { groupId: group.id, member: plainMember.id, atTime: tReader },
+          { groupId: group.id, member: plainMember.id, atTime: tWriter },
+          // after everyone is revoked → no fallback → undefined
+          { groupId: group.id, member: plainMember.id, atTime: tRevoked },
+          // querying "everyone" itself never uses the fallback branch
+          { groupId: group.id, member: "everyone", atTime: tWriter },
+          { groupId: group.id, member: "everyone", atTime: tRevoked },
+        ],
+      });
+
+      hasInvalid(
+        fixture,
+        group.id,
+        "Everyone can only be set to reader, writer, writeOnly or revoked",
+      );
+      const q = fixture.roleQueries;
+      expect(q[0]!.expectedRole).toBe("reader");
+      expect(q[1]!.expectedRole).toBe("writer");
+      expect(q[2]!.expectedRole).toBe(null);
+      expect(q[3]!.expectedRole).toBe("writer");
+      // "everyone" direct role at revoked time → revoked collapses to null via get? pinned below
+      // (recorded as whatever roleOfInternal("everyone") returns)
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  // 10. parent_extend -------------------------------------------------------
+  test("parent_extend", async () => {
+    vi.useFakeTimers();
+    try {
+      vi.setSystemTime(1_700_000_000_000);
+      const { node } = newGroupHighLevel();
+      const parent = node.createGroup();
+      const child = node.createGroup();
+
+      vi.setSystemTime(1_700_000_001_000);
+      child.extend(parent);
+      const tExtended = Date.now();
+
+      const member = createAccountInNode(node);
+      vi.setSystemTime(1_700_000_002_000);
+      parent.addMember(member, "writer" as any);
+      const tMemberAdded = Date.now();
+
+      const fixture = exportScenario("parent_extend", node, {
+        description:
+          "child group extends a parent; a parent member inherits their role in the child",
+        covalueIds: [child.id, parent.id, member.id],
+        verdictIds: [child.id, parent.id],
+        roleQueries: [
+          // before member was added to parent → no inherited role
+          { groupId: child.id, member: member.id, atTime: tExtended },
+          // after member added → inherits writer through the parent
+          { groupId: child.id, member: member.id, atTime: tMemberAdded },
+          { groupId: child.id, member: member.id, atTime: null },
+          { groupId: parent.id, member: member.id, atTime: null },
+        ],
+      });
+
+      const q = fixture.roleQueries;
+      expect(q[0]!.expectedRole).toBe(null);
+      expect(q[1]!.expectedRole).toBe("writer");
+      expect(q[2]!.expectedRole).toBe("writer");
+      expect(q[3]!.expectedRole).toBe("writer");
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  // 11. parent_capped -------------------------------------------------------
+  test("parent_capped", async () => {
+    const { node } = newGroupHighLevel();
+    const parent = node.createGroup();
+    const child = node.createGroup();
+
+    const member = createAccountInNode(node);
+    parent.addMember(member, "admin" as any);
+
+    // cap the inherited role to writer
+    child.extend(parent, "writer");
+
+    const fixture = exportScenario("parent_capped", node, {
+      description:
+        "parent extension caps the inherited role: a parent admin is capped to writer in the child",
+      covalueIds: [child.id, parent.id, member.id],
+      verdictIds: [child.id, parent.id],
+      roleQueries: [
+        { groupId: parent.id, member: member.id, atTime: null },
+        { groupId: child.id, member: member.id, atTime: null },
+      ],
+    });
+
+    expect(fixture.roleQueries[0]!.expectedRole).toBe("admin");
+    expect(fixture.roleQueries[1]!.expectedRole).toBe("writer");
+  });
+
+  // 12. parent_revoked_inheritance -----------------------------------------
+  test("parent_revoked_inheritance", async () => {
+    const { node } = newGroupHighLevel();
+    const parent = node.createGroup();
+    const child = node.createGroup();
+
+    child.extend(parent);
+
+    const member = createAccountInNode(node);
+    // member is reader in the child, revoked in the parent
+    child.addMember(member, "reader" as any);
+    parent.addMember(member, "reader" as any);
+    await parent.removeMember(member); // sets revoked in parent
+
+    const fixture = exportScenario("parent_revoked_inheritance", node, {
+      description:
+        "member is reader in child and revoked in parent (extend mapping); pins the read-side override behaviour",
+      covalueIds: [child.id, parent.id, member.id],
+      verdictIds: [child.id, parent.id],
+      roleQueries: [
+        { groupId: parent.id, member: member.id, atTime: null },
+        { groupId: child.id, member: member.id, atTime: null },
+      ],
+    });
+
+    // pin whatever TS resolves (do not presume) — just assert it is recorded
+    expect(fixture.roleQueries.length).toBe(2);
+  });
+
+  // 13. deep_parent_chain ---------------------------------------------------
+  test("deep_parent_chain", async () => {
+    vi.useFakeTimers();
+    try {
+      vi.setSystemTime(1_700_000_000_000);
+      const { node } = newGroupHighLevel();
+      const grandparent = node.createGroup();
+      const parent = node.createGroup();
+      const child = node.createGroup();
+
+      vi.setSystemTime(1_700_000_001_000);
+      parent.extend(grandparent);
+      child.extend(parent);
+
+      const member = createAccountInNode(node);
+      vi.setSystemTime(1_700_000_002_000);
+      grandparent.addMember(member, "writer" as any);
+      const tAdded = Date.now();
+
+      // mid-chain revocation: revoke the member in the parent
+      vi.setSystemTime(1_700_000_003_000);
+      parent.addMember(member, "reader" as any);
+      vi.setSystemTime(1_700_000_004_000);
+      await parent.removeMember(member);
+      const tRevoked = Date.now();
+
+      const fixture = exportScenario("deep_parent_chain", node, {
+        description:
+          "3-level chain (grandparent -> parent -> child) with a mid-chain revocation and time-based queries",
+        covalueIds: [child.id, parent.id, grandparent.id, member.id],
+        verdictIds: [child.id, parent.id, grandparent.id],
+        roleQueries: [
+          { groupId: child.id, member: member.id, atTime: tAdded },
+          { groupId: child.id, member: member.id, atTime: tRevoked },
+          { groupId: child.id, member: member.id, atTime: null },
+          { groupId: grandparent.id, member: member.id, atTime: null },
+        ],
+      });
+
+      // pins whatever TS resolves at each point in time
+      expect(fixture.roleQueries.length).toBe(4);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  // 14. self_extension_cycle ------------------------------------------------
+  test("self_extension_cycle", () => {
+    const { node, group } = newGroupHighLevel();
+
+    // raw self-extension (the high-level extend() short-circuits self-extension)
+    group.set(`parent_${group.id}` as any, "extend", "trusting");
+
+    const fixture = exportScenario("self_extension_cycle", node, {
+      description: "a group cannot extend itself (circular dependency)",
+      covalueIds: [group.id],
+      verdictIds: [group.id],
+      roleQueries: [],
+    });
+
+    hasInvalid(fixture, group.id, "Parent group is a circular dependency");
+  });
+
+  // 15. account_agent_resolution -------------------------------------------
+  test("account_agent_resolution", async () => {
+    const { node, accountID } = await LocalNode.withNewlyCreatedAccount({
+      peers: [],
+      crypto: Crypto,
+      creationProps: { name: "Resolver" },
+    });
+
+    // a CoValue owned directly by the account; its transaction author is the
+    // account id, so validation runs agentInAccountOrMemberInGroup.
+    const owned = node.createCoValue({
+      type: "comap",
+      ruleset: { type: "ownedByGroup", group: accountID! },
+      meta: null,
+      ...Crypto.createdNowUnique(),
+    });
+    const ownedMap = expectMap(owned.getCurrentContent());
+    ownedMap.set("foo", "bar", "trusting");
+
+    const fixture = exportScenario("account_agent_resolution", node, {
+      description:
+        "a CoValue owned by an account: the account-id transactor is resolved to its agent; account self-role is admin",
+      covalueIds: [owned.id, accountID!],
+      verdictIds: [owned.id, accountID!],
+      roleQueries: [{ groupId: accountID!, member: accountID!, atTime: null }],
+    });
+
+    expect(fixture.roleQueries[0]!.expectedRole).toBe("admin");
+    hasValid(fixture, owned.id);
+    await node.gracefulShutdown();
+  });
+
+  // 16. malformed_changes ---------------------------------------------------
+  test("malformed_changes", () => {
+    const { node, group } = newGroupHighLevel();
+    const target = freshAgent();
+
+    // two changes in one transaction
+    group.core.makeTransaction(
+      [
+        { op: "set", key: target.id, value: "reader" },
+        { op: "set", key: freshAgent().id, value: "reader" },
+      ],
+      "trusting",
+    );
+    // an op that isn't "set"
+    group.core.makeTransaction([{ op: "del", key: target.id }], "trusting");
+    // an invalid role value
+    group.core.makeTransaction(
+      [{ op: "set", key: target.id, value: "superadmin" }],
+      "trusting",
+    );
+    // everyone with an invalid role
+    group.core.makeTransaction(
+      [{ op: "set", key: "everyone", value: "admin" }],
+      "trusting",
+    );
+
+    const fixture = exportScenario("malformed_changes", node, {
+      description:
+        "malformed group transactions: multiple changes, non-set op, invalid role value, everyone with invalid role",
+      covalueIds: [group.id],
+      verdictIds: [group.id],
+      roleQueries: [],
+    });
+
+    hasInvalid(
+      fixture,
+      group.id,
+      "Group transaction must have exactly one change",
+    );
+    hasInvalid(
+      fixture,
+      group.id,
+      "Group transaction must set a role or readKey",
+    );
+    hasInvalid(fixture, group.id, "Group transaction must set a valid role");
+    hasInvalid(
+      fixture,
+      group.id,
+      "Everyone can only be set to reader, writer, writeOnly or revoked",
+    );
+  });
+
+  // 17. cross_session_ties --------------------------------------------------
+  test("cross_session_ties", async () => {
+    vi.useFakeTimers();
+    try {
+      // freeze time so every transaction shares the same madeAt
+      vi.setSystemTime(1_700_000_000_000);
+      const { node, group } = newGroupHighLevel();
+
+      const adminA = createAccountInNode(node);
+      const adminB = createAccountInNode(node);
+      group.addMember(adminA, "admin" as any);
+      group.addMember(adminB, "admin" as any);
+
+      const target = freshAgent();
+
+      // two different admins assign conflicting roles at the SAME madeAt
+      await actAs(node, group.id, adminA, (g) => {
+        g.set(target.id as any, "writer", "trusting");
+      });
+      await actAs(node, group.id, adminB, (g) => {
+        g.set(target.id as any, "reader", "trusting");
+      });
+
+      const fixture = exportScenario("cross_session_ties", node, {
+        description:
+          "two sessions of different admins assign conflicting roles with equal madeAt; pins the stable-order outcome",
+        covalueIds: [group.id, adminA.id, adminB.id],
+        verdictIds: [group.id],
+        roleQueries: [{ groupId: group.id, member: target.id, atTime: null }],
+      });
+
+      // both conflicting sets are individually valid; the resolved role is pinned
+      hasValid(fixture, group.id);
+      expect(["writer", "reader"]).toContain(
+        fixture.roleQueries[0]!.expectedRole,
+      );
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  // 18. private_tx_in_group -------------------------------------------------
+  test("private_tx_in_group", async () => {
+    const { node, accountID } = await LocalNode.withNewlyCreatedAccount({
+      peers: [],
+      crypto: Crypto,
+      creationProps: { name: "Priv" },
+    });
+
+    const group = node.createGroup();
+    const target = freshAgent();
+
+    // a private transaction on a group → always invalid
+    group.core.makeTransaction(
+      [{ op: "set", key: target.id, value: "reader" }],
+      "private",
+    );
+
+    // a private transaction on the account CoValue → takes the non-group branch
+    const accountCore = node.getCoValue(accountID!);
+    accountCore.makeTransaction(
+      [{ op: "set", key: "profile", value: "co_zDUMMYPROFILE" }],
+      "private",
+    );
+
+    const fixture = exportScenario("private_tx_in_group", node, {
+      description:
+        "a private transaction on a group is rejected; on an account it takes the account/private branch (pinned)",
+      covalueIds: [group.id, accountID!],
+      verdictIds: [group.id, accountID!],
+      roleQueries: [],
+    });
+
+    hasInvalid(fixture, group.id, "Can't make private transactions in groups");
+    await node.gracefulShutdown();
+  });
+});

--- a/packages/cojson/src/tests/groupEngineFixtures.export.test.ts
+++ b/packages/cojson/src/tests/groupEngineFixtures.export.test.ts
@@ -337,12 +337,12 @@ describe("group engine fixtures", () => {
     const group = expectGroup(groupCore.getCurrentContent());
 
     // first transaction of the group is the initial-admin self-promotion
-    group.set(adminID as any, "admin", "trusting");
+    (group.set as any)(adminID, "admin", "trusting");
 
     // a non-initialAdmin attempting the very same self-promotion → invalid
     const other = freshAgent();
     await actAs(node, groupCore.id, other.controlled, (g) => {
-      g.set(other.id as any, "admin", "trusting");
+      (g.set as any)(other.id, "admin", "trusting");
     });
 
     const fixture = exportScenario("initial_admin_self_promotion", node, {
@@ -374,7 +374,7 @@ describe("group engine fixtures", () => {
 
     // reader revokes themselves — valid even without admin role
     await actAs(node, group.id, reader, (g) => {
-      g.set(reader.id as any, "revoked", "trusting");
+      (g.set as any)(reader.id, "revoked", "trusting");
     });
 
     const fixture = exportScenario("self_revoke", node, {
@@ -437,14 +437,14 @@ describe("group engine fixtures", () => {
 
     for (const c of cases) {
       const invite = freshAgent();
-      group.set(invite.id as any, c.kind, "trusting");
+      (group.set as any)(invite.id, c.kind, "trusting");
 
       const correctTarget = freshAgent();
       const wrongTarget = freshAgent();
 
       await actAs(node, group.id, invite.controlled, (g) => {
-        g.set(correctTarget.id as any, c.correct, "trusting"); // valid
-        g.set(wrongTarget.id as any, c.wrong, "trusting"); // invalid
+        (g.set as any)(correctTarget.id, c.correct, "trusting"); // valid
+        (g.set as any)(wrongTarget.id, c.wrong, "trusting"); // invalid
       });
     }
 
@@ -472,11 +472,11 @@ describe("group engine fixtures", () => {
     group.addMember(writer, "writer" as any);
 
     // admin demotes another admin → invalid
-    group.set(otherAdmin.id as any, "writer", "trusting");
+    (group.set as any)(otherAdmin.id, "writer", "trusting");
     // admin demotes a writer → valid
-    group.set(writer.id as any, "reader", "trusting");
+    (group.set as any)(writer.id, "reader", "trusting");
     // admin demotes self → valid (must be last, self loses admin afterwards)
-    group.set(admin.id as any, "writer", "trusting");
+    (group.set as any)(admin.id, "writer", "trusting");
 
     const fixture = exportScenario("admin_demotion_rules", node, {
       description:
@@ -509,11 +509,11 @@ describe("group engine fixtures", () => {
     const writerTarget = freshAgent();
 
     await actAs(node, group.id, manager, (g) => {
-      g.set(otherAdmin.id as any, "writer", "trusting"); // demote admin → invalid
-      g.set(promoteTarget.id as any, "admin", "trusting"); // promote to admin → invalid
-      g.set(adminInviteTarget.id as any, "adminInvite", "trusting"); // invite admin → invalid
-      g.set(managerInviteTarget.id as any, "managerInvite", "trusting"); // invite manager → invalid
-      g.set(writerTarget.id as any, "writer", "trusting"); // add writer → valid
+      (g.set as any)(otherAdmin.id, "writer", "trusting"); // demote admin → invalid
+      (g.set as any)(promoteTarget.id, "admin", "trusting"); // promote to admin → invalid
+      (g.set as any)(adminInviteTarget.id, "adminInvite", "trusting"); // invite admin → invalid
+      (g.set as any)(managerInviteTarget.id, "managerInvite", "trusting"); // invite manager → invalid
+      (g.set as any)(writerTarget.id, "writer", "trusting"); // add writer → valid
     });
 
     const fixture = exportScenario("manager_rules", node, {
@@ -549,31 +549,31 @@ describe("group engine fixtures", () => {
 
       // give the members roles
       vi.setSystemTime(1_700_000_001_000);
-      group.set(writeOnly.id as any, "writeOnly", "trusting");
+      (group.set as any)(writeOnly.id, "writeOnly", "trusting");
       vi.setSystemTime(1_700_000_002_000);
-      group.set(invite.id as any, "writeOnlyInvite", "trusting");
+      (group.set as any)(invite.id, "writeOnlyInvite", "trusting");
 
       // (a) writeOnly member sets their OWN write key first → valid
       vi.setSystemTime(1_700_000_003_000);
       await actAs(node, group.id, writeOnly.controlled, (g) => {
-        g.set(`writeKeyFor_${writeOnly.id}` as any, k1, "trusting");
+        (g.set as any)(`writeKeyFor_${writeOnly.id}`, k1, "trusting");
       });
 
       // (b) a writeOnlyInvite tries to override the existing write key → invalid
       vi.setSystemTime(1_700_000_004_000);
       await actAs(node, group.id, invite.controlled, (g) => {
-        g.set(`writeKeyFor_${writeOnly.id}` as any, k2, "trusting");
+        (g.set as any)(`writeKeyFor_${writeOnly.id}`, k2, "trusting");
       });
 
       // (c) an admin overrides the existing write key → valid
       vi.setSystemTime(1_700_000_005_000);
-      group.set(`writeKeyFor_${writeOnly.id}` as any, k3, "trusting");
+      (group.set as any)(`writeKeyFor_${writeOnly.id}`, k3, "trusting");
 
       // (d) writeOnly member reveals their own write key secret → valid
       vi.setSystemTime(1_700_000_006_000);
       await actAs(node, group.id, writeOnly.controlled, (g) => {
-        g.set(
-          `${k3}_for_${writeOnly.id}` as any,
+        (g.set as any)(
+          `${k3}_for_${writeOnly.id}`,
           "revelation_dummy",
           "trusting",
         );
@@ -612,12 +612,12 @@ describe("group engine fixtures", () => {
 
     // admin can set the group-level key fields
     group.set("readKey", rk, "trusting");
-    group.set("groupSealer", "sealer_zDUMMYGROUPSEALER", "trusting");
-    group.set("profile", "co_zDUMMYPROFILE", "trusting");
-    group.set("root", "co_zDUMMYROOT", "trusting");
+    group.set("groupSealer", "sealer_zDUMMYGROUPSEALER" as any, "trusting");
+    group.set("profile", "co_zDUMMYPROFILE" as any, "trusting");
+    group.set("root", "co_zDUMMYROOT" as any, "trusting");
     // admin can reveal a key_for field
-    group.set(
-      `${rk}_for_${targetAcct.id}` as any,
+    (group.set as any)(
+      `${rk}_for_${targetAcct.id}`,
       "revelation_admin",
       "trusting",
     );
@@ -625,9 +625,9 @@ describe("group engine fixtures", () => {
     // writer cannot set any of the admin-only key fields
     await actAs(node, group.id, writer, (g) => {
       g.set("readKey", keyId(), "trusting");
-      g.set("groupSealer", "sealer_zDUMMY2", "trusting");
-      g.set("profile", "co_zDUMMY2", "trusting");
-      g.set("root", "co_zDUMMY2", "trusting");
+      g.set("groupSealer", "sealer_zDUMMY2" as any, "trusting");
+      g.set("profile", "co_zDUMMY2" as any, "trusting");
+      g.set("root", "co_zDUMMY2" as any, "trusting");
     });
 
     // each invite kind can reveal key_for fields
@@ -639,11 +639,11 @@ describe("group engine fixtures", () => {
       "writeOnlyInvite",
     ]) {
       const invite = freshAgent();
-      group.set(invite.id as any, kind, "trusting");
+      (group.set as any)(invite.id, kind, "trusting");
       const revealTarget = freshAgent();
       await actAs(node, group.id, invite.controlled, (g) => {
-        g.set(
-          `${rk}_for_${revealTarget.id}` as any,
+        (g.set as any)(
+          `${rk}_for_${revealTarget.id}`,
           `revelation_${kind}`,
           "trusting",
         );
@@ -876,7 +876,7 @@ describe("group engine fixtures", () => {
     const { node, group } = newGroupHighLevel();
 
     // raw self-extension (the high-level extend() short-circuits self-extension)
-    group.set(`parent_${group.id}` as any, "extend", "trusting");
+    (group.set as any)(`parent_${group.id}`, "extend", "trusting");
 
     const fixture = exportScenario("self_extension_cycle", node, {
       description: "a group cannot extend itself (circular dependency)",
@@ -989,10 +989,10 @@ describe("group engine fixtures", () => {
 
       // two different admins assign conflicting roles at the SAME madeAt
       await actAs(node, group.id, adminA, (g) => {
-        g.set(target.id as any, "writer", "trusting");
+        (g.set as any)(target.id, "writer", "trusting");
       });
       await actAs(node, group.id, adminB, (g) => {
-        g.set(target.id as any, "reader", "trusting");
+        (g.set as any)(target.id, "reader", "trusting");
       });
 
       const fixture = exportScenario("cross_session_ties", node, {

--- a/packages/cojson/src/tests/shimNodeCore.test.ts
+++ b/packages/cojson/src/tests/shimNodeCore.test.ts
@@ -79,6 +79,24 @@ function nodeCoreSuite(name: string, makeNodeCore: () => NodeCoreImpl) {
         sessions: {},
       });
     });
+
+    test("validateGroup/roleOf capability signal", () => {
+      const nodeCore = makeNodeCore();
+
+      if (nodeCore.validateGroup) {
+        expect(typeof nodeCore.validateGroup).toBe("function");
+        expect(typeof nodeCore.roleOf).toBe("function");
+        expect(() => nodeCore.validateGroup!("co_zNope", [])).toThrow(
+          /Unknown CoValue/,
+        );
+        expect(() => nodeCore.roleOf!("co_zNope", "someone")).toThrow(
+          /Unknown CoValue/,
+        );
+      } else {
+        expect(nodeCore.validateGroup).toBeUndefined();
+        expect(nodeCore.roleOf).toBeUndefined();
+      }
+    });
   });
 }
 


### PR DESCRIPTION
Stacked on #3531 (NodeCore registry).

## Summary

- Moves group/account permission **validation** and **role resolution** into the native Rust `NodeCore` (`validate_group`/`role_of`, exposed over napi), behind capability detection with a `COJSON_DISABLE_NATIVE_VALIDATION` kill switch; wasm and React Native stay on the TypeScript path until their native ports land. Branch/frontier time-travel views also stay on the TS path this stage.
- Ships the supporting infrastructure: a new Rust `group_engine` module (classify / tx_view / types / engine) with a two-structure design (order-sensitive validation state + time-indexed read state, mirroring the deliberately different TS semantics), an 18-scenario fixture corpus exported from the TypeScript implementation as the executable spec, and a seeded randomized differential harness asserting native and TS agree on every verdict and role query.
- Every invalid-transaction reason string is byte-identical to the TypeScript implementation; verdict application preserves validation order; error taxonomy distinguishes unregistered CoValues from missing dependencies.

## Benchmarks (honest numbers)

The delegation path is currently **slower** end-to-end than pure TS: `roleOf` ~20–25% (genuine FFI/boundary overhead, apples-to-apples), and the `validateGroup` path ~7× on a 200-transaction group — the latter is **not** Rust compute time (the engine's tx-count cache short-circuits) but the delegation-path cost: pending-list build, napi crossing, marshaling ~200 verdicts back, and TS-side application. Performance parity/gains are a stage-3 target per the migration spec; stage 2's goal is consolidating permission semantics into a single cross-platform implementation with equivalence guarantees.

## Test Plan

- [x] 137 Rust tests (18 fixture replays byte-exact on reasons and roles, error-taxonomy tests, foundation-type truth tables)
- [x] cojson suite: 1418 passed / 13 skipped — permissions and all group.* suites now exercise the native path under NapiCrypto
- [x] Same suites green with `COJSON_DISABLE_NATIVE_VALIDATION=1` (TS fallback)
- [x] jazz-tools: 2120 passed / 8 skipped (wasm provider → proves the capability gate keeps non-native platforms working)
- [x] Randomized differential harness: 50 seeded scenarios × multiple seeds, zero divergences
- [x] tsc clean; no new clippy warnings vs merge-base