### PR TITLE
perf(cojson): faster CoStream and FileStream processing

### DIFF
--- a/.changeset/costream-fetch-optimization.md
+++ b/.changeset/costream-fetch-optimization.md
@@ -1,0 +1,7 @@
+---
+"cojson": patch
+---
+
+Performance: faster CoStream and FileStream processing — per-session stream
+histories skip re-sorting when items arrive in order, and binary chunks are
+decoded incrementally instead of re-decoding the whole file on every read.

--- a/bench/costream.load.bench.ts
+++ b/bench/costream.load.bench.ts
@@ -1,0 +1,184 @@
+/**
+ * Benchmark: fetch (import content) + processing (build view) of CoStreams.
+ *
+ * Two workloads, selected via MODE:
+ *  - MODE=stream (default): a RawCoStream with ITEMS pushed values
+ *    (one tx each, single session).
+ *  - MODE=binary: a RawBinaryCoStream file of ITEMS chunks x CHUNK_KB.
+ *    SUBSCRIBED=1 mimics download-progress polling: the listener calls
+ *    getBinaryChunks(allowUnfinished) on every update.
+ *
+ * Run: pnpm exec tsx bench/costream.load.bench.ts [items] [chunkKB]
+ */
+import { WasmCrypto } from "cojson/crypto/WasmCrypto";
+import type { RawBinaryCoStream, RawCoStream } from "cojson";
+import { createNode, measureLoad, ms } from "./loadBenchUtils.js";
+
+const MODE = (process.env.MODE ?? "stream") as "stream" | "binary";
+const ITEMS = Number(process.argv[2] ?? (MODE === "binary" ? 100 : 20_000));
+const CHUNK_KB = Number(process.argv[3] ?? 100);
+const PRIVACY = (process.env.PRIVACY ?? "private") as "private" | "trusting";
+const SUBSCRIBED = Boolean(process.env.SUBSCRIBED);
+
+const crypto = await WasmCrypto.create();
+
+// --- Node A: create the stream ------------------------------------------------
+const { node: nodeA, agentSecret } = createNode(crypto);
+const group = nodeA.createGroup();
+
+let streamID: string;
+let originalBytes: Uint8Array | undefined;
+
+const tCreate0 = performance.now();
+if (MODE === "binary") {
+  const stream = group.createBinaryStream();
+  streamID = stream.id;
+  stream.startBinaryStream({ mimeType: "application/octet-stream" }, PRIVACY);
+  originalBytes = new Uint8Array(ITEMS * CHUNK_KB * 1024);
+  for (let i = 0; i < originalBytes.length; i++) {
+    originalBytes[i] = (i * 31 + 7) & 0xff;
+  }
+  for (let i = 0; i < ITEMS; i++) {
+    stream.pushBinaryStreamChunk(
+      originalBytes.subarray(i * CHUNK_KB * 1024, (i + 1) * CHUNK_KB * 1024),
+      PRIVACY,
+    );
+  }
+  stream.endBinaryStream(PRIVACY);
+} else {
+  const stream = group.createStream<RawCoStream<string>>();
+  streamID = stream.id;
+  for (let i = 0; i < ITEMS; i++) {
+    stream.push(`item-with-some-payload-${i}`, PRIVACY);
+  }
+}
+const tCreate1 = performance.now();
+
+console.log(
+  `create (${MODE}): ${ITEMS} ${MODE === "binary" ? `chunks x ${CHUNK_KB}KB` : "pushes"} -> ${ms(tCreate1 - tCreate0)}`,
+);
+
+// --- Export content messages ---------------------------------------------------
+const groupContent = nodeA.getCoValue(group.id).newContentSince(undefined)!;
+const streamContent = nodeA
+  .getCoValue(streamID as any)
+  .newContentSince(undefined)!;
+console.log(
+  `content chunks: group=${groupContent.length} stream=${streamContent.length}`,
+);
+
+// --- Node B: import + read ------------------------------------------------------
+async function loadOnFreshNode() {
+  const { node: nodeB } = createNode(crypto, agentSecret);
+
+  let listenerReads = 0;
+  if (SUBSCRIBED) {
+    nodeB.getCoValue(streamID as any).subscribe((core) => {
+      if (core.isAvailable()) {
+        const content = core.getCurrentContent();
+        if (MODE === "binary") {
+          (content as RawBinaryCoStream).getBinaryChunks(true);
+        } else {
+          (content as RawCoStream).sessions();
+        }
+        listenerReads++;
+      }
+    }, false);
+  }
+
+  const tImport0 = performance.now();
+  for (const chunk of groupContent) {
+    nodeB.syncManager.handleNewContent(chunk, "import");
+  }
+  for (const chunk of streamContent) {
+    nodeB.syncManager.handleNewContent(chunk, "import");
+    if (SUBSCRIBED) {
+      await new Promise((resolve) => setImmediate(resolve));
+    }
+  }
+  const tImport1 = performance.now();
+
+  const contentB = nodeB.getCoValue(streamID as any).getCurrentContent();
+  let tRead1: number;
+
+  if (MODE === "binary") {
+    const streamB = contentB as RawBinaryCoStream;
+    const result = streamB.getBinaryChunks(false);
+    tRead1 = performance.now();
+
+    if (!result || !result.finished) {
+      throw new Error("expected finished binary stream");
+    }
+    const totalBytes = result.chunks.reduce((sum, c) => sum + c.length, 0);
+    if (totalBytes !== originalBytes!.length) {
+      throw new Error(
+        `expected ${originalBytes!.length} bytes, got ${totalBytes}`,
+      );
+    }
+
+    if (process.env.VERIFY) {
+      let offset = 0;
+      for (const chunk of result.chunks) {
+        for (let i = 0; i < chunk.length; i++) {
+          if (chunk[i] !== originalBytes![offset + i]) {
+            throw new Error(`byte mismatch at ${offset + i}`);
+          }
+        }
+        offset += chunk.length;
+      }
+      // Reading twice must yield identical content (cached or not).
+      const again = streamB.getBinaryChunks(false)!;
+      if (
+        again.chunks.length !== result.chunks.length ||
+        again.chunks.some((c, i) => c.length !== result.chunks[i]!.length)
+      ) {
+        throw new Error("second getBinaryChunks read diverges");
+      }
+      // And the imported view must equal a from-scratch rebuild.
+      streamB.rebuildFromCore();
+      const rebuilt = streamB.getBinaryChunks(false)!;
+      let rOffset = 0;
+      for (const chunk of rebuilt.chunks) {
+        for (let i = 0; i < chunk.length; i++) {
+          if (chunk[i] !== originalBytes![rOffset + i]) {
+            throw new Error(`rebuild byte mismatch at ${rOffset + i}`);
+          }
+        }
+        rOffset += chunk.length;
+      }
+    }
+  } else {
+    const streamB = contentB as RawCoStream<string>;
+    const items = streamB.getSingleStream();
+    tRead1 = performance.now();
+
+    if (!items || items.length !== ITEMS) {
+      throw new Error(`expected ${ITEMS} items, got ${items?.length}`);
+    }
+
+    if (process.env.VERIFY) {
+      const before = JSON.stringify(streamB.toJSON());
+      streamB.rebuildFromCore();
+      const after = JSON.stringify(streamB.toJSON());
+      if (before !== after) {
+        throw new Error("imported view diverges from full rebuild");
+      }
+      for (let i = 0; i < items.length; i++) {
+        if (items[i] !== `item-with-some-payload-${i}`) {
+          throw new Error(`order mismatch at ${i}: ${items[i]}`);
+        }
+      }
+    }
+  }
+
+  nodeB.gracefulShutdown();
+
+  return {
+    import: tImport1 - tImport0,
+    read: tRead1 - tImport1,
+    total: tRead1 - tImport0,
+    listenerReads,
+  };
+}
+
+await measureLoad(loadOnFreshNode);

