### PR TITLE
perf(jazz-tools): use op-sqlite's sync JSI path for reads

### DIFF
--- a/.changeset/op-sqlite-sync-reads.md
+++ b/.changeset/op-sqlite-sync-reads.md
@@ -1,0 +1,5 @@
+---
+"jazz-tools": patch
+---
+
+Route OP-SQLite reads through op-sqlite's synchronous JSI path where it is available. Its native thread pool is hardcoded to a single thread, so async reads gained no parallelism and paid for a thread hop plus a promise round-trip each. Measured on a cold covalue-load storm: 2.36x lower wall time and 20.5x lower p95. Reads inside a transaction and older op-sqlite versions without `executeSync` keep the async path.

--- a/packages/jazz-tools/src/react-native/storage/op-sqlite-adapter.ts
+++ b/packages/jazz-tools/src/react-native/storage/op-sqlite-adapter.ts
@@ -65,12 +65,35 @@ export class OPSQLiteAdapter implements SQLiteDatabaseDriverAsync {
     }
   }
 
+  /**
+   * Reads go through op-sqlite's synchronous JSI path where it is available.
+   *
+   * op-sqlite's native thread pool is hardcoded to a single thread
+   * (`cpp/OPThreadPool.cpp`), so async reads gain no parallelism — they just
+   * queue behind one another, and each one pays for a thread hop plus a promise
+   * round-trip. On a cold covalue-load storm that overhead dominates: reads are
+   * ~0.2ms of actual work wrapped in ~0.5ms of dispatch.
+   *
+   * Transaction-scoped adapters (`withDB`) get an op-sqlite `Transaction`, which
+   * exposes neither `transaction` nor `executeSync`, so their reads stay on the
+   * async path and remain ordered with the transaction's own writes.
+   */
+  private read(sql: string, params?: unknown[]) {
+    const db = this.db!;
+
+    if ("transaction" in db && "executeSync" in db) {
+      return db.executeSync(sql, params as any[]);
+    }
+
+    return db.execute(sql, params as any[]);
+  }
+
   public async query<T>(sql: string, params?: unknown[]): Promise<T[]> {
     if (!this.db) {
       throw new Error("Database not initialized");
     }
 
-    const result = await this.db.execute(sql, params as any[]);
+    const result = await this.read(sql, params);
 
     return result.rows as T[];
   }
@@ -80,7 +103,7 @@ export class OPSQLiteAdapter implements SQLiteDatabaseDriverAsync {
       throw new Error("Database not initialized");
     }
 
-    const result = await this.db.execute(sql, params as any[]);
+    const result = await this.read(sql, params);
 
     return result.rows[0] as T | undefined;
   }

