### PR TITLE
fix(jazz-tools): preserve active dirty sessions

### DIFF
--- a/.changeset/preserve-active-dirty-sessions.md
+++ b/.changeset/preserve-active-dirty-sessions.md
@@ -1,0 +1,5 @@
+---
+"jazz-tools": patch
+---
+
+Preserve active browser sessions whose transactions have not yet been persisted instead of reclaiming their session slots.

--- a/packages/jazz-tools/src/browser/provideBrowserLockSession/BrowserSessionProvider.test.ts
+++ b/packages/jazz-tools/src/browser/provideBrowserLockSession/BrowserSessionProvider.test.ts
@@ -406,6 +406,36 @@ describe("BrowserSessionProvider", () => {
   });
 
   describe("session durability marker", () => {
+    test("does not reclaim an active dirty session", async () => {
+      const accountID = account.$jazz.id;
+      const dirtySession = Crypto.newRandomSessionID(
+        accountID as unknown as RawAccountID,
+      ) as SessionID;
+      SessionIDStorage.storeSessionID(accountID, dirtySession, 0);
+      BrowserSessionDurabilityMarker.set(dirtySession);
+
+      const lockName = `load_session_${dirtySession}`;
+      mockLocks.set(lockName, {
+        mode: "exclusive",
+        release: () => {
+          mockLocks.delete(lockName);
+        },
+      });
+
+      const { sessionID, sessionDone } = await sessionProvider.acquireSession(
+        accountID,
+        Crypto as CryptoProvider,
+      );
+      const sessions = SessionIDStorage.getSessionsList(accountID);
+      const markerIsSet = BrowserSessionDurabilityMarker.isSet(dirtySession);
+
+      sessionDone();
+      mockLocks.delete(lockName);
+
+      expect(sessions).toEqual([dirtySession, sessionID]);
+      expect(markerIsSet).toBe(true);
+    });
+
     test("acquireSession skips a dirty session and reclaims its slot", async () => {
       const provider = new BrowserSessionProvider();
       const accountID = account.$jazz.id;

--- a/packages/jazz-tools/src/browser/provideBrowserLockSession/BrowserSessionProvider.ts
+++ b/packages/jazz-tools/src/browser/provideBrowserLockSession/BrowserSessionProvider.ts
@@ -20,7 +20,13 @@ export class BrowserSessionProvider implements SessionProvider {
       // If the session crashed while it had sent-but-unpersisted transactions,
       // reusing it could fork the session's hash chain on the server.
       if (BrowserSessionDurabilityMarker.isSet(sessionID)) {
-        dirtySlot ??= { index, sessionID };
+        const sessionIsAbandoned = await tryToAcquireSession(
+          sessionID,
+          Promise.resolve(),
+        );
+        if (sessionIsAbandoned) {
+          dirtySlot ??= { index, sessionID };
+        }
         continue;
       }
 


### PR DESCRIPTION
## Summary

- preserve active dirty browser sessions while their session lock is held
- reclaim dirty slots only after confirming that the session is abandoned
- cover the concurrent session-acquisition regression

## CI impact

This is intended to fix the SessionLock E2E CI failures. Under concurrent browser contexts, an active session can be marked dirty before local persistence completes; reclaiming that slot drops a stored session and leaves CI waiting for a session count that never arrives.

## Testing

- `fnm exec --using=22.21.1 -- pnpm --filter jazz-tools exec vitest run src/browser/provideBrowserLockSession/BrowserSessionProvider.test.ts --project jazz-tools`
- `fnm exec --using=22.21.1 -- pnpm --filter jazz-tools run check`
- `fnm exec --using=22.21.1 -- pnpm turbo build` from `tests/e2e`
- SessionLock Chromium E2E under CI settings passed on retry; the first attempt hit the existing log-order flake