--- a/bench/package.json
+++ b/bench/package.json
@@ -15,6 +15,7 @@
     "bench:cojson": "vitest bench",
     "bench:colist": "tsx ./colist.load.bench.ts",
     "bench:comap": "tsx ./comap.load.bench.ts",
+    "bench:costream": "tsx ./costream.load.bench.ts",
     "bench:jazz-tools": "pnpm exec tsx ./jazz-tools/comap.create.jazz-tools.bench.ts",
     "bench:filestream:write": "node --experimental-strip-types --no-warnings ./jazz-tools/binaryCoStream.write.bench.ts",
     "bench:filestream:getChunks": "node --experimental-strip-types --no-warnings ./jazz-tools/filestream.getChunks.bench.ts",

--- a/packages/cojson/src/coValues/binaryCoStream.ts
+++ b/packages/cojson/src/coValues/binaryCoStream.ts
@@ -45,6 +45,16 @@ export class RawBinaryCoStreamView<
   totalValidTransactions: number = 0;
   version: number = 0;
   private chunks: string[];
+  /**
+   * Incrementally decoded prefix of `chunks`, maintained only while the
+   * stream is unfinished so that download-progress polling
+   * (`getBinaryChunks(allowUnfinished)` per update) decodes each chunk once
+   * instead of re-decoding the whole file on every read. Dropped as soon as
+   * the stream ends: finished files are decoded fresh per read (typically
+   * exactly once, e.g. `toBlob`), so nothing is retained long-term. The
+   * buffers are shared across polling reads and must be treated as immutable.
+   */
+  private decodedChunks: Uint8Array<ArrayBuffer>[];
   private start: BinaryStreamStart | undefined;
   private ended: boolean;
 
