### PR TITLE
perf(cojson): batch the checkpoint reads for streaming coValues

### DIFF
--- a/.changeset/batch-per-session-reads.md
+++ b/.changeset/batch-per-session-reads.md
@@ -1,0 +1,5 @@
+---
+"cojson": patch
+---
+
+Batch the per-session reads in the SQLite storage load path. Loading a coValue issued one `signatureAfter` query and one `transactions` query per session — `2 + 2 * sessions` reads — so cost scaled with the number of writers rather than the amount of content. Both are now a single query per coValue, making a load a flat 4 reads.

--- a/.changeset/stream-read-batching.md
+++ b/.changeset/stream-read-batching.md
@@ -1,0 +1,5 @@
+---
+"cojson": patch
+---
+
+Batch the checkpoint reads when loading a streaming coValue from SQLite storage. A coValue long enough to be split across signature checkpoints was read one checkpoint at a time — a round trip per ~100KB of transaction log, so a coValue with tens of thousands of transactions cost tens of sequential reads. Checkpoints are now read several at a time and sliced in memory, keeping peak memory bounded.

--- a/packages/cojson/src/storage/sqliteAsync/client.ts
+++ b/packages/cojson/src/storage/sqliteAsync/client.ts
@@ -283,6 +283,41 @@ export class SQLiteClientAsync implements DBClientInterfaceAsync {
     );
   }
 
+  /**
+   * Fans out over the sessions index rather than binding one parameter per
+   * session, so a coValue with many sessions is still a single statement and
+   * can never hit SQLite's bound-variable limit.
+   */
+  async getSignaturesForCoValue(
+    coValueRowId: number,
+  ): Promise<SignatureAfterRow[]> {
+    return this.db.query<SignatureAfterRow>(
+      `SELECT * FROM signatureAfter
+       WHERE ses IN (SELECT rowID FROM sessions WHERE coValue = ?)`,
+      [coValueRowId],
+    );
+  }
+
+  async getAllTransactionsForCoValue(
+    coValueRowId: number,
+  ): Promise<TransactionRow[]> {
+    const txs = await this.db.query<RawTransactionRow>(
+      `SELECT * FROM transactions
+       WHERE ses IN (SELECT rowID FROM sessions WHERE coValue = ?)`,
+      [coValueRowId],
+    );
+
+    try {
+      return txs.map((transactionRow) => ({
+        ...transactionRow,
+        tx: JSON.parse(transactionRow.tx) as Transaction,
+      }));
+    } catch (e) {
+      logger.warn("Invalid JSON in transaction", { err: e });
+      return [];
+    }
+  }
+
   async getCoValueRowID(id: RawCoID): Promise<number | undefined> {
     const row = await this.db.get<{ rowID: number }>(
       "SELECT rowID FROM coValues WHERE id = ?",

--- a/packages/cojson/src/storage/storageAsync.ts
+++ b/packages/cojson/src/storage/storageAsync.ts
@@ -31,6 +31,7 @@ import type {
   StoredCoValueRow,
   StoredSessionRow,
   StorageReconciliationAcquireResult,
+  TransactionRow,
 } from "./types.js";
 import { isDeleteSessionID } from "../ids.js";
 
@@ -140,19 +141,26 @@ export class StorageApiAsync implements StorageAPI {
 
     let contentStreaming = false;
 
-    await Promise.all(
-      allCoValueSessions.map(async (sessionRow) => {
-        const signatures = await this.dbClient.getSignatures(
-          sessionRow.rowID,
-          0,
-        );
-
-        if (signatures.length > 0) {
-          contentStreaming = true;
-          signaturesBySession.set(sessionRow.sessionID, signatures);
-        }
-      }),
+    const signaturesByRowID = await this.getSignaturesByRowID(
+      coValueRow.rowID,
+      allCoValueSessions,
     );
+
+    for (const sessionRow of allCoValueSessions) {
+      const signatures = signaturesByRowID.get(sessionRow.rowID);
+
+      if (signatures?.length) {
+        contentStreaming = true;
+        signaturesBySession.set(sessionRow.sessionID, signatures);
+      }
+    }
+
+    // Without stored signatures every session's requested range is its whole
+    // transaction log, so all of them can be fetched in a single query rather
+    // than one per session. Streaming coValues keep the per-range reads.
+    const prefetchedTxs = contentStreaming
+      ? undefined
+      : await this.getTransactionsByRowID(coValueRow.rowID);
 
     const knownState = this.knownStates.getKnownState(coValueRow.id);
     knownState.header = true;
@@ -188,11 +196,13 @@ export class StorageApiAsync implements StorageAPI {
       }
 
       for (const signature of signatures) {
-        const newTxsInSession = await this.dbClient.getNewTransactionInSession(
-          sessionRow.rowID,
-          idx,
-          signature.idx,
-        );
+        const newTxsInSession =
+          prefetchedTxs?.get(sessionRow.rowID) ??
+          (await this.dbClient.getNewTransactionInSession(
+            sessionRow.rowID,
+            idx,
+            signature.idx,
+          ));
 
         collectNewTxs({
           newTxsInSession,
@@ -234,6 +244,82 @@ export class StorageApiAsync implements StorageAPI {
 
     this.knownStates.handleUpdate(coValueRow.id, knownState);
     done?.(true);
+  }
+
+  /**
+   * Groups rows carrying a `ses` column by that session rowID.
+   */
+  private groupBySession<T extends { ses: number }>(
+    rows: T[],
+  ): Map<number, T[]> {
+    const bySession = new Map<number, T[]>();
+
+    for (const row of rows) {
+      const existing = bySession.get(row.ses);
+
+      if (existing) {
+        existing.push(row);
+      } else {
+        bySession.set(row.ses, [row]);
+      }
+    }
+
+    return bySession;
+  }
+
+  /**
+   * Every stored signature for a coValue, keyed by session rowID.
+   *
+   * Loading a coValue used to cost one signature query per session — with the
+   * transaction query below, `2 + 2 * sessions` reads per coValue. Signatures
+   * are rare (they only exist for content large enough to need streaming), so
+   * the overwhelming majority of those queries returned nothing.
+   */
+  private async getSignaturesByRowID(
+    coValueRowId: number,
+    sessions: StoredSessionRow[],
+  ): Promise<Map<number, Pick<SignatureAfterRow, "idx" | "signature">[]>> {
+    if (this.dbClient.getSignaturesForCoValue) {
+      return this.groupBySession(
+        await this.dbClient.getSignaturesForCoValue(coValueRowId),
+      );
+    }
+
+    const bySession = new Map<
+      number,
+      Pick<SignatureAfterRow, "idx" | "signature">[]
+    >();
+
+    await Promise.all(
+      sessions.map(async (sessionRow) => {
+        const signatures = await this.dbClient.getSignatures(
+          sessionRow.rowID,
+          0,
+        );
+
+        if (signatures.length > 0) {
+          bySession.set(sessionRow.rowID, signatures);
+        }
+      }),
+    );
+
+    return bySession;
+  }
+
+  /**
+   * Every transaction for a coValue, keyed by session rowID, or `undefined`
+   * when the client can't batch and the caller should read per session.
+   */
+  private async getTransactionsByRowID(
+    coValueRowId: number,
+  ): Promise<Map<number, TransactionRow[]> | undefined> {
+    if (!this.dbClient.getAllTransactionsForCoValue) {
+      return undefined;
+    }
+
+    return this.groupBySession(
+      await this.dbClient.getAllTransactionsForCoValue(coValueRowId),
+    );
   }
 
   private async pushContentWithDependencies(

--- a/packages/cojson/src/storage/storageAsync.ts
+++ b/packages/cojson/src/storage/storageAsync.ts
@@ -196,8 +196,15 @@ export class StorageApiAsync implements StorageAPI {
       }
 
       for (const signature of signatures) {
+        // The batched read has no idx bound, so apply the one the per-range
+        // query carried. Session metadata and transactions are read in separate
+        // non-transactional queries, and a concurrent writer can land a row at
+        // idx=lastIdx in between — pairing it with a signature that doesn't
+        // cover it fails verification.
         const newTxsInSession =
-          prefetchedTxs?.get(sessionRow.rowID) ??
+          prefetchedTxs
+            ?.get(sessionRow.rowID)
+            ?.filter((row) => row.idx >= idx && row.idx <= signature.idx) ??
           (await this.dbClient.getNewTransactionInSession(
             sessionRow.rowID,
             idx,

--- a/packages/cojson/src/storage/storageAsync.ts
+++ b/packages/cojson/src/storage/storageAsync.ts
@@ -35,6 +35,17 @@ import type {
 } from "./types.js";
 import { isDeleteSessionID } from "../ids.js";
 
+/**
+ * How many signature checkpoints one streaming read covers. Checkpoints are
+ * written every `MAX_RECOMMENDED_TX_SIZE` (100KB), so this caps a read at
+ * roughly 1MB — low enough for a phone, high enough to take an order of
+ * magnitude off the round trips on a long log.
+ *
+ * ponytail: a constant, not an option. Make it configurable when a platform
+ * actually needs a different bound.
+ */
+const SIGNATURE_READ_BATCH = 10;
+
 export class StorageApiAsync implements StorageAPI {
   private readonly dbClient: DBClientInterfaceAsync;
 
@@ -195,21 +206,51 @@ export class StorageApiAsync implements StorageAPI {
         });
       }
 
-      for (const signature of signatures) {
-        // The batched read has no idx bound, so apply the one the per-range
-        // query carried. Session metadata and transactions are read in separate
-        // non-transactional queries, and a concurrent writer can land a row at
-        // idx=lastIdx in between — pairing it with a signature that doesn't
-        // cover it fails verification.
-        const newTxsInSession =
-          prefetchedTxs
-            ?.get(sessionRow.rowID)
-            ?.filter((row) => row.idx >= idx && row.idx <= signature.idx) ??
-          (await this.dbClient.getNewTransactionInSession(
+      // Rows backing the checkpoints being handed out. Either the whole
+      // session — prefetched in one query when nothing streams — or a window of
+      // checkpoints read at a time. A streaming session otherwise costs one
+      // round trip per ~MAX_RECOMMENDED_TX_SIZE of log; batching cuts that by
+      // SIGNATURE_READ_BATCH× while keeping peak memory bounded, which reading
+      // the whole log at once would not.
+      //
+      // `transactions` is PRIMARY KEY (ses, idx) WITHOUT ROWID, so either read
+      // comes back in idx order — the assumption the per-checkpoint read
+      // already made.
+      // Gate on this session's entry, not on the prefetch as a whole: the
+      // batched read returns [] if any row fails to parse, and falling back to
+      // the per-range reads recovers the ranges that are still intact.
+      const prefetched = prefetchedTxs?.get(sessionRow.rowID);
+
+      let window: TransactionRow[] = prefetched ?? [];
+      let windowCursor = 0;
+      let windowEnd = prefetched ? Number.POSITIVE_INFINITY : -1;
+
+      for (const [i, signature] of signatures.entries()) {
+        if (signature.idx > windowEnd) {
+          windowEnd =
+            signatures[
+              Math.min(i + SIGNATURE_READ_BATCH - 1, signatures.length - 1)
+            ]!.idx;
+          window = await this.dbClient.getNewTransactionInSession(
             sessionRow.rowID,
             idx,
-            signature.idx,
-          ));
+            windowEnd,
+          );
+          windowCursor = 0;
+        }
+
+        // Never hand out past the signature that covers it. Session metadata and
+        // transactions are read in separate non-transactional queries, so a
+        // concurrent writer can land a row at idx=lastIdx in between; pairing it
+        // with this signature would fail verification.
+        const from = windowCursor;
+        while (
+          windowCursor < window.length &&
+          window[windowCursor]!.idx <= signature.idx
+        ) {
+          windowCursor++;
+        }
+        const newTxsInSession = window.slice(from, windowCursor);
 
         collectNewTxs({
           newTxsInSession,

--- a/packages/cojson/src/storage/types.ts
+++ b/packages/cojson/src/storage/types.ts
@@ -285,6 +285,28 @@ export interface DBClientInterfaceAsync {
     firstNewTxIdx: number,
   ): Promise<SignatureAfterRow[]>;
 
+  /**
+   * Batched variant of {@link getSignatures}: every stored signature across all
+   * of a coValue's sessions, in one query.
+   *
+   * Optional — clients that don't implement it fall back to one
+   * {@link getSignatures} call per session. Rows carry `ses`, so the caller
+   * groups them by session itself.
+   */
+  getSignaturesForCoValue?(coValueRowId: number): Promise<SignatureAfterRow[]>;
+
+  /**
+   * Every transaction across all of a coValue's sessions, in one query.
+   *
+   * Only valid for coValues with no stored signatures, where each session's
+   * requested range is its whole transaction log. Optional — clients that
+   * don't implement it fall back to one {@link getNewTransactionInSession}
+   * call per session.
+   */
+  getAllTransactionsForCoValue?(
+    coValueRowId: number,
+  ): Promise<TransactionRow[]>;
+
   transaction(
     callback: (tx: DBTransactionInterfaceAsync) => Promise<unknown>,
   ): Promise<unknown>;

--- a/packages/cojson/src/tests/StorageApiAsync.readAmplification.test.ts
+++ b/packages/cojson/src/tests/StorageApiAsync.readAmplification.test.ts
@@ -1,0 +1,150 @@
+import { randomUUID } from "node:crypto";
+import { unlinkSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import Database, { type Database as DatabaseT } from "libsql";
+import { afterEach, expect, test, vi } from "vitest";
+import type { SessionID } from "../exports.js";
+import { getSqliteStorageAsync } from "../storage/sqliteAsync/index.js";
+import type { SQLiteDatabaseDriverAsync } from "../storage/sqliteAsync/types.js";
+import type { NewContentMessage } from "../sync.js";
+import { setupTestNode } from "./testUtils.js";
+
+/**
+ * Loading a coValue used to issue one `signatureAfter` query and one
+ * `transactions` query per session — `2 + 2 * sessions` reads. Signatures are
+ * rare, so nearly all of those queries returned nothing.
+ *
+ * This asserts the per-session queries are batched, i.e. the read count no
+ * longer grows with the session count.
+ */
+class CountingDriver implements SQLiteDatabaseDriverAsync {
+  private readonly db: DatabaseT;
+  public reads: string[] = [];
+
+  constructor(filename: string) {
+    this.db = new Database(filename, {});
+  }
+
+  async initialize() {
+    await this.db.pragma("journal_mode = WAL");
+  }
+
+  private record(sql: string) {
+    this.reads.push(sql.replace(/\s+/g, " ").trim());
+  }
+
+  async run(sql: string, params: unknown[]) {
+    this.db.prepare(sql).run(params);
+  }
+
+  async query<T>(sql: string, params: unknown[]): Promise<T[]> {
+    this.record(sql);
+    return this.db.prepare(sql).all(params) as T[];
+  }
+
+  async get<T>(sql: string, params: unknown[]): Promise<T | undefined> {
+    this.record(sql);
+    return this.db.prepare(sql).get(params) as T | undefined;
+  }
+
+  async transaction(callback: (tx: CountingDriver) => unknown) {
+    await this.run("BEGIN TRANSACTION", []);
+    try {
+      await callback(this);
+      await this.run("COMMIT", []);
+    } catch (error) {
+      await this.run("ROLLBACK", []);
+      throw error;
+    }
+  }
+
+  async closeDb() {
+    this.db.close();
+  }
+}
+
+const dbPaths: string[] = [];
+
+function newDbPath() {
+  const path = join(tmpdir(), `jazz-read-amp-${randomUUID()}.db`);
+  dbPaths.push(path);
+  return path;
+}
+
+afterEach(() => {
+  for (const path of dbPaths.splice(0)) {
+    for (const suffix of ["", "-wal", "-shm"]) {
+      try {
+        unlinkSync(`${path}${suffix}`);
+      } catch {
+        // already gone
+      }
+    }
+  }
+});
+
+/**
+ * Stores a coValue whose content is spread across `sessionCount` sessions, then
+ * returns how many reads a single load of it costs.
+ */
+async function readsToLoadCoValueWithSessions(sessionCount: number) {
+  const driver = new CountingDriver(newDbPath());
+  const storage = await getSqliteStorageAsync(driver);
+
+  const node = setupTestNode().node;
+  const group = node.createGroup();
+  const map = group.createMap();
+  map.set("hello", "world");
+  await map.core.waitForSync();
+
+  const original = map.core.verified.newContentSince(undefined)?.[0];
+  if (!original) throw new Error("no content to store");
+
+  // Fan the same session entry out across N distinct session IDs. Storage
+  // persists sessions verbatim and does not verify signatures, so this
+  // faithfully reproduces a coValue with many writers.
+  const [firstSessionID] = Object.keys(original.new) as SessionID[];
+  if (!firstSessionID) throw new Error("content has no sessions");
+  const entry = original.new[firstSessionID]!;
+
+  const msg: NewContentMessage = {
+    ...original,
+    new: Object.fromEntries(
+      Array.from({ length: sessionCount }, (_, i) => [
+        `${firstSessionID}${i === 0 ? "" : `-clone${i}`}` as SessionID,
+        { ...entry, newTransactions: [...entry.newTransactions] },
+      ]),
+    ),
+  };
+
+  await new Promise<void>((resolve) => {
+    storage.store(msg, () => undefined, resolve);
+  });
+
+  // A loaded coValue is served from memory, so drop that bookkeeping to force
+  // this load to actually hit the database.
+  storage.onCoValueUnmounted(map.id);
+  driver.reads = [];
+
+  await storage.load(map.id, vi.fn(), vi.fn());
+  await storage.close();
+
+  return driver.reads;
+}
+
+test("load cost does not grow with the number of sessions", async () => {
+  const oneSession = await readsToLoadCoValueWithSessions(1);
+  const manySessions = await readsToLoadCoValueWithSessions(30);
+
+  const countMatching = (reads: string[], table: string) =>
+    reads.filter((sql) => sql.includes(`FROM ${table}`)).length;
+
+  // The two formerly per-session queries are now one apiece, either way.
+  for (const reads of [oneSession, manySessions]) {
+    expect(countMatching(reads, "signatureAfter")).toBe(1);
+    expect(countMatching(reads, "transactions")).toBe(1);
+  }
+
+  expect(manySessions.length).toBe(oneSession.length);
+});

--- a/packages/cojson/src/tests/StorageApiAsync.readAmplification.test.ts
+++ b/packages/cojson/src/tests/StorageApiAsync.readAmplification.test.ts
@@ -133,6 +133,134 @@ async function readsToLoadCoValueWithSessions(sessionCount: number) {
   return driver.reads;
 }
 
+/**
+ * A coValue long enough to be split across signature checkpoints — the case the
+ * batched whole-coValue read deliberately skips. Returns the reads a load costs
+ * plus the content it produced.
+ */
+async function loadStreamingCoValue(txCount: number) {
+  const driver = new CountingDriver(newDbPath());
+  const storage = await getSqliteStorageAsync(driver);
+
+  const node = setupTestNode().node;
+  const group = node.createGroup();
+  const map = group.createMap();
+  for (let i = 0; i < txCount; i++) {
+    map.set(`k${i}`, "A".repeat(2048));
+  }
+  await map.core.waitForSync();
+
+  for (const msg of map.core.verified.newContentSince(undefined) ?? []) {
+    await new Promise<void>((resolve) => {
+      storage.store(msg, () => undefined, resolve);
+    });
+  }
+
+  storage.onCoValueUnmounted(map.id);
+  driver.reads = [];
+
+  const content: NewContentMessage[] = [];
+  await new Promise<void>((resolve) => {
+    storage.load(
+      map.id,
+      (data) => content.push(data),
+      () => resolve(),
+    );
+  });
+  await storage.close();
+
+  const flatten = (msgs: NewContentMessage[]) =>
+    msgs.flatMap((msg) =>
+      Object.values(msg.new).flatMap((entry) => entry.newTransactions),
+    );
+
+  return {
+    txReads: driver.reads.filter((sql) => sql.includes("FROM transactions"))
+      .length,
+    transactions: flatten(content),
+    // What was written, in order — the batched read has to reproduce it exactly.
+    expected: flatten(map.core.verified.newContentSince(undefined) ?? []),
+  };
+}
+
+test("a corrupt transaction row only costs its own session", async () => {
+  const driver = new CountingDriver(newDbPath());
+  const storage = await getSqliteStorageAsync(driver);
+
+  const node = setupTestNode().node;
+  const group = node.createGroup();
+  const map = group.createMap();
+  map.set("hello", "world");
+  await map.core.waitForSync();
+
+  const original = map.core.verified.newContentSince(undefined)?.[0];
+  if (!original) throw new Error("no content to store");
+
+  const [firstSessionID] = Object.keys(original.new) as SessionID[];
+  if (!firstSessionID) throw new Error("content has no sessions");
+  const entry = original.new[firstSessionID]!;
+
+  const msg: NewContentMessage = {
+    ...original,
+    new: Object.fromEntries(
+      Array.from({ length: 3 }, (_, i) => [
+        `${firstSessionID}${i === 0 ? "" : `-clone${i}`}` as SessionID,
+        { ...entry, newTransactions: [...entry.newTransactions] },
+      ]),
+    ),
+  };
+
+  await new Promise<void>((resolve) => {
+    storage.store(msg, () => undefined, resolve);
+  });
+
+  // The batched whole-coValue read parses every row under a single try/catch,
+  // so one bad row makes it return nothing for every session. Falling back to
+  // the per-session reads has to still recover the two intact ones.
+  const sessions = await driver.query<{ rowID: number }>(
+    "SELECT rowID FROM sessions WHERE coValue = (SELECT rowID FROM coValues WHERE id = ?) ORDER BY rowID",
+    [map.id],
+  );
+  expect(sessions).toHaveLength(3);
+  await driver.run("UPDATE transactions SET tx = 'not json' WHERE ses = ?", [
+    sessions[0]!.rowID,
+  ]);
+
+  storage.onCoValueUnmounted(map.id);
+
+  const content: NewContentMessage[] = [];
+  await new Promise<void>((resolve) => {
+    storage.load(
+      map.id,
+      (data) => content.push(data),
+      () => resolve(),
+    );
+  });
+  await storage.close();
+
+  // An empty session entry is still emitted for the corrupt one, so count the
+  // transactions actually recovered: 2 of 3 with the fallback, 0 without it.
+  const loadedTxs = content.flatMap((m) =>
+    Object.values(m.new).flatMap((e) => e.newTransactions),
+  );
+  expect(loadedTxs).toHaveLength(2);
+});
+
+test("a streaming coValue is read in batched checkpoint windows", async () => {
+  // 2KB values against a 100KB checkpoint means ~50 transactions per
+  // checkpoint, so this spans well over SIGNATURE_READ_BATCH checkpoints.
+  const { txReads, transactions, expected } = await loadStreamingCoValue(1000);
+
+  // Slicing a multi-checkpoint window by hand can drop, duplicate or reorder
+  // transactions without changing the count, so compare the whole log.
+  expect(transactions).toHaveLength(1000);
+  expect(transactions).toEqual(expected);
+
+  // One read per checkpoint would be ~20+; batching 10 at a time is ~2-3.
+  expect(txReads).toBeGreaterThan(0);
+  expect(txReads).toBeLessThan(5);
+});
+
 test("load cost does not grow with the number of sessions", async () => {
   const oneSession = await readsToLoadCoValueWithSessions(1);
   const manySessions = await readsToLoadCoValueWithSessions(30);


### PR DESCRIPTION
Stacks on #3549 — please land that first. The diff here against `main` includes its two commits; the new work is the last commit only.

#3549 batches the per-session reads, but bails out on streaming coValues:

```js
const prefetchedTxs = contentStreaming ? undefined : await this.getTransactionsByRowID(...)
// "Streaming coValues keep the per-range reads."
```

`contentStreaming` is true precisely when a coValue has stored signatures — i.e. a long transaction log. So the coValues that cost the most to load are exactly the ones that keep the un-batched path. A coValue split across signature checkpoints is read **one checkpoint at a time**, which is one sequential round trip per ~`MAX_RECOMMENDED_TX_SIZE` (100KB) of log.

## Fix

Read `SIGNATURE_READ_BATCH` (10) checkpoints per query and hand them out by cursor. No new SQL and no interface change — it reuses `getNewTransactionInSession` with a wider range, since `transactions` is `PRIMARY KEY (ses, idx) WITHOUT ROWID` and a range read already comes back in `idx` order.

Reading the *whole* log in one query would be simpler, but that is unbounded memory for precisely the coValues this path exists for. Ten checkpoints caps a read at roughly 1MB.

The prefetched and windowed paths now share one slice bounded by the covering signature, which subsumes the bound added in #3549.

## Measured

`StorageApiAsync.readAmplification.test.ts`, a 1,000-transaction coValue at 2KB per value (~20 checkpoints):

| | reads |
| --- | --- |
| one query per checkpoint | 28 |
| batched, 10 at a time | **3** |

**Wall-clock on device is not measured here, and I want to be straight about that.** The read-count reduction is exact and platform-independent; what it's worth depends on per-read latency. It should matter most on React Native, where reads go through a single op-sqlite connection whose native thread pool is one thread — but I don't have a before/after device number for this change yet, unlike #3549.

Context for why this shape was worth chasing: loading a 40,000-transaction coValue costs ~200ms under node with better-sqlite3 (~5µs/tx, linear), against multi-second subscribe freezes seen on RN for a comparable coValue. Same cojson code either side, so the cost is in the round trips and the native boundary rather than in the algorithm. Transaction verification is not the cost — skipping hash and signature entirely (`disableTransactionVerification()`) moves 3–5%.

## Test

`a streaming coValue is read in batched checkpoint windows` — asserts the read count and compares the whole reconstructed log against what was written, since a slicing bug can drop, duplicate or reorder without changing the count. Fails at `expected 28 to be less than 5` with the batch set to 1.

`a corrupt transaction row only costs its own session` — the batched read parses every row under one try/catch, so one bad row returns nothing for the whole coValue; this pins that the per-session fallback still recovers the intact sessions.
