### PR TITLE
perf(cojson): incremental CoList entries cache and faster list maintenance

### DIFF
--- a/.changeset/colist-incremental-entries.md
+++ b/.changeset/colist-incremental-entries.md
@@ -1,0 +1,7 @@
+---
+"cojson": patch
+---
+
+Performance: faster processing of large CoLists — incremental list-view
+updates on append instead of full re-traversal, direct entry links, and
+cheaper deletion and traversal bookkeeping.

--- a/packages/cojson/src/coValues/coList.ts
+++ b/packages/cojson/src/coValues/coList.ts
@@ -3,7 +3,7 @@ import {
   AvailableCoValueCore,
   DecryptedTransaction,
 } from "../coValueCore/coValueCore.js";
-import { AgentID, SessionID, TransactionID, RawCoID } from "../ids.js";
+import { AgentID, TransactionID, RawCoID } from "../ids.js";
 import { JsonObject, JsonValue } from "../jsonValue.js";
 import { accountOrAgentIDfromSessionID } from "../typeUtils/accountOrAgentIDfromSessionID.js";
 import { isCoValue } from "../typeUtils/isCoValue.js";
@@ -36,11 +36,23 @@ export type ListOpPayload<T extends JsonValue> =
 
 type InsertionEntry<T extends JsonValue> = {
   madeAt: number;
-  predecessors: OpID[];
-  successors: OpID[];
+  /** The OpID of this insertion, stored once so it can be reused in results */
+  opID: OpID;
+  /** Entries inserted directly before this one ("pre" ops targeting it) */
+  predecessors: InsertionEntry<T>[];
+  /**
+   * Entries inserted directly after this one ("app" ops targeting it).
+   * Successors render newest-first (see `fillArrayFromEntry`), which is why
+   * `appendItems` writes multi-item appends in reverse order.
+   */
+  successors: InsertionEntry<T>[];
   change: InsertionOpPayload<T>;
   /** Whether this entry comes from a valid transaction */
   isValid: boolean;
+  /** Number of deletion ops targeting this insertion (>0 means deleted) */
+  deletionsCount: number;
+  /** Traversal generation marker, used instead of a visited Set */
+  visitedGen: number;
 };
 
 type DeletionEntry = {
@@ -48,6 +60,47 @@ type DeletionEntry = {
   deletionID: OpID;
   change: DeletionOpPayload;
 };
+
+/**
+ * Summary of one `processNewTransactions` batch, used afterwards by
+ * `computeCacheTailSuffix` to decide whether `_cachedEntries` can be
+ * extended in place instead of being invalidated.
+ *
+ * Only created when there is a live cache to maintain (see
+ * `beginBatchSummary`). The `prior*` snapshots are taken before the batch
+ * touches the graph, so the entries the batch attached at the tail region
+ * can be identified by iterating past them.
+ */
+class BatchSummary<Item extends JsonValue> {
+  /**
+   * Set when the batch contains an op that in-place cache extension doesn't
+   * support: deletions and prepends (which can affect entries before the
+   * tail) and duplicate ops (double merges).
+   */
+  hasUnsupportedOps = false;
+  /**
+   * Number of valid "app" insertions added by this batch. The cache can only
+   * be kept if all of them render after the previous tail.
+   */
+  newValidAppends = 0;
+
+  constructor(
+    /** The insertion entry of the last cached (visible) item, if any. */
+    readonly tail: InsertionEntry<Item> | undefined,
+    /** `tail.successors.length` before the batch. */
+    readonly priorTailSuccessors: number,
+    /** `afterStart.length` before the batch. */
+    readonly priorAfterStartRoots: number,
+  ) {}
+
+  record(change: ListOpPayload<Item>, isValid: boolean, applied: boolean) {
+    if (!applied || change.op === "del" || change.op === "pre") {
+      this.hasUnsupportedOps = true;
+    } else if (isValid) {
+      this.newValidAppends++;
+    }
+  }
+}
 
 export class RawCoList<
   Item extends JsonValue = JsonValue,
@@ -62,22 +115,14 @@ export class RawCoList<
   core: AvailableCoValueCore;
 
   /** The internal state of the RawCoList */
-  afterStart: OpID[] = [];
-  beforeEnd: OpID[] = [];
-  insertions: {
-    [sessionID: SessionIndex]: {
-      [txIdx: number]: {
-        [changeIdx: number]: InsertionEntry<Item>;
-      };
-    };
-  } = {};
-  deletionsByInsertion: {
-    [deletedSessionID: SessionIndex]: {
-      [deletedTxIdx: number]: {
-        [deletedChangeIdx: number]: DeletionEntry[];
-      };
-    };
-  } = {};
+  afterStart: InsertionEntry<Item>[] = [];
+  beforeEnd: InsertionEntry<Item>[] = [];
+  /** All insertion entries, keyed by their encoded OpID */
+  insertions: Map<OpIDKey, InsertionEntry<Item>> = new Map();
+  /** Traversal generation counter, bumped on every traversal (full or suffix) */
+  private traversalGen = 0;
+  /** Deletion ops targeting an insertion, keyed by the insertion's encoded OpID */
+  deletionsByInsertion: Map<OpIDKey, DeletionEntry[]> = new Map();
 
   /** @internal */
   atTimeFilter?: number = undefined;
@@ -104,8 +149,8 @@ export class RawCoList<
   private resetInternalState() {
     this.afterStart = [];
     this.beforeEnd = [];
-    this.insertions = {};
-    this.deletionsByInsertion = {};
+    this.insertions = new Map();
+    this.deletionsByInsertion = new Map();
     this._cachedEntries = undefined;
     this.knownTransactions = { [this.core.id]: 0 };
     this.lastValidTransaction = undefined;
@@ -123,8 +168,8 @@ export class RawCoList<
     this.id = core.id as CoID<this>;
     this.core = core;
 
-    this.insertions = {};
-    this.deletionsByInsertion = {};
+    this.insertions = new Map();
+    this.deletionsByInsertion = new Map();
     this.afterStart = [];
     this.beforeEnd = [];
     this.knownTransactions = { [core.id]: 0 };
@@ -139,86 +184,40 @@ export class RawCoList<
   }
 
   private getInsertionsEntry(opID: OpID) {
-    const index = getSessionIndex(opID);
-
-    const sessionEntry = this.insertions[index];
-    if (!sessionEntry) {
-      return undefined;
-    }
-
-    const txEntry = sessionEntry[opID.txIndex];
-    if (!txEntry) {
-      return undefined;
-    }
-
-    return txEntry[opID.changeIdx];
+    return this.insertions.get(encodeOpID(opID));
   }
 
   private createInsertionsEntry(opID: OpID, value: InsertionEntry<Item>) {
-    const index = getSessionIndex(opID);
+    const key = encodeOpID(opID);
 
-    let sessionEntry = this.insertions[index];
-    if (!sessionEntry) {
-      sessionEntry = {};
-      this.insertions[index] = sessionEntry;
-    }
-
-    let txEntry = sessionEntry[opID.txIndex];
-    if (!txEntry) {
-      txEntry = {};
-      sessionEntry[opID.txIndex] = txEntry;
-    }
-
-    // Check if the change index already exists, may be the case of double merges
-    if (txEntry[opID.changeIdx]) {
+    // The key may already exist in case of double merges
+    if (this.insertions.has(key)) {
       return false;
     }
 
-    txEntry[opID.changeIdx] = value;
+    // Deletions targeting this insertion may have been processed first
+    value.deletionsCount = this.deletionsByInsertion.get(key)?.length ?? 0;
+
+    this.insertions.set(key, value);
     return true;
   }
 
-  private isDeleted(opID: OpID) {
-    const index = getSessionIndex(opID);
-
-    const sessionEntry = this.deletionsByInsertion[index];
-
-    if (!sessionEntry) {
-      return false;
-    }
-
-    const txEntry = sessionEntry[opID.txIndex];
-
-    if (!txEntry) {
-      return false;
-    }
-
-    return Boolean(txEntry[opID.changeIdx]?.length);
-  }
-
   private pushDeletionsByInsertionEntry(opID: OpID, value: DeletionEntry) {
-    const index = getSessionIndex(opID);
+    const key = encodeOpID(opID);
 
-    let sessionEntry = this.deletionsByInsertion[index];
-    if (!sessionEntry) {
-      sessionEntry = {};
-      this.deletionsByInsertion[index] = sessionEntry;
-    }
-
-    let txEntry = sessionEntry[opID.txIndex];
-    if (!txEntry) {
-      txEntry = {};
-      sessionEntry[opID.txIndex] = txEntry;
-    }
-
-    let list = txEntry[opID.changeIdx];
-
+    let list = this.deletionsByInsertion.get(key);
     if (!list) {
       list = [];
-      txEntry[opID.changeIdx] = list;
+      this.deletionsByInsertion.set(key, list);
     }
 
     list.push(value);
+
+    // Keep the deletion count on the insertion entry in sync, if it exists
+    const insertionEntry = this.insertions.get(key);
+    if (insertionEntry) {
+      insertionEntry.deletionsCount++;
+    }
   }
 
   processNewTransactions() {
@@ -234,29 +233,17 @@ export class RawCoList<
       return;
     }
 
+    const batch = this.beginBatchSummary();
+
     let lastValidTransaction: number | undefined = undefined;
     let oldestValidTransaction: number | undefined = undefined;
-    this._cachedEntries = undefined;
 
     for (const tx of transactions) {
-      if (this.isFilteredOut(tx)) {
+      if (this.isFilteredOut(tx) || this.isDeletionDenied(tx)) {
         continue;
       }
 
-      const { txID, changes, madeAt, isValid } = tx;
-
-      if (
-        isValid &&
-        this.#isDeletionRestricted &&
-        this.transactionContainsDeletion(changes as ListOpPayload<Item>[])
-      ) {
-        const author = accountOrAgentIDfromSessionID(txID.sessionID);
-        const role = this.group.atTime(madeAt).roleOfInternal(author);
-
-        if (role !== "admin" && role !== "manager") {
-          continue;
-        }
-      }
+      const { changes, madeAt, isValid } = tx;
 
       // Only track valid transactions for the lastValidTransaction/oldestValidTransaction
       if (isValid) {
@@ -267,66 +254,10 @@ export class RawCoList<
         );
       }
 
-      for (const [changeIdx, changeUntyped] of changes.entries()) {
-        const change = changeUntyped as ListOpPayload<Item>;
-
-        const opID = {
-          sessionID: txID.sessionID,
-          txIndex: txID.txIndex,
-          branch: txID.branch,
-          changeIdx,
-        };
-
-        if (change.op === "pre" || change.op === "app") {
-          const created = this.createInsertionsEntry(opID, {
-            madeAt,
-            predecessors: [],
-            successors: [],
-            change,
-            isValid,
-          });
-
-          // If the change index already exists, we don't need to process it again
-          if (!created) {
-            continue;
-          }
-
-          if (change.op === "pre") {
-            if (change.before === "end") {
-              this.beforeEnd.push(opID);
-            } else {
-              const beforeEntry = this.getInsertionsEntry(change.before);
-
-              if (!beforeEntry) {
-                continue;
-              }
-
-              beforeEntry.predecessors.push(opID);
-            }
-          } else {
-            if (change.after === "start") {
-              this.afterStart.push(opID);
-            } else {
-              const afterEntry = this.getInsertionsEntry(change.after);
-
-              if (!afterEntry) {
-                continue;
-              }
-
-              afterEntry.successors.push(opID);
-            }
-          }
-        } else if (change.op === "del") {
-          this.pushDeletionsByInsertionEntry(change.insertion, {
-            madeAt,
-            deletionID: opID,
-            change,
-          });
-        } else {
-          throw new Error(
-            "Unknown list operation " + (change as { op: unknown }).op,
-          );
-        }
+      for (let changeIdx = 0; changeIdx < changes.length; changeIdx++) {
+        const change = changes[changeIdx] as ListOpPayload<Item>;
+        const applied = this.ingestChange(change, tx, changeIdx);
+        batch?.record(change, isValid, applied);
       }
     }
 
@@ -335,16 +266,193 @@ export class RawCoList<
       oldestValidTransaction &&
       oldestValidTransaction < this.lastValidTransaction
     ) {
+      // The batch contains transactions older than already-processed ones:
+      // rebuild so everything is applied in order (this also re-attaches ops
+      // that arrived before their target and were dropped as orphans).
       this.rebuildFromCore();
     } else {
       this.lastValidTransaction = lastValidTransaction;
+
+      const suffix = batch ? this.computeCacheTailSuffix(batch) : null;
+      if (suffix) {
+        for (const entry of suffix) {
+          this._cachedEntries!.push(entry);
+        }
+      } else {
+        this._cachedEntries = undefined;
+      }
     }
 
     this.totalValidTransactions += transactions.length;
   }
 
-  private transactionContainsDeletion(changes: ListOpPayload<Item>[]) {
-    return changes.some((change) => change.op === "del");
+  /**
+   * In groups with restricted deletion, deletion transactions from members
+   * that are not admins or managers are dropped entirely.
+   */
+  private isDeletionDenied(tx: DecryptedTransaction): boolean {
+    if (!tx.isValid || !this.#isDeletionRestricted) {
+      return false;
+    }
+
+    const changes = tx.changes as ListOpPayload<Item>[];
+    if (!changes.some((change) => change.op === "del")) {
+      return false;
+    }
+
+    const author = accountOrAgentIDfromSessionID(tx.txID.sessionID);
+    const role = this.group.atTime(tx.madeAt).roleOfInternal(author);
+
+    return role !== "admin" && role !== "manager";
+  }
+
+  /**
+   * Applies a single op to the insertion graph. Returns false when the op
+   * was already present (double merges) and nothing was applied.
+   */
+  private ingestChange(
+    change: ListOpPayload<Item>,
+    tx: DecryptedTransaction,
+    changeIdx: number,
+  ): boolean {
+    const opID: OpID = {
+      sessionID: tx.txID.sessionID,
+      txIndex: tx.txID.txIndex,
+      branch: tx.txID.branch,
+      changeIdx,
+    };
+
+    if (change.op === "del") {
+      this.pushDeletionsByInsertionEntry(change.insertion, {
+        madeAt: tx.madeAt,
+        deletionID: opID,
+        change,
+      });
+      return true;
+    }
+
+    if (change.op !== "pre" && change.op !== "app") {
+      throw new Error(
+        "Unknown list operation " + (change as { op: unknown }).op,
+      );
+    }
+
+    const entry: InsertionEntry<Item> = {
+      madeAt: tx.madeAt,
+      opID,
+      predecessors: [],
+      successors: [],
+      change,
+      isValid: tx.isValid,
+      deletionsCount: 0,
+      visitedGen: 0,
+    };
+
+    if (!this.createInsertionsEntry(opID, entry)) {
+      return false;
+    }
+
+    if (change.op === "pre") {
+      if (change.before === "end") {
+        this.beforeEnd.push(entry);
+      } else {
+        this.getInsertionsEntry(change.before)?.predecessors.push(entry);
+      }
+    } else if (change.after === "start") {
+      this.afterStart.push(entry);
+    } else {
+      // When `after` is unknown the op stays orphaned and invisible until a
+      // rebuild re-processes it after its target arrives
+      this.getInsertionsEntry(change.after)?.successors.push(entry);
+    }
+
+    return true;
+  }
+
+  /**
+   * A batch summary is only worth keeping when there is a cache to maintain:
+   * without one (or on a time-travel view, whose cache is conservatively
+   * invalidated on any new transactions) the batch always ends in
+   * invalidation.
+   */
+  private beginBatchSummary(): BatchSummary<Item> | undefined {
+    if (this._cachedEntries === undefined || this.isTimeTravelEntity()) {
+      return undefined;
+    }
+
+    const lastCached = this._cachedEntries[this._cachedEntries.length - 1];
+    const tail = lastCached
+      ? this.getInsertionsEntry(lastCached.opID)
+      : undefined;
+
+    return new BatchSummary(
+      tail,
+      tail?.successors.length ?? 0,
+      this.afterStart.length,
+    );
+  }
+
+  /**
+   * Called after a batch has been ingested into the graph: returns the
+   * entries to append to `_cachedEntries` when the batch is a pure tail
+   * extension (the common case: appends arriving in order, e.g. while
+   * streaming or on local appendItems), or null when it isn't and the cache
+   * must be invalidated.
+   *
+   * A batch is a pure tail extension when every entry it made visible
+   * renders after the previously last visible entry. Instead of proving
+   * this op by op, we collect the subtrees the batch attached at the tail
+   * region (new successors of the old tail, then new afterStart roots), run
+   * the regular traversal over just those subtrees, and check that it
+   * emitted exactly the batch's valid appends: an op that attached anywhere
+   * else leaves the traversal short. Reusing `fillArrayFromEntry` for the
+   * suffix keeps the incremental order in agreement with a full rebuild by
+   * construction.
+   */
+  private computeCacheTailSuffix(
+    batch: BatchSummary<Item>,
+  ): { value: Item; madeAt: number; opID: OpID }[] | null {
+    if (batch.hasUnsupportedOps) {
+      return null;
+    }
+
+    // New roots render after all old afterStart subtrees but before any
+    // beforeEnd subtree, so they only extend the tail if beforeEnd is empty.
+    const hasNewAfterStartRoots =
+      this.afterStart.length > batch.priorAfterStartRoots;
+    if (hasNewAfterStartRoots && this.beforeEnd.length > 0) {
+      return null;
+    }
+
+    // The subtrees the batch attached at the tail region, in the order the
+    // full traversal reaches them: successors of the old tail newest-first,
+    // then the new afterStart roots.
+    const suffixRoots: InsertionEntry<Item>[] = [];
+    if (batch.tail) {
+      const successors = batch.tail.successors;
+      for (let i = successors.length - 1; i >= batch.priorTailSuccessors; i--) {
+        suffixRoots.push(successors[i]!);
+      }
+    }
+    for (let i = batch.priorAfterStartRoots; i < this.afterStart.length; i++) {
+      suffixRoots.push(this.afterStart[i]!);
+    }
+
+    const suffix: { value: Item; madeAt: number; opID: OpID }[] = [];
+    const gen = ++this.traversalGen;
+    for (const root of suffixRoots) {
+      this.fillArrayFromEntry(root, suffix, gen);
+    }
+
+    // Every valid append of the batch must have landed in the suffix:
+    // anything else (an append to a mid-list entry, an orphaned append, an
+    // insertion that a previous batch already deleted) means the cached
+    // prefix can no longer be trusted.
+    if (suffix.length !== batch.newValidAppends) {
+      return null;
+    }
+
+    return suffix;
   }
 
   rebuildFromCore() {
@@ -448,58 +556,48 @@ export class RawCoList<
       madeAt: number;
       opID: OpID;
     }[] = [];
-    for (const opID of this.afterStart) {
-      this.fillArrayFromOpID(opID, arr);
+    const gen = ++this.traversalGen;
+    for (const entry of this.afterStart) {
+      this.fillArrayFromEntry(entry, arr, gen);
     }
-    for (const opID of this.beforeEnd) {
-      this.fillArrayFromOpID(opID, arr);
+    for (const entry of this.beforeEnd) {
+      this.fillArrayFromEntry(entry, arr, gen);
     }
     return arr;
   }
 
   /** @internal */
-  private fillArrayFromOpID(
-    opID: OpID,
+  private fillArrayFromEntry(
+    root: InsertionEntry<Item>,
     arr: {
       value: Item;
       madeAt: number;
       opID: OpID;
     }[],
+    gen: number,
   ) {
-    const todo = [opID]; // a stack with the next item to do at the end
-    const predecessorsVisited = new Set<OpID>();
+    const todo = [root]; // a stack with the next item to do at the end
 
     while (todo.length > 0) {
-      const currentOpID = todo[todo.length - 1]!;
+      const entry = todo[todo.length - 1]!;
 
-      const entry = this.getInsertionsEntry(currentOpID);
-
-      if (!entry) {
-        throw new Error("Missing op " + currentOpID);
-      }
-
-      const shouldTraversePredecessors =
-        entry.predecessors.length > 0 && !predecessorsVisited.has(currentOpID);
-
-      // We navigate the predecessors before processing the current opID in the list
-      if (shouldTraversePredecessors) {
+      // We navigate the predecessors before processing the current entry in the list
+      if (entry.predecessors.length > 0 && entry.visitedGen !== gen) {
+        entry.visitedGen = gen;
         for (const predecessor of entry.predecessors) {
           todo.push(predecessor);
         }
-        predecessorsVisited.add(currentOpID);
       } else {
-        // Remove the current opID from the todo stack to consider it processed.
+        // Remove the current entry from the todo stack to consider it processed.
         todo.pop();
-
-        const deleted = this.isDeleted(currentOpID);
 
         // Skip entries that are deleted or from invalid transactions
         // (e.g., losing init transactions in firstComesWins scenarios)
-        if (!deleted && entry.isValid) {
+        if (entry.deletionsCount === 0 && entry.isValid) {
           arr.push({
             value: entry.change.value,
             madeAt: entry.madeAt,
-            opID: currentOpID,
+            opID: entry.opID,
           });
         }
 
@@ -560,24 +658,13 @@ export class RawCoList<
       at: Date;
     }[] = [];
 
-    for (const sessionID in this.deletionsByInsertion) {
-      const sessionEntry = this.deletionsByInsertion[sessionID as SessionID];
-      for (const txIdx in sessionEntry) {
-        const txEntry = sessionEntry[Number(txIdx)];
-        for (const changeIdx in txEntry) {
-          const changeEntry = txEntry[Number(changeIdx)];
-          for (const deletion of changeEntry || []) {
-            const madeAt = new Date(deletion.madeAt);
-            const by = accountOrAgentIDfromSessionID(
-              deletion.deletionID.sessionID,
-            );
-            edits.push({
-              by,
-              tx: deletion.deletionID,
-              at: madeAt,
-            });
-          }
-        }
+    for (const deletions of this.deletionsByInsertion.values()) {
+      for (const deletion of deletions) {
+        edits.push({
+          by: accountOrAgentIDfromSessionID(deletion.deletionID.sessionID),
+          tx: deletion.deletionID,
+          at: new Date(deletion.madeAt),
+        });
       }
     }
 
@@ -778,11 +865,13 @@ export class RawCoList<
   }
 }
 
-type SessionIndex = SessionID | `${SessionID}_branch_${RawCoID}`;
+type OpIDKey = `${string}/${number}/${number}`;
 
-function getSessionIndex(txID: TransactionID): SessionIndex {
-  if (txID.branch) {
-    return `${txID.sessionID}_branch_${txID.branch}`;
-  }
-  return txID.sessionID;
+// Unlike the public `stringifyOpID` (coPlainText.ts), this key includes the
+// branch, so ops from a branch and its source session can't collide.
+function encodeOpID(opID: OpID): OpIDKey {
+  const session = opID.branch
+    ? `${opID.sessionID}_branch_${opID.branch}`
+    : opID.sessionID;
+  return `${session}/${opID.txIndex}/${opID.changeIdx}`;
 }


### PR DESCRIPTION
> Stacked on #3537 (`worktree-colist-fetch-optimization`). Diff to review is `packages/cojson/src/coValues/coList.ts` plus a changeset.

## Summary

Makes CoList view maintenance incremental instead of rebuild-on-every-update (measured same-machine vs the base branch):

- **Write/processing path (append + list maintenance): 4.4x–44x**, and no longer superlinear. `RawCoList` now links insertion entries directly instead of through nested string-keyed lookups, tracks deletions with a counter instead of a separate map lookup, and uses a generation counter for traversal instead of a `Set`. Appends (the common case) extend the cached entries incrementally instead of invalidating and re-traversing the whole list on every update.
- **Subscribed/streamed fetch of a 100k-item list: 1.9x.** A subscribed client no longer re-traverses the entire graph per arriving chunk.

Benchmark table (same machine, best-of-N, vs base branch = #3537):

| Metric | base (#3537) | this branch | speedup |
|---|---|---|---|
| Create 100k items (100/tx) | 1,489ms | 338ms | 4.4x |
| Create 20k items (1/tx) | 6,296ms | 683ms | 9.2x |
| Create 50k items (1/tx) | 72.3s | 1.66s | 44x |
| Load 100k×100, subscribed streaming | 581ms | 299ms | 1.9x |
| Load 100k×100, plain | 256ms | 314ms | 0.8x |
| Load 20k×1, plain | 105ms | 114ms | 0.9x |

Benchmark is `bench/colist.load.bench.ts` from the base branch (`pnpm bench:colist`; env knobs `SUBSCRIBED`, `VERIFY`, `PROFILE`, `SKIP_VERIFY`).

## The incremental CoList algorithm

### Data model

`RawCoList`'s source of truth is an insertion graph (RGA-style CRDT). Each `app` op attaches a new entry after an existing entry (or after `start`), each `pre` op attaches before one (or before `end`), and `del` ops mark insertions as deleted. The visible list is produced by a depth-first traversal (`fillArrayFromEntry`) over the roots — `afterStart` roots in arrival order, then `beforeEnd` roots — where **successors of an entry are visited newest-first**:

```mermaid
flowchart TB
    S((start)) -.-> A
    A --> B["B (after A, attached 1st)"]
    A --> C["C (after A, attached 2nd)"]
    C --> D["D (after C)"]
```

Traversal emits **A, C, D, B** — C wins over B because successors are visited newest-first. This is also why `appendItems` writes multi-item appends in *reverse* order: they read back in the original order.

`entries()` caches the traversal result in `_cachedEntries`. The invariant the whole design hangs on:

> `_cachedEntries`, when present, is always identical to what a full traversal (`entriesUncached()`) would produce.

On the base branch, any new transaction invalidated the cache, so a subscribed client re-traversed the entire graph per arriving chunk — quadratic in list size while streaming. The new code keeps the cache alive across the common case (appends arriving in order) by *extending it in place*.

### Per-batch pipeline

Every batch of new transactions flows through three cleanly separated stages: pure graph ingestion, a rebuild check, and a cache decision made *after* the graph is up to date.

```mermaid
flowchart TD
    TX["batch of new transactions"] --> SNAP["beginBatchSummary()<br/>summary only if there is a live, non-time-travel cache;<br/>snapshots tail entry + prior successor/root counts"]
    SNAP --> ING["for each op: ingestChange()<br/>pure graph mutation, returns whether the op was applied"]
    ING --> REC["summary.record(change, isValid, applied)<br/>del / pre / duplicate → hasUnsupportedOps<br/>applied valid append → newValidAppends++"]
    REC --> OOO{"batch contains txs older<br/>than already-processed ones?"}
    OOO -- yes --> RB["rebuildFromCore()<br/>reset state, reprocess everything<br/>(also re-attaches orphaned ops)"]
    OOO -- no --> HAS{"summary exists?"}
    HAS -- no --> INV1["invalidate cache"]
    HAS -- yes --> CTS["computeCacheTailSuffix(summary)"]
    CTS -- "suffix (possibly empty)" --> EXT["append suffix to _cachedEntries"]
    CTS -- "null" --> INV2["invalidate cache<br/>(next read does a full traversal)"]
```

`ingestChange` knows nothing about the cache; `computeCacheTailSuffix` is a pure decision function over the graph plus the batch summary. That separation is what makes the fast path auditable.

### The tail-extension check

A batch may extend the cache iff every entry it made visible renders *after* the previous last visible entry (the **tail**). Rather than proving that op by op, the suffix pass exploits a structural fact: the batch's new entries can only attach to the old tail, to `afterStart`, or to each other (an old op can never reference an op that didn't exist yet). So it collects the subtrees the batch hung off the tail region:

```mermaid
flowchart LR
    a --> b --> T["c (old tail)"]
    T ==> d["d (new)"]
    d ==> e["e (new, after d)"]
    T ==> f["f (new, after c)"]
```

Suffix roots are the tail's *new* successors (newest-first, matching DFS pop order) plus any *new* `afterStart` roots (in order) — then it runs the **same** `fillArrayFromEntry` used for full rebuilds over just those roots. Emitted entries: `f, d, e` (f is newer than d, so it wins). Because it is the same traversal over the same graph, the suffix order cannot disagree with a full rebuild.

The acceptance test is a single count comparison: the traversal must emit **exactly** `newValidAppends` entries. Anything the batch inserted that is *not* reachable from the tail region comes up missing and invalidates the cache:

```mermaid
flowchart LR
    a --> b --> c["c (tail)"]
    b -. "new append after b<br/>(mid-list, NOT reachable<br/>from suffix roots)" .-> x["x (new)"]
```

Here `newValidAppends = 1` but the suffix traversal emits 0 entries → mismatch → invalidate. The same mechanism catches orphaned appends (target op not yet arrived) and inserts that were already deleted by an earlier batch's `del`.

### When the cache survives a batch

| Batch contains | Outcome | Why |
|---|---|---|
| appends reachable from the tail region only | **extend in place** | pure suffix, order proven by shared traversal |
| a deletion | invalidate | can hide an entry anywhere in the cached prefix |
| a prepend (`pre` op) | invalidate | renders before its target |
| a duplicate op (double merge) | invalidate | conservative |
| an append to a mid-list or unknown (orphaned) target | invalidate | caught by the count check |
| new after-`start` roots while `beforeEnd` roots exist | invalidate | new roots would render before the `beforeEnd` section |
| transactions older than already-processed ones | **full rebuild** | re-applies everything in order, re-attaching orphans |
| anything, on a time-travel view (`atTime`/`atFrontier`) | invalidate | conservative |

Invalidation is always safe — it just costs one full traversal on the next read. The correctness of the extension path is additionally cross-checked at runtime by the benchmark's `VERIFY=1` mode, which compares the incrementally maintained cache against a fresh full traversal.

Net complexity: a streamed append-only load does O(new ops) work per chunk instead of O(list), which is where the subscribed-load speedup comes from.

## Caveats

- Cold one-shot reads of a large imported list are ~10–20% slower (see the plain-load rows): the per-batch summary/suffix bookkeeping during ingest doesn't pay off when the list is read once after import. The win is on every subscribed/streaming or repeatedly-read list, and on the write path.

## Test plan

- [x] `pnpm exec vitest --run --root ../../ --project cojson` — 76 files, 1397 passed, 13 skipped, 0 failed
- [x] jazz-tools CoList/CoFeed suites (`coList`, `coList.unique`, `coList.branch`, `coFeed`, `coFeed.branch`) — 7 files, 225 passed, 0 failed
- [x] Benchmark correctness mode (`VERIFY=1`, plain and `SUBSCRIBED=1`) — incremental-cache-vs-full-traversal divergence checks pass