@@ -53,6 +63,7 @@ export class RawBinaryCoStreamView<
 
   private resetInternalState() {
     this.chunks = [];
+    this.decodedChunks = [];
     this.start = undefined;
     this.ended = false;
     this.knownTransactions = { [this.core.id]: 0 };
@@ -69,6 +80,7 @@ export class RawBinaryCoStreamView<
     this.core = core;
     this.ended = false;
     this.chunks = [];
+    this.decodedChunks = [];
     this.knownTransactions = { [core.id]: 0 };
     this.atFrontierFilter = options?.atFrontierFilter;
     this.processNewTransactions();
@@ -137,6 +149,12 @@ export class RawBinaryCoStreamView<
       }
     }
 
+    if (this.ended) {
+      // The progress-polling decode cache is only worth its memory while the
+      // stream is still growing
+      this.decodedChunks = [];
+    }
+
     this.totalValidTransactions += newValidTransactions.length;
   }
 
@@ -167,11 +185,26 @@ export class RawBinaryCoStreamView<
 
     const start = this.start;
 
+    let chunks: Uint8Array<ArrayBuffer>[];
+    if (this.ended) {
+      // Finished files are read rarely (typically once): decode fresh and
+      // retain nothing
+      chunks = this.chunks.map(base64URLtoBytes);
+    } else {
+      // Unfinished files are polled repeatedly while chunks stream in:
+      // decode only the chunks added since the previous read
+      const decoded = this.decodedChunks;
+      for (let i = decoded.length; i < this.chunks.length; i++) {
+        decoded.push(base64URLtoBytes(this.chunks[i]!));
+      }
+      chunks = decoded.slice();
+    }
+
     return {
       mimeType: start.mimeType,
       fileName: start.fileName,
       totalSizeBytes: start.totalSizeBytes,
-      chunks: this.chunks.map(base64URLtoBytes),
+      chunks,
       finished: this.ended,
     };
   }

