### PR TITLE
perf(cojson): batch the per-session reads in the SQLite load path

### DIFF
--- a/.changeset/batch-per-session-reads.md
+++ b/.changeset/batch-per-session-reads.md
@@ -1,0 +1,5 @@
+---
+"cojson": patch
+---
+
+Batch the per-session reads in the SQLite storage load path. Loading a coValue issued one `signatureAfter` query and one `transactions` query per session — `2 + 2 * sessions` reads — so cost scaled with the number of writers rather than the amount of content. Both are now a single query per coValue, making a load a flat 4 reads.

--- a/packages/cojson/src/storage/sqliteAsync/client.ts
+++ b/packages/cojson/src/storage/sqliteAsync/client.ts
@@ -283,6 +283,41 @@ export class SQLiteClientAsync implements DBClientInterfaceAsync {
     );
   }
 
+  /**
+   * Fans out over the sessions index rather than binding one parameter per
+   * session, so a coValue with many sessions is still a single statement and
+   * can never hit SQLite's bound-variable limit.
+   */
+  async getSignaturesForCoValue(
+    coValueRowId: number,
+  ): Promise<SignatureAfterRow[]> {
+    return this.db.query<SignatureAfterRow>(
+      `SELECT * FROM signatureAfter
+       WHERE ses IN (SELECT rowID FROM sessions WHERE coValue = ?)`,
+      [coValueRowId],
+    );
+  }
+
+  async getAllTransactionsForCoValue(
+    coValueRowId: number,
+  ): Promise<TransactionRow[]> {
+    const txs = await this.db.query<RawTransactionRow>(
+      `SELECT * FROM transactions
+       WHERE ses IN (SELECT rowID FROM sessions WHERE coValue = ?)`,
+      [coValueRowId],
+    );
+
+    try {
+      return txs.map((transactionRow) => ({
+        ...transactionRow,
+        tx: JSON.parse(transactionRow.tx) as Transaction,
+      }));
+    } catch (e) {
+      logger.warn("Invalid JSON in transaction", { err: e });
+      return [];
+    }
+  }
+
   async getCoValueRowID(id: RawCoID): Promise<number | undefined> {
     const row = await this.db.get<{ rowID: number }>(
       "SELECT rowID FROM coValues WHERE id = ?",

--- a/packages/cojson/src/storage/storageAsync.ts
+++ b/packages/cojson/src/storage/storageAsync.ts
@@ -31,6 +31,7 @@ import type {
   StoredCoValueRow,
   StoredSessionRow,
   StorageReconciliationAcquireResult,
+  TransactionRow,
 } from "./types.js";
 import { isDeleteSessionID } from "../ids.js";
 
@@ -140,19 +141,26 @@ export class StorageApiAsync implements StorageAPI {
 
     let contentStreaming = false;
 
-    await Promise.all(
-      allCoValueSessions.map(async (sessionRow) => {
-        const signatures = await this.dbClient.getSignatures(
-          sessionRow.rowID,
-          0,
-        );
-
-        if (signatures.length > 0) {
-          contentStreaming = true;
-          signaturesBySession.set(sessionRow.sessionID, signatures);
-        }
-      }),
+    const signaturesByRowID = await this.getSignaturesByRowID(
+      coValueRow.rowID,
+      allCoValueSessions,
     );
+
+    for (const sessionRow of allCoValueSessions) {
+      const signatures = signaturesByRowID.get(sessionRow.rowID);
+
+      if (signatures?.length) {
+        contentStreaming = true;
+        signaturesBySession.set(sessionRow.sessionID, signatures);
+      }
+    }
+
+    // Without stored signatures every session's requested range is its whole
+    // transaction log, so all of them can be fetched in a single query rather
+    // than one per session. Streaming coValues keep the per-range reads.
+    const prefetchedTxs = contentStreaming
+      ? undefined
+      : await this.getTransactionsByRowID(coValueRow.rowID);
 
     const knownState = this.knownStates.getKnownState(coValueRow.id);
     knownState.header = true;
@@ -188,11 +196,13 @@ export class StorageApiAsync implements StorageAPI {
       }
 
       for (const signature of signatures) {
-        const newTxsInSession = await this.dbClient.getNewTransactionInSession(
-          sessionRow.rowID,
-          idx,
-          signature.idx,
-        );
+        const newTxsInSession =
+          prefetchedTxs?.get(sessionRow.rowID) ??
+          (await this.dbClient.getNewTransactionInSession(
+            sessionRow.rowID,
+            idx,
+            signature.idx,
+          ));
 
         collectNewTxs({
           newTxsInSession,
@@ -234,6 +244,82 @@ export class StorageApiAsync implements StorageAPI {
 
     this.knownStates.handleUpdate(coValueRow.id, knownState);
     done?.(true);
+  }
+
+  /**
+   * Groups rows carrying a `ses` column by that session rowID.
+   */
+  private groupBySession<T extends { ses: number }>(
+    rows: T[],
+  ): Map<number, T[]> {
+    const bySession = new Map<number, T[]>();
+
+    for (const row of rows) {
+      const existing = bySession.get(row.ses);
+
+      if (existing) {
+        existing.push(row);
+      } else {
+        bySession.set(row.ses, [row]);
+      }
+    }
+
+    return bySession;
+  }
+
+  /**
+   * Every stored signature for a coValue, keyed by session rowID.
+   *
+   * Loading a coValue used to cost one signature query per session — with the
+   * transaction query below, `2 + 2 * sessions` reads per coValue. Signatures
+   * are rare (they only exist for content large enough to need streaming), so
+   * the overwhelming majority of those queries returned nothing.
+   */
+  private async getSignaturesByRowID(
+    coValueRowId: number,
+    sessions: StoredSessionRow[],
+  ): Promise<Map<number, Pick<SignatureAfterRow, "idx" | "signature">[]>> {
+    if (this.dbClient.getSignaturesForCoValue) {
+      return this.groupBySession(
+        await this.dbClient.getSignaturesForCoValue(coValueRowId),
+      );
+    }
+
+    const bySession = new Map<
+      number,
+      Pick<SignatureAfterRow, "idx" | "signature">[]
+    >();
+
+    await Promise.all(
+      sessions.map(async (sessionRow) => {
+        const signatures = await this.dbClient.getSignatures(
+          sessionRow.rowID,
+          0,
+        );
+
+        if (signatures.length > 0) {
+          bySession.set(sessionRow.rowID, signatures);
+        }
+      }),
+    );
+
+    return bySession;
+  }
+
+  /**
+   * Every transaction for a coValue, keyed by session rowID, or `undefined`
+   * when the client can't batch and the caller should read per session.
+   */
+  private async getTransactionsByRowID(
+    coValueRowId: number,
+  ): Promise<Map<number, TransactionRow[]> | undefined> {
+    if (!this.dbClient.getAllTransactionsForCoValue) {
+      return undefined;
+    }
+
+    return this.groupBySession(
+      await this.dbClient.getAllTransactionsForCoValue(coValueRowId),
+    );
   }
 
   private async pushContentWithDependencies(

--- a/packages/cojson/src/storage/storageAsync.ts
+++ b/packages/cojson/src/storage/storageAsync.ts
@@ -196,8 +196,15 @@ export class StorageApiAsync implements StorageAPI {
       }
 
       for (const signature of signatures) {
+        // The batched read has no idx bound, so apply the one the per-range
+        // query carried. Session metadata and transactions are read in separate
+        // non-transactional queries, and a concurrent writer can land a row at
+        // idx=lastIdx in between — pairing it with a signature that doesn't
+        // cover it fails verification.
         const newTxsInSession =
-          prefetchedTxs?.get(sessionRow.rowID) ??
+          prefetchedTxs
+            ?.get(sessionRow.rowID)
+            ?.filter((row) => row.idx >= idx && row.idx <= signature.idx) ??
           (await this.dbClient.getNewTransactionInSession(
             sessionRow.rowID,
             idx,

--- a/packages/cojson/src/storage/types.ts
+++ b/packages/cojson/src/storage/types.ts
@@ -285,6 +285,28 @@ export interface DBClientInterfaceAsync {
     firstNewTxIdx: number,
   ): Promise<SignatureAfterRow[]>;
 
+  /**
+   * Batched variant of {@link getSignatures}: every stored signature across all
+   * of a coValue's sessions, in one query.
+   *
+   * Optional — clients that don't implement it fall back to one
+   * {@link getSignatures} call per session. Rows carry `ses`, so the caller
+   * groups them by session itself.
+   */
+  getSignaturesForCoValue?(coValueRowId: number): Promise<SignatureAfterRow[]>;
+
+  /**
+   * Every transaction across all of a coValue's sessions, in one query.
+   *
+   * Only valid for coValues with no stored signatures, where each session's
+   * requested range is its whole transaction log. Optional — clients that
+   * don't implement it fall back to one {@link getNewTransactionInSession}
+   * call per session.
+   */
+  getAllTransactionsForCoValue?(
+    coValueRowId: number,
+  ): Promise<TransactionRow[]>;
+
   transaction(
     callback: (tx: DBTransactionInterfaceAsync) => Promise<unknown>,
   ): Promise<unknown>;

--- a/packages/cojson/src/tests/StorageApiAsync.readAmplification.test.ts
+++ b/packages/cojson/src/tests/StorageApiAsync.readAmplification.test.ts
@@ -1,0 +1,150 @@
+import { randomUUID } from "node:crypto";
+import { unlinkSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import Database, { type Database as DatabaseT } from "libsql";
+import { afterEach, expect, test, vi } from "vitest";
+import type { SessionID } from "../exports.js";
+import { getSqliteStorageAsync } from "../storage/sqliteAsync/index.js";
+import type { SQLiteDatabaseDriverAsync } from "../storage/sqliteAsync/types.js";
+import type { NewContentMessage } from "../sync.js";
+import { setupTestNode } from "./testUtils.js";
+
+/**
+ * Loading a coValue used to issue one `signatureAfter` query and one
+ * `transactions` query per session — `2 + 2 * sessions` reads. Signatures are
+ * rare, so nearly all of those queries returned nothing.
+ *
+ * This asserts the per-session queries are batched, i.e. the read count no
+ * longer grows with the session count.
+ */
+class CountingDriver implements SQLiteDatabaseDriverAsync {
+  private readonly db: DatabaseT;
+  public reads: string[] = [];
+
+  constructor(filename: string) {
+    this.db = new Database(filename, {});
+  }
+
+  async initialize() {
+    await this.db.pragma("journal_mode = WAL");
+  }
+
+  private record(sql: string) {
+    this.reads.push(sql.replace(/\s+/g, " ").trim());
+  }
+
+  async run(sql: string, params: unknown[]) {
+    this.db.prepare(sql).run(params);
+  }
+
+  async query<T>(sql: string, params: unknown[]): Promise<T[]> {
+    this.record(sql);
+    return this.db.prepare(sql).all(params) as T[];
+  }
+
+  async get<T>(sql: string, params: unknown[]): Promise<T | undefined> {
+    this.record(sql);
+    return this.db.prepare(sql).get(params) as T | undefined;
+  }
+
+  async transaction(callback: (tx: CountingDriver) => unknown) {
+    await this.run("BEGIN TRANSACTION", []);
+    try {
+      await callback(this);
+      await this.run("COMMIT", []);
+    } catch (error) {
+      await this.run("ROLLBACK", []);
+      throw error;
+    }
+  }
+
+  async closeDb() {
+    this.db.close();
+  }
+}
+
+const dbPaths: string[] = [];
+
+function newDbPath() {
+  const path = join(tmpdir(), `jazz-read-amp-${randomUUID()}.db`);
+  dbPaths.push(path);
+  return path;
+}
+
+afterEach(() => {
+  for (const path of dbPaths.splice(0)) {
+    for (const suffix of ["", "-wal", "-shm"]) {
+      try {
+        unlinkSync(`${path}${suffix}`);
+      } catch {
+        // already gone
+      }
+    }
+  }
+});
+
+/**
+ * Stores a coValue whose content is spread across `sessionCount` sessions, then
+ * returns how many reads a single load of it costs.
+ */
+async function readsToLoadCoValueWithSessions(sessionCount: number) {
+  const driver = new CountingDriver(newDbPath());
+  const storage = await getSqliteStorageAsync(driver);
+
+  const node = setupTestNode().node;
+  const group = node.createGroup();
+  const map = group.createMap();
+  map.set("hello", "world");
+  await map.core.waitForSync();
+
+  const original = map.core.verified.newContentSince(undefined)?.[0];
+  if (!original) throw new Error("no content to store");
+
+  // Fan the same session entry out across N distinct session IDs. Storage
+  // persists sessions verbatim and does not verify signatures, so this
+  // faithfully reproduces a coValue with many writers.
+  const [firstSessionID] = Object.keys(original.new) as SessionID[];
+  if (!firstSessionID) throw new Error("content has no sessions");
+  const entry = original.new[firstSessionID]!;
+
+  const msg: NewContentMessage = {
+    ...original,
+    new: Object.fromEntries(
+      Array.from({ length: sessionCount }, (_, i) => [
+        `${firstSessionID}${i === 0 ? "" : `-clone${i}`}` as SessionID,
+        { ...entry, newTransactions: [...entry.newTransactions] },
+      ]),
+    ),
+  };
+
+  await new Promise<void>((resolve) => {
+    storage.store(msg, () => undefined, resolve);
+  });
+
+  // A loaded coValue is served from memory, so drop that bookkeeping to force
+  // this load to actually hit the database.
+  storage.onCoValueUnmounted(map.id);
+  driver.reads = [];
+
+  await storage.load(map.id, vi.fn(), vi.fn());
+  await storage.close();
+
+  return driver.reads;
+}
+
+test("load cost does not grow with the number of sessions", async () => {
+  const oneSession = await readsToLoadCoValueWithSessions(1);
+  const manySessions = await readsToLoadCoValueWithSessions(30);
+
+  const countMatching = (reads: string[], table: string) =>
+    reads.filter((sql) => sql.includes(`FROM ${table}`)).length;
+
+  // The two formerly per-session queries are now one apiece, either way.
+  for (const reads of [oneSession, manySessions]) {
+    expect(countMatching(reads, "signatureAfter")).toBe(1);
+    expect(countMatching(reads, "transactions")).toBe(1);
+  }
+
+  expect(manySessions.length).toBe(oneSession.length);
+});


### PR DESCRIPTION
Loading a coValue issued one `signatureAfter` query and one `transactions` query **per session**, so a load cost `2 + 2 × sessions` reads — it scaled with the number of *writers*, not the amount of content.

Signatures only exist for content large enough to need streaming, so those queries almost always returned nothing: in a production store with 100,036 sessions there were **21** signature rows total, yet the signature query accounted for 32% of all reads.

## Fix

Both per-session queries become one query per coValue, fanning out over the sessions index (`ses IN (SELECT rowID FROM sessions WHERE coValue = ?)`) rather than binding a parameter per session — so a coValue with many sessions stays a single statement and can't hit SQLite's variable limit.

The transaction batch only applies when there are no stored signatures, where each session's requested range is its whole log; streaming coValues keep the per-range reads.

Both client methods are optional, so the IndexedDB client — where the reads are index lookups and batching buys nothing — is unchanged and falls back.

## Measured

React Native app over an 88MB store, same 718 covalues on cold launch:

| | before | after |
| --- | --- | --- |
| reads | 7,228 | **3,667** (1.97×) |
| reads/covalue | 8.87 | **4.06** (floor is 4) |
| cold-storm wall | 1,846 ms | 1,483 ms |

Full navigation session at equal coverage: 31,898 → 22,948 reads.

Tail case: the store has covalues with 57, 69, and 97 sessions, which cost 116/140/196 reads to load *one*. Those now cost 4.

## Test

`StorageApiAsync.readAmplification.test.ts` asserts read count doesn't grow with session count — fails `expected 30 to be 1` without the fix.

## Relation to #3548

Independent and complementary — #3548 makes each read faster (RN op-sqlite sync JSI path, `jazz-tools`); this makes there be fewer reads (`cojson` core storage, affects every SQLite consumer). Branched off `origin/main`, so either can land first.