--- a/packages/jazz-tools/src/react-native/tests/op-sqlite-adapter.test.ts
+++ b/packages/jazz-tools/src/react-native/tests/op-sqlite-adapter.test.ts
@@ -1,0 +1,104 @@
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("@op-engineering/op-sqlite", () => ({
+  open: vi.fn(),
+  ANDROID_DATABASE_PATH: "/android",
+  IOS_LIBRARY_PATH: "/ios",
+}));
+
+import { OPSQLiteAdapter } from "../storage/op-sqlite-adapter.js";
+
+/**
+ * A top-level connection: has `transaction` and the synchronous JSI path.
+ */
+function createFakeDb() {
+  return {
+    execute: vi.fn().mockResolvedValue({ rows: [{ id: "async" }] }),
+    executeSync: vi.fn().mockReturnValue({ rows: [{ id: "sync" }] }),
+    executeRaw: vi.fn().mockResolvedValue({ rows: [] }),
+    transaction: vi.fn(),
+  };
+}
+
+/**
+ * An op-sqlite `Transaction` exposes neither `transaction` nor `executeSync`
+ * (see its `Transaction` type), so reads on a tx-scoped adapter must stay async.
+ */
+function createFakeTx() {
+  return {
+    execute: vi.fn().mockResolvedValue({ rows: [{ id: "tx" }] }),
+    commit: vi.fn().mockResolvedValue({ rows: [] }),
+    rollback: vi.fn().mockResolvedValue({ rows: [] }),
+  };
+}
+
+describe("OPSQLiteAdapter", () => {
+  describe("reads", () => {
+    it("routes get() through executeSync", async () => {
+      const db = createFakeDb();
+      const adapter = OPSQLiteAdapter.withDB(db as any);
+
+      expect(await adapter.get("SELECT 1", [1])).toEqual({ id: "sync" });
+      expect(db.executeSync).toHaveBeenCalledWith("SELECT 1", [1]);
+      expect(db.execute).not.toHaveBeenCalled();
+    });
+
+    it("routes query() through executeSync", async () => {
+      const db = createFakeDb();
+      const adapter = OPSQLiteAdapter.withDB(db as any);
+
+      expect(await adapter.query("SELECT 1")).toEqual([{ id: "sync" }]);
+      expect(db.executeSync).toHaveBeenCalled();
+      expect(db.execute).not.toHaveBeenCalled();
+    });
+
+    it("falls back to async execute when executeSync is unavailable", async () => {
+      // The op-sqlite peer is "*", so older versions without the sync JSI path
+      // must keep working rather than throwing on a missing method.
+      const db: any = createFakeDb();
+      delete db.executeSync;
+      const adapter = OPSQLiteAdapter.withDB(db);
+
+      expect(await adapter.get("SELECT 1")).toEqual({ id: "async" });
+      expect(db.execute).toHaveBeenCalled();
+    });
+
+    it("keeps transaction-scoped reads on the async path", async () => {
+      // A sync read would bypass the transaction's ordering on the connection.
+      const tx = createFakeTx();
+      const adapter = OPSQLiteAdapter.withDB(tx as any);
+
+      expect(await adapter.get("SELECT 1")).toEqual({ id: "tx" });
+      expect(tx.execute).toHaveBeenCalled();
+    });
+  });
+
+  describe("writes", () => {
+    it("keeps run() on the async path", async () => {
+      const db = createFakeDb();
+      const adapter = OPSQLiteAdapter.withDB(db as any);
+
+      await adapter.run("INSERT INTO t VALUES (?)", [1]);
+
+      expect(db.executeRaw).toHaveBeenCalledWith(
+        "INSERT INTO t VALUES (?)",
+        [1],
+      );
+      expect(db.executeSync).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("getInstance", () => {
+    it("returns the same instance for the same database name", () => {
+      expect(OPSQLiteAdapter.getInstance("db-a")).toBe(
+        OPSQLiteAdapter.getInstance("db-a"),
+      );
+    });
+
+    it("returns different instances for different database names", () => {
+      expect(OPSQLiteAdapter.getInstance("db-a")).not.toBe(
+        OPSQLiteAdapter.getInstance("db-b"),
+      );
+    });
+  });
+});

--- a/packages/jazz-tools/src/react-native/tests/react-native-stub.ts
+++ b/packages/jazz-tools/src/react-native/tests/react-native-stub.ts
@@ -1,0 +1,9 @@
+/**
+ * `react-native`'s entrypoint is Flow-typed source that Vite cannot parse, so
+ * importing it from a test fails at transform time — before `vi.mock` gets a
+ * chance to intercept. The vitest config aliases `react-native` here instead.
+ *
+ * Only what the adapters actually touch at module scope lives here; add to it
+ * as more of the react-native surface gets tests.
+ */
+export const Platform = { OS: "ios" };

--- a/packages/jazz-tools/vitest.config.ts
+++ b/packages/jazz-tools/vitest.config.ts
@@ -25,6 +25,12 @@ export default defineProject({
     alias: {
       // Force source resolution for jazz-tools/svelte during tests
       "jazz-tools/svelte": resolve(__dirname, "./src/svelte/index.ts"),
+      // react-native's entrypoint is Flow source that Vite cannot parse, which
+      // fails at transform time before vi.mock can intercept it
+      "react-native": resolve(
+        __dirname,
+        "./src/react-native/tests/react-native-stub.ts",
+      ),
     },
   },
   test: {


### PR DESCRIPTION
## TL;DR

Route `get`/`query` in the OP-SQLite adapter through `executeSync`. **2.36x lower wall time, 20.5x lower p95** on a cold covalue-load storm. Net +25 lines, one connection, no new dependencies, no peer changes.

## Why async reads were slow

op-sqlite's native thread pool is **hardcoded to a single thread** — `cpp/OPThreadPool.cpp` sets `numberOfThreads = 1` with the `hardware_concurrency()` call commented out directly above it. So async reads never ran in parallel to begin with; they queued behind one another and each paid for a thread hop plus a promise round-trip.

I instrumented the adapter in a production app (Spicy Golf, ~88MB local store) to size the problem before touching anything. Cold launch, iOS, op-sqlite 15.2.5:

- **7,202 reads in 3,920 ms**
- **peak 876 concurrent in-flight reads**, average queue depth 194 (Little's Law, `sum(latency)/wall`)
- service time **0.544 ms/read** — for indexed point lookups that should be 5–50 µs

So ~90%+ of each read was dispatch overhead, not database work, and measured p50 of 36.97 ms was almost entirely queue wait.

## What I measured before implementing

The obvious fix is a second connection — `open()` is uncached and the thread pool is per-`DBHostObject` (`cpp/DBHostObject.cpp:152`), so a second connection genuinely gets its own thread. I benchmarked that against `executeSync` rather than assuming. All numbers are the first cold-launch storm, same workload:

| | baseline | 2nd connection | 2nd conn + sync | **sync only** |
|---|---|---|---|---|
| wall | 3920 ms | 3703 ms | 2058 ms | **1658 ms** |
| p50 | 36.97 ms | 39.16 ms | 7.68 ms | **5.13 ms** |
| p95 | 376.95 ms | 374.47 ms | 30.46 ms | **18.38 ms** |
| throughput | 1837/s | 1952/s | 3499/s | **4359/s** |

Two findings worth the detour:

1. **A second connection is worth ~6%** — inside run-to-run noise, with p50/p95 unmoved. The overhead isn't native-thread time, so adding a thread parallelises something that was never the bottleneck.
2. **A second connection makes `executeSync` *worse*** (2058 ms vs 1658 ms). `executeSync` never touches the thread pool, so the reader buys nothing while adding a second cold page cache competing for the same file.

Which is why this PR is just the sync path. It avoids the extra fd, extra thread, extra page cache, WAL-checkpoint starvation, and read-your-writes staleness that the two-connection version would have brought — there is still exactly one connection, so read-your-writes semantics are completely unchanged.

## Safety

```ts
if ("transaction" in db && "executeSync" in db) {
  return db.executeSync(sql, params as any[]);
}
return db.execute(sql, params as any[]);
```

- **Transaction reads stay async.** An op-sqlite `Transaction` exposes neither `transaction` nor `executeSync`, so `withDB(tx)` adapters route to `execute` and stay ordered with the transaction's own writes.
- **Old op-sqlite keeps working.** The peer is `"*"`, so the same guard covers versions predating `executeSync` rather than throwing on a missing method.
- **Writes are untouched** — `run` and `transaction` are unchanged.

## The tradeoff to be aware of

`executeSync` blocks the JS thread for the duration of the call. For the point lookups that dominate covalue loading that's microseconds, and it won on every metric here including the tail. But a `query` returning a very large row set is a bigger block than the async path would be. Happy to restrict the sync path to `get` and leave `query` async if you'd prefer the conservative version — say the word and I'll push it. I measured both-sync because that's what won; I didn't want to ship an unmeasured hybrid.

## Tests

Adds `packages/jazz-tools/src/react-native/tests/op-sqlite-adapter.test.ts` (7 tests) covering the routing: `get`/`query` on the sync path, fallback to async when `executeSync` is absent, transaction-scoped reads staying async, and `run` staying async.

One infra note: nothing importing `react-native` had a test in this repo before, and `vi.mock` can't help — RN's entrypoint is Flow source that Vite fails to parse at transform time, before the mock applies. So the vitest config aliases `react-native` to a small stub. Open to a different approach if you have a preferred pattern.

Full `jazz-tools` suite is unchanged by this PR: 62 failed files / 6 failed tests / 25 errors both before and after on `main` (all pre-existing and unrelated), with 7 added passing tests.