--- a/packages/cojson/src/coValues/coStream.ts
+++ b/packages/cojson/src/coValues/coStream.ts
@@ -104,7 +104,10 @@ export class RawCoStreamView<
 
   /** @internal */
   processNewTransactions() {
-    const changeEntries = new Set<CoStreamItem<Item>[]>();
+    // Session streams whose appended items arrived out of time order (rare):
+    // only these need a re-sort; in-order appends keep the sorted invariant
+    // by themselves.
+    const unsortedEntries = new Set<CoStreamItem<Item>[]>();
 
     const newValidTransactions = this.core.getValidTransactions({
       ignorePrivateTransactions: false,
@@ -130,12 +133,16 @@ export class RawCoStreamView<
           entries = [];
           this.items[txID.sessionID] = entries;
         }
-        entries.push({ value: change, madeAt, tx: txID });
-        changeEntries.add(entries);
+        const item = { value: change, madeAt, tx: txID };
+        const last = entries[entries.length - 1];
+        if (last && this.compareStreamItems(last, item) > 0) {
+          unsortedEntries.add(entries);
+        }
+        entries.push(item);
       }
     }
 
-    for (const entries of changeEntries) {
+    for (const entries of unsortedEntries) {
       entries.sort(this.compareStreamItems);
     }
 


### PR DESCRIPTION
> Stacked on #3538 (`comap-fetch-optimization`), which stacks on #3537 — review only the last commit.

## Summary

Applies the CoMap treatment (#3538) to `RawCoStream` and `RawBinaryCoStream`: benchmark the write path and the streamed/subscribed read path, then remove the superlinear costs (measured same-machine):

| Scenario | before | after | speedup |
|---|---|---|---|
| CoStream: 20k local pushes (1 per tx) | 2,871ms | 627ms | 4.6x, now linear |
| FileStream: subscribed progress-polling import, 10MB / 100 chunks | 719ms | 141ms | 5.1x |
| CoStream: plain import + read, 20k items | ~48ms | ~47ms | unchanged |
| FileStream: plain import + read | 132ms | 118ms | 1.1x |

## The two hot paths

**1. Per-session full re-sort on every batch** (`coStream.ts`). Every batch re-sorted each touched session's *entire* item array to maintain `compareStreamItems` order, so each local `push()` paid an O(history) sort — 2.2s of the 2.9s spent pushing 20k items was pure re-sorting. Same fix as CoMap: an out-of-order arrival is detected at append time with a single tail comparison, and only flagged session arrays (rare) are re-sorted, with exactly the previous sort. In-order appends — the common case, since per-session items arrive in txIndex order with non-decreasing timestamps — keep the sorted invariant by themselves.

**2. Full re-decode of every chunk on every read** (`binaryCoStream.ts`). `getBinaryChunks` did `this.chunks.map(base64URLtoBytes)` per call, so polling download progress (`getBinaryChunks(allowUnfinished)` on every update, as `FileStream.getChunks`/`toBlob` consumers do) decoded O(chunks²) bytes over a download.

The decode cache is deliberately **transient**: it only exists while the stream is unfinished — the one window where repeated reads actually happen — and each poll decodes just the chunks added since the previous read. The moment the `end` op arrives the cache is dropped, so a finished file retains nothing beyond the base64 chunks it always kept, and finished reads decode fresh per call exactly as before (they typically happen once, e.g. `toBlob`). A permanent cache was considered and rejected: it would pin decoded bytes (+75% of file size) for the lifetime of the view to speed up a read that rarely repeats. During polling, returned buffers are shared across reads and documented as immutable; all in-repo consumers treat them as read-only.

## Benchmark

`bench/costream.load.bench.ts` (`pnpm bench:costream [items] [chunkKB]`): `MODE=stream` (default, single-session pushes) or `MODE=binary` (file of N chunks), with the shared `SUBSCRIBED` / `VERIFY` / `PROFILE` / `PRIVACY` knobs. `VERIFY=1` byte-compares the decoded file against the original, re-reads to check stability, and cross-checks the imported view against a full `rebuildFromCore()`.

## Test plan

- [x] `pnpm exec vitest --run --root ../../ --project cojson` — 1397 passed, 13 skipped, 0 failed
- [x] jazz-tools `coFeed` suites (includes FileStream) — 76 passed, 0 failed
- [x] `tsc --noEmit` and biome clean
- [x] Benchmark `VERIFY=1` on stream and binary modes, plain and subscribed — byte-level and rebuild-parity checks pass
