### PR TITLE
feat(cojson): native NodeCore for the React Native binding

### DIFF
--- a/.changeset/nodecore-rn.md
+++ b/.changeset/nodecore-rn.md
@@ -1,0 +1,10 @@
+---
+"cojson": patch
+"cojson-core-rn": patch
+---
+
+Native NodeCore for the React Native binding: RNCrypto now runs
+group/permission validation and role resolution natively (same engine as
+napi/wasm). RN error messages now pass through the inner error verbatim
+(previously prefixed with "SessionMap error: "), preserving the error
+contracts the TypeScript layer matches on.

--- a/crates/cojson-core-napi/src/lib.rs
+++ b/crates/cojson-core-napi/src/lib.rs
@@ -413,7 +413,12 @@ impl NodeCore {
   ) -> napi::Result<()> {
     self
       .internal
-      .create_co_value(&co_id, &header_json, max_tx_size, skip_verify.unwrap_or(false))
+      .create_co_value(
+        &co_id,
+        &header_json,
+        max_tx_size,
+        skip_verify.unwrap_or(false),
+      )
       .map_err(to_napi_err)
   }
 
@@ -548,7 +553,13 @@ impl NodeCore {
   /// Get all session IDs as native array
   #[napi]
   pub fn get_session_ids(&self, co_id: String) -> napi::Result<Vec<String>> {
-    Ok(self.internal.get(&co_id).map_err(to_napi_err)?.get_session_ids())
+    Ok(
+      self
+        .internal
+        .get(&co_id)
+        .map_err(to_napi_err)?
+        .get_session_ids(),
+    )
   }
 
   /// Get transaction count for a session (returns -1 if session not found)
@@ -556,7 +567,11 @@ impl NodeCore {
   pub fn get_transaction_count(&self, co_id: String, session_id: String) -> napi::Result<i32> {
     let sm = self.internal.get(&co_id).map_err(to_napi_err)?;
     // Same -1-if-absent convention as the SessionMap wrapper
-    Ok(sm.get_transaction_count(&session_id).map(|c| c as i32).unwrap_or(-1))
+    Ok(
+      sm.get_transaction_count(&session_id)
+        .map(|c| c as i32)
+        .unwrap_or(-1),
+    )
   }
 
   /// Get single transaction by index as JSON string (returns undefined if not found)
@@ -567,11 +582,13 @@ impl NodeCore {
     session_id: String,
     tx_index: u32,
   ) -> napi::Result<Option<String>> {
-    Ok(self
-      .internal
-      .get(&co_id)
-      .map_err(to_napi_err)?
-      .get_transaction(&session_id, tx_index))
+    Ok(
+      self
+        .internal
+        .get(&co_id)
+        .map_err(to_napi_err)?
+        .get_transaction(&session_id, tx_index),
+    )
   }
 
   /// Get transactions for a session from index as JSON strings (returns undefined if session not found)
@@ -582,21 +599,29 @@ impl NodeCore {
     session_id: String,
     from_index: u32,
   ) -> napi::Result<Option<Vec<String>>> {
-    Ok(self
-      .internal
-      .get(&co_id)
-      .map_err(to_napi_err)?
-      .get_session_transactions(&session_id, from_index))
+    Ok(
+      self
+        .internal
+        .get(&co_id)
+        .map_err(to_napi_err)?
+        .get_session_transactions(&session_id, from_index),
+    )
   }
 
   /// Get last signature for a session (returns undefined if session not found)
   #[napi]
-  pub fn get_last_signature(&self, co_id: String, session_id: String) -> napi::Result<Option<String>> {
-    Ok(self
-      .internal
-      .get(&co_id)
-      .map_err(to_napi_err)?
-      .get_last_signature(&session_id))
+  pub fn get_last_signature(
+    &self,
+    co_id: String,
+    session_id: String,
+  ) -> napi::Result<Option<String>> {
+    Ok(
+      self
+        .internal
+        .get(&co_id)
+        .map_err(to_napi_err)?
+        .get_last_signature(&session_id),
+    )
   }
 
   /// Get signature after specific transaction index
@@ -607,11 +632,13 @@ impl NodeCore {
     session_id: String,
     tx_index: u32,
   ) -> napi::Result<Option<String>> {
-    Ok(self
-      .internal
-      .get(&co_id)
-      .map_err(to_napi_err)?
-      .get_signature_after(&session_id, tx_index))
+    Ok(
+      self
+        .internal
+        .get(&co_id)
+        .map_err(to_napi_err)?
+        .get_signature_after(&session_id, tx_index),
+    )
   }
 
   /// Get the last signature checkpoint index (-1 if no checkpoints, undefined if session not found)
@@ -621,11 +648,13 @@ impl NodeCore {
     co_id: String,
     session_id: String,
   ) -> napi::Result<Option<i32>> {
-    Ok(self
-      .internal
-      .get(&co_id)
-      .map_err(to_napi_err)?
-      .get_last_signature_checkpoint(&session_id))
+    Ok(
+      self
+        .internal
+        .get(&co_id)
+        .map_err(to_napi_err)?
+        .get_last_signature_checkpoint(&session_id),
+    )
   }
 
   // --- Known State ---
@@ -633,35 +662,49 @@ impl NodeCore {
   /// Get the known state as a native JavaScript object
   #[napi]
   pub fn get_known_state(&self, co_id: String) -> napi::Result<KnownState> {
-    Ok(self
-      .internal
-      .get(&co_id)
-      .map_err(to_napi_err)?
-      .get_known_state()
-      .clone()
-      .into())
+    Ok(
+      self
+        .internal
+        .get(&co_id)
+        .map_err(to_napi_err)?
+        .get_known_state()
+        .clone()
+        .into(),
+    )
   }
 
   /// Get the known state with streaming as a native JavaScript object
   #[napi]
   pub fn get_known_state_with_streaming(&self, co_id: String) -> napi::Result<Option<KnownState>> {
-    Ok(self
-      .internal
-      .get(&co_id)
-      .map_err(to_napi_err)?
-      .get_known_state_with_streaming()
-      .map(|ks| ks.clone().into()))
+    Ok(
+      self
+        .internal
+        .get(&co_id)
+        .map_err(to_napi_err)?
+        .get_known_state_with_streaming()
+        .map(|ks| ks.clone().into()),
+    )
   }
 
   /// Check whether the CoValue still has pending streaming content.
   #[napi]
   pub fn is_streaming(&self, co_id: String) -> napi::Result<bool> {
-    Ok(self.internal.get(&co_id).map_err(to_napi_err)?.is_streaming())
+    Ok(
+      self
+        .internal
+        .get(&co_id)
+        .map_err(to_napi_err)?
+        .is_streaming(),
+    )
   }
 
   /// Set streaming known state
   #[napi]
-  pub fn set_streaming_known_state(&mut self, co_id: String, streaming_json: String) -> napi::Result<()> {
+  pub fn set_streaming_known_state(
+    &mut self,
+    co_id: String,
+    streaming_json: String,
+  ) -> napi::Result<()> {
     self
       .internal
       .get_mut(&co_id)
@@ -675,7 +718,11 @@ impl NodeCore {
   /// Mark this CoValue as deleted
   #[napi]
   pub fn mark_as_deleted(&mut self, co_id: String) -> napi::Result<()> {
-    self.internal.get_mut(&co_id).map_err(to_napi_err)?.mark_as_deleted();
+    self
+      .internal
+      .get_mut(&co_id)
+      .map_err(to_napi_err)?
+      .mark_as_deleted();
     Ok(())
   }
 

--- a/crates/cojson-core-rn/CojsonCoreRnFramework.xcframework/Info.plist
+++ b/crates/cojson-core-rn/CojsonCoreRnFramework.xcframework/Info.plist
@@ -8,20 +8,6 @@
 			<key>BinaryPath</key>
 			<string>libcojson_core_rn.a</string>
 			<key>LibraryIdentifier</key>
-			<string>ios-arm64</string>
-			<key>LibraryPath</key>
-			<string>libcojson_core_rn.a</string>
-			<key>SupportedArchitectures</key>
-			<array>
-				<string>arm64</string>
-			</array>
-			<key>SupportedPlatform</key>
-			<string>ios</string>
-		</dict>
-		<dict>
-			<key>BinaryPath</key>
-			<string>libcojson_core_rn.a</string>
-			<key>LibraryIdentifier</key>
 			<string>ios-arm64_x86_64-simulator</string>
 			<key>LibraryPath</key>
 			<string>libcojson_core_rn.a</string>
@@ -34,6 +20,20 @@
 			<string>ios</string>
 			<key>SupportedPlatformVariant</key>
 			<string>simulator</string>
+		</dict>
+		<dict>
+			<key>BinaryPath</key>
+			<string>libcojson_core_rn.a</string>
+			<key>LibraryIdentifier</key>
+			<string>ios-arm64</string>
+			<key>LibraryPath</key>
+			<string>libcojson_core_rn.a</string>
+			<key>SupportedArchitectures</key>
+			<array>
+				<string>arm64</string>
+			</array>
+			<key>SupportedPlatform</key>
+			<string>ios</string>
 		</dict>
 	</array>
 	<key>CFBundlePackageType</key>

--- a/crates/cojson-core-rn/rust/src/lib.rs
+++ b/crates/cojson-core-rn/rust/src/lib.rs
@@ -26,3 +26,6 @@ pub mod crypto {
 
 pub mod session_map;
 pub use session_map::*;
+
+pub mod node_core;
+pub use node_core::*;

--- a/crates/cojson-core-rn/rust/src/node_core.rs
+++ b/crates/cojson-core-rn/rust/src/node_core.rs
@@ -100,7 +100,12 @@ impl NodeCore {
             .lock()
             .map_err(|_| SessionMapError::LockError)?;
         internal
-            .create_co_value(&co_id, &header_json, max_tx_size, skip_verify.unwrap_or(false))
+            .create_co_value(
+                &co_id,
+                &header_json,
+                max_tx_size,
+                skip_verify.unwrap_or(false),
+            )
             .map_err(|e| SessionMapError::Internal(e.to_string()))
     }
 
@@ -610,7 +615,9 @@ mod tests {
     #[test]
     fn remove_absent_is_noop() {
         let node = NodeCore::new();
-        assert!(!node.remove_co_value("co_zDoesNotExist".to_string()).unwrap());
+        assert!(!node
+            .remove_co_value("co_zDoesNotExist".to_string())
+            .unwrap());
     }
 
     #[test]
@@ -627,14 +634,20 @@ mod tests {
     #[test]
     fn reset_validation_on_absent_id_is_noop() {
         let node = NodeCore::new();
-        assert!(node.reset_validation("co_zDoesNotExist".to_string()).is_ok());
+        assert!(node
+            .reset_validation("co_zDoesNotExist".to_string())
+            .is_ok());
     }
 
     #[test]
     fn role_of_unknown_group_errors_with_prefix() {
         let node = NodeCore::new();
         let err = node
-            .role_of("co_zDoesNotExist".to_string(), "co_zMember".to_string(), None)
+            .role_of(
+                "co_zDoesNotExist".to_string(),
+                "co_zMember".to_string(),
+                None,
+            )
             .unwrap_err();
         assert_eq!(err.to_string(), "Unknown CoValue: co_zDoesNotExist");
     }

--- a/crates/cojson-core-rn/rust/src/node_core.rs
+++ b/crates/cojson-core-rn/rust/src/node_core.rs
@@ -1,0 +1,641 @@
+use crate::session_map::{KnownState, SessionMapError};
+use cojson_core::core::{
+    NodeCore as RustNodeCore, PendingTxIn as RustPendingTxIn, Verdict as RustVerdict,
+};
+use std::sync::Mutex;
+
+// ============================================================================
+// NodeCore - uniffi wrapper for the node-level CoValue registry
+// ============================================================================
+
+/// A merged transaction's source identity, mirroring the `(session_id,
+/// tx_index)` tuple carried by `PendingTxIn::source_tx_id` on the Rust side.
+/// Plain camelCase on the generated TS side (uniffi lower-cases record field
+/// names the same way napi objects do) — unlike the JSON wire format used
+/// elsewhere in this codebase (`TransactionID`'s `sessionID`), uniffi records
+/// bypass serde entirely, so there is no `#[serde(rename)]` to apply here.
+/// The TS adapter (added in a later task) is responsible for bridging its
+/// `sessionID`-cased public type to this `sessionId`-cased record.
+#[derive(uniffi::Record, Clone, Debug)]
+pub struct SourceTxId {
+    pub session_id: String,
+    pub tx_index: u32,
+}
+
+/// A pending (not-yet-persisted) transaction handed to `validate_transactions`,
+/// mirroring `PendingTxIn` on the Rust side.
+#[derive(uniffi::Record, Clone, Debug)]
+pub struct PendingTx {
+    pub session_id: String,
+    pub tx_index: u32,
+    pub source_made_at: Option<f64>,
+    pub meta_json: Option<String>,
+    pub source_tx_id: Option<SourceTxId>,
+}
+
+/// Validation verdict for a single transaction, mirroring `Verdict` on the
+/// Rust side.
+#[derive(uniffi::Record, Clone, Debug)]
+pub struct GroupVerdict {
+    pub session_id: String,
+    pub tx_index: u32,
+    pub valid: bool,
+    /// One of "valid" / "invalid" / "validBranchPointerOnly", mirroring
+    /// `VerdictOutcome` on the Rust side.
+    pub outcome: String,
+    pub reason: Option<String>,
+}
+
+/// Mirrors the napi binding's `verdict_outcome_to_str` / the wasm binding's
+/// `impl From<RustVerdict> for GroupVerdictWire` — a reviewer designated the
+/// wasm `From` idiom the cleaner target of the two, so this binding follows
+/// it rather than a free helper fn.
+impl From<RustVerdict> for GroupVerdict {
+    fn from(v: RustVerdict) -> Self {
+        GroupVerdict {
+            session_id: v.session_id,
+            tx_index: v.tx_index,
+            valid: v.valid,
+            outcome: v.outcome.as_str().to_string(),
+            reason: v.reason,
+        }
+    }
+}
+
+#[derive(uniffi::Object)]
+pub struct NodeCore {
+    internal: Mutex<RustNodeCore>,
+}
+
+// NOTE: a parallel copy of every method body in `impl SessionMap` (session_map.rs)
+// lives here (co_id-first). When editing a lifted method in `impl SessionMap`,
+// update its NodeCore twin too — and vice versa: this comment is the other
+// half of the "parallel copy" breadcrumb at the top of `impl SessionMap` in
+// that file.
+#[uniffi::export]
+impl NodeCore {
+    /// Create a new empty NodeCore registry (one LocalNode owns one instance).
+    #[uniffi::constructor]
+    #[allow(clippy::new_without_default)]
+    pub fn new() -> Self {
+        NodeCore {
+            internal: Mutex::new(RustNodeCore::new()),
+        }
+    }
+
+    // === Registry ===
+
+    /// Creates or replaces; replacing drops the previous session state.
+    /// Mirrors TS semantics where constructing a new VerifiedState for an
+    /// already-known id creates a fresh SessionMap.
+    pub fn create_co_value(
+        &self,
+        co_id: String,
+        header_json: String,
+        max_tx_size: Option<u32>,
+        skip_verify: Option<bool>,
+    ) -> Result<(), SessionMapError> {
+        let mut internal = self
+            .internal
+            .lock()
+            .map_err(|_| SessionMapError::LockError)?;
+        internal
+            .create_co_value(&co_id, &header_json, max_tx_size, skip_verify.unwrap_or(false))
+            .map_err(|e| SessionMapError::Internal(e.to_string()))
+    }
+
+    pub fn has_co_value(&self, co_id: String) -> Result<bool, SessionMapError> {
+        let internal = self
+            .internal
+            .lock()
+            .map_err(|_| SessionMapError::LockError)?;
+        Ok(internal.has_co_value(&co_id))
+    }
+
+    pub fn remove_co_value(&self, co_id: String) -> Result<bool, SessionMapError> {
+        let mut internal = self
+            .internal
+            .lock()
+            .map_err(|_| SessionMapError::LockError)?;
+        Ok(internal.remove_co_value(&co_id))
+    }
+
+    pub fn co_value_count(&self) -> Result<u32, SessionMapError> {
+        let internal = self
+            .internal
+            .lock()
+            .map_err(|_| SessionMapError::LockError)?;
+        Ok(internal.co_value_count() as u32)
+    }
+
+    // === Lifted SessionMap surface ===
+    // Each method prepends `co_id: String` and resolves the entry via
+    // get()/get_mut() before delegating, mapping UnknownCoValue through
+    // SessionMapError::Internal. Method bodies are lifted verbatim from
+    // impl SessionMap so every conversion (JSON strings, KnownState::from,
+    // -1 conventions, Option -> None) is preserved.
+
+    // --- Header ---
+
+    /// Get the header as JSON
+    pub fn get_header(&self, co_id: String) -> Result<String, SessionMapError> {
+        let internal = self
+            .internal
+            .lock()
+            .map_err(|_| SessionMapError::LockError)?;
+        Ok(internal
+            .get(&co_id)
+            .map_err(|e| SessionMapError::Internal(e.to_string()))?
+            .get_header())
+    }
+
+    // --- Transaction Operations ---
+
+    /// Add transactions to a session
+    pub fn add_transactions(
+        &self,
+        co_id: String,
+        session_id: String,
+        signer_id: Option<String>,
+        transactions_json: String,
+        signature: String,
+        skip_verify: bool,
+    ) -> Result<(), SessionMapError> {
+        let mut internal = self
+            .internal
+            .lock()
+            .map_err(|_| SessionMapError::LockError)?;
+        internal
+            .get_mut(&co_id)
+            .map_err(|e| SessionMapError::Internal(e.to_string()))?
+            .add_transactions(
+                &session_id,
+                signer_id.as_deref(),
+                &transactions_json,
+                &signature,
+                skip_verify,
+            )
+            .map_err(|e| SessionMapError::Internal(e.to_string()))
+    }
+
+    /// Create new private transaction (for local writes)
+    /// Returns JSON: { signature: string, transaction: Transaction }
+    #[allow(clippy::too_many_arguments)]
+    pub fn make_new_private_transaction(
+        &self,
+        co_id: String,
+        session_id: String,
+        signer_secret: String,
+        changes_json: String,
+        key_id: String,
+        key_secret: String,
+        meta_json: Option<String>,
+        made_at: f64,
+    ) -> Result<String, SessionMapError> {
+        let mut internal = self
+            .internal
+            .lock()
+            .map_err(|_| SessionMapError::LockError)?;
+        let signed_tx = internal
+            .get_mut(&co_id)
+            .map_err(|e| SessionMapError::Internal(e.to_string()))?
+            .make_new_private_transaction(
+                session_id,
+                signer_secret,
+                &changes_json,
+                key_id,
+                key_secret,
+                meta_json,
+                made_at as u64,
+            )
+            .map_err(|e| SessionMapError::Internal(e.to_string()))?;
+
+        let tx_json = serde_json::to_string(&signed_tx.transaction)
+            .map_err(|e| SessionMapError::Internal(e.to_string()))?;
+        Ok(format!(
+            r#"{{"signature":"{}","transaction":{}}}"#,
+            signed_tx.signature.0, tx_json
+        ))
+    }
+
+    /// Create new trusting transaction (for local writes)
+    /// Returns JSON: { signature: string, transaction: Transaction }
+    pub fn make_new_trusting_transaction(
+        &self,
+        co_id: String,
+        session_id: String,
+        signer_secret: String,
+        changes_json: String,
+        meta_json: Option<String>,
+        made_at: f64,
+    ) -> Result<String, SessionMapError> {
+        let mut internal = self
+            .internal
+            .lock()
+            .map_err(|_| SessionMapError::LockError)?;
+        let signed_tx = internal
+            .get_mut(&co_id)
+            .map_err(|e| SessionMapError::Internal(e.to_string()))?
+            .make_new_trusting_transaction(
+                session_id,
+                signer_secret,
+                &changes_json,
+                meta_json,
+                made_at as u64,
+            )
+            .map_err(|e| SessionMapError::Internal(e.to_string()))?;
+
+        let tx_json = serde_json::to_string(&signed_tx.transaction)
+            .map_err(|e| SessionMapError::Internal(e.to_string()))?;
+        Ok(format!(
+            r#"{{"signature":"{}","transaction":{}}}"#,
+            signed_tx.signature.0, tx_json
+        ))
+    }
+
+    // --- Session Queries ---
+
+    /// Get all session IDs as native array
+    pub fn get_session_ids(&self, co_id: String) -> Result<Vec<String>, SessionMapError> {
+        let internal = self
+            .internal
+            .lock()
+            .map_err(|_| SessionMapError::LockError)?;
+        Ok(internal
+            .get(&co_id)
+            .map_err(|e| SessionMapError::Internal(e.to_string()))?
+            .get_session_ids())
+    }
+
+    /// Get transaction count for a session (returns -1 if session not found)
+    pub fn get_transaction_count(
+        &self,
+        co_id: String,
+        session_id: String,
+    ) -> Result<i32, SessionMapError> {
+        let internal = self
+            .internal
+            .lock()
+            .map_err(|_| SessionMapError::LockError)?;
+        let sm = internal
+            .get(&co_id)
+            .map_err(|e| SessionMapError::Internal(e.to_string()))?;
+        // Same -1-if-absent convention as the SessionMap wrapper
+        Ok(sm
+            .get_transaction_count(&session_id)
+            .map(|c| c as i32)
+            .unwrap_or(-1))
+    }
+
+    /// Get single transaction by index as JSON string (returns None if not found)
+    pub fn get_transaction(
+        &self,
+        co_id: String,
+        session_id: String,
+        tx_index: u32,
+    ) -> Result<Option<String>, SessionMapError> {
+        let internal = self
+            .internal
+            .lock()
+            .map_err(|_| SessionMapError::LockError)?;
+        Ok(internal
+            .get(&co_id)
+            .map_err(|e| SessionMapError::Internal(e.to_string()))?
+            .get_transaction(&session_id, tx_index))
+    }
+
+    /// Get transactions for a session from index as JSON strings (returns None if session not found)
+    pub fn get_session_transactions(
+        &self,
+        co_id: String,
+        session_id: String,
+        from_index: u32,
+    ) -> Result<Option<Vec<String>>, SessionMapError> {
+        let internal = self
+            .internal
+            .lock()
+            .map_err(|_| SessionMapError::LockError)?;
+        Ok(internal
+            .get(&co_id)
+            .map_err(|e| SessionMapError::Internal(e.to_string()))?
+            .get_session_transactions(&session_id, from_index))
+    }
+
+    /// Get last signature for a session (returns None if session not found)
+    pub fn get_last_signature(
+        &self,
+        co_id: String,
+        session_id: String,
+    ) -> Result<Option<String>, SessionMapError> {
+        let internal = self
+            .internal
+            .lock()
+            .map_err(|_| SessionMapError::LockError)?;
+        Ok(internal
+            .get(&co_id)
+            .map_err(|e| SessionMapError::Internal(e.to_string()))?
+            .get_last_signature(&session_id))
+    }
+
+    /// Get signature after specific transaction index
+    pub fn get_signature_after(
+        &self,
+        co_id: String,
+        session_id: String,
+        tx_index: u32,
+    ) -> Result<Option<String>, SessionMapError> {
+        let internal = self
+            .internal
+            .lock()
+            .map_err(|_| SessionMapError::LockError)?;
+        Ok(internal
+            .get(&co_id)
+            .map_err(|e| SessionMapError::Internal(e.to_string()))?
+            .get_signature_after(&session_id, tx_index))
+    }
+
+    /// Get the last signature checkpoint index (-1 if no checkpoints, None if session not found)
+    pub fn get_last_signature_checkpoint(
+        &self,
+        co_id: String,
+        session_id: String,
+    ) -> Result<Option<i32>, SessionMapError> {
+        let internal = self
+            .internal
+            .lock()
+            .map_err(|_| SessionMapError::LockError)?;
+        Ok(internal
+            .get(&co_id)
+            .map_err(|e| SessionMapError::Internal(e.to_string()))?
+            .get_last_signature_checkpoint(&session_id))
+    }
+
+    // --- Known State ---
+
+    /// Get the known state as a native Record
+    pub fn get_known_state(&self, co_id: String) -> Result<KnownState, SessionMapError> {
+        let internal = self
+            .internal
+            .lock()
+            .map_err(|_| SessionMapError::LockError)?;
+        Ok(internal
+            .get(&co_id)
+            .map_err(|e| SessionMapError::Internal(e.to_string()))?
+            .get_known_state()
+            .into())
+    }
+
+    /// Get the known state with streaming as a native Record
+    pub fn get_known_state_with_streaming(
+        &self,
+        co_id: String,
+    ) -> Result<Option<KnownState>, SessionMapError> {
+        let internal = self
+            .internal
+            .lock()
+            .map_err(|_| SessionMapError::LockError)?;
+        Ok(internal
+            .get(&co_id)
+            .map_err(|e| SessionMapError::Internal(e.to_string()))?
+            .get_known_state_with_streaming()
+            .map(|ks| ks.into()))
+    }
+
+    /// Check whether the CoValue still has pending streaming content.
+    pub fn is_streaming(&self, co_id: String) -> Result<bool, SessionMapError> {
+        let internal = self
+            .internal
+            .lock()
+            .map_err(|_| SessionMapError::LockError)?;
+        Ok(internal
+            .get(&co_id)
+            .map_err(|e| SessionMapError::Internal(e.to_string()))?
+            .is_streaming())
+    }
+
+    /// Set streaming known state
+    pub fn set_streaming_known_state(
+        &self,
+        co_id: String,
+        streaming_json: String,
+    ) -> Result<(), SessionMapError> {
+        let mut internal = self
+            .internal
+            .lock()
+            .map_err(|_| SessionMapError::LockError)?;
+        internal
+            .get_mut(&co_id)
+            .map_err(|e| SessionMapError::Internal(e.to_string()))?
+            .set_streaming_known_state(&streaming_json)
+            .map_err(|e| SessionMapError::Internal(e.to_string()))
+    }
+
+    // --- Deletion ---
+
+    /// Mark this CoValue as deleted
+    pub fn mark_as_deleted(&self, co_id: String) -> Result<(), SessionMapError> {
+        let mut internal = self
+            .internal
+            .lock()
+            .map_err(|_| SessionMapError::LockError)?;
+        internal
+            .get_mut(&co_id)
+            .map_err(|e| SessionMapError::Internal(e.to_string()))?
+            .mark_as_deleted();
+        Ok(())
+    }
+
+    /// Check if this CoValue is deleted
+    pub fn is_deleted(&self, co_id: String) -> Result<bool, SessionMapError> {
+        let internal = self
+            .internal
+            .lock()
+            .map_err(|_| SessionMapError::LockError)?;
+        Ok(internal
+            .get(&co_id)
+            .map_err(|e| SessionMapError::Internal(e.to_string()))?
+            .is_deleted())
+    }
+
+    // --- Decryption ---
+
+    /// Decrypt transaction changes
+    pub fn decrypt_transaction(
+        &self,
+        co_id: String,
+        session_id: String,
+        tx_index: u32,
+        key_secret: String,
+    ) -> Result<Option<String>, SessionMapError> {
+        let internal = self
+            .internal
+            .lock()
+            .map_err(|_| SessionMapError::LockError)?;
+        internal
+            .get(&co_id)
+            .map_err(|e| SessionMapError::Internal(e.to_string()))?
+            .decrypt_transaction(&session_id, tx_index, &key_secret)
+            .map_err(|e| SessionMapError::Internal(e.to_string()))
+    }
+
+    /// Decrypt transaction meta
+    pub fn decrypt_transaction_meta(
+        &self,
+        co_id: String,
+        session_id: String,
+        tx_index: u32,
+        key_secret: String,
+    ) -> Result<Option<String>, SessionMapError> {
+        let internal = self
+            .internal
+            .lock()
+            .map_err(|_| SessionMapError::LockError)?;
+        internal
+            .get(&co_id)
+            .map_err(|e| SessionMapError::Internal(e.to_string()))?
+            .decrypt_transaction_meta(&session_id, tx_index, &key_secret)
+            .map_err(|e| SessionMapError::Internal(e.to_string()))
+    }
+
+    // === Stage 2/3: Group engine surface ===
+    // These methods are NodeCore-ONLY — there is no SessionMap twin (the
+    // group engine is inherently cross-CoValue, so it can't live on a single
+    // SessionMap). Do not go looking for a `parallel copy` in `impl SessionMap`
+    // above; the "lifted verbatim" breadcrumb on that section doesn't apply
+    // here.
+
+    /// Validate a group/account CoValue; verdicts for ALL its transactions in
+    /// validation order.
+    /// Throws "Unknown CoValue: <id>" if `co_id` itself is not registered, and
+    /// "CoValue not loaded: <id>" if a dependency (parent group / owning
+    /// account) is missing.
+    pub fn validate_transactions(
+        &self,
+        co_id: String,
+        pending: Vec<PendingTx>,
+    ) -> Result<Vec<GroupVerdict>, SessionMapError> {
+        let pending: Vec<RustPendingTxIn> = pending
+            .into_iter()
+            .map(|p| RustPendingTxIn {
+                session_id: p.session_id,
+                tx_index: p.tx_index,
+                source_made_at: p.source_made_at.map(|v| v as u64),
+                meta_json: p.meta_json,
+                source_tx_id: p.source_tx_id.map(|s| (s.session_id, s.tx_index)),
+            })
+            .collect();
+        let mut internal = self
+            .internal
+            .lock()
+            .map_err(|_| SessionMapError::LockError)?;
+        let verdicts = internal
+            .validate_transactions(&co_id, &pending)
+            .map_err(|e| SessionMapError::Internal(e.to_string()))?;
+        Ok(verdicts.into_iter().map(GroupVerdict::from).collect())
+    }
+
+    /// Drop the cached validation engine for `co_id`, forcing a full recompute
+    /// on the next `validate_transactions` / `role_of`. An absent `co_id` is a
+    /// no-op (not `UnknownCoValue`): callers invoke this on dependants that may
+    /// never have been registered on this node, so erroring would be hostile.
+    pub fn reset_validation(&self, co_id: String) -> Result<(), SessionMapError> {
+        let mut internal = self
+            .internal
+            .lock()
+            .map_err(|_| SessionMapError::LockError)?;
+        internal.reset_validation(&co_id);
+        Ok(())
+    }
+
+    /// Role of member in group at time (ms). Returns the role string or None.
+    /// Throws "Unknown CoValue: <id>" if `group_id` itself is not registered,
+    /// and "CoValue not loaded: <id>" if a parent group / owning account is
+    /// missing.
+    pub fn role_of(
+        &self,
+        group_id: String,
+        member: String,
+        at_time: Option<f64>,
+    ) -> Result<Option<String>, SessionMapError> {
+        let mut internal = self
+            .internal
+            .lock()
+            .map_err(|_| SessionMapError::LockError)?;
+        let role = internal
+            .role_of(&group_id, &member, at_time.map(|v| v as u64))
+            .map_err(|e| SessionMapError::Internal(e.to_string()))?;
+        Ok(role.map(|r| r.as_str().to_string()))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // Build a valid header + matching co_id, mirroring
+    // `crates/cojson-core/src/core/node.rs`'s own test helper.
+    fn valid_header() -> (String, String) {
+        use cojson_core::core::{CoValueHeader, NullableString, RulesetDef, Uniqueness};
+
+        let header = CoValueHeader {
+            created_at: NullableString::Missing,
+            meta: None,
+            ruleset: RulesetDef::unsafe_allow_all(),
+            co_type: "comap".to_string(),
+            uniqueness: Uniqueness::String("test".to_string()),
+        };
+        let header_json = serde_json::to_string(&header).unwrap();
+        let co_id =
+            cojson_core::hash::blake3::short_hash_with_prefix(header_json.as_bytes(), "co_z");
+        (co_id, header_json)
+    }
+
+    #[test]
+    fn create_has_remove_roundtrip() {
+        let (co_id, header_json) = valid_header();
+        let node = NodeCore::new();
+        assert!(!node.has_co_value(co_id.clone()).unwrap());
+        assert_eq!(node.co_value_count().unwrap(), 0);
+
+        node.create_co_value(co_id.clone(), header_json, None, None)
+            .unwrap();
+        assert!(node.has_co_value(co_id.clone()).unwrap());
+        assert_eq!(node.co_value_count().unwrap(), 1);
+
+        assert!(node.remove_co_value(co_id.clone()).unwrap());
+        assert!(!node.has_co_value(co_id).unwrap());
+        assert_eq!(node.co_value_count().unwrap(), 0);
+    }
+
+    #[test]
+    fn remove_absent_is_noop() {
+        let node = NodeCore::new();
+        assert!(!node.remove_co_value("co_zDoesNotExist".to_string()).unwrap());
+    }
+
+    #[test]
+    fn unknown_co_value_error_preserves_prefix() {
+        let node = NodeCore::new();
+        let err = node.get_header("co_zDoesNotExist".to_string()).unwrap_err();
+        // Load-bearing: TS-side error translation does
+        // `message.startsWith("Unknown CoValue: ")` / `"CoValue not loaded: "`.
+        // If SessionMapError::Internal's Display ever re-adds a wrapping
+        // prefix, this assertion catches the regression.
+        assert_eq!(err.to_string(), "Unknown CoValue: co_zDoesNotExist");
+    }
+
+    #[test]
+    fn reset_validation_on_absent_id_is_noop() {
+        let node = NodeCore::new();
+        assert!(node.reset_validation("co_zDoesNotExist".to_string()).is_ok());
+    }
+
+    #[test]
+    fn role_of_unknown_group_errors_with_prefix() {
+        let node = NodeCore::new();
+        let err = node
+            .role_of("co_zDoesNotExist".to_string(), "co_zMember".to_string(), None)
+            .unwrap_err();
+        assert_eq!(err.to_string(), "Unknown CoValue: co_zDoesNotExist");
+    }
+}

--- a/crates/cojson-core-rn/rust/src/session_map.rs
+++ b/crates/cojson-core-rn/rust/src/session_map.rs
@@ -4,7 +4,18 @@ use thiserror::Error;
 
 #[derive(Error, Debug, uniffi::Error)]
 pub enum SessionMapError {
-    #[error("SessionMap error: {0}")]
+    /// Wraps any inner `cojson-core` error's `Display` output VERBATIM — no
+    /// added prefix. This is load-bearing once `NodeCore` (node_core.rs)
+    /// reuses this same variant for its registry-lookup errors: TS-side error
+    /// translation does `message.startsWith("CoValue not loaded: ")`
+    /// (packages/cojson/src/permissions.ts:322) and matches `"Unknown CoValue: "`
+    /// similarly, so a wrapped format like the previous `"SessionMap error: {0}"`
+    /// would silently break that match by shifting the prefix. Kept as a plain
+    /// format string rather than `#[error(transparent)]`, since `String` doesn't
+    /// implement `std::error::Error`; kept as one variant rather than adding a
+    /// parallel one, since nothing in the tree depended on the old
+    /// "SessionMap error: " prefix text.
+    #[error("{0}")]
     Internal(String),
     #[error("Failed to acquire lock")]
     LockError,
@@ -33,6 +44,10 @@ pub struct SessionMap {
     internal: std::sync::Mutex<SessionMapImpl>,
 }
 
+// NOTE: a parallel copy of every method body below lives in `impl NodeCore`
+// (node_core.rs, co_id-first). When editing a method here, update its
+// NodeCore twin too — see the matching breadcrumb on `impl NodeCore` in that
+// file.
 #[uniffi::export]
 impl SessionMap {
     /// Create a new SessionMap for a CoValue

--- a/crates/cojson-core-rn/src/generated/cojson_core_rn-ffi.ts
+++ b/crates/cojson-core-rn/src/generated/cojson_core_rn-ffi.ts
@@ -47,6 +47,185 @@ interface NativeModuleInterface {
     data: Uint8Array,
     uniffi_out_err: UniffiRustCallStatus
   ): void;
+  ubrn_uniffi_cojson_core_rn_fn_clone_nodecore(
+    ptr: bigint,
+    uniffi_out_err: UniffiRustCallStatus
+  ): bigint;
+  ubrn_uniffi_cojson_core_rn_fn_free_nodecore(
+    ptr: bigint,
+    uniffi_out_err: UniffiRustCallStatus
+  ): void;
+  ubrn_uniffi_cojson_core_rn_fn_constructor_nodecore_new(
+    uniffi_out_err: UniffiRustCallStatus
+  ): bigint;
+  ubrn_uniffi_cojson_core_rn_fn_method_nodecore_add_transactions(
+    ptr: bigint,
+    coId: Uint8Array,
+    sessionId: Uint8Array,
+    signerId: Uint8Array,
+    transactionsJson: Uint8Array,
+    signature: Uint8Array,
+    skipVerify: number,
+    uniffi_out_err: UniffiRustCallStatus
+  ): void;
+  ubrn_uniffi_cojson_core_rn_fn_method_nodecore_co_value_count(
+    ptr: bigint,
+    uniffi_out_err: UniffiRustCallStatus
+  ): number;
+  ubrn_uniffi_cojson_core_rn_fn_method_nodecore_create_co_value(
+    ptr: bigint,
+    coId: Uint8Array,
+    headerJson: Uint8Array,
+    maxTxSize: Uint8Array,
+    skipVerify: Uint8Array,
+    uniffi_out_err: UniffiRustCallStatus
+  ): void;
+  ubrn_uniffi_cojson_core_rn_fn_method_nodecore_decrypt_transaction(
+    ptr: bigint,
+    coId: Uint8Array,
+    sessionId: Uint8Array,
+    txIndex: number,
+    keySecret: Uint8Array,
+    uniffi_out_err: UniffiRustCallStatus
+  ): Uint8Array;
+  ubrn_uniffi_cojson_core_rn_fn_method_nodecore_decrypt_transaction_meta(
+    ptr: bigint,
+    coId: Uint8Array,
+    sessionId: Uint8Array,
+    txIndex: number,
+    keySecret: Uint8Array,
+    uniffi_out_err: UniffiRustCallStatus
+  ): Uint8Array;
+  ubrn_uniffi_cojson_core_rn_fn_method_nodecore_get_header(
+    ptr: bigint,
+    coId: Uint8Array,
+    uniffi_out_err: UniffiRustCallStatus
+  ): Uint8Array;
+  ubrn_uniffi_cojson_core_rn_fn_method_nodecore_get_known_state(
+    ptr: bigint,
+    coId: Uint8Array,
+    uniffi_out_err: UniffiRustCallStatus
+  ): Uint8Array;
+  ubrn_uniffi_cojson_core_rn_fn_method_nodecore_get_known_state_with_streaming(
+    ptr: bigint,
+    coId: Uint8Array,
+    uniffi_out_err: UniffiRustCallStatus
+  ): Uint8Array;
+  ubrn_uniffi_cojson_core_rn_fn_method_nodecore_get_last_signature(
+    ptr: bigint,
+    coId: Uint8Array,
+    sessionId: Uint8Array,
+    uniffi_out_err: UniffiRustCallStatus
+  ): Uint8Array;
+  ubrn_uniffi_cojson_core_rn_fn_method_nodecore_get_last_signature_checkpoint(
+    ptr: bigint,
+    coId: Uint8Array,
+    sessionId: Uint8Array,
+    uniffi_out_err: UniffiRustCallStatus
+  ): Uint8Array;
+  ubrn_uniffi_cojson_core_rn_fn_method_nodecore_get_session_ids(
+    ptr: bigint,
+    coId: Uint8Array,
+    uniffi_out_err: UniffiRustCallStatus
+  ): Uint8Array;
+  ubrn_uniffi_cojson_core_rn_fn_method_nodecore_get_session_transactions(
+    ptr: bigint,
+    coId: Uint8Array,
+    sessionId: Uint8Array,
+    fromIndex: number,
+    uniffi_out_err: UniffiRustCallStatus
+  ): Uint8Array;
+  ubrn_uniffi_cojson_core_rn_fn_method_nodecore_get_signature_after(
+    ptr: bigint,
+    coId: Uint8Array,
+    sessionId: Uint8Array,
+    txIndex: number,
+    uniffi_out_err: UniffiRustCallStatus
+  ): Uint8Array;
+  ubrn_uniffi_cojson_core_rn_fn_method_nodecore_get_transaction(
+    ptr: bigint,
+    coId: Uint8Array,
+    sessionId: Uint8Array,
+    txIndex: number,
+    uniffi_out_err: UniffiRustCallStatus
+  ): Uint8Array;
+  ubrn_uniffi_cojson_core_rn_fn_method_nodecore_get_transaction_count(
+    ptr: bigint,
+    coId: Uint8Array,
+    sessionId: Uint8Array,
+    uniffi_out_err: UniffiRustCallStatus
+  ): number;
+  ubrn_uniffi_cojson_core_rn_fn_method_nodecore_has_co_value(
+    ptr: bigint,
+    coId: Uint8Array,
+    uniffi_out_err: UniffiRustCallStatus
+  ): number;
+  ubrn_uniffi_cojson_core_rn_fn_method_nodecore_is_deleted(
+    ptr: bigint,
+    coId: Uint8Array,
+    uniffi_out_err: UniffiRustCallStatus
+  ): number;
+  ubrn_uniffi_cojson_core_rn_fn_method_nodecore_is_streaming(
+    ptr: bigint,
+    coId: Uint8Array,
+    uniffi_out_err: UniffiRustCallStatus
+  ): number;
+  ubrn_uniffi_cojson_core_rn_fn_method_nodecore_make_new_private_transaction(
+    ptr: bigint,
+    coId: Uint8Array,
+    sessionId: Uint8Array,
+    signerSecret: Uint8Array,
+    changesJson: Uint8Array,
+    keyId: Uint8Array,
+    keySecret: Uint8Array,
+    metaJson: Uint8Array,
+    madeAt: number,
+    uniffi_out_err: UniffiRustCallStatus
+  ): Uint8Array;
+  ubrn_uniffi_cojson_core_rn_fn_method_nodecore_make_new_trusting_transaction(
+    ptr: bigint,
+    coId: Uint8Array,
+    sessionId: Uint8Array,
+    signerSecret: Uint8Array,
+    changesJson: Uint8Array,
+    metaJson: Uint8Array,
+    madeAt: number,
+    uniffi_out_err: UniffiRustCallStatus
+  ): Uint8Array;
+  ubrn_uniffi_cojson_core_rn_fn_method_nodecore_mark_as_deleted(
+    ptr: bigint,
+    coId: Uint8Array,
+    uniffi_out_err: UniffiRustCallStatus
+  ): void;
+  ubrn_uniffi_cojson_core_rn_fn_method_nodecore_remove_co_value(
+    ptr: bigint,
+    coId: Uint8Array,
+    uniffi_out_err: UniffiRustCallStatus
+  ): number;
+  ubrn_uniffi_cojson_core_rn_fn_method_nodecore_reset_validation(
+    ptr: bigint,
+    coId: Uint8Array,
+    uniffi_out_err: UniffiRustCallStatus
+  ): void;
+  ubrn_uniffi_cojson_core_rn_fn_method_nodecore_role_of(
+    ptr: bigint,
+    groupId: Uint8Array,
+    member: Uint8Array,
+    atTime: Uint8Array,
+    uniffi_out_err: UniffiRustCallStatus
+  ): Uint8Array;
+  ubrn_uniffi_cojson_core_rn_fn_method_nodecore_set_streaming_known_state(
+    ptr: bigint,
+    coId: Uint8Array,
+    streamingJson: Uint8Array,
+    uniffi_out_err: UniffiRustCallStatus
+  ): void;
+  ubrn_uniffi_cojson_core_rn_fn_method_nodecore_validate_transactions(
+    ptr: bigint,
+    coId: Uint8Array,
+    pending: Uint8Array,
+    uniffi_out_err: UniffiRustCallStatus
+  ): Uint8Array;
   ubrn_uniffi_cojson_core_rn_fn_clone_sessionmap(
     ptr: bigint,
     uniffi_out_err: UniffiRustCallStatus
@@ -354,6 +533,32 @@ interface NativeModuleInterface {
   ubrn_uniffi_cojson_core_rn_checksum_method_blake3hasher_clone_hasher(): number;
   ubrn_uniffi_cojson_core_rn_checksum_method_blake3hasher_finalize(): number;
   ubrn_uniffi_cojson_core_rn_checksum_method_blake3hasher_update(): number;
+  ubrn_uniffi_cojson_core_rn_checksum_method_nodecore_add_transactions(): number;
+  ubrn_uniffi_cojson_core_rn_checksum_method_nodecore_co_value_count(): number;
+  ubrn_uniffi_cojson_core_rn_checksum_method_nodecore_create_co_value(): number;
+  ubrn_uniffi_cojson_core_rn_checksum_method_nodecore_decrypt_transaction(): number;
+  ubrn_uniffi_cojson_core_rn_checksum_method_nodecore_decrypt_transaction_meta(): number;
+  ubrn_uniffi_cojson_core_rn_checksum_method_nodecore_get_header(): number;
+  ubrn_uniffi_cojson_core_rn_checksum_method_nodecore_get_known_state(): number;
+  ubrn_uniffi_cojson_core_rn_checksum_method_nodecore_get_known_state_with_streaming(): number;
+  ubrn_uniffi_cojson_core_rn_checksum_method_nodecore_get_last_signature(): number;
+  ubrn_uniffi_cojson_core_rn_checksum_method_nodecore_get_last_signature_checkpoint(): number;
+  ubrn_uniffi_cojson_core_rn_checksum_method_nodecore_get_session_ids(): number;
+  ubrn_uniffi_cojson_core_rn_checksum_method_nodecore_get_session_transactions(): number;
+  ubrn_uniffi_cojson_core_rn_checksum_method_nodecore_get_signature_after(): number;
+  ubrn_uniffi_cojson_core_rn_checksum_method_nodecore_get_transaction(): number;
+  ubrn_uniffi_cojson_core_rn_checksum_method_nodecore_get_transaction_count(): number;
+  ubrn_uniffi_cojson_core_rn_checksum_method_nodecore_has_co_value(): number;
+  ubrn_uniffi_cojson_core_rn_checksum_method_nodecore_is_deleted(): number;
+  ubrn_uniffi_cojson_core_rn_checksum_method_nodecore_is_streaming(): number;
+  ubrn_uniffi_cojson_core_rn_checksum_method_nodecore_make_new_private_transaction(): number;
+  ubrn_uniffi_cojson_core_rn_checksum_method_nodecore_make_new_trusting_transaction(): number;
+  ubrn_uniffi_cojson_core_rn_checksum_method_nodecore_mark_as_deleted(): number;
+  ubrn_uniffi_cojson_core_rn_checksum_method_nodecore_remove_co_value(): number;
+  ubrn_uniffi_cojson_core_rn_checksum_method_nodecore_reset_validation(): number;
+  ubrn_uniffi_cojson_core_rn_checksum_method_nodecore_role_of(): number;
+  ubrn_uniffi_cojson_core_rn_checksum_method_nodecore_set_streaming_known_state(): number;
+  ubrn_uniffi_cojson_core_rn_checksum_method_nodecore_validate_transactions(): number;
   ubrn_uniffi_cojson_core_rn_checksum_method_sessionmap_add_transactions(): number;
   ubrn_uniffi_cojson_core_rn_checksum_method_sessionmap_decrypt_transaction(): number;
   ubrn_uniffi_cojson_core_rn_checksum_method_sessionmap_decrypt_transaction_meta(): number;
@@ -374,9 +579,14 @@ interface NativeModuleInterface {
   ubrn_uniffi_cojson_core_rn_checksum_method_sessionmap_mark_as_deleted(): number;
   ubrn_uniffi_cojson_core_rn_checksum_method_sessionmap_set_streaming_known_state(): number;
   ubrn_uniffi_cojson_core_rn_checksum_constructor_blake3hasher_new(): number;
+  ubrn_uniffi_cojson_core_rn_checksum_constructor_nodecore_new(): number;
   ubrn_uniffi_cojson_core_rn_checksum_constructor_sessionmap_new(): number;
   ubrn_ffi_cojson_core_rn_uniffi_contract_version(): number;
   ubrn_uniffi_internal_fn_method_blake3hasher_ffi__bless_pointer(
+    pointer: bigint,
+    uniffi_out_err: UniffiRustCallStatus
+  ): UniffiRustArcPtr;
+  ubrn_uniffi_internal_fn_method_nodecore_ffi__bless_pointer(
     pointer: bigint,
     uniffi_out_err: UniffiRustCallStatus
   ): UniffiRustArcPtr;

--- a/crates/cojson-core-rn/src/generated/cojson_core_rn.ts
+++ b/crates/cojson-core-rn/src/generated/cojson_core_rn.ts
@@ -821,6 +821,84 @@ export function x25519PublicKey(
 }
 
 /**
+ * Validation verdict for a single transaction, mirroring `Verdict` on the
+ * Rust side.
+ */
+export type GroupVerdict = {
+  sessionId: string;
+  txIndex: /*u32*/ number;
+  valid: boolean;
+  /**
+   * One of "valid" / "invalid" / "validBranchPointerOnly", mirroring
+   * `VerdictOutcome` on the Rust side.
+   */
+  outcome: string;
+  reason: string | undefined;
+};
+
+/**
+ * Generated factory for {@link GroupVerdict} record objects.
+ */
+export const GroupVerdict = (() => {
+  const defaults = () => ({});
+  const create = (() => {
+    return uniffiCreateRecord<GroupVerdict, ReturnType<typeof defaults>>(
+      defaults
+    );
+  })();
+  return Object.freeze({
+    /**
+     * Create a frozen instance of {@link GroupVerdict}, with defaults specified
+     * in Rust, in the {@link cojson_core_rn} crate.
+     */
+    create,
+
+    /**
+     * Create a frozen instance of {@link GroupVerdict}, with defaults specified
+     * in Rust, in the {@link cojson_core_rn} crate.
+     */
+    new: create,
+
+    /**
+     * Defaults specified in the {@link cojson_core_rn} crate.
+     */
+    defaults: () => Object.freeze(defaults()) as Partial<GroupVerdict>,
+  });
+})();
+
+const FfiConverterTypeGroupVerdict = (() => {
+  type TypeName = GroupVerdict;
+  class FFIConverter extends AbstractFfiConverterByteArray<TypeName> {
+    read(from: RustBuffer): TypeName {
+      return {
+        sessionId: FfiConverterString.read(from),
+        txIndex: FfiConverterUInt32.read(from),
+        valid: FfiConverterBool.read(from),
+        outcome: FfiConverterString.read(from),
+        reason: FfiConverterOptionalString.read(from),
+      };
+    }
+    write(value: TypeName, into: RustBuffer): void {
+      FfiConverterString.write(value.sessionId, into);
+      FfiConverterUInt32.write(value.txIndex, into);
+      FfiConverterBool.write(value.valid, into);
+      FfiConverterString.write(value.outcome, into);
+      FfiConverterOptionalString.write(value.reason, into);
+    }
+    allocationSize(value: TypeName): number {
+      return (
+        FfiConverterString.allocationSize(value.sessionId) +
+        FfiConverterUInt32.allocationSize(value.txIndex) +
+        FfiConverterBool.allocationSize(value.valid) +
+        FfiConverterString.allocationSize(value.outcome) +
+        FfiConverterOptionalString.allocationSize(value.reason)
+      );
+    }
+  }
+  return new FFIConverter();
+})();
+
+/**
  * KnownState as a native Record (no JSON serialization needed)
  */
 export type KnownState = {
@@ -879,6 +957,146 @@ const FfiConverterTypeKnownState = (() => {
         FfiConverterString.allocationSize(value.id) +
         FfiConverterBool.allocationSize(value.header) +
         FfiConverterMapStringUInt32.allocationSize(value.sessions)
+      );
+    }
+  }
+  return new FFIConverter();
+})();
+
+/**
+ * A pending (not-yet-persisted) transaction handed to `validate_transactions`,
+ * mirroring `PendingTxIn` on the Rust side.
+ */
+export type PendingTx = {
+  sessionId: string;
+  txIndex: /*u32*/ number;
+  sourceMadeAt: /*f64*/ number | undefined;
+  metaJson: string | undefined;
+  sourceTxId: SourceTxId | undefined;
+};
+
+/**
+ * Generated factory for {@link PendingTx} record objects.
+ */
+export const PendingTx = (() => {
+  const defaults = () => ({});
+  const create = (() => {
+    return uniffiCreateRecord<PendingTx, ReturnType<typeof defaults>>(defaults);
+  })();
+  return Object.freeze({
+    /**
+     * Create a frozen instance of {@link PendingTx}, with defaults specified
+     * in Rust, in the {@link cojson_core_rn} crate.
+     */
+    create,
+
+    /**
+     * Create a frozen instance of {@link PendingTx}, with defaults specified
+     * in Rust, in the {@link cojson_core_rn} crate.
+     */
+    new: create,
+
+    /**
+     * Defaults specified in the {@link cojson_core_rn} crate.
+     */
+    defaults: () => Object.freeze(defaults()) as Partial<PendingTx>,
+  });
+})();
+
+const FfiConverterTypePendingTx = (() => {
+  type TypeName = PendingTx;
+  class FFIConverter extends AbstractFfiConverterByteArray<TypeName> {
+    read(from: RustBuffer): TypeName {
+      return {
+        sessionId: FfiConverterString.read(from),
+        txIndex: FfiConverterUInt32.read(from),
+        sourceMadeAt: FfiConverterOptionalFloat64.read(from),
+        metaJson: FfiConverterOptionalString.read(from),
+        sourceTxId: FfiConverterOptionalTypeSourceTxId.read(from),
+      };
+    }
+    write(value: TypeName, into: RustBuffer): void {
+      FfiConverterString.write(value.sessionId, into);
+      FfiConverterUInt32.write(value.txIndex, into);
+      FfiConverterOptionalFloat64.write(value.sourceMadeAt, into);
+      FfiConverterOptionalString.write(value.metaJson, into);
+      FfiConverterOptionalTypeSourceTxId.write(value.sourceTxId, into);
+    }
+    allocationSize(value: TypeName): number {
+      return (
+        FfiConverterString.allocationSize(value.sessionId) +
+        FfiConverterUInt32.allocationSize(value.txIndex) +
+        FfiConverterOptionalFloat64.allocationSize(value.sourceMadeAt) +
+        FfiConverterOptionalString.allocationSize(value.metaJson) +
+        FfiConverterOptionalTypeSourceTxId.allocationSize(value.sourceTxId)
+      );
+    }
+  }
+  return new FFIConverter();
+})();
+
+/**
+ * A merged transaction's source identity, mirroring the `(session_id,
+ * tx_index)` tuple carried by `PendingTxIn::source_tx_id` on the Rust side.
+ * Plain camelCase on the generated TS side (uniffi lower-cases record field
+ * names the same way napi objects do) — unlike the JSON wire format used
+ * elsewhere in this codebase (`TransactionID`'s `sessionID`), uniffi records
+ * bypass serde entirely, so there is no `#[serde(rename)]` to apply here.
+ * The TS adapter (added in a later task) is responsible for bridging its
+ * `sessionID`-cased public type to this `sessionId`-cased record.
+ */
+export type SourceTxId = {
+  sessionId: string;
+  txIndex: /*u32*/ number;
+};
+
+/**
+ * Generated factory for {@link SourceTxId} record objects.
+ */
+export const SourceTxId = (() => {
+  const defaults = () => ({});
+  const create = (() => {
+    return uniffiCreateRecord<SourceTxId, ReturnType<typeof defaults>>(
+      defaults
+    );
+  })();
+  return Object.freeze({
+    /**
+     * Create a frozen instance of {@link SourceTxId}, with defaults specified
+     * in Rust, in the {@link cojson_core_rn} crate.
+     */
+    create,
+
+    /**
+     * Create a frozen instance of {@link SourceTxId}, with defaults specified
+     * in Rust, in the {@link cojson_core_rn} crate.
+     */
+    new: create,
+
+    /**
+     * Defaults specified in the {@link cojson_core_rn} crate.
+     */
+    defaults: () => Object.freeze(defaults()) as Partial<SourceTxId>,
+  });
+})();
+
+const FfiConverterTypeSourceTxId = (() => {
+  type TypeName = SourceTxId;
+  class FFIConverter extends AbstractFfiConverterByteArray<TypeName> {
+    read(from: RustBuffer): TypeName {
+      return {
+        sessionId: FfiConverterString.read(from),
+        txIndex: FfiConverterUInt32.read(from),
+      };
+    }
+    write(value: TypeName, into: RustBuffer): void {
+      FfiConverterString.write(value.sessionId, into);
+      FfiConverterUInt32.write(value.txIndex, into);
+    }
+    allocationSize(value: TypeName): number {
+      return (
+        FfiConverterString.allocationSize(value.sessionId) +
+        FfiConverterUInt32.allocationSize(value.txIndex)
       );
     }
   }
@@ -1598,6 +1816,19 @@ export const SessionMapError = (() => {
     inner: Readonly<[string]>;
   };
 
+  /**
+   * Wraps any inner `cojson-core` error's `Display` output VERBATIM — no
+   * added prefix. This is load-bearing once `NodeCore` (node_core.rs)
+   * reuses this same variant for its registry-lookup errors: TS-side error
+   * translation does `message.startsWith("CoValue not loaded: ")`
+   * (packages/cojson/src/permissions.ts:322) and matches `"Unknown CoValue: "`
+   * similarly, so a wrapped format like the previous `"SessionMap error: {0}"`
+   * would silently break that match by shifting the prefix. Kept as a plain
+   * format string rather than `#[error(transparent)]`, since `String` doesn't
+   * implement `std::error::Error`; kept as one variant rather than adding a
+   * parallel one, since nothing in the tree depended on the old
+   * "SessionMap error: " prefix text.
+   */
   class Internal_ extends UniffiError implements Internal__interface {
     /**
      * @private
@@ -1891,6 +2122,945 @@ const uniffiTypeBlake3HasherObjectFactory: UniffiObjectFactory<Blake3HasherInter
 // FfiConverter for Blake3HasherInterface
 const FfiConverterTypeBlake3Hasher = new FfiConverterObject(
   uniffiTypeBlake3HasherObjectFactory
+);
+
+export interface NodeCoreInterface {
+  /**
+   * Add transactions to a session
+   */
+  addTransactions(
+    coId: string,
+    sessionId: string,
+    signerId: string | undefined,
+    transactionsJson: string,
+    signature: string,
+    skipVerify: boolean
+  ) /*throws*/ : void;
+  coValueCount() /*throws*/ : /*u32*/ number;
+  /**
+   * Creates or replaces; replacing drops the previous session state.
+   * Mirrors TS semantics where constructing a new VerifiedState for an
+   * already-known id creates a fresh SessionMap.
+   */
+  createCoValue(
+    coId: string,
+    headerJson: string,
+    maxTxSize: /*u32*/ number | undefined,
+    skipVerify: boolean | undefined
+  ) /*throws*/ : void;
+  /**
+   * Decrypt transaction changes
+   */
+  decryptTransaction(
+    coId: string,
+    sessionId: string,
+    txIndex: /*u32*/ number,
+    keySecret: string
+  ) /*throws*/ : string | undefined;
+  /**
+   * Decrypt transaction meta
+   */
+  decryptTransactionMeta(
+    coId: string,
+    sessionId: string,
+    txIndex: /*u32*/ number,
+    keySecret: string
+  ) /*throws*/ : string | undefined;
+  /**
+   * Get the header as JSON
+   */
+  getHeader(coId: string) /*throws*/ : string;
+  /**
+   * Get the known state as a native Record
+   */
+  getKnownState(coId: string) /*throws*/ : KnownState;
+  /**
+   * Get the known state with streaming as a native Record
+   */
+  getKnownStateWithStreaming(coId: string) /*throws*/ : KnownState | undefined;
+  /**
+   * Get last signature for a session (returns None if session not found)
+   */
+  getLastSignature(
+    coId: string,
+    sessionId: string
+  ) /*throws*/ : string | undefined;
+  /**
+   * Get the last signature checkpoint index (-1 if no checkpoints, None if session not found)
+   */
+  getLastSignatureCheckpoint(
+    coId: string,
+    sessionId: string
+  ) /*throws*/ : /*i32*/ number | undefined;
+  /**
+   * Get all session IDs as native array
+   */
+  getSessionIds(coId: string) /*throws*/ : Array<string>;
+  /**
+   * Get transactions for a session from index as JSON strings (returns None if session not found)
+   */
+  getSessionTransactions(
+    coId: string,
+    sessionId: string,
+    fromIndex: /*u32*/ number
+  ) /*throws*/ : Array<string> | undefined;
+  /**
+   * Get signature after specific transaction index
+   */
+  getSignatureAfter(
+    coId: string,
+    sessionId: string,
+    txIndex: /*u32*/ number
+  ) /*throws*/ : string | undefined;
+  /**
+   * Get single transaction by index as JSON string (returns None if not found)
+   */
+  getTransaction(
+    coId: string,
+    sessionId: string,
+    txIndex: /*u32*/ number
+  ) /*throws*/ : string | undefined;
+  /**
+   * Get transaction count for a session (returns -1 if session not found)
+   */
+  getTransactionCount(
+    coId: string,
+    sessionId: string
+  ) /*throws*/ : /*i32*/ number;
+  hasCoValue(coId: string) /*throws*/ : boolean;
+  /**
+   * Check if this CoValue is deleted
+   */
+  isDeleted(coId: string) /*throws*/ : boolean;
+  /**
+   * Check whether the CoValue still has pending streaming content.
+   */
+  isStreaming(coId: string) /*throws*/ : boolean;
+  /**
+   * Create new private transaction (for local writes)
+   * Returns JSON: { signature: string, transaction: Transaction }
+   */
+  makeNewPrivateTransaction(
+    coId: string,
+    sessionId: string,
+    signerSecret: string,
+    changesJson: string,
+    keyId: string,
+    keySecret: string,
+    metaJson: string | undefined,
+    madeAt: /*f64*/ number
+  ) /*throws*/ : string;
+  /**
+   * Create new trusting transaction (for local writes)
+   * Returns JSON: { signature: string, transaction: Transaction }
+   */
+  makeNewTrustingTransaction(
+    coId: string,
+    sessionId: string,
+    signerSecret: string,
+    changesJson: string,
+    metaJson: string | undefined,
+    madeAt: /*f64*/ number
+  ) /*throws*/ : string;
+  /**
+   * Mark this CoValue as deleted
+   */
+  markAsDeleted(coId: string) /*throws*/ : void;
+  removeCoValue(coId: string) /*throws*/ : boolean;
+  /**
+   * Drop the cached validation engine for `co_id`, forcing a full recompute
+   * on the next `validate_transactions` / `role_of`. An absent `co_id` is a
+   * no-op (not `UnknownCoValue`): callers invoke this on dependants that may
+   * never have been registered on this node, so erroring would be hostile.
+   */
+  resetValidation(coId: string) /*throws*/ : void;
+  /**
+   * Role of member in group at time (ms). Returns the role string or None.
+   * Throws "Unknown CoValue: <id>" if `group_id` itself is not registered,
+   * and "CoValue not loaded: <id>" if a parent group / owning account is
+   * missing.
+   */
+  roleOf(
+    groupId: string,
+    member: string,
+    atTime: /*f64*/ number | undefined
+  ) /*throws*/ : string | undefined;
+  /**
+   * Set streaming known state
+   */
+  setStreamingKnownState(coId: string, streamingJson: string) /*throws*/ : void;
+  /**
+   * Validate a group/account CoValue; verdicts for ALL its transactions in
+   * validation order.
+   * Throws "Unknown CoValue: <id>" if `co_id` itself is not registered, and
+   * "CoValue not loaded: <id>" if a dependency (parent group / owning
+   * account) is missing.
+   */
+  validateTransactions(
+    coId: string,
+    pending: Array<PendingTx>
+  ) /*throws*/ : Array<GroupVerdict>;
+}
+
+export class NodeCore
+  extends UniffiAbstractObject
+  implements NodeCoreInterface
+{
+  readonly [uniffiTypeNameSymbol] = 'NodeCore';
+  readonly [destructorGuardSymbol]: UniffiRustArcPtr;
+  readonly [pointerLiteralSymbol]: UnsafeMutableRawPointer;
+  /**
+   * Create a new empty NodeCore registry (one LocalNode owns one instance).
+   */
+  constructor() {
+    super();
+    const pointer = uniffiCaller.rustCall(
+      /*caller:*/ (callStatus) => {
+        return nativeModule().ubrn_uniffi_cojson_core_rn_fn_constructor_nodecore_new(
+          callStatus
+        );
+      },
+      /*liftString:*/ FfiConverterString.lift
+    );
+    this[pointerLiteralSymbol] = pointer;
+    this[destructorGuardSymbol] =
+      uniffiTypeNodeCoreObjectFactory.bless(pointer);
+  }
+
+  /**
+   * Add transactions to a session
+   */
+  public addTransactions(
+    coId: string,
+    sessionId: string,
+    signerId: string | undefined,
+    transactionsJson: string,
+    signature: string,
+    skipVerify: boolean
+  ): void /*throws*/ {
+    uniffiCaller.rustCallWithError(
+      /*liftError:*/ FfiConverterTypeSessionMapError.lift.bind(
+        FfiConverterTypeSessionMapError
+      ),
+      /*caller:*/ (callStatus) => {
+        nativeModule().ubrn_uniffi_cojson_core_rn_fn_method_nodecore_add_transactions(
+          uniffiTypeNodeCoreObjectFactory.clonePointer(this),
+          FfiConverterString.lower(coId),
+          FfiConverterString.lower(sessionId),
+          FfiConverterOptionalString.lower(signerId),
+          FfiConverterString.lower(transactionsJson),
+          FfiConverterString.lower(signature),
+          FfiConverterBool.lower(skipVerify),
+          callStatus
+        );
+      },
+      /*liftString:*/ FfiConverterString.lift
+    );
+  }
+
+  public coValueCount(): /*u32*/ number /*throws*/ {
+    return FfiConverterUInt32.lift(
+      uniffiCaller.rustCallWithError(
+        /*liftError:*/ FfiConverterTypeSessionMapError.lift.bind(
+          FfiConverterTypeSessionMapError
+        ),
+        /*caller:*/ (callStatus) => {
+          return nativeModule().ubrn_uniffi_cojson_core_rn_fn_method_nodecore_co_value_count(
+            uniffiTypeNodeCoreObjectFactory.clonePointer(this),
+            callStatus
+          );
+        },
+        /*liftString:*/ FfiConverterString.lift
+      )
+    );
+  }
+
+  /**
+   * Creates or replaces; replacing drops the previous session state.
+   * Mirrors TS semantics where constructing a new VerifiedState for an
+   * already-known id creates a fresh SessionMap.
+   */
+  public createCoValue(
+    coId: string,
+    headerJson: string,
+    maxTxSize: /*u32*/ number | undefined,
+    skipVerify: boolean | undefined
+  ): void /*throws*/ {
+    uniffiCaller.rustCallWithError(
+      /*liftError:*/ FfiConverterTypeSessionMapError.lift.bind(
+        FfiConverterTypeSessionMapError
+      ),
+      /*caller:*/ (callStatus) => {
+        nativeModule().ubrn_uniffi_cojson_core_rn_fn_method_nodecore_create_co_value(
+          uniffiTypeNodeCoreObjectFactory.clonePointer(this),
+          FfiConverterString.lower(coId),
+          FfiConverterString.lower(headerJson),
+          FfiConverterOptionalUInt32.lower(maxTxSize),
+          FfiConverterOptionalBool.lower(skipVerify),
+          callStatus
+        );
+      },
+      /*liftString:*/ FfiConverterString.lift
+    );
+  }
+
+  /**
+   * Decrypt transaction changes
+   */
+  public decryptTransaction(
+    coId: string,
+    sessionId: string,
+    txIndex: /*u32*/ number,
+    keySecret: string
+  ): string | undefined /*throws*/ {
+    return FfiConverterOptionalString.lift(
+      uniffiCaller.rustCallWithError(
+        /*liftError:*/ FfiConverterTypeSessionMapError.lift.bind(
+          FfiConverterTypeSessionMapError
+        ),
+        /*caller:*/ (callStatus) => {
+          return nativeModule().ubrn_uniffi_cojson_core_rn_fn_method_nodecore_decrypt_transaction(
+            uniffiTypeNodeCoreObjectFactory.clonePointer(this),
+            FfiConverterString.lower(coId),
+            FfiConverterString.lower(sessionId),
+            FfiConverterUInt32.lower(txIndex),
+            FfiConverterString.lower(keySecret),
+            callStatus
+          );
+        },
+        /*liftString:*/ FfiConverterString.lift
+      )
+    );
+  }
+
+  /**
+   * Decrypt transaction meta
+   */
+  public decryptTransactionMeta(
+    coId: string,
+    sessionId: string,
+    txIndex: /*u32*/ number,
+    keySecret: string
+  ): string | undefined /*throws*/ {
+    return FfiConverterOptionalString.lift(
+      uniffiCaller.rustCallWithError(
+        /*liftError:*/ FfiConverterTypeSessionMapError.lift.bind(
+          FfiConverterTypeSessionMapError
+        ),
+        /*caller:*/ (callStatus) => {
+          return nativeModule().ubrn_uniffi_cojson_core_rn_fn_method_nodecore_decrypt_transaction_meta(
+            uniffiTypeNodeCoreObjectFactory.clonePointer(this),
+            FfiConverterString.lower(coId),
+            FfiConverterString.lower(sessionId),
+            FfiConverterUInt32.lower(txIndex),
+            FfiConverterString.lower(keySecret),
+            callStatus
+          );
+        },
+        /*liftString:*/ FfiConverterString.lift
+      )
+    );
+  }
+
+  /**
+   * Get the header as JSON
+   */
+  public getHeader(coId: string): string /*throws*/ {
+    return FfiConverterString.lift(
+      uniffiCaller.rustCallWithError(
+        /*liftError:*/ FfiConverterTypeSessionMapError.lift.bind(
+          FfiConverterTypeSessionMapError
+        ),
+        /*caller:*/ (callStatus) => {
+          return nativeModule().ubrn_uniffi_cojson_core_rn_fn_method_nodecore_get_header(
+            uniffiTypeNodeCoreObjectFactory.clonePointer(this),
+            FfiConverterString.lower(coId),
+            callStatus
+          );
+        },
+        /*liftString:*/ FfiConverterString.lift
+      )
+    );
+  }
+
+  /**
+   * Get the known state as a native Record
+   */
+  public getKnownState(coId: string): KnownState /*throws*/ {
+    return FfiConverterTypeKnownState.lift(
+      uniffiCaller.rustCallWithError(
+        /*liftError:*/ FfiConverterTypeSessionMapError.lift.bind(
+          FfiConverterTypeSessionMapError
+        ),
+        /*caller:*/ (callStatus) => {
+          return nativeModule().ubrn_uniffi_cojson_core_rn_fn_method_nodecore_get_known_state(
+            uniffiTypeNodeCoreObjectFactory.clonePointer(this),
+            FfiConverterString.lower(coId),
+            callStatus
+          );
+        },
+        /*liftString:*/ FfiConverterString.lift
+      )
+    );
+  }
+
+  /**
+   * Get the known state with streaming as a native Record
+   */
+  public getKnownStateWithStreaming(
+    coId: string
+  ): KnownState | undefined /*throws*/ {
+    return FfiConverterOptionalTypeKnownState.lift(
+      uniffiCaller.rustCallWithError(
+        /*liftError:*/ FfiConverterTypeSessionMapError.lift.bind(
+          FfiConverterTypeSessionMapError
+        ),
+        /*caller:*/ (callStatus) => {
+          return nativeModule().ubrn_uniffi_cojson_core_rn_fn_method_nodecore_get_known_state_with_streaming(
+            uniffiTypeNodeCoreObjectFactory.clonePointer(this),
+            FfiConverterString.lower(coId),
+            callStatus
+          );
+        },
+        /*liftString:*/ FfiConverterString.lift
+      )
+    );
+  }
+
+  /**
+   * Get last signature for a session (returns None if session not found)
+   */
+  public getLastSignature(
+    coId: string,
+    sessionId: string
+  ): string | undefined /*throws*/ {
+    return FfiConverterOptionalString.lift(
+      uniffiCaller.rustCallWithError(
+        /*liftError:*/ FfiConverterTypeSessionMapError.lift.bind(
+          FfiConverterTypeSessionMapError
+        ),
+        /*caller:*/ (callStatus) => {
+          return nativeModule().ubrn_uniffi_cojson_core_rn_fn_method_nodecore_get_last_signature(
+            uniffiTypeNodeCoreObjectFactory.clonePointer(this),
+            FfiConverterString.lower(coId),
+            FfiConverterString.lower(sessionId),
+            callStatus
+          );
+        },
+        /*liftString:*/ FfiConverterString.lift
+      )
+    );
+  }
+
+  /**
+   * Get the last signature checkpoint index (-1 if no checkpoints, None if session not found)
+   */
+  public getLastSignatureCheckpoint(
+    coId: string,
+    sessionId: string
+  ): /*i32*/ number | undefined /*throws*/ {
+    return FfiConverterOptionalInt32.lift(
+      uniffiCaller.rustCallWithError(
+        /*liftError:*/ FfiConverterTypeSessionMapError.lift.bind(
+          FfiConverterTypeSessionMapError
+        ),
+        /*caller:*/ (callStatus) => {
+          return nativeModule().ubrn_uniffi_cojson_core_rn_fn_method_nodecore_get_last_signature_checkpoint(
+            uniffiTypeNodeCoreObjectFactory.clonePointer(this),
+            FfiConverterString.lower(coId),
+            FfiConverterString.lower(sessionId),
+            callStatus
+          );
+        },
+        /*liftString:*/ FfiConverterString.lift
+      )
+    );
+  }
+
+  /**
+   * Get all session IDs as native array
+   */
+  public getSessionIds(coId: string): Array<string> /*throws*/ {
+    return FfiConverterArrayString.lift(
+      uniffiCaller.rustCallWithError(
+        /*liftError:*/ FfiConverterTypeSessionMapError.lift.bind(
+          FfiConverterTypeSessionMapError
+        ),
+        /*caller:*/ (callStatus) => {
+          return nativeModule().ubrn_uniffi_cojson_core_rn_fn_method_nodecore_get_session_ids(
+            uniffiTypeNodeCoreObjectFactory.clonePointer(this),
+            FfiConverterString.lower(coId),
+            callStatus
+          );
+        },
+        /*liftString:*/ FfiConverterString.lift
+      )
+    );
+  }
+
+  /**
+   * Get transactions for a session from index as JSON strings (returns None if session not found)
+   */
+  public getSessionTransactions(
+    coId: string,
+    sessionId: string,
+    fromIndex: /*u32*/ number
+  ): Array<string> | undefined /*throws*/ {
+    return FfiConverterOptionalArrayString.lift(
+      uniffiCaller.rustCallWithError(
+        /*liftError:*/ FfiConverterTypeSessionMapError.lift.bind(
+          FfiConverterTypeSessionMapError
+        ),
+        /*caller:*/ (callStatus) => {
+          return nativeModule().ubrn_uniffi_cojson_core_rn_fn_method_nodecore_get_session_transactions(
+            uniffiTypeNodeCoreObjectFactory.clonePointer(this),
+            FfiConverterString.lower(coId),
+            FfiConverterString.lower(sessionId),
+            FfiConverterUInt32.lower(fromIndex),
+            callStatus
+          );
+        },
+        /*liftString:*/ FfiConverterString.lift
+      )
+    );
+  }
+
+  /**
+   * Get signature after specific transaction index
+   */
+  public getSignatureAfter(
+    coId: string,
+    sessionId: string,
+    txIndex: /*u32*/ number
+  ): string | undefined /*throws*/ {
+    return FfiConverterOptionalString.lift(
+      uniffiCaller.rustCallWithError(
+        /*liftError:*/ FfiConverterTypeSessionMapError.lift.bind(
+          FfiConverterTypeSessionMapError
+        ),
+        /*caller:*/ (callStatus) => {
+          return nativeModule().ubrn_uniffi_cojson_core_rn_fn_method_nodecore_get_signature_after(
+            uniffiTypeNodeCoreObjectFactory.clonePointer(this),
+            FfiConverterString.lower(coId),
+            FfiConverterString.lower(sessionId),
+            FfiConverterUInt32.lower(txIndex),
+            callStatus
+          );
+        },
+        /*liftString:*/ FfiConverterString.lift
+      )
+    );
+  }
+
+  /**
+   * Get single transaction by index as JSON string (returns None if not found)
+   */
+  public getTransaction(
+    coId: string,
+    sessionId: string,
+    txIndex: /*u32*/ number
+  ): string | undefined /*throws*/ {
+    return FfiConverterOptionalString.lift(
+      uniffiCaller.rustCallWithError(
+        /*liftError:*/ FfiConverterTypeSessionMapError.lift.bind(
+          FfiConverterTypeSessionMapError
+        ),
+        /*caller:*/ (callStatus) => {
+          return nativeModule().ubrn_uniffi_cojson_core_rn_fn_method_nodecore_get_transaction(
+            uniffiTypeNodeCoreObjectFactory.clonePointer(this),
+            FfiConverterString.lower(coId),
+            FfiConverterString.lower(sessionId),
+            FfiConverterUInt32.lower(txIndex),
+            callStatus
+          );
+        },
+        /*liftString:*/ FfiConverterString.lift
+      )
+    );
+  }
+
+  /**
+   * Get transaction count for a session (returns -1 if session not found)
+   */
+  public getTransactionCount(
+    coId: string,
+    sessionId: string
+  ): /*i32*/ number /*throws*/ {
+    return FfiConverterInt32.lift(
+      uniffiCaller.rustCallWithError(
+        /*liftError:*/ FfiConverterTypeSessionMapError.lift.bind(
+          FfiConverterTypeSessionMapError
+        ),
+        /*caller:*/ (callStatus) => {
+          return nativeModule().ubrn_uniffi_cojson_core_rn_fn_method_nodecore_get_transaction_count(
+            uniffiTypeNodeCoreObjectFactory.clonePointer(this),
+            FfiConverterString.lower(coId),
+            FfiConverterString.lower(sessionId),
+            callStatus
+          );
+        },
+        /*liftString:*/ FfiConverterString.lift
+      )
+    );
+  }
+
+  public hasCoValue(coId: string): boolean /*throws*/ {
+    return FfiConverterBool.lift(
+      uniffiCaller.rustCallWithError(
+        /*liftError:*/ FfiConverterTypeSessionMapError.lift.bind(
+          FfiConverterTypeSessionMapError
+        ),
+        /*caller:*/ (callStatus) => {
+          return nativeModule().ubrn_uniffi_cojson_core_rn_fn_method_nodecore_has_co_value(
+            uniffiTypeNodeCoreObjectFactory.clonePointer(this),
+            FfiConverterString.lower(coId),
+            callStatus
+          );
+        },
+        /*liftString:*/ FfiConverterString.lift
+      )
+    );
+  }
+
+  /**
+   * Check if this CoValue is deleted
+   */
+  public isDeleted(coId: string): boolean /*throws*/ {
+    return FfiConverterBool.lift(
+      uniffiCaller.rustCallWithError(
+        /*liftError:*/ FfiConverterTypeSessionMapError.lift.bind(
+          FfiConverterTypeSessionMapError
+        ),
+        /*caller:*/ (callStatus) => {
+          return nativeModule().ubrn_uniffi_cojson_core_rn_fn_method_nodecore_is_deleted(
+            uniffiTypeNodeCoreObjectFactory.clonePointer(this),
+            FfiConverterString.lower(coId),
+            callStatus
+          );
+        },
+        /*liftString:*/ FfiConverterString.lift
+      )
+    );
+  }
+
+  /**
+   * Check whether the CoValue still has pending streaming content.
+   */
+  public isStreaming(coId: string): boolean /*throws*/ {
+    return FfiConverterBool.lift(
+      uniffiCaller.rustCallWithError(
+        /*liftError:*/ FfiConverterTypeSessionMapError.lift.bind(
+          FfiConverterTypeSessionMapError
+        ),
+        /*caller:*/ (callStatus) => {
+          return nativeModule().ubrn_uniffi_cojson_core_rn_fn_method_nodecore_is_streaming(
+            uniffiTypeNodeCoreObjectFactory.clonePointer(this),
+            FfiConverterString.lower(coId),
+            callStatus
+          );
+        },
+        /*liftString:*/ FfiConverterString.lift
+      )
+    );
+  }
+
+  /**
+   * Create new private transaction (for local writes)
+   * Returns JSON: { signature: string, transaction: Transaction }
+   */
+  public makeNewPrivateTransaction(
+    coId: string,
+    sessionId: string,
+    signerSecret: string,
+    changesJson: string,
+    keyId: string,
+    keySecret: string,
+    metaJson: string | undefined,
+    madeAt: /*f64*/ number
+  ): string /*throws*/ {
+    return FfiConverterString.lift(
+      uniffiCaller.rustCallWithError(
+        /*liftError:*/ FfiConverterTypeSessionMapError.lift.bind(
+          FfiConverterTypeSessionMapError
+        ),
+        /*caller:*/ (callStatus) => {
+          return nativeModule().ubrn_uniffi_cojson_core_rn_fn_method_nodecore_make_new_private_transaction(
+            uniffiTypeNodeCoreObjectFactory.clonePointer(this),
+            FfiConverterString.lower(coId),
+            FfiConverterString.lower(sessionId),
+            FfiConverterString.lower(signerSecret),
+            FfiConverterString.lower(changesJson),
+            FfiConverterString.lower(keyId),
+            FfiConverterString.lower(keySecret),
+            FfiConverterOptionalString.lower(metaJson),
+            FfiConverterFloat64.lower(madeAt),
+            callStatus
+          );
+        },
+        /*liftString:*/ FfiConverterString.lift
+      )
+    );
+  }
+
+  /**
+   * Create new trusting transaction (for local writes)
+   * Returns JSON: { signature: string, transaction: Transaction }
+   */
+  public makeNewTrustingTransaction(
+    coId: string,
+    sessionId: string,
+    signerSecret: string,
+    changesJson: string,
+    metaJson: string | undefined,
+    madeAt: /*f64*/ number
+  ): string /*throws*/ {
+    return FfiConverterString.lift(
+      uniffiCaller.rustCallWithError(
+        /*liftError:*/ FfiConverterTypeSessionMapError.lift.bind(
+          FfiConverterTypeSessionMapError
+        ),
+        /*caller:*/ (callStatus) => {
+          return nativeModule().ubrn_uniffi_cojson_core_rn_fn_method_nodecore_make_new_trusting_transaction(
+            uniffiTypeNodeCoreObjectFactory.clonePointer(this),
+            FfiConverterString.lower(coId),
+            FfiConverterString.lower(sessionId),
+            FfiConverterString.lower(signerSecret),
+            FfiConverterString.lower(changesJson),
+            FfiConverterOptionalString.lower(metaJson),
+            FfiConverterFloat64.lower(madeAt),
+            callStatus
+          );
+        },
+        /*liftString:*/ FfiConverterString.lift
+      )
+    );
+  }
+
+  /**
+   * Mark this CoValue as deleted
+   */
+  public markAsDeleted(coId: string): void /*throws*/ {
+    uniffiCaller.rustCallWithError(
+      /*liftError:*/ FfiConverterTypeSessionMapError.lift.bind(
+        FfiConverterTypeSessionMapError
+      ),
+      /*caller:*/ (callStatus) => {
+        nativeModule().ubrn_uniffi_cojson_core_rn_fn_method_nodecore_mark_as_deleted(
+          uniffiTypeNodeCoreObjectFactory.clonePointer(this),
+          FfiConverterString.lower(coId),
+          callStatus
+        );
+      },
+      /*liftString:*/ FfiConverterString.lift
+    );
+  }
+
+  public removeCoValue(coId: string): boolean /*throws*/ {
+    return FfiConverterBool.lift(
+      uniffiCaller.rustCallWithError(
+        /*liftError:*/ FfiConverterTypeSessionMapError.lift.bind(
+          FfiConverterTypeSessionMapError
+        ),
+        /*caller:*/ (callStatus) => {
+          return nativeModule().ubrn_uniffi_cojson_core_rn_fn_method_nodecore_remove_co_value(
+            uniffiTypeNodeCoreObjectFactory.clonePointer(this),
+            FfiConverterString.lower(coId),
+            callStatus
+          );
+        },
+        /*liftString:*/ FfiConverterString.lift
+      )
+    );
+  }
+
+  /**
+   * Drop the cached validation engine for `co_id`, forcing a full recompute
+   * on the next `validate_transactions` / `role_of`. An absent `co_id` is a
+   * no-op (not `UnknownCoValue`): callers invoke this on dependants that may
+   * never have been registered on this node, so erroring would be hostile.
+   */
+  public resetValidation(coId: string): void /*throws*/ {
+    uniffiCaller.rustCallWithError(
+      /*liftError:*/ FfiConverterTypeSessionMapError.lift.bind(
+        FfiConverterTypeSessionMapError
+      ),
+      /*caller:*/ (callStatus) => {
+        nativeModule().ubrn_uniffi_cojson_core_rn_fn_method_nodecore_reset_validation(
+          uniffiTypeNodeCoreObjectFactory.clonePointer(this),
+          FfiConverterString.lower(coId),
+          callStatus
+        );
+      },
+      /*liftString:*/ FfiConverterString.lift
+    );
+  }
+
+  /**
+   * Role of member in group at time (ms). Returns the role string or None.
+   * Throws "Unknown CoValue: <id>" if `group_id` itself is not registered,
+   * and "CoValue not loaded: <id>" if a parent group / owning account is
+   * missing.
+   */
+  public roleOf(
+    groupId: string,
+    member: string,
+    atTime: /*f64*/ number | undefined
+  ): string | undefined /*throws*/ {
+    return FfiConverterOptionalString.lift(
+      uniffiCaller.rustCallWithError(
+        /*liftError:*/ FfiConverterTypeSessionMapError.lift.bind(
+          FfiConverterTypeSessionMapError
+        ),
+        /*caller:*/ (callStatus) => {
+          return nativeModule().ubrn_uniffi_cojson_core_rn_fn_method_nodecore_role_of(
+            uniffiTypeNodeCoreObjectFactory.clonePointer(this),
+            FfiConverterString.lower(groupId),
+            FfiConverterString.lower(member),
+            FfiConverterOptionalFloat64.lower(atTime),
+            callStatus
+          );
+        },
+        /*liftString:*/ FfiConverterString.lift
+      )
+    );
+  }
+
+  /**
+   * Set streaming known state
+   */
+  public setStreamingKnownState(
+    coId: string,
+    streamingJson: string
+  ): void /*throws*/ {
+    uniffiCaller.rustCallWithError(
+      /*liftError:*/ FfiConverterTypeSessionMapError.lift.bind(
+        FfiConverterTypeSessionMapError
+      ),
+      /*caller:*/ (callStatus) => {
+        nativeModule().ubrn_uniffi_cojson_core_rn_fn_method_nodecore_set_streaming_known_state(
+          uniffiTypeNodeCoreObjectFactory.clonePointer(this),
+          FfiConverterString.lower(coId),
+          FfiConverterString.lower(streamingJson),
+          callStatus
+        );
+      },
+      /*liftString:*/ FfiConverterString.lift
+    );
+  }
+
+  /**
+   * Validate a group/account CoValue; verdicts for ALL its transactions in
+   * validation order.
+   * Throws "Unknown CoValue: <id>" if `co_id` itself is not registered, and
+   * "CoValue not loaded: <id>" if a dependency (parent group / owning
+   * account) is missing.
+   */
+  public validateTransactions(
+    coId: string,
+    pending: Array<PendingTx>
+  ): Array<GroupVerdict> /*throws*/ {
+    return FfiConverterArrayTypeGroupVerdict.lift(
+      uniffiCaller.rustCallWithError(
+        /*liftError:*/ FfiConverterTypeSessionMapError.lift.bind(
+          FfiConverterTypeSessionMapError
+        ),
+        /*caller:*/ (callStatus) => {
+          return nativeModule().ubrn_uniffi_cojson_core_rn_fn_method_nodecore_validate_transactions(
+            uniffiTypeNodeCoreObjectFactory.clonePointer(this),
+            FfiConverterString.lower(coId),
+            FfiConverterArrayTypePendingTx.lower(pending),
+            callStatus
+          );
+        },
+        /*liftString:*/ FfiConverterString.lift
+      )
+    );
+  }
+
+  /**
+   * {@inheritDoc uniffi-bindgen-react-native#UniffiAbstractObject.uniffiDestroy}
+   */
+  uniffiDestroy(): void {
+    const ptr = (this as any)[destructorGuardSymbol];
+    if (ptr !== undefined) {
+      const pointer = uniffiTypeNodeCoreObjectFactory.pointer(this);
+      uniffiTypeNodeCoreObjectFactory.freePointer(pointer);
+      uniffiTypeNodeCoreObjectFactory.unbless(ptr);
+      delete (this as any)[destructorGuardSymbol];
+    }
+  }
+
+  static instanceOf(obj: any): obj is NodeCore {
+    return uniffiTypeNodeCoreObjectFactory.isConcreteType(obj);
+  }
+}
+
+const uniffiTypeNodeCoreObjectFactory: UniffiObjectFactory<NodeCoreInterface> =
+  (() => {
+    return {
+      create(pointer: UnsafeMutableRawPointer): NodeCoreInterface {
+        const instance = Object.create(NodeCore.prototype);
+        instance[pointerLiteralSymbol] = pointer;
+        instance[destructorGuardSymbol] = this.bless(pointer);
+        instance[uniffiTypeNameSymbol] = 'NodeCore';
+        return instance;
+      },
+
+      bless(p: UnsafeMutableRawPointer): UniffiRustArcPtr {
+        return uniffiCaller.rustCall(
+          /*caller:*/ (status) =>
+            nativeModule().ubrn_uniffi_internal_fn_method_nodecore_ffi__bless_pointer(
+              p,
+              status
+            ),
+          /*liftString:*/ FfiConverterString.lift
+        );
+      },
+
+      unbless(ptr: UniffiRustArcPtr) {
+        ptr.markDestroyed();
+      },
+
+      pointer(obj: NodeCoreInterface): UnsafeMutableRawPointer {
+        if ((obj as any)[destructorGuardSymbol] === undefined) {
+          throw new UniffiInternalError.UnexpectedNullPointer();
+        }
+        return (obj as any)[pointerLiteralSymbol];
+      },
+
+      clonePointer(obj: NodeCoreInterface): UnsafeMutableRawPointer {
+        const pointer = this.pointer(obj);
+        return uniffiCaller.rustCall(
+          /*caller:*/ (callStatus) =>
+            nativeModule().ubrn_uniffi_cojson_core_rn_fn_clone_nodecore(
+              pointer,
+              callStatus
+            ),
+          /*liftString:*/ FfiConverterString.lift
+        );
+      },
+
+      freePointer(pointer: UnsafeMutableRawPointer): void {
+        uniffiCaller.rustCall(
+          /*caller:*/ (callStatus) =>
+            nativeModule().ubrn_uniffi_cojson_core_rn_fn_free_nodecore(
+              pointer,
+              callStatus
+            ),
+          /*liftString:*/ FfiConverterString.lift
+        );
+      },
+
+      isConcreteType(obj: any): obj is NodeCoreInterface {
+        return (
+          obj[destructorGuardSymbol] && obj[uniffiTypeNameSymbol] === 'NodeCore'
+        );
+      },
+    };
+  })();
+// FfiConverter for NodeCoreInterface
+const FfiConverterTypeNodeCore = new FfiConverterObject(
+  uniffiTypeNodeCoreObjectFactory
 );
 
 export interface SessionMapInterface {
@@ -2592,6 +3762,11 @@ const FfiConverterTypeSessionMap = new FfiConverterObject(
 // FfiConverter for boolean | undefined
 const FfiConverterOptionalBool = new FfiConverterOptional(FfiConverterBool);
 
+// FfiConverter for /*f64*/number | undefined
+const FfiConverterOptionalFloat64 = new FfiConverterOptional(
+  FfiConverterFloat64
+);
+
 // FfiConverter for /*i32*/number | undefined
 const FfiConverterOptionalInt32 = new FfiConverterOptional(FfiConverterInt32);
 
@@ -2600,11 +3775,26 @@ const FfiConverterOptionalTypeKnownState = new FfiConverterOptional(
   FfiConverterTypeKnownState
 );
 
+// FfiConverter for SourceTxId | undefined
+const FfiConverterOptionalTypeSourceTxId = new FfiConverterOptional(
+  FfiConverterTypeSourceTxId
+);
+
 // FfiConverter for string | undefined
 const FfiConverterOptionalString = new FfiConverterOptional(FfiConverterString);
 
 // FfiConverter for /*u32*/number | undefined
 const FfiConverterOptionalUInt32 = new FfiConverterOptional(FfiConverterUInt32);
+
+// FfiConverter for Array<GroupVerdict>
+const FfiConverterArrayTypeGroupVerdict = new FfiConverterArray(
+  FfiConverterTypeGroupVerdict
+);
+
+// FfiConverter for Array<PendingTx>
+const FfiConverterArrayTypePendingTx = new FfiConverterArray(
+  FfiConverterTypePendingTx
+);
 
 // FfiConverter for Array<string>
 const FfiConverterArrayString = new FfiConverterArray(FfiConverterString);
@@ -2903,6 +4093,214 @@ function uniffiEnsureInitialized() {
     );
   }
   if (
+    nativeModule().ubrn_uniffi_cojson_core_rn_checksum_method_nodecore_add_transactions() !==
+    51668
+  ) {
+    throw new UniffiInternalError.ApiChecksumMismatch(
+      'uniffi_cojson_core_rn_checksum_method_nodecore_add_transactions'
+    );
+  }
+  if (
+    nativeModule().ubrn_uniffi_cojson_core_rn_checksum_method_nodecore_co_value_count() !==
+    32815
+  ) {
+    throw new UniffiInternalError.ApiChecksumMismatch(
+      'uniffi_cojson_core_rn_checksum_method_nodecore_co_value_count'
+    );
+  }
+  if (
+    nativeModule().ubrn_uniffi_cojson_core_rn_checksum_method_nodecore_create_co_value() !==
+    30755
+  ) {
+    throw new UniffiInternalError.ApiChecksumMismatch(
+      'uniffi_cojson_core_rn_checksum_method_nodecore_create_co_value'
+    );
+  }
+  if (
+    nativeModule().ubrn_uniffi_cojson_core_rn_checksum_method_nodecore_decrypt_transaction() !==
+    65084
+  ) {
+    throw new UniffiInternalError.ApiChecksumMismatch(
+      'uniffi_cojson_core_rn_checksum_method_nodecore_decrypt_transaction'
+    );
+  }
+  if (
+    nativeModule().ubrn_uniffi_cojson_core_rn_checksum_method_nodecore_decrypt_transaction_meta() !==
+    17956
+  ) {
+    throw new UniffiInternalError.ApiChecksumMismatch(
+      'uniffi_cojson_core_rn_checksum_method_nodecore_decrypt_transaction_meta'
+    );
+  }
+  if (
+    nativeModule().ubrn_uniffi_cojson_core_rn_checksum_method_nodecore_get_header() !==
+    19909
+  ) {
+    throw new UniffiInternalError.ApiChecksumMismatch(
+      'uniffi_cojson_core_rn_checksum_method_nodecore_get_header'
+    );
+  }
+  if (
+    nativeModule().ubrn_uniffi_cojson_core_rn_checksum_method_nodecore_get_known_state() !==
+    4274
+  ) {
+    throw new UniffiInternalError.ApiChecksumMismatch(
+      'uniffi_cojson_core_rn_checksum_method_nodecore_get_known_state'
+    );
+  }
+  if (
+    nativeModule().ubrn_uniffi_cojson_core_rn_checksum_method_nodecore_get_known_state_with_streaming() !==
+    62621
+  ) {
+    throw new UniffiInternalError.ApiChecksumMismatch(
+      'uniffi_cojson_core_rn_checksum_method_nodecore_get_known_state_with_streaming'
+    );
+  }
+  if (
+    nativeModule().ubrn_uniffi_cojson_core_rn_checksum_method_nodecore_get_last_signature() !==
+    37437
+  ) {
+    throw new UniffiInternalError.ApiChecksumMismatch(
+      'uniffi_cojson_core_rn_checksum_method_nodecore_get_last_signature'
+    );
+  }
+  if (
+    nativeModule().ubrn_uniffi_cojson_core_rn_checksum_method_nodecore_get_last_signature_checkpoint() !==
+    33702
+  ) {
+    throw new UniffiInternalError.ApiChecksumMismatch(
+      'uniffi_cojson_core_rn_checksum_method_nodecore_get_last_signature_checkpoint'
+    );
+  }
+  if (
+    nativeModule().ubrn_uniffi_cojson_core_rn_checksum_method_nodecore_get_session_ids() !==
+    25250
+  ) {
+    throw new UniffiInternalError.ApiChecksumMismatch(
+      'uniffi_cojson_core_rn_checksum_method_nodecore_get_session_ids'
+    );
+  }
+  if (
+    nativeModule().ubrn_uniffi_cojson_core_rn_checksum_method_nodecore_get_session_transactions() !==
+    45827
+  ) {
+    throw new UniffiInternalError.ApiChecksumMismatch(
+      'uniffi_cojson_core_rn_checksum_method_nodecore_get_session_transactions'
+    );
+  }
+  if (
+    nativeModule().ubrn_uniffi_cojson_core_rn_checksum_method_nodecore_get_signature_after() !==
+    28724
+  ) {
+    throw new UniffiInternalError.ApiChecksumMismatch(
+      'uniffi_cojson_core_rn_checksum_method_nodecore_get_signature_after'
+    );
+  }
+  if (
+    nativeModule().ubrn_uniffi_cojson_core_rn_checksum_method_nodecore_get_transaction() !==
+    39147
+  ) {
+    throw new UniffiInternalError.ApiChecksumMismatch(
+      'uniffi_cojson_core_rn_checksum_method_nodecore_get_transaction'
+    );
+  }
+  if (
+    nativeModule().ubrn_uniffi_cojson_core_rn_checksum_method_nodecore_get_transaction_count() !==
+    42928
+  ) {
+    throw new UniffiInternalError.ApiChecksumMismatch(
+      'uniffi_cojson_core_rn_checksum_method_nodecore_get_transaction_count'
+    );
+  }
+  if (
+    nativeModule().ubrn_uniffi_cojson_core_rn_checksum_method_nodecore_has_co_value() !==
+    43079
+  ) {
+    throw new UniffiInternalError.ApiChecksumMismatch(
+      'uniffi_cojson_core_rn_checksum_method_nodecore_has_co_value'
+    );
+  }
+  if (
+    nativeModule().ubrn_uniffi_cojson_core_rn_checksum_method_nodecore_is_deleted() !==
+    44155
+  ) {
+    throw new UniffiInternalError.ApiChecksumMismatch(
+      'uniffi_cojson_core_rn_checksum_method_nodecore_is_deleted'
+    );
+  }
+  if (
+    nativeModule().ubrn_uniffi_cojson_core_rn_checksum_method_nodecore_is_streaming() !==
+    26456
+  ) {
+    throw new UniffiInternalError.ApiChecksumMismatch(
+      'uniffi_cojson_core_rn_checksum_method_nodecore_is_streaming'
+    );
+  }
+  if (
+    nativeModule().ubrn_uniffi_cojson_core_rn_checksum_method_nodecore_make_new_private_transaction() !==
+    15320
+  ) {
+    throw new UniffiInternalError.ApiChecksumMismatch(
+      'uniffi_cojson_core_rn_checksum_method_nodecore_make_new_private_transaction'
+    );
+  }
+  if (
+    nativeModule().ubrn_uniffi_cojson_core_rn_checksum_method_nodecore_make_new_trusting_transaction() !==
+    6184
+  ) {
+    throw new UniffiInternalError.ApiChecksumMismatch(
+      'uniffi_cojson_core_rn_checksum_method_nodecore_make_new_trusting_transaction'
+    );
+  }
+  if (
+    nativeModule().ubrn_uniffi_cojson_core_rn_checksum_method_nodecore_mark_as_deleted() !==
+    27776
+  ) {
+    throw new UniffiInternalError.ApiChecksumMismatch(
+      'uniffi_cojson_core_rn_checksum_method_nodecore_mark_as_deleted'
+    );
+  }
+  if (
+    nativeModule().ubrn_uniffi_cojson_core_rn_checksum_method_nodecore_remove_co_value() !==
+    50835
+  ) {
+    throw new UniffiInternalError.ApiChecksumMismatch(
+      'uniffi_cojson_core_rn_checksum_method_nodecore_remove_co_value'
+    );
+  }
+  if (
+    nativeModule().ubrn_uniffi_cojson_core_rn_checksum_method_nodecore_reset_validation() !==
+    42426
+  ) {
+    throw new UniffiInternalError.ApiChecksumMismatch(
+      'uniffi_cojson_core_rn_checksum_method_nodecore_reset_validation'
+    );
+  }
+  if (
+    nativeModule().ubrn_uniffi_cojson_core_rn_checksum_method_nodecore_role_of() !==
+    37661
+  ) {
+    throw new UniffiInternalError.ApiChecksumMismatch(
+      'uniffi_cojson_core_rn_checksum_method_nodecore_role_of'
+    );
+  }
+  if (
+    nativeModule().ubrn_uniffi_cojson_core_rn_checksum_method_nodecore_set_streaming_known_state() !==
+    2898
+  ) {
+    throw new UniffiInternalError.ApiChecksumMismatch(
+      'uniffi_cojson_core_rn_checksum_method_nodecore_set_streaming_known_state'
+    );
+  }
+  if (
+    nativeModule().ubrn_uniffi_cojson_core_rn_checksum_method_nodecore_validate_transactions() !==
+    60283
+  ) {
+    throw new UniffiInternalError.ApiChecksumMismatch(
+      'uniffi_cojson_core_rn_checksum_method_nodecore_validate_transactions'
+    );
+  }
+  if (
     nativeModule().ubrn_uniffi_cojson_core_rn_checksum_method_sessionmap_add_transactions() !==
     19976
   ) {
@@ -3063,6 +4461,14 @@ function uniffiEnsureInitialized() {
     );
   }
   if (
+    nativeModule().ubrn_uniffi_cojson_core_rn_checksum_constructor_nodecore_new() !==
+    38599
+  ) {
+    throw new UniffiInternalError.ApiChecksumMismatch(
+      'uniffi_cojson_core_rn_checksum_constructor_nodecore_new'
+    );
+  }
+  if (
     nativeModule().ubrn_uniffi_cojson_core_rn_checksum_constructor_sessionmap_new() !==
     2008
   ) {
@@ -3078,8 +4484,12 @@ export default Object.freeze({
     FfiConverterTypeBlake3Error,
     FfiConverterTypeBlake3Hasher,
     FfiConverterTypeCryptoErrorUniffi,
+    FfiConverterTypeGroupVerdict,
     FfiConverterTypeKnownState,
+    FfiConverterTypeNodeCore,
+    FfiConverterTypePendingTx,
     FfiConverterTypeSessionMap,
     FfiConverterTypeSessionMapError,
+    FfiConverterTypeSourceTxId,
   },
 });

--- a/crates/cojson-core/src/core/group_engine/engine.rs
+++ b/crates/cojson-core/src/core/group_engine/engine.rs
@@ -51,11 +51,15 @@ use crate::core::group_engine::classify::{
     is_key_for_key_field, is_key_sealed_for_group_field, is_own_write_key_revelation,
     is_parent_extension, is_write_key_for_member, parent_group_id_from_key,
 };
-use crate::core::group_engine::tx_view::{collect_group_txs, sort_for_validation, PendingTxIn, Privacy};
+use crate::core::group_engine::tx_view::{
+    collect_group_txs, sort_for_validation, PendingTxIn, Privacy,
+};
 use crate::core::group_engine::types::{
     is_higher_role, is_more_permissive_and_should_inherit, ParentRoleMapping, Role, TimeBasedEntry,
 };
-use crate::core::session_map::{CoValueHeader, JsonValue, RulesetDef, SessionMapError, SessionMapImpl};
+use crate::core::session_map::{
+    CoValueHeader, JsonValue, RulesetDef, SessionMapError, SessionMapImpl,
+};
 
 /// The `"everyone"` pseudo-member key (`EVERYONE`, group.ts:49).
 const EVERYONE: &str = "everyone";
@@ -250,7 +254,9 @@ fn is_truthy(v: Option<&serde_json::Value>) -> bool {
     match v {
         None | Some(serde_json::Value::Null) => false,
         Some(serde_json::Value::Bool(b)) => *b,
-        Some(serde_json::Value::Number(n)) => n.as_f64().map(|f| f != 0.0 && !f.is_nan()).unwrap_or(false),
+        Some(serde_json::Value::Number(n)) => {
+            n.as_f64().map(|f| f != 0.0 && !f.is_nan()).unwrap_or(false)
+        }
         Some(serde_json::Value::String(s)) => !s.is_empty(),
         Some(serde_json::Value::Array(_)) | Some(serde_json::Value::Object(_)) => true,
     }
@@ -372,13 +378,7 @@ pub fn build_group_engine(
         }
         RulesetKind::OwnedByGroup(group_id) => {
             build_owned_by_group(
-                covalues,
-                engines,
-                &mut state,
-                sm,
-                &group_id,
-                pending,
-                visited,
+                covalues, engines, &mut state, sm, &group_id, pending, visited,
             )?;
         }
         RulesetKind::UnsafeAllowAll => {
@@ -577,7 +577,9 @@ fn build_group_ruleset(
                         .add_change(effective, ParentRoleMapping::Revoked);
                 }
                 Some(mapping) => {
-                    resolver.parent_groups.insert(parent_group_id.clone(), mapping);
+                    resolver
+                        .parent_groups
+                        .insert(parent_group_id.clone(), mapping);
                     state
                         .parent_history
                         .entry(parent_group_id.clone())
@@ -650,7 +652,9 @@ fn build_group_ruleset(
             && affected_member == transactor
             && assigned_role == Role::Admin
         {
-            resolver.member_roles.insert(affected_member.clone(), assigned_role);
+            resolver
+                .member_roles
+                .insert(affected_member.clone(), assigned_role);
             state
                 .role_history
                 .entry(affected_member.clone())
@@ -662,7 +666,9 @@ fn build_group_ruleset(
 
         // self revoke is always valid (permissions.ts:478-482)
         if transactor == affected_member && assigned_role == Role::Revoked {
-            resolver.member_roles.insert(affected_member.clone(), assigned_role);
+            resolver
+                .member_roles
+                .insert(affected_member.clone(), assigned_role);
             state
                 .role_history
                 .entry(affected_member.clone())
@@ -690,7 +696,9 @@ fn build_group_ruleset(
                 verdict!(invalid "Admins can't demote admins.");
                 continue;
             }
-            resolver.member_roles.insert(affected_member.clone(), assigned_role);
+            resolver
+                .member_roles
+                .insert(affected_member.clone(), assigned_role);
             state
                 .role_history
                 .entry(affected_member.clone())
@@ -718,7 +726,9 @@ fn build_group_ruleset(
                 verdict!(invalid "Managers can't invite managers.");
                 continue;
             }
-            resolver.member_roles.insert(affected_member.clone(), assigned_role);
+            resolver
+                .member_roles
+                .insert(affected_member.clone(), assigned_role);
             state
                 .role_history
                 .entry(affected_member.clone())
@@ -773,7 +783,9 @@ fn build_group_ruleset(
             continue;
         }
 
-        resolver.member_roles.insert(affected_member.clone(), assigned_role);
+        resolver
+            .member_roles
+            .insert(affected_member.clone(), assigned_role);
         state
             .role_history
             .entry(affected_member.clone())
@@ -816,7 +828,9 @@ fn build_owned_by_group(
         // used as-is (so the "Transactor not found in group" branch is
         // unreachable — this helper never returns undefined).
         let effective_transactor = if tx.author == group_id && group_is_account {
-            group_initial_admin.clone().unwrap_or_else(|| tx.author.clone())
+            group_initial_admin
+                .clone()
+                .unwrap_or_else(|| tx.author.clone())
         } else {
             tx.author.clone()
         };
@@ -1157,7 +1171,13 @@ mod tests {
                 let txs_json = format!("[{}]", session.transactions.join(","));
                 node.get_mut(&cov.co_id)
                     .unwrap()
-                    .add_transactions(&session.session_id, None, &txs_json, &session.last_signature, true)
+                    .add_transactions(
+                        &session.session_id,
+                        None,
+                        &txs_json,
+                        &session.last_signature,
+                        true,
+                    )
                     .unwrap_or_else(|e| panic!("[{name}] add txs {}: {e}", session.session_id));
             }
         }
@@ -1309,8 +1329,8 @@ mod tests {
     /// `ValidBranchPointerOnly` — the trim's `role == reader` guard.
     #[test]
     fn merged_tx_ties_admin_branch_pointer_is_not_trimmed() {
-        use crate::core::group_engine::tx_view::PendingTxIn;
         use super::VerdictOutcome;
+        use crate::core::group_engine::tx_view::PendingTxIn;
 
         let owned_id = "co_zSKK5oFqS8LcD3Rj14nYJQf5S6B";
         let fix = FixtureFile::load("merged_tx_ties");
@@ -1374,8 +1394,8 @@ mod tests {
     /// Also asserts the absent-id no-op contract.
     #[test]
     fn reset_validation_forces_rebuild_with_fresh_pending() {
-        use crate::core::group_engine::tx_view::PendingTxIn;
         use super::VerdictOutcome;
+        use crate::core::group_engine::tx_view::PendingTxIn;
 
         let owned_id = "co_zaNLWDF81o7S9DV94nkS9NPhLTE";
         // The reader's PRIVATE tx — meta is unavailable at validation, so it is
@@ -1396,7 +1416,10 @@ mod tests {
 
         // 1) Baseline: no pending meta -> reader's private write is rejected.
         let base = node.validate_transactions(owned_id, &[]).unwrap();
-        assert!(!private_verdict(&base).valid, "private write rejected without meta");
+        assert!(
+            !private_verdict(&base).valid,
+            "private write rejected without meta"
+        );
 
         // Branch-pointer meta the reader "intended" — visible only once decrypted.
         let pending = vec![PendingTxIn {
@@ -1505,7 +1528,13 @@ mod tests {
             let txs_json = format!("[{}]", session.transactions.join(","));
             node.get_mut(&child.co_id)
                 .unwrap()
-                .add_transactions(&session.session_id, None, &txs_json, &session.last_signature, true)
+                .add_transactions(
+                    &session.session_id,
+                    None,
+                    &txs_json,
+                    &session.last_signature,
+                    true,
+                )
                 .unwrap_or_else(|e| panic!("[parent_extend] add txs {}: {e}", session.session_id));
         }
 

--- a/crates/cojson-core/src/core/group_engine/tx_view.rs
+++ b/crates/cojson-core/src/core/group_engine/tx_view.rs
@@ -34,9 +34,7 @@ struct SourceTxIdWire {
 
 /// Deserializes the optional `sourceTxId: {"sessionID", "txIndex"}` wire
 /// object into `Option<(String, u32)>`.
-fn deserialize_source_tx_id<'de, D>(
-    deserializer: D,
-) -> Result<Option<(String, u32)>, D::Error>
+fn deserialize_source_tx_id<'de, D>(deserializer: D) -> Result<Option<(String, u32)>, D::Error>
 where
     D: serde::Deserializer<'de>,
 {
@@ -164,10 +162,11 @@ pub fn collect_group_txs(sm: &SessionMapImpl, pending_info: &[PendingTxIn]) -> V
                 .or(trusting_meta.as_deref())
                 .and_then(|s| serde_json::from_str(s).ok());
 
-            let (source_session_id, source_tx_index) = match pending.and_then(|p| p.source_tx_id.clone()) {
-                Some((sid, idx)) => (Some(sid), Some(idx)),
-                None => (None, None),
-            };
+            let (source_session_id, source_tx_index) =
+                match pending.and_then(|p| p.source_tx_id.clone()) {
+                    Some((sid, idx)) => (Some(sid), Some(idx)),
+                    None => (None, None),
+                };
 
             views.push(GroupTxView {
                 session_id: session_id.to_string(),
@@ -199,21 +198,19 @@ pub fn collect_group_txs(sm: &SessionMapImpl, pending_info: &[PendingTxIn]) -> V
 /// with no source identity this collapses to the original current-session-only
 /// rule.
 pub fn sort_for_validation(txs: &mut [GroupTxView]) {
-    txs.sort_by(|a, b| {
-        match a.effective_made_at.cmp(&b.effective_made_at) {
-            core::cmp::Ordering::Equal => {
-                let a_session = a.source_session_id.as_deref().unwrap_or(&a.session_id);
-                let b_session = b.source_session_id.as_deref().unwrap_or(&b.session_id);
-                if a_session == b_session {
-                    let a_index = a.source_tx_index.unwrap_or(a.tx_index);
-                    let b_index = b.source_tx_index.unwrap_or(b.tx_index);
-                    a_index.cmp(&b_index)
-                } else {
-                    core::cmp::Ordering::Equal
-                }
+    txs.sort_by(|a, b| match a.effective_made_at.cmp(&b.effective_made_at) {
+        core::cmp::Ordering::Equal => {
+            let a_session = a.source_session_id.as_deref().unwrap_or(&a.session_id);
+            let b_session = b.source_session_id.as_deref().unwrap_or(&b.session_id);
+            if a_session == b_session {
+                let a_index = a.source_tx_index.unwrap_or(a.tx_index);
+                let b_index = b.source_tx_index.unwrap_or(b.tx_index);
+                a_index.cmp(&b_index)
+            } else {
+                core::cmp::Ordering::Equal
             }
-            other => other,
         }
+        other => other,
     });
 }
 
@@ -325,8 +322,7 @@ pub(crate) mod fixtures {
             let path = format!("data/group_engine/{name}.json");
             let text =
                 std::fs::read_to_string(&path).unwrap_or_else(|e| panic!("read {path}: {e}"));
-            serde_json::from_str(&text)
-                .unwrap_or_else(|e| panic!("parse {path}: {e}"))
+            serde_json::from_str(&text).unwrap_or_else(|e| panic!("parse {path}: {e}"))
         }
     }
 
@@ -533,9 +529,13 @@ mod tests {
             .find(|v| v.session_id == b_session)
             .expect("session B present");
         assert_eq!(b.current_made_at, 1_700_000_000_000, "current unchanged");
-        assert_eq!(b.effective_made_at, 1_800_000_000_000, "effective overridden");
         assert_eq!(
-            views.last().unwrap().session_id, b_session,
+            b.effective_made_at, 1_800_000_000_000,
+            "effective overridden"
+        );
+        assert_eq!(
+            views.last().unwrap().session_id,
+            b_session,
             "later effective time sorts last"
         );
     }
@@ -612,10 +612,7 @@ mod tests {
             source_tx_id: None,
         }];
         let with_pending = collect_group_txs(&sm, &pending);
-        let overridden_meta = with_pending[2]
-            .meta
-            .clone()
-            .expect("pending meta parses");
+        let overridden_meta = with_pending[2].meta.clone().expect("pending meta parses");
         assert_eq!(
             overridden_meta["mi"], 999,
             "pending meta_json overrides the trusting tx's own wire meta"
@@ -653,7 +650,10 @@ mod tests {
 
         let tx3 = &verdicts[3];
         assert_eq!(
-            tx3.source_tx_id.as_ref().expect("sourceTxId present").tx_index,
+            tx3.source_tx_id
+                .as_ref()
+                .expect("sourceTxId present")
+                .tx_index,
             2
         );
     }

--- a/crates/cojson-core/src/core/node.rs
+++ b/crates/cojson-core/src/core/node.rs
@@ -172,7 +172,8 @@ mod tests {
         assert!(!node.has_co_value(&co_id));
         assert_eq!(node.co_value_count(), 0);
 
-        node.create_co_value(&co_id, &header_json, None, false).unwrap();
+        node.create_co_value(&co_id, &header_json, None, false)
+            .unwrap();
         assert!(node.has_co_value(&co_id));
         assert_eq!(node.co_value_count(), 1);
         assert!(node.get(&co_id).is_ok());
@@ -188,7 +189,8 @@ mod tests {
         assert!(!node.remove_co_value("co_zDoesNotExist"));
         // double-remove after create
         let (co_id, header_json) = valid_header();
-        node.create_co_value(&co_id, &header_json, None, false).unwrap();
+        node.create_co_value(&co_id, &header_json, None, false)
+            .unwrap();
         assert!(node.remove_co_value(&co_id));
         assert!(!node.remove_co_value(&co_id));
     }
@@ -208,15 +210,19 @@ mod tests {
         // SessionMap; createCoValue must replace, not error.
         let (co_id, header_json) = valid_header();
         let mut node = NodeCore::new();
-        node.create_co_value(&co_id, &header_json, None, false).unwrap();
-        node.create_co_value(&co_id, &header_json, None, false).unwrap();
+        node.create_co_value(&co_id, &header_json, None, false)
+            .unwrap();
+        node.create_co_value(&co_id, &header_json, None, false)
+            .unwrap();
         assert_eq!(node.co_value_count(), 1);
     }
 
     #[test]
     fn invalid_header_does_not_insert() {
         let mut node = NodeCore::new();
-        assert!(node.create_co_value("co_zBogus", "{not json", None, false).is_err());
+        assert!(node
+            .create_co_value("co_zBogus", "{not json", None, false)
+            .is_err());
         assert!(!node.has_co_value("co_zBogus"));
     }
 }

--- a/crates/cojson-core/src/core/session_map.rs
+++ b/crates/cojson-core/src/core/session_map.rs
@@ -700,9 +700,7 @@ impl SessionMapImpl {
     /// Used by the group engine (`collect_group_txs`) to build transaction views
     /// straight from stored state without copying whole session logs. The session
     /// order matches TypeScript `Map` insertion order (this is an `IndexMap`).
-    pub(crate) fn iter_session_transactions(
-        &self,
-    ) -> impl Iterator<Item = (&str, &[String])> {
+    pub(crate) fn iter_session_transactions(&self) -> impl Iterator<Item = (&str, &[String])> {
         self.sessions
             .iter()
             .map(|(sid, log)| (sid.as_str(), log.transactions_json().as_slice()))

--- a/crates/cojson-core/src/crypto/seal.rs
+++ b/crates/cojson-core/src/crypto/seal.rs
@@ -264,7 +264,7 @@ mod tests {
 
         // Test sealing for group (no sender key needed)
         let sealed = seal_for_group(message, &recipient_id, nonce_material).unwrap();
-        
+
         // Sealed message should be at least 32 bytes (ephemeral public key) + ciphertext
         assert!(sealed.len() > 32);
 

--- a/docs/superpowers/plans/2026-07-04-deletion-inventory.md
+++ b/docs/superpowers/plans/2026-07-04-deletion-inventory.md
@@ -1,0 +1,191 @@
+# Deletion inventory — Cleanup Phase Part C (Task C1)
+
+> **Purpose:** authoritative decision on exactly what the deletion PR (C2) may
+> remove. Every entry was verified by reading callers, not by assumption. A wrong
+> DELETE here becomes a wrong deletion in C2.
+>
+> **HEAD when produced:** `be0c5203d` (Part B tip — RN NodeCore adapter merged).
+> **Scope basis:** `docs/superpowers/plans/2026-07-04-cleanup-phase.md` Part C +
+> `docs/superpowers/plans/2026-07-04-group-engine-porter-notes.md` (esp. note 17).
+
+Classifications: **DELETE** (remove entirely), **KEEP** (survives, reason given),
+**NARROW** (survives but a kill-switch/optionality/fallback branch inside it is removed).
+
+## Ground truth established
+
+- All three providers now `override createNodeCore()` returning a **native**
+  adapter that wraps a native `NodeCore` (`WasmNodeCore`/`RNNodeCore`/napi) —
+  `NapiCrypto.ts:238`, `WasmCrypto.ts:283`, `RNCrypto.ts:209`. None of these
+  adapters touch `createSessionMap`/`SessionMapAdapter` (verified `WasmCrypto.ts:283-285`).
+- The base `CryptoProvider.createNodeCore()` (`crypto.ts:307`) is the **only**
+  remaining producer of `ShimNodeCore`, and `ShimNodeCore` is the **only**
+  runtime consumer of `createSessionMap` / `SessionMapImpl` / `SessionMapAdapter`.
+- `VerifiedState` addresses everything through `nodeCore.*` (verified
+  `verifiedState.ts:83-669`), never `createSessionMap`. So once the shim dies,
+  the entire per-CoValue `SessionMap` path is dead code.
+- `SessionMapImpl.dispose?()` has exactly one caller family: the shim
+  (`ShimNodeCore.ts:41,51`). Every other `.dispose(` hit in the tree is an
+  unrelated scheduler (`storageAsync.ts:581`, `storageSync.ts:555`, eraser tests).
+
+## Inventory table
+
+| # | Item | Class | Evidence (file:line) | Notes |
+|---|------|-------|----------------------|-------|
+| **permissions.ts** |
+| 1 | `determineValidTransactionsForGroup` | DELETE | def `permissions.ts:390`; only caller `permissions.ts:111` (the group fallback branch, itself deleted) | TS group engine; native path (`determineValidTransactionsNative`) subsumes it. |
+| 2 | `MemberRoleResolver` (class) | DELETE | def `permissions.ts:209`; only use `permissions.ts:398` (inside #1) | Role-resolution helper for the TS group engine only. |
+| 3 | `isHigherRole` | DELETE | def `permissions.ts:197`; only use `permissions.ts:246` (inside `MemberRoleResolver.getRoleAtTime`) | Dies with #2. |
+| 4 | `canAdmin` (private) | DELETE | def `permissions.ts:75`; uses 454/462/470/478/507/569 — all inside #1 | The jazz-tools `canAdmin` hits are `Account.canAdmin`, unrelated. |
+| 5 | `agentInAccountOrMemberInGroup` (private) | DELETE | def `permissions.ts:734`; only call `permissions.ts:134` (ownedByGroup fallback) | Test hits are comments only. |
+| 6 | ownedByGroup fallback branch (`determineValidTransactions` body) | DELETE | `permissions.ts:116-181` | Reached only when `!validateTransactions \|\| killSwitch`. Native handles ownedByGroup (`determineValidTransactionsNative` + `validBranchPointerOnly`). |
+| 7 | `unsafeAllowAll` fallback branch | DELETE | `permissions.ts:184-189` | Same gate; native marks all valid. |
+| 8 | group fallback branch + `"Group must have initialAdmin"` throw | DELETE | `permissions.ts:105-113` | Native fails closed at deserialize (comment `permissions.ts:97-99`). |
+| 9 | `nativeValidationDisabled` + its call site in the dispatch | DELETE | def `permissions.ts:80`; gate `permissions.ts:93` | Kill switch. See group.ts #18 for the second gate. |
+| 10 | `determineValidTransactions` (exported wrapper) | KEEP/NARROW | body `permissions.ts:87`; callers `coValueCore.ts:1472,1594` | Live entry point. NARROW to: `isAvailable()` guard + `determineValidTransactionsNative(coValue, nodeCore)` unconditionally. |
+| 11 | `determineValidTransactionsNative` | KEEP | `permissions.ts:271-388` | Becomes the sole body of #10. |
+| 12 | `NodeCorePendingTx` / `NodeCoreGroupVerdict` build in #11 | KEEP | `permissions.ts:275-307`, `367-387` | Native path plumbing. |
+| 13 | `isKeyForKeyField` (exported) | KEEP | def `permissions.ts:756`; imported `group.ts:33`, used `group.ts:369` | External import — MUST stay. |
+| 14 | `isKeyForAccountField` (exported) | DELETE | def `permissions.ts:760`; uses only `permissions.ts:486-489` (inside #1) | Not re-exported publicly (`exports.ts` only re-exports `AccountRole`/`Role`/`isAccountRole`); no jazz-tools import. |
+| 15 | `isKeySealedForGroupField` (exported) | DELETE | def `permissions.ts:770`; use `permissions.ts:488` (inside #1) | Same as #14. |
+| 16 | `isWriteKeyForMember` (exported) | DELETE | def `permissions.ts:744`; use `permissions.ts:546` (inside #1) | Same as #14. |
+| 17 | `getAccountOrAgentFromWriteKeyForMember` (exported) | DELETE | def `permissions.ts:750`; use `permissions.ts:547` (inside #1) | Same as #14. |
+| 17b | `isParentExtension` / `isChildExtension` / `isOwnWriteKeyRevelation` (private) | DELETE | defs `permissions.ts:776/780/784`; uses 506/543/498 — all inside #1 | Private; die with #1. |
+| **group.ts** |
+| 18 | roleOf gate kill-switch condition | NARROW | `group.ts:463-472` — remove `!nativeValidationDisabled() &&` (line 466) and the import at `group.ts:34` | KEEP the branch/frontier carve-out (`branchSourceId === undefined && atFrontierFilter === undefined`, lines 467-468) and the TS body below (474-508). Rewrite the comment to "native unless branch/frontier view" (no kill switch). |
+| 19 | `roleOfInternal` TS body (474-508) | KEEP | live callers: `coValueCore.ts:984`, `coList.ts:254`, `group.ts:443`(roleOf)/`488`(parent recursion)/`564`(myRole), `account.ts:68`(override) | Carve-out per plan — native models only `atTime`; branch/frontier views stay on TS. Non-fallback callers keep it live regardless. |
+| 20 | `parentGroupsChanges` + `updateParentGroupCache` | KEEP | `group.ts:319/392`; used by **key-revelation** `getUncachedReadKey` `group.ts:974`, and by `getParentGroups` `group.ts:528` | Shared with NON-role machinery (key rotation/read-key resolution). Not role-only. |
+| 21 | `TimeBasedEntry<T>` | KEEP | `group.ts:255`; backs `parentGroupsChanges` (#20) | Dies only if #20 dies — it doesn't. |
+| 22 | `getParentGroup` | KEEP | `group.ts:510`; used `group.ts:487,533` + `getUncachedReadKey`/`findValidParentKeys` neighborhood | Shared key + role machinery. |
+| **crypto.ts / ShimNodeCore.ts** |
+| 23 | `ShimNodeCore` (whole file) | DELETE | `ShimNodeCore.ts:17`; instantiated only `crypto.ts:308` + test `shimNodeCore.test.ts:34,150` | No provider uses it — all override `createNodeCore` natively. |
+| 24 | `CryptoProvider.createNodeCore()` base default | NARROW | `crypto.ts:307-311` → `abstract createNodeCore(): NodeCoreImpl;` | Removes the last shim producer + the `ShimNodeCore` import (`crypto.ts:14`). All three providers already override. |
+| 25 | `validateTransactions?` / `roleOf?` / `resetValidation?` optionality | NARROW | interface `crypto.ts:547/556/571`; presence-check sites simplify: `permissions.ts:93` (`&&`→drop), `permissions.ts:319` (`!`→`.`), `group.ts:465` (`&&`→drop), `group.ts:470`, `coValueCore.ts:1324` (`?.`→`.`) | Make all three **required** on `NodeCoreImpl`. Only 5 presence-check sites total (grep-complete). |
+| 26 | `SessionMapImpl.dispose?()` field + `SessionMapAdapter.dispose` impls | DELETE (with caveat) | field `crypto.ts:404`; impls `WasmCrypto.ts:294` etc.; sole caller shim `ShimNodeCore.ts:41,51` | Caller-less once shim dies. **See createSessionMap recommendation — bundle with #27, not standalone.** |
+| 27 | `createSessionMap` + `SessionMapImpl` + `SessionMapAdapter` (×3) + binding `SessionMap` structs | DELETE — **DEFER to a dedicated follow-up PR** | `crypto.ts:295/332`; `WasmCrypto.ts:272/291`, `NapiCrypto.ts:227/246`, `RNCrypto.ts:198/291`; native structs in 3 crates | Provably dead after shim (only shim consumed it; VerifiedState uses `nodeCore`). Blast radius = 3 binding crates + wasm artifact rebuild (no CI gate). See recommendation below. |
+| **Tests / bench** |
+| 28 | `groupEngineDifferential.test.ts` (whole file) | DELETE | `groupEngineDifferential.test.ts:1-623`; kill-switch arm `:559` | Oracle (TS engine) gone; harness cannot run its pass-(b) TS comparison without the kill switch. Per plan C2. |
+| 29 | `shimNodeCore.test.ts` — shim arms | NARROW | `makeShim`/`makeNodeCore` `:34`; `nodeCoreSuite("ShimNodeCore", …)` `:127`; `describe("ShimNodeCore" … dispose semantics)` `:145-end` | DELETE shim-specific arms + dispose-semantics block. KEEP the parameterized `nodeCoreSuite` for native providers (Napi/Wasm, add RN). Capability test `:103-123`: the `else`/`toBeUndefined` branch is now unreachable — assert presence on ALL arms. Consider renaming the file (no "shim" left). |
+| 30 | `permissions.nativeGroupFlip.test.ts` | KEEP | single native test `:76`; NO `stubEnv` — the kill-switch mention is comment-only (`:25-26`) | Native late-revocation flip regression. NARROW: drop the stale "when run under COJSON_DISABLE_NATIVE_VALIDATION=1 … TS path (parity)" line from the header comment. |
+| 31 | `groupEngineFixtures.export.test.ts` (the fixture exporter) | KEEP + NARROW | file; 7 dead `vi.stubEnv("COJSON_DISABLE_NATIVE_VALIDATION","1")` at `:1201,1290,1365,1408,1468,1527,1570`; stale gate comment `:1186-1197` | KEEP per plan (oracle-inversion decision). NARROW: the `stubEnv` calls become **no-ops** once the env gate is deleted — remove them and rewrite the block comment. **CRITICAL:** removing the forcing flips these 7 scenarios from TS-captured to native-captured; C2 MUST verify regenerated verdict CONTENT is unchanged (see exporter note). |
+| 32 | `bench/cojson/groupEngine.bench.ts` — TS-fallback arms | NARROW | kill-switch arms `:165-205` (2 "(TS fallback)" cases) | The `COJSON_DISABLE_NATIVE_VALIDATION=1` arms can no longer force the TS path. DELETE the two "(TS fallback)" cases; keep the "(native)" cases. Update the file header comment `:7`. |
+
+## Key findings that change C2's assumed scope
+
+1. **Four exported classifiers are DELETE, not KEEP.** The plan text ("group.ts
+   imports some — those stay") is true only for `isKeyForKeyField` (#13).
+   `isKeyForAccountField`, `isKeySealedForGroupField`, `isWriteKeyForMember`,
+   `getAccountOrAgentFromWriteKeyForMember` are exported but consumed **only**
+   inside `determineValidTransactionsForGroup`, are **not** re-exported from
+   `cojson`'s public `exports.ts`, and have **no** jazz-tools importers → safe DELETE.
+
+2. **`parentGroupsChanges`/`TimeBasedEntry`/`getParentGroup` are unambiguously
+   KEEP** — they are shared by the key-revelation/read-key path
+   (`getUncachedReadKey` at `group.ts:974` iterates `parentGroupsChanges.keys()`),
+   not just role resolution. Deleting them would break key decryption.
+
+3. **`createSessionMap` and the entire per-CoValue `SessionMap` layer are dead
+   after the shim** (finding above). The stage-1 plan's deferral was correct;
+   recommendation is to keep deferring the *binding-struct* half (below).
+
+4. **`permissions.nativeGroupFlip.test.ts` does NOT use the kill switch** despite
+   its header comment — it is a native-only regression and simply survives.
+
+5. **The exporter's kill-switch usage is load-bearing for fixture content.**
+   Its 7 `stubEnv` calls currently pin specific ownedByGroup/stage-3 scenarios to
+   TS-captured verdicts. Deleting the gate silently reroutes them through native.
+   This is the oracle inversion in concrete form and is the single highest-risk
+   item in C2.
+
+6. **Only 5 optionality presence-check sites** exist for the three NodeCore
+   methods (grep-complete), so flipping them to required is small and mechanical.
+
+## C2 execution notes
+
+### Ordering hazard: flip optionality LAST, after the shim is gone
+
+`tsc` will break the moment `validateTransactions`/`roleOf`/`resetValidation`
+become required (#25) if `ShimNodeCore` still exists — the shim does **not**
+implement them, so it stops satisfying `NodeCoreImpl`. Correct order:
+
+1. Delete `groupEngineDifferential.test.ts` (#28) and the bench TS arms (#32) —
+   removes external kill-switch consumers first.
+2. permissions.ts (#1-9, #14-17b): narrow `determineValidTransactions` to the
+   native call; delete the TS engine + helpers + kill switch. Clean now-unused
+   imports (`RawGroup`, `ParentGroupReferenceRole`, `EVERYONE`, `getParentGroupId`,
+   `MapOpPayload`, `JsonValue`, etc. — let `tsc`/lint drive).
+3. group.ts (#18): remove `!nativeValidationDisabled() &&` and the
+   `nativeValidationDisabled` import; rewrite the gate comment.
+4. Delete `ShimNodeCore.ts` (#23) and make base `createNodeCore` abstract (#24),
+   dropping its import in `crypto.ts`.
+5. **Only now** flip the three methods to required (#25) and simplify the 5
+   presence-check sites. (Do it after step 4 so no non-native `NodeCoreImpl`
+   implementer remains — otherwise `tsc` red mid-edit.)
+6. Tests (#29-31): narrow `shimNodeCore.test.ts`, fix the two comment-only files.
+7. Full gates: `pnpm test` (cojson) + jazz-tools + `tsc --noEmit` + cargo +
+   **re-run Task A3 manual example-app verification** (wasm now has no fallback).
+
+`dispose` (#26): its only caller vanishes at step 4. Because `dispose` lives on
+the `createSessionMap`/`SessionMapImpl` layer that this inventory recommends
+deferring (below), **leave `dispose?` in place in C2** and remove it together
+with the rest of that layer in the follow-up PR — removing it alone buys nothing
+and splits one coherent change across two PRs.
+
+### Exporter oracle-inversion note (text to add to `groupEngineFixtures.export.test.ts`)
+
+Replace the Stage-3 block comment (`:1183-1197`) and add a file-level note:
+
+> **Oracle inversion (post Part C):** the `COJSON_DISABLE_NATIVE_VALIDATION`
+> kill switch is gone, so this exporter no longer captures an INDEPENDENT TS
+> oracle — it captures whatever the native NodeCore produces. The committed
+> fixtures are **frozen golden files** originating from the TypeScript engine
+> (commit `b84f15310`). They are now the authority; the exporter is only a
+> *regenerator*. Regeneration MUST NOT change verdict CONTENT — only tx/session
+> identities may churn. Any content diff on regeneration is a native-engine
+> regression, not a fixture update. Before landing C2, regenerate once and diff
+> the 7 previously-kill-switch-forced scenarios (owned_by_group_roles and the
+> reader-branch-pointer / merged-tx cases) against the committed fixtures to
+> confirm the native ownedByGroup engine reproduces `validBranchPointerOnly` and
+> the "Transactor has no write permissions" verdicts byte-for-byte. If cheap,
+> add a CI assertion that regenerated verdict content equals the committed
+> fixtures (identities aside); else document the manual diff step here.
+
+Porter-note cross-refs to preserve: note 12 (ownedByGroup reader branch-pointer
+was the stage-2 unported case — verify stage-3 native now emits
+`validBranchPointerOnly`), note 17 (the recompute-all vs drain-to-`[]` asymmetry
+that made the differential harness need `resetParsedTransactions` — that harness
+is being deleted, but the asymmetry still governs `determineValidTransactionsNative`'s
+`applyTo` scoping in `permissions.ts:358-361`, which is KEEP).
+
+### `createSessionMap` recommendation: DEFER to a dedicated follow-up PR
+
+**Evidence:** after the shim (#23) and base `createNodeCore` (#24) are removed,
+`createSessionMap` / `SessionMapImpl` / the three `SessionMapAdapter` classes /
+`SessionMapImpl.dispose?` have **zero** remaining consumers — `VerifiedState`
+uses `nodeCore.*` exclusively, and every native `createNodeCore` override wraps a
+native `NodeCore`, never a `SessionMap`. So they are genuinely dead.
+
+**Recommendation: DELETE them, but in a SEPARATE PR after C2 — do NOT fold into C2.**
+
+Reasoning:
+- **Blast radius / no-CI hazard.** A coherent removal deletes not just the TS
+  layer but the three Rust binding structs (`WasmSessionMap`, napi
+  `NativeSessionMap`, `RNSessionMap`). Deleting the Rust structs forces a
+  **wasm artifact rebuild** whose only gate is manual browser testing (there is
+  NO CI recompile gate for wasm — the checked-in `public/` binary IS the ship),
+  plus an RN uniffi regen and a napi rebuild. That is precisely the risk profile
+  C2 already carries once (the deletion re-verification); doubling it inside the
+  same PR makes a bisect-hostile mega-diff across four crates.
+- **Splitting TS-now / Rust-later is worse.** If C2 deleted only the TS wrappers
+  it would orphan exported binding structs with no TS caller — an ugly interim
+  state — while still not saving the wasm rebuild. Keep TS + Rust together in one
+  focused PR where the wasm rebuild is verified exactly once.
+- **The stage-1 plan already deferred this to "final cleanup."** Honoring that
+  keeps C2 scoped to the validation-logic deletion, whose manual re-verification
+  is the phase's highest-stakes gate. Adding a dead-code-removal that can't break
+  runtime behavior to that PR only dilutes review attention on the part that can.
+- **Cost of waiting is nil.** The dead layer compiles cleanly and `tsc` stays
+  green; leaving it one PR longer costs nothing.
+
+Name the follow-up e.g. `cojson-delete-sessionmap-layer`, base on C2, and treat it
+with the same wasm manual-verification gate as Part A. Move `dispose?` (#26) into
+that PR too.

--- a/packages/cojson/src/crypto/RNCrypto.ts
+++ b/packages/cojson/src/crypto/RNCrypto.ts
@@ -12,6 +12,9 @@ import { logger } from "../logger.js";
 import { Transaction } from "../coValueCore/verifiedState.js";
 import {
   CryptoProvider,
+  NodeCoreGroupVerdict,
+  NodeCoreImpl,
+  NodeCorePendingTx,
   Sealed,
   SealedForGroup,
   SealerID,
@@ -44,6 +47,7 @@ import {
   base64urlToBytes as nativeBase64urlToBytes,
   bytesToBase64 as nativeBytesToBase64,
   SessionMap as RNSessionMap,
+  NodeCore as NativeNodeCore,
 } from "cojson-core-rn";
 import { setNativeBase64Implementation } from "../base64url.js";
 
@@ -200,6 +204,10 @@ export class RNCrypto extends CryptoProvider<Blake3State> {
     return new SessionMapAdapter(
       new RNSessionMap(coID, headerJson, maxTxSize, skipVerify),
     );
+  }
+
+  override createNodeCore(): NodeCoreImpl {
+    return new RNNodeCoreAdapter(new NativeNodeCore());
   }
 
   static async create(): Promise<RNCrypto> {
@@ -452,5 +460,281 @@ class SessionMapAdapter implements SessionMapImpl {
       this.sessionMap.decryptTransactionMeta(sessionId, txIndex, keySecret) ??
       undefined
     );
+  }
+}
+
+/**
+ * Adapter wrapping the native NodeCore registry to implement NodeCoreImpl.
+ */
+class RNNodeCoreAdapter implements NodeCoreImpl {
+  constructor(private readonly nodeCore: NativeNodeCore) {}
+
+  // === Registry ===
+  createCoValue(
+    coId: string,
+    headerJson: string,
+    maxTxSize?: number,
+    skipVerify?: boolean,
+  ): void {
+    this.nodeCore.createCoValue(coId, headerJson, maxTxSize, skipVerify);
+  }
+
+  hasCoValue(coId: string): boolean {
+    return this.nodeCore.hasCoValue(coId);
+  }
+
+  removeCoValue(coId: string): void {
+    this.nodeCore.removeCoValue(coId);
+  }
+
+  coValueCount(): number {
+    return this.nodeCore.coValueCount();
+  }
+
+  // === Header ===
+  getHeader(coId: string): string {
+    return this.nodeCore.getHeader(coId);
+  }
+
+  // === Transaction Operations ===
+  addTransactions(
+    coId: string,
+    sessionId: string,
+    signerId: string | undefined,
+    transactionsJson: string,
+    signature: string,
+    skipVerify: boolean,
+  ): void {
+    this.nodeCore.addTransactions(
+      coId,
+      sessionId,
+      signerId,
+      transactionsJson,
+      signature,
+      skipVerify,
+    );
+  }
+
+  makeNewPrivateTransaction(
+    coId: string,
+    sessionId: string,
+    signerSecret: string,
+    changesJson: string,
+    keyId: string,
+    keySecret: string,
+    metaJson: string | undefined,
+    madeAt: number,
+  ): string {
+    return this.nodeCore.makeNewPrivateTransaction(
+      coId,
+      sessionId,
+      signerSecret,
+      changesJson,
+      keyId,
+      keySecret,
+      metaJson,
+      madeAt,
+    );
+  }
+
+  makeNewTrustingTransaction(
+    coId: string,
+    sessionId: string,
+    signerSecret: string,
+    changesJson: string,
+    metaJson: string | undefined,
+    madeAt: number,
+  ): string {
+    return this.nodeCore.makeNewTrustingTransaction(
+      coId,
+      sessionId,
+      signerSecret,
+      changesJson,
+      metaJson,
+      madeAt,
+    );
+  }
+
+  // === Session Queries ===
+  getSessionIds(coId: string): string[] {
+    return this.nodeCore.getSessionIds(coId);
+  }
+
+  getTransactionCount(coId: string, sessionId: string): number {
+    return this.nodeCore.getTransactionCount(coId, sessionId);
+  }
+
+  getTransaction(
+    coId: string,
+    sessionId: string,
+    txIndex: number,
+  ): Transaction | undefined {
+    const result = this.nodeCore.getTransaction(coId, sessionId, txIndex);
+    if (!result) return undefined;
+    return JSON.parse(result) as Transaction;
+  }
+
+  getSessionTransactions(
+    coId: string,
+    sessionId: string,
+    fromIndex: number,
+  ): Transaction[] | undefined {
+    const result = this.nodeCore.getSessionTransactions(
+      coId,
+      sessionId,
+      fromIndex,
+    );
+    if (!result) return undefined;
+    return result.map((tx) => JSON.parse(tx) as Transaction);
+  }
+
+  getLastSignature(coId: string, sessionId: string): string | undefined {
+    return this.nodeCore.getLastSignature(coId, sessionId) ?? undefined;
+  }
+
+  getSignatureAfter(
+    coId: string,
+    sessionId: string,
+    txIndex: number,
+  ): string | undefined {
+    return (
+      this.nodeCore.getSignatureAfter(coId, sessionId, txIndex) ?? undefined
+    );
+  }
+
+  getLastSignatureCheckpoint(
+    coId: string,
+    sessionId: string,
+  ): number | undefined {
+    return (
+      this.nodeCore.getLastSignatureCheckpoint(coId, sessionId) ?? undefined
+    );
+  }
+
+  // === Known State ===
+  getKnownState(coId: string): {
+    id: string;
+    header: boolean;
+    sessions: Record<string, number>;
+  } {
+    // Uniffi returns a Record with Map<string, number> for sessions
+    const ks = this.nodeCore.getKnownState(coId) as unknown as {
+      id: string;
+      header: boolean;
+      sessions: Map<string, number>;
+    };
+    return {
+      id: ks.id,
+      header: ks.header,
+      sessions: Object.fromEntries(ks.sessions),
+    };
+  }
+
+  getKnownStateWithStreaming(
+    coId: string,
+  ):
+    | { id: string; header: boolean; sessions: Record<string, number> }
+    | undefined {
+    // Uniffi returns a Record with Map<string, number> for sessions
+    const ks = this.nodeCore.getKnownStateWithStreaming(coId) as unknown as
+      | { id: string; header: boolean; sessions: Map<string, number> }
+      | undefined;
+    if (!ks || ks === undefined) return undefined;
+    return {
+      id: ks.id,
+      header: ks.header,
+      sessions: Object.fromEntries(ks.sessions),
+    };
+  }
+
+  isStreaming(coId: string): boolean {
+    return this.nodeCore.isStreaming(coId);
+  }
+
+  setStreamingKnownState(coId: string, streamingJson: string): void {
+    this.nodeCore.setStreamingKnownState(coId, streamingJson);
+  }
+
+  // === Deletion ===
+  markAsDeleted(coId: string): void {
+    this.nodeCore.markAsDeleted(coId);
+  }
+
+  isDeleted(coId: string): boolean {
+    return this.nodeCore.isDeleted(coId);
+  }
+
+  // === Decryption ===
+  decryptTransaction(
+    coId: string,
+    sessionId: string,
+    txIndex: number,
+    keySecret: string,
+  ): string | undefined {
+    return (
+      this.nodeCore.decryptTransaction(coId, sessionId, txIndex, keySecret) ??
+      undefined
+    );
+  }
+
+  decryptTransactionMeta(
+    coId: string,
+    sessionId: string,
+    txIndex: number,
+    keySecret: string,
+  ): string | undefined {
+    return (
+      this.nodeCore.decryptTransactionMeta(
+        coId,
+        sessionId,
+        txIndex,
+        keySecret,
+      ) ?? undefined
+    );
+  }
+
+  // === Transaction Validation (stage 3) ===
+  validateTransactions(
+    coId: string,
+    pending: NodeCorePendingTx[],
+  ): NodeCoreGroupVerdict[] {
+    return this.nodeCore
+      .validateTransactions(
+        coId,
+        pending.map((p) => ({
+          sessionId: p.sessionId,
+          txIndex: p.txIndex,
+          sourceMadeAt: p.sourceMadeAt,
+          metaJson: p.metaJson,
+          // Seam: the generated uniffi `SourceTxId` record is plain
+          // camelCase (`sessionId`/`txIndex`) because uniffi records bypass
+          // serde's `#[serde(rename)]` the same way napi objects do (see
+          // node_core.rs's `SourceTxId` doc comment); the public TS type
+          // follows this codebase's `sessionID` convention for
+          // transaction-identity wire objects (matching `TransactionID`).
+          // Bridge the casing here, identically to NapiNodeCoreAdapter.
+          sourceTxId: p.sourceTxId
+            ? {
+                sessionId: p.sourceTxId.sessionID,
+                txIndex: p.sourceTxId.txIndex,
+              }
+            : undefined,
+        })),
+      )
+      .map((v) => ({
+        sessionId: v.sessionId,
+        txIndex: v.txIndex,
+        valid: v.valid,
+        outcome: v.outcome as "valid" | "invalid" | "validBranchPointerOnly",
+        reason: v.reason ?? undefined,
+      }));
+  }
+
+  roleOf(groupId: string, member: string, atTime?: number): string | undefined {
+    return this.nodeCore.roleOf(groupId, member, atTime) ?? undefined;
+  }
+
+  resetValidation(coId: string): void {
+    this.nodeCore.resetValidation(coId);
   }
 }

--- a/packages/cojson/src/tests/shimNodeCore.test.ts
+++ b/packages/cojson/src/tests/shimNodeCore.test.ts
@@ -9,9 +9,19 @@ import type {
 } from "../crypto/crypto.js";
 import type { RawCoID } from "../ids.js";
 
-// ShimNodeCore's remaining consumer is RNCrypto (no native NodeCore port yet
-// — see Part B of the cleanup-phase plan) — keep the shim arm/tests below
-// until that lands.
+// RNCrypto now has a native NodeCore adapter (RNNodeCoreAdapter, mirroring
+// NapiNodeCoreAdapter's casing bridge) — see Part B of the cleanup-phase
+// plan. It can't be added to nodeCoreSuite here: `RNCrypto.create()` loads
+// `cojson-core-rn`'s generated bindings, which register a React Native
+// TurboModule (`NativeCojsonCoreRn` via `TurboModuleRegistry.getEnforcing`)
+// at import time — that requires the RN runtime and cannot be instantiated
+// under vitest/node. RN NodeCore capability is exercised by CI/e2e only
+// (rn-build-reusable + the Maestro e2e run); `tsc --noEmit` covers
+// RNNodeCoreAdapter's `NodeCoreImpl` conformance in the meantime. ShimNodeCore
+// no longer has any production consumer (Napi/Wasm/RN all override
+// `createNodeCore()`), but it's kept until Part C's deletion pass — its
+// dispose-semantics tests below still exercise real behavior via a fake
+// SessionMapImpl.
 let crypto: CryptoProvider;
 let wasmCrypto: CryptoProvider;
 


### PR DESCRIPTION
Stacked on #3534 (wasm NodeCore) → #3533 → #3532 → #3531. Part B of the cleanup phase.

## Summary

- Ports the `NodeCore` registry + unified validation surface to `cojson-core-rn` (uniffi mirror, 25-member parity with napi/wasm; `Mutex`-wrapped for uniffi's Send+Sync requirement, single lock per call), regenerates the shared TS bindings via the iOS build, and gives `RNCrypto` a native adapter mirroring the napi one (including the `sessionID → sessionId` casing bridge and the Map→Record known-state conversion).
- Fixes a latent RN error-contract break: `SessionMapError::Internal` previously wrapped every message with `"SessionMap error: "` — which would have broken the TypeScript layer's `startsWith("CoValue not loaded: ")` / `"Unknown CoValue: "` matching the moment registry errors flowed through it. RN errors now pass the inner message through verbatim, matching napi/wasm (nothing in the tree consumed the old prefix; regression tests pin the preserved strings).

## ⚠️ Merge gate: CI, not local verification

This environment has no Android NDK and RN can't instantiate under vitest (`TurboModuleRegistry.getEnforcing` needs the live runtime). Locally verified: `cargo test -p cojson-core-rn` 9/9, `tsc --noEmit` clean (interface conformance), wasm/napi suites untouched (1431/13). **Before merging, reviewers must confirm:**
- `rn-build-reusable` (android + ios) green
- `e2e-rn-test-cloud` (Maestro on `examples/chat-rn-expo`) green

## Test Plan

- [x] cargo 9/9 (incl. error-prefix regression tests)
- [x] tsc clean; cojson suite 1431/13 unaffected
- [x] Generated bindings inspected (machine-generated, no hand edits; records camelCased as expected)
- [ ] CI: rn-build-reusable android+ios
- [ ] CI: Maestro e2e on chat-rn-